### PR TITLE
Allocate correct memory size to dListBuf

### DIFF
--- a/mm/src/code/z_vr_box.c
+++ b/mm/src/code/z_vr_box.c
@@ -349,7 +349,7 @@ void Skybox_Init(GameState* gameState, SkyboxContext* skyboxCtx, s16 skyboxId) {
     Skybox_Setup(gameState, skyboxCtx, skyboxId);
 
     if (skyboxId != SKYBOX_NONE) {
-        skyboxCtx->dListBuf = THA_AllocTailAlign16(&gameState->tha, sizeof(Gfx) * 150 * 12);
+        skyboxCtx->dListBuf = THA_AllocTailAlign16(&gameState->tha, 12 * 150 * sizeof(Gfx));
 
         if (skyboxId == SKYBOX_CUTSCENE_MAP) {
             // Allocate enough space for the vertices for a 6 sided skybox (cube)


### PR DESCRIPTION
Caused crashes with skyboxes on file select screen due to sizeof Gfx issues