### PR TITLE
Fix segment pointer truncation

### DIFF
--- a/mm/src/code/z_actor.c
+++ b/mm/src/code/z_actor.c
@@ -3385,7 +3385,7 @@ Actor* Actor_SpawnAsChildAndCutscene(ActorContext* actorCtx, PlayState* play, s1
     Actor_AddToCategory(actorCtx, actor, actorInit->type);
 
     {
-        u32 sp20 = gSegments[6];
+        uintptr_t sp20 = gSegments[6];
 
         Actor_Init(actor, play);
         gSegments[6] = sp20;


### PR DESCRIPTION
Segment 6 was being stored in a backup for some actor inits, and then restore. This backup value was incorrectly a u32 which was truncating the segment value on x64 bit machines.

Changing to `uintptr_t` prevents the truncation and matches one other spot where this happens in decomp https://github.com/HarbourMasters/2ship2harkinian/blob/47b6f1fbc512ca9b9f242ead455951ea88d6e0ae/mm/src/overlays/effects/ovl_Effect_Ss_Extra/z_eff_ss_extra.c#L38

Notably, this fixes the deku nut crash in North Clock town area.