### PR TITLE
Temporarily disable framebuffer effects for lens actors

### DIFF
--- a/mm/src/code/z_actor.c
+++ b/mm/src/code/z_actor.c
@@ -2832,7 +2832,8 @@ void Actor_DrawLensActors(PlayState* play, s32 numLensActors, Actor** lensActors
 
     // Remnant of debug
     dbgVar1 = true;
-    dbgVar2 = true;
+    // BENTODO: Disabling the framebufer effects temporarily for lens actors until we can restore framebuffer effects for real
+    dbgVar2 = false;
 
     if (dbgVar1) {
         dbgVar1 = (numLensActors > 0);


### PR DESCRIPTION
This just temporarily disables the frame buffer effects that are done when a "lens actor" is on screen.
Disabling this effect allows the lens to be used basically as intended (lens actors are drawn in the circle).

Once we restore framebuffer effects, we should be able to add this back.