### PR TITLE
[64bit] Add macro to convert 0x0E segment values

### DIFF
--- a/mm/include/macros.h
+++ b/mm/include/macros.h
@@ -106,4 +106,9 @@
     }                       \
     (void)0
 
+// #region 2S2H [Port]
+// Compute 0x0E segment value as compile time constant for 32bit and 64bit
+#define D_0E000000_TO_SEGMENTED(member) ((0x0E000000 + offsetof(GfxMasterList, member)) | 1)
+// #endregion
+
 #endif // MACROS_H

--- a/mm/src/code/z_rcp.c
+++ b/mm/src/code/z_rcp.c
@@ -840,9 +840,7 @@ Gfx sFillSetupDL[] = {
                          G_TD_CLAMP | G_TP_PERSP | G_CYC_FILL | G_PM_NPRIMITIVE,
                      G_AC_NONE | G_ZS_PIXEL | G_RM_NOOP | G_RM_NOOP2),
     gsSPLoadGeometryMode(G_ZBUFFER | G_SHADE | G_CULL_BACK | G_LIGHTING | G_SHADING_SMOOTH),
-    // BENTODO: CRASH
-    // gsSPDisplayList(D_0E000000.setScissor),
-    gsSPDisplayList(0x0E0001C8 | 1),
+    gsSPDisplayList(D_0E000000_TO_SEGMENTED(setScissor)),
     gsDPSetBlendColor(0x00, 0x00, 0x00, 0x08),
     gsSPClipRatio(FRUSTRATIO_2),
     gsSPEndDisplayList(),
@@ -1451,8 +1449,8 @@ void func_8012CF0C(GraphicsContext* gfxCtx, s32 clearFb, s32 clearZb, u8 r, u8 g
     s32 i;
 
     gSegments[0x00] = 0;
-    gSegments[0x0F] = gfxCtx->curFrameBuffer;
-    gSegments[0x0E] = gGfxMasterDL;
+    gSegments[0x0F] = (uintptr_t)gfxCtx->curFrameBuffer;
+    gSegments[0x0E] = (uintptr_t)gGfxMasterDL;
 
     zbuffer = gfxCtx->zbuffer;
 
@@ -1540,12 +1538,10 @@ void func_8012CF0C(GraphicsContext* gfxCtx, s32 clearFb, s32 clearZb, u8 r, u8 g
 
     OPEN_DISPS(gfxCtx);
 
-    // #region 2S2H [Port] Crashes on MacOS
     gSPDisplayList(POLY_OPA_DISP++, gGfxMasterDL->setupBuffers);
     gSPDisplayList(POLY_XLU_DISP++, gGfxMasterDL->setupBuffers);
     gSPDisplayList(OVERLAY_DISP++, gGfxMasterDL->setupBuffers);
     gSPDisplayList(DEBUG_DISP++, gGfxMasterDL->setupBuffers);
-    // #endregion
 
     if (clearZb) {
         __gSPDisplayList(POLY_OPA_DISP++,

--- a/mm/src/code/z_viscvg.c
+++ b/mm/src/code/z_viscvg.c
@@ -5,9 +5,7 @@ Gfx D_801C5DD0[] = {
     gsDPSetOtherMode(G_AD_PATTERN | G_CD_MAGICSQ | G_CK_NONE | G_TC_CONV | G_TF_POINT | G_TT_NONE | G_TL_TILE |
                          G_TD_CLAMP | G_TP_NONE | G_CYC_1CYCLE | G_PM_NPRIMITIVE,
                      G_AC_NONE | G_ZS_PRIM | G_RM_VISCVG | G_RM_VISCVG2),
-    // BENTODO: CRASH
-    // gsSPBranchList(D_0E000000.fillRect),
-    gsSPBranchList(0x0E0002E0 | 1),
+    gsSPBranchList(D_0E000000_TO_SEGMENTED(fillRect)),
 };
 
 Gfx D_801C5DE0[] = {
@@ -16,9 +14,7 @@ Gfx D_801C5DE0[] = {
                      G_AC_NONE | G_ZS_PRIM | IM_RD | CVG_DST_CLAMP | ZMODE_OPA | FORCE_BL |
                          GBL_c1(G_BL_CLR_FOG, G_BL_A_FOG, G_BL_CLR_MEM, G_BL_A_MEM) |
                          GBL_c2(G_BL_CLR_FOG, G_BL_A_FOG, G_BL_CLR_MEM, G_BL_A_MEM)),
-    // BENTODO: CRASH
-    //gsSPBranchList(D_0E000000.fillRect),
-    gsSPBranchList(0x0E0002E0 | 1),
+    gsSPBranchList(D_0E000000_TO_SEGMENTED(fillRect)),
 };
 
 Gfx D_801C5DF0[] = {
@@ -27,9 +23,7 @@ Gfx D_801C5DF0[] = {
                      G_AC_NONE | G_ZS_PRIM | IM_RD | CVG_DST_CLAMP | ZMODE_OPA | FORCE_BL |
                          GBL_c1(G_BL_CLR_IN, G_BL_0, G_BL_CLR_MEM, G_BL_A_MEM) |
                          GBL_c2(G_BL_CLR_IN, G_BL_0, G_BL_CLR_MEM, G_BL_A_MEM)),
-    // BENTODO: CRASH
-    //gsSPBranchList(D_0E000000.fillRect),
-    gsSPBranchList(0x0E0002E0 | 1),
+    gsSPBranchList(D_0E000000_TO_SEGMENTED(fillRect)),
 };
 
 Gfx D_801C5E00[] = {
@@ -37,17 +31,13 @@ Gfx D_801C5E00[] = {
     gsDPSetOtherMode(G_AD_NOTPATTERN | G_CD_DISABLE | G_CK_NONE | G_TC_CONV | G_TF_POINT | G_TT_NONE | G_TL_TILE |
                          G_TD_CLAMP | G_TP_NONE | G_CYC_1CYCLE | G_PM_NPRIMITIVE,
                      G_AC_NONE | G_ZS_PRIM | G_RM_CLD_SURF | G_RM_CLD_SURF2),
-    // BENTODO: CRASH
-    //gsSPDisplayList(D_0E000000.fillRect),
-    gsSPBranchList(0x0E0002E0 | 1),
+    gsSPBranchList(D_0E000000_TO_SEGMENTED(fillRect)),
     gsDPSetOtherMode(G_AD_PATTERN | G_CD_MAGICSQ | G_CK_NONE | G_TC_CONV | G_TF_POINT | G_TT_NONE | G_TL_TILE |
                          G_TD_CLAMP | G_TP_NONE | G_CYC_1CYCLE | G_PM_NPRIMITIVE,
                      G_AC_NONE | G_ZS_PRIM | IM_RD | CVG_DST_CLAMP | ZMODE_OPA | FORCE_BL |
                          GBL_c1(G_BL_CLR_IN, G_BL_0, G_BL_CLR_MEM, G_BL_A_MEM) |
                          GBL_c2(G_BL_CLR_IN, G_BL_0, G_BL_CLR_MEM, G_BL_A_MEM)),
-    // BENTODO: CRASH
-    //gsSPBranchList(D_0E000000.fillRect),
-    gsSPBranchList(0x0E0002E0 | 1),
+    gsSPBranchList(D_0E000000_TO_SEGMENTED(fillRect)),
 };
 
 void VisCvg_Init(VisCvg* this) {


### PR DESCRIPTION
Previously the temp changes to things like `gsSPBranchList(0x0E0002E0 | 1)` only supported 32bit which lead to crashing on 64bit, and the patterns like `0x0E000000 + ((uintptr_t)&D_0E000000.syncSegments - (uintptr_t)&D_0E000000) + 1` couldn't be used since those were not compile-time constant.

I've added a macro that works at compile-time to do the same offset calculation by using `offsetof` which will support 32bit and 64bit offset values for the segment address.

With this macro I think we can also clean up all the runtime uses of things like `0x0E000000 + ((uintptr_t)&D_0E000000.syncSegments - (uintptr_t)&D_0E000000) + 1`, but I'll wait to see if we want to do that or not.