### PR TITLE
Fix A Button Positioning

### DIFF
--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -1325,6 +1325,40 @@ extern "C" int16_t OTRGetRectDimensionFromRightEdge(float v) {
     return ((int)ceilf(OTRGetDimensionFromRightEdge(v)));
 }
 
+// Takes a HUD coordinate(320x240) and converts it to the game window pixel coordinates (any size, any aspect ratio)
+// Though the HUD uses a 320x240 coordinates system, the size of the HUD box is scaled up to match the window height
+// If the game window is 4:3, this will return the same value.
+
+/*
+Example, if the game window is 16:9 at twice the resolution of the HUD:
+Calling with X (0,0) will return 8
+Calling with Y (1,1) will return 10
+
+. . . x _ _ _ _ _ _ _ . . .
+. . . _ y _ _ _ _ _ _ . . .
+. . . _ _ _ HUD _ _ _ . . .
+. . . _ _ _ _ _ _ _ _ . . .
+. . . _ _ _ _ _ _ _ _ . . .
+*/
+extern "C" int32_t OTRConvertHUDXToScreenX(int32_t v) {
+    float gameAspectRatio = gfx_current_dimensions.aspect_ratio;
+    int32_t gameHeight = gfx_current_dimensions.height;
+    int32_t gameWidth = gfx_current_dimensions.width;
+    float hudAspectRatio = 4.0f / 3.0f;
+    int32_t hudHeight = gameHeight;
+    int32_t hudWidth = hudHeight * hudAspectRatio;
+
+    float hudScreenRatio = (hudWidth / 320.0f);
+    float hudCoord = v * hudScreenRatio;
+    float gameOffset = (gameWidth - hudWidth) / 2;
+    float gameCoord = hudCoord + gameOffset;
+    float gameScreenRatio = (320.0f / gameWidth);
+    float screenScaledCoord = gameCoord * gameScreenRatio;
+    int32_t screenScaledCoordInt = screenScaledCoord;
+
+    return screenScaledCoordInt;
+}
+
 extern "C" int AudioPlayer_Buffered(void) {
     return AudioPlayerBuffered();
 }

--- a/mm/2s2h/BenPort.h
+++ b/mm/2s2h/BenPort.h
@@ -108,6 +108,7 @@ uint64_t GetFrequency();
 uint32_t OTRGetCurrentWidth(void);
 uint32_t OTRGetCurrentHeight(void);
 float OTRGetAspectRatio(void);
+int32_t OTRConvertHUDXToScreenX(int32_t v);
 float OTRGetDimensionFromLeftEdge(float v);
 float OTRGetDimensionFromRightEdge(float v);
 int16_t OTRGetRectDimensionFromLeftEdge(float v);

--- a/mm/src/code/z_parameter.c
+++ b/mm/src/code/z_parameter.c
@@ -15,6 +15,7 @@
 #include "interface/week_static/week_static.h"
 #include "BenPort.h"
 #include <string.h>
+#include "libultraship/libultraship.h"
 
 // #region 2S2H [Port] Asset tables we can pull from instead of from ROM
 #define dgEmptyTexture "__OTR__textures/virtual/gEmptyTexture"
@@ -4018,8 +4019,8 @@ void Interface_SetPerspectiveView(PlayState* play, s32 topY, s32 bottomY, s32 le
 
     interfaceCtx->viewport.topY = topY;
     interfaceCtx->viewport.bottomY = bottomY;
-    interfaceCtx->viewport.leftX = leftX;
-    interfaceCtx->viewport.rightX = rightX;
+    interfaceCtx->viewport.leftX = OTRConvertHUDXToScreenX(leftX);
+    interfaceCtx->viewport.rightX = OTRConvertHUDXToScreenX(rightX);
     View_SetViewport(&interfaceCtx->view, &interfaceCtx->viewport);
 
     View_SetPerspective(&interfaceCtx->view, 60.0f, 10.0f, 60.0f);


### PR DESCRIPTION
This is a generic fix to the Interface Set Perspective View, but only the A button ends up using it. The idea here is to map the original camera view position for the A button, to the expanded camera view taking into account both the game screen width for that view, and the hud width range we want the A button to appear in.