### PR TITLE
Properly array bounds check the font table

### DIFF
--- a/mm/src/code/z_kanfont.c
+++ b/mm/src/code/z_kanfont.c
@@ -181,8 +181,9 @@ void Font_LoadCharNES(PlayState* play, u8 codePointIndex, s32 offset) {
 
     int fontIdx = codePointIndex - 0x20;
 
-    if (codePointIndex < 0x8B)
+    if (fontIdx >= 0 && fontIdx < ARRAY_COUNT(fontTbl)) {
         memcpy(&font->charBuf[font->unk_11D88][offset], fontTbl[fontIdx], strlen(fontTbl[fontIdx]) + 1);
+    }
 
     // DmaMgr_SendRequest0(&font->charBuf[font->unk_11D88][offset],
     //&((u8*)SEGMENT_ROM_START(nes_font_static))[(codePointIndex - ' ') * FONT_CHAR_TEX_SIZE],


### PR DESCRIPTION
The index check was copied from OOT and doesn't match the larger font table that MM has.
Instead of updating the value to match the largest code point `0xBB` as a hardcoded value, I changed it to a proper array bounds check with the normalized font index.