### PR TITLE
Fix billboard mtx segment values

### DIFF
--- a/mm/include/macros.h
+++ b/mm/include/macros.h
@@ -107,6 +107,7 @@
     (void)0
 
 // #region 2S2H [Port]
+#define D_01000000_TO_SEGMENTED (0x01000000 | 1)
 // Compute 0x0E segment value as compile time constant for 32bit and 64bit
 #define D_0E000000_TO_SEGMENTED(member) ((0x0E000000 + offsetof(GfxMasterList, member)) | 1)
 // #endregion

--- a/mm/src/code/z_kankyo.c
+++ b/mm/src/code/z_kankyo.c
@@ -1947,7 +1947,7 @@ void Environment_DrawLensFlare(PlayState* play, EnvironmentContext* envCtx, View
                                   TEXEL0, 0, PRIMITIVE, 0);
                 gDPSetAlphaDither(POLY_XLU_DISP++, G_AD_DISABLE);
                 gDPSetColorDither(POLY_XLU_DISP++, G_CD_DISABLE);
-                gSPMatrix(POLY_XLU_DISP++, &D_01000000, G_MTX_NOPUSH | G_MTX_MUL | G_MTX_MODELVIEW);
+                gSPMatrix(POLY_XLU_DISP++, D_01000000_TO_SEGMENTED, G_MTX_NOPUSH | G_MTX_MUL | G_MTX_MODELVIEW);
 
                 switch (sLensFlareTypes[i]) {
                     case LENS_FLARE_CIRCLE0:
@@ -2080,7 +2080,7 @@ void Environment_DrawRainImpl(PlayState* play, View* view, GraphicsContext* gfxC
     for (i = 0; i < precip; i++) {
         Matrix_Translate(((Rand_ZeroOne() - 0.7f) * 100.0f) + spF0, ((Rand_ZeroOne() - 0.7f) * 100.0f) + spEC,
                          ((Rand_ZeroOne() - 0.7f) * 100.0f) + spE8, MTXMODE_NEW);
-        gSPMatrix(POLY_XLU_DISP++, &D_01000000, G_MTX_NOPUSH | G_MTX_MUL | G_MTX_MODELVIEW);
+        gSPMatrix(POLY_XLU_DISP++, D_01000000_TO_SEGMENTED, G_MTX_NOPUSH | G_MTX_MUL | G_MTX_MODELVIEW);
         Matrix_RotateYS(yaw + (s16)(i << 5), MTXMODE_APPLY);
         Matrix_RotateXS(pitch + (s16)(i << 5), MTXMODE_APPLY);
         Matrix_Scale(0.3f, 1.0f, 0.3f, MTXMODE_APPLY);
@@ -2377,7 +2377,7 @@ void Environment_DrawLightning(PlayState* play, s32 unused) {
             gSPSegment(POLY_XLU_DISP++, 0x08,
                        Lib_SegmentedToVirtual(sLightningTextures[sLightningBolts[i].textureIndex]));
             Gfx_SetupDL61_Xlu(play->state.gfxCtx);
-            gSPMatrix(POLY_XLU_DISP++, &D_01000000, G_MTX_NOPUSH | G_MTX_MUL | G_MTX_MODELVIEW);
+            gSPMatrix(POLY_XLU_DISP++, D_01000000_TO_SEGMENTED, G_MTX_NOPUSH | G_MTX_MUL | G_MTX_MODELVIEW);
             gSPDisplayList(POLY_XLU_DISP++, gEffLightningDL);
         }
     }

--- a/mm/src/overlays/actors/ovl_En_Arrow/z_en_arrow.c
+++ b/mm/src/overlays/actors/ovl_En_Arrow/z_en_arrow.c
@@ -681,7 +681,7 @@ void EnArrow_Draw(Actor* thisx, PlayState* play) {
             Matrix_ReplaceRotation(&gIdentityMtxF);
 
             gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(play->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-            gSPMatrix(POLY_XLU_DISP++, &D_01000000, G_MTX_NOPUSH | G_MTX_MUL | G_MTX_MODELVIEW);
+            gSPMatrix(POLY_XLU_DISP++, D_01000000_TO_SEGMENTED, G_MTX_NOPUSH | G_MTX_MUL | G_MTX_MODELVIEW);
             gSPDisplayList(POLY_XLU_DISP++, gameplay_keep_DL_06F9F0);
         } else {
             func_800B8050(&this->actor, play, 0);

--- a/mm/src/overlays/actors/ovl_Object_Kankyo/z_object_kankyo.c
+++ b/mm/src/overlays/actors/ovl_Object_Kankyo/z_object_kankyo.c
@@ -676,7 +676,7 @@ void func_808DDE9C(Actor* thisx, PlayState* play2) {
         if (!((temp_f20 < -252.0f) && (temp_f20 > -500.0f) && (temp_f2 > 3820.0f) && (temp_f2 < 4150.0f))) {
             Matrix_Translate(temp_f20, temp_f22, temp_f2, MTXMODE_NEW);
 
-            gSPMatrix(POLY_XLU_DISP++, &D_01000000, G_MTX_NOPUSH | G_MTX_MUL | G_MTX_MODELVIEW);
+            gSPMatrix(POLY_XLU_DISP++, D_01000000_TO_SEGMENTED, G_MTX_NOPUSH | G_MTX_MUL | G_MTX_MODELVIEW);
 
             Matrix_RotateYS((s16)this->unk_14C[2].unk_04 + (s16)(i << 5), MTXMODE_APPLY);
             Matrix_RotateXS((s16)this->unk_14C[2].unk_00 + (s16)(i << 5), MTXMODE_APPLY);

--- a/mm/src/overlays/effects/ovl_Effect_Ss_Dead_Dd/z_eff_ss_dead_dd.c
+++ b/mm/src/overlays/effects/ovl_Effect_Ss_Dead_Dd/z_eff_ss_dead_dd.c
@@ -113,7 +113,7 @@ void EffectSsDeadDd_Draw(PlayState* play, u32 index, EffectSs* this) {
         gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, this->rPrimColorR, this->rPrimColorG, this->rPrimColorB, this->rAlpha);
         gDPSetEnvColor(POLY_XLU_DISP++, this->rEnvColorR, this->rEnvColorG, this->rEnvColorB, this->rAlpha);
         gSPMatrix(POLY_XLU_DISP++, mtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-        gSPMatrix(POLY_XLU_DISP++, &D_01000000, G_MTX_NOPUSH | G_MTX_MUL | G_MTX_MODELVIEW);
+        gSPMatrix(POLY_XLU_DISP++, D_01000000_TO_SEGMENTED, G_MTX_NOPUSH | G_MTX_MUL | G_MTX_MODELVIEW);
         gDPSetCombineLERP(POLY_XLU_DISP++, 0, 0, 0, PRIMITIVE, TEXEL0, 0, PRIMITIVE, 0, 0, 0, 0, PRIMITIVE, TEXEL0, 0,
                           PRIMITIVE, 0);
         gSPDisplayList(POLY_XLU_DISP++, gLensFlareCircleDL);


### PR DESCRIPTION
Fix billboard mtx segment values following the patterns for the other segment fixes like #6 

This makes lightning look normal, bubble blowing with deku shows (although maybe the hilite textures are wrong, but at least the bubble shows now)
Supposedly fixes lens flare, but there may be something else wrong with lens flare