### PR TITLE
Re-order F1 menu

### DIFF
--- a/mm/2s2h/BenMenuBar.cpp
+++ b/mm/2s2h/BenMenuBar.cpp
@@ -268,17 +268,17 @@ void DrawSettingsMenu() {
 
 void DrawEnhancementsMenu() {
     if (UIWidgets::BeginMenu("Enhancements")) {
-        if (UIWidgets::BeginMenu("Masks")) {
-            UIWidgets::CVarCheckbox("Remove Blast Mask Cooldown", "gRemoveBlastMaskCooldown", {
-                .tooltip = "Removes the cooldown after using Blast Mask."
-            });
-
-            ImGui::EndMenu();
-        }
 
         ImGui::EndMenu();
     }
     
+}
+
+void DrawCheatsMenu() {
+    if (UIWidgets::BeginMenu("Cheats")) {
+
+        ImGui::EndMenu();
+    }
 }
 
 extern std::shared_ptr<LUS::GuiWindow> mStatsWindow;
@@ -352,6 +352,10 @@ void BenMenuBar::DrawElement() {
         ImGui::SetCursorPosY(0.0f);
 
         DrawEnhancementsMenu();
+
+        ImGui::SetCursorPosY(0.0f);
+
+        DrawCheatsMenu();
 
         ImGui::SetCursorPosY(0.0f);
 

--- a/mm/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/mm/src/overlays/actors/ovl_player_actor/z_player.c
@@ -45,8 +45,6 @@
 #include "objects/object_link_nuts/object_link_nuts.h"
 #include "objects/object_link_child/object_link_child.h"
 
-#include "libultraship/libultraship.h"
-
 #define THIS ((Player*)thisx)
 
 void Player_Init(Actor* thisx, PlayState* play);
@@ -3728,9 +3726,7 @@ void Player_ProcessItemButtons(Player* this, PlayState* play) {
 
                 if (bomb != NULL) {
                     bomb->timer = 0;
-                    if (!CVarGetInteger("gRemoveBlastMaskCooldown", 0)) {
-                        this->blastMaskTimer = 310;
-                    }
+                    this->blastMaskTimer = 310;
                 }
             }
         } else if (item == ITEM_F1) {


### PR DESCRIPTION
- Moves controller stuff inside the controller submenu
- Moves Graphics menu inside Settings
- Adds empty enhancements/cheats menus in F1 bar for later use