### PR TITLE
fix master dl overflows

### DIFF
--- a/mm/include/gfx.h
+++ b/mm/include/gfx.h
@@ -98,8 +98,10 @@ typedef struct {
     /* 0x1C8 */ Gfx setScissor[2];
     /* 0x1D8 */ Gfx unk_1D8[25]; // unused
     /* 0x2A0 */ Gfx disps[5];
-    /* 0x2C8 */ Gfx clearFillRect[3]; // fillrect for clearing buffers
-    /* 0x2E0 */ Gfx fillRect[3];      // fillrect for general purpose
+    // #region 2S2H [Cosmetic] clearFillRect and fillRect increased to 4 instructions to account for gDPFillWideRectangle
+    /* 0x2C8 */ Gfx clearFillRect[4]; // fillrect for clearing buffers
+    /* 0x2E0 */ Gfx fillRect[4];      // fillrect for general purpose
+    // #endregion
     /* 0x2F8 */ Gfx debugDisp[1];
 } GfxMasterList; // size = 0x300
 

--- a/mm/src/code/z_rcp.c
+++ b/mm/src/code/z_rcp.c
@@ -1512,9 +1512,11 @@ void func_8012CF0C(GraphicsContext* gfxCtx, s32 clearFb, s32 clearZb, u8 r, u8 g
     masterGfx = gGfxMasterDL->clearFillRect;
 
     // #region 2S2H [Cosmetic] Account for different aspect ratios than 4:3
-    gDPFillWideRectangle(&masterGfx[0], OTRGetRectDimensionFromLeftEdge(0), 0, OTRGetRectDimensionFromRightEdge(gCfbWidth - 1), gCfbHeight - 1);
-    gDPPipeSync(&masterGfx[1]);
-    gSPEndDisplayList(&masterGfx[2]);
+    // WideRectangle consumes two instructions and requires ++ for the macro to work
+    Gfx* tmpGfx = masterGfx;
+    gDPFillWideRectangle(tmpGfx++, OTRGetRectDimensionFromLeftEdge(0), 0, OTRGetRectDimensionFromRightEdge(gCfbWidth - 1), gCfbHeight - 1);
+    gDPPipeSync(&masterGfx[2]);
+    gSPEndDisplayList(&masterGfx[3]);
     // #endregion
 
     // General Fillrect?
@@ -1522,9 +1524,11 @@ void func_8012CF0C(GraphicsContext* gfxCtx, s32 clearFb, s32 clearZb, u8 r, u8 g
     masterGfx = gGfxMasterDL->fillRect;
 
     // #region 2S2H [Cosmetic] Account for different aspect ratios than 4:3
-    gDPFillWideRectangle(&masterGfx[0], OTRGetRectDimensionFromLeftEdge(0), 0, OTRGetRectDimensionFromRightEdge(gCfbWidth), gCfbHeight);
-    gDPPipeSync(&masterGfx[1]);
-    gSPEndDisplayList(&masterGfx[2]);
+    // WideRectangle consumes two instructions and requires ++ for the macro to work
+    tmpGfx = masterGfx;
+    gDPFillWideRectangle(tmpGfx++, OTRGetRectDimensionFromLeftEdge(0), 0, OTRGetRectDimensionFromRightEdge(gCfbWidth), gCfbHeight);
+    gDPPipeSync(&masterGfx[2]);
+    gSPEndDisplayList(&masterGfx[3]);
     // #endregion
 
     // Sync SP Segments with current CPU Segments


### PR DESCRIPTION
`gDPFillWideRectangle` adds two instructions instead of one like the original `gDPFillRectangle`, and the `++` postfix is required for the macro to work properly.

To be able to use the wide rectangle command in the master DLs we need to increase the buffers size and index correctly in rcp setup for them.