### PR TITLE
V1 Hud Editor

### DIFF
--- a/mm/2s2h/BenGui/BenGui.cpp
+++ b/mm/2s2h/BenGui/BenGui.cpp
@@ -7,6 +7,7 @@
 #include <libultraship/libultraship.h>
 #include <Fast3D/gfx_pc.h>
 #include "UIWidgets.hpp"
+#include "HudEditor.h"
 
 #ifdef __APPLE__
 #include "graphic/Fast3D/gfx_metal.h"
@@ -33,6 +34,7 @@ namespace BenGui {
     std::shared_ptr<LUS::GuiWindow> mGfxDebuggerWindow;
 
     std::shared_ptr<SaveEditorWindow> mSaveEditorWindow;
+    std::shared_ptr<HudEditorWindow> mHudEditorWindow;
 
     void SetupGuiElements() {
         auto gui = LUS::Context::GetInstance()->GetWindow()->GetGui();
@@ -73,12 +75,16 @@ namespace BenGui {
             SPDLOG_ERROR("Could not find input GfxDebuggerWindow");
         }
 
-        mSaveEditorWindow = std::make_shared<SaveEditorWindow>("gSaveEditorEnabled", "Save Editor");
+        mSaveEditorWindow = std::make_shared<SaveEditorWindow>("gWindows.SaveEditor", "Save Editor");
         gui->AddGuiWindow(mSaveEditorWindow);
+
+        mHudEditorWindow = std::make_shared<HudEditorWindow>("gWindows.HudEditor", "Hud Editor");
+        gui->AddGuiWindow(mHudEditorWindow);
     }
 
     void Destroy() {
         mSaveEditorWindow = nullptr;
+        mHudEditorWindow = nullptr;
         mStatsWindow = nullptr;
         mConsoleWindow = nullptr;
         mBenMenuBar = nullptr;

--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -8,6 +8,7 @@
 #include <string>
 #include "z64.h"
 #include "2s2h/Enhancements/Enhancements.h"
+#include "HudEditor.h"
 
 extern bool ShouldClearTextureCacheAtEndOfFrame;
 
@@ -259,8 +260,16 @@ void DrawSettingsMenu() {
     }
 }
 
+extern std::shared_ptr<HudEditorWindow> mHudEditorWindow;
+
 void DrawEnhancementsMenu() {
     if (UIWidgets::BeginMenu("Enhancements")) {
+
+        if (mHudEditorWindow) {
+            UIWidgets::WindowButton("Hud Editor", "gWindows.HudEditor", mHudEditorWindow, {
+                .tooltip = "Enables the Hud Editor window, allowing you to edit your hud"
+            });
+        }
 
         ImGui::EndMenu();
     }

--- a/mm/2s2h/BenGui/HudEditor.cpp
+++ b/mm/2s2h/BenGui/HudEditor.cpp
@@ -1,0 +1,142 @@
+
+#include "HudEditor.h"
+
+extern "C" int16_t OTRGetRectDimensionFromLeftEdge(float v);
+extern "C" int16_t OTRGetRectDimensionFromRightEdge(float v);
+
+HudEditorElementID hudEditorActiveElement = HUD_EDITOR_ELEMENT_NONE;
+
+HudEditorElement hudEditorElements[HUD_EDITOR_ELEMENT_MAX] = {
+    HUD_EDITOR_ELEMENT(HUD_EDITOR_ELEMENT_B,             "B Button",       "B",      167, 17,  100, 255, 120, 255),
+    HUD_EDITOR_ELEMENT(HUD_EDITOR_ELEMENT_C_LEFT,        "C-Left Button",  "CLeft",  227, 18,  255, 240, 0,   255),
+    HUD_EDITOR_ELEMENT(HUD_EDITOR_ELEMENT_C_DOWN,        "C-Down Button",  "CDown",  249, 34,  255, 240, 0,   255),
+    HUD_EDITOR_ELEMENT(HUD_EDITOR_ELEMENT_C_RIGHT,       "C-Right Button", "CRight", 271, 18,  255, 240, 0,   255),
+    HUD_EDITOR_ELEMENT(HUD_EDITOR_ELEMENT_A,             "A Button",       "A",      191, 18,  100, 200, 255, 255),
+    HUD_EDITOR_ELEMENT(HUD_EDITOR_ELEMENT_C_UP,          "C-Up Button",    "CUp",    254, 16,  255, 240, 0,   255),
+    HUD_EDITOR_ELEMENT(HUD_EDITOR_ELEMENT_START,         "Start Button",   "Start",  136, 17,  255, 130, 60,  255),
+    HUD_EDITOR_ELEMENT(HUD_EDITOR_ELEMENT_MAGIC_METER,   "Magic",          "Magic",  18,  34,  0,   200, 0,   255),
+    HUD_EDITOR_ELEMENT(HUD_EDITOR_ELEMENT_HEARTS,        "Hearts",         "Hearts", 30,  26,  255, 70,  50,  255),
+    HUD_EDITOR_ELEMENT(HUD_EDITOR_ELEMENT_RUPEE_COUNTER, "Rupees",         "Rupees", 26,  206, 200, 255, 100, 255),
+};
+
+extern "C" bool HudEditor_ShouldOverrideDraw() {
+    return hudEditorActiveElement != HUD_EDITOR_ELEMENT_NONE && CVarGetInteger(hudEditorElements[hudEditorActiveElement].modeCvar, HUD_EDITOR_ELEMENT_MODE_VANILLA) != HUD_EDITOR_ELEMENT_MODE_VANILLA;
+}
+
+extern "C" void HudEditor_SetActiveElement(HudEditorElementID id) {
+    hudEditorActiveElement = id;
+}
+
+extern "C" void HudEditor_ModifyDrawValues(s16* rectLeft, s16* rectTop, s16* rectWidth, s16* rectHeight, s16* dsdx, s16* dtdy) {
+    s16 offsetFromBaseX = *rectLeft - hudEditorElements[hudEditorActiveElement].defaultX;
+    s16 offsetFromBaseY = *rectTop - hudEditorElements[hudEditorActiveElement].defaultY;
+    *rectLeft = CVarGetInteger(hudEditorElements[hudEditorActiveElement].xCvar, hudEditorElements[hudEditorActiveElement].defaultX) + (offsetFromBaseX * CVarGetFloat(hudEditorElements[hudEditorActiveElement].scaleCvar, 1.0f));
+    *rectTop = CVarGetInteger(hudEditorElements[hudEditorActiveElement].yCvar, hudEditorElements[hudEditorActiveElement].defaultY) + (offsetFromBaseY * CVarGetFloat(hudEditorElements[hudEditorActiveElement].scaleCvar, 1.0f));
+
+    if (CVarGetInteger(hudEditorElements[hudEditorActiveElement].modeCvar, HUD_EDITOR_ELEMENT_MODE_VANILLA) == HUD_EDITOR_ELEMENT_MODE_MOVABLE_LEFT) {
+        *rectLeft = OTRGetRectDimensionFromLeftEdge(*rectLeft);
+    } else if (CVarGetInteger(hudEditorElements[hudEditorActiveElement].modeCvar, HUD_EDITOR_ELEMENT_MODE_VANILLA) == HUD_EDITOR_ELEMENT_MODE_MOVABLE_RIGHT) {
+        *rectLeft = OTRGetRectDimensionFromRightEdge(*rectLeft);
+    }
+
+    *rectWidth *= CVarGetFloat(hudEditorElements[hudEditorActiveElement].scaleCvar, 1.0f);
+    *rectHeight *= CVarGetFloat(hudEditorElements[hudEditorActiveElement].scaleCvar, 1.0f);
+    *dsdx /= CVarGetFloat(hudEditorElements[hudEditorActiveElement].scaleCvar, 1.0f);
+    *dtdy /= CVarGetFloat(hudEditorElements[hudEditorActiveElement].scaleCvar, 1.0f);
+}
+
+const char* modeNames[] = {
+    "Vanilla (4:3)",
+    "Hidden",
+    "Movable (Align Center)",
+    "Movable (Align Left)",
+    "Movable (Align Right)",
+};
+
+const char* presetNames[] = {
+    "Vanilla (4:3)",
+    "Hidden",
+    "Widescreen",
+};
+
+void HudEditorWindow::DrawElement() {
+    ImGui::SetNextWindowSize(ImVec2(480,600), ImGuiCond_FirstUseEver);
+    if (!ImGui::Begin("Hud Editor", &mIsVisible, ImGuiWindowFlags_NoFocusOnAppearing)) {
+        ImGui::End();
+        return;
+    }
+
+    static int preset = 0;
+    if (UIWidgets::Combobox("Preset", &preset, presetNames)) {
+        for (int i = HUD_EDITOR_ELEMENT_B; i < HUD_EDITOR_ELEMENT_MAX; i++) {
+            CVarClear(hudEditorElements[i].xCvar);
+            CVarClear(hudEditorElements[i].yCvar);
+            CVarClear(hudEditorElements[i].scaleCvar);
+            CVarClear(hudEditorElements[i].colorCvar);
+            CVarClear(hudEditorElements[i].modeCvar);
+        }
+
+        switch (preset) {
+            case 1: {
+                for (int i = HUD_EDITOR_ELEMENT_B; i < HUD_EDITOR_ELEMENT_MAX; i++) {
+                    CVarSetInteger(hudEditorElements[i].modeCvar, HUD_EDITOR_ELEMENT_MODE_HIDDEN);
+                }
+                break;
+            }
+            case 2: {
+                CVarSetInteger(hudEditorElements[HUD_EDITOR_ELEMENT_B].modeCvar, HUD_EDITOR_ELEMENT_MODE_MOVABLE_RIGHT);
+                CVarSetInteger(hudEditorElements[HUD_EDITOR_ELEMENT_C_LEFT].modeCvar, HUD_EDITOR_ELEMENT_MODE_MOVABLE_RIGHT);
+                CVarSetInteger(hudEditorElements[HUD_EDITOR_ELEMENT_C_DOWN].modeCvar, HUD_EDITOR_ELEMENT_MODE_MOVABLE_RIGHT);
+                CVarSetInteger(hudEditorElements[HUD_EDITOR_ELEMENT_C_RIGHT].modeCvar, HUD_EDITOR_ELEMENT_MODE_MOVABLE_RIGHT);
+                CVarSetInteger(hudEditorElements[HUD_EDITOR_ELEMENT_A].modeCvar, HUD_EDITOR_ELEMENT_MODE_MOVABLE_RIGHT);
+                CVarSetInteger(hudEditorElements[HUD_EDITOR_ELEMENT_C_UP].modeCvar, HUD_EDITOR_ELEMENT_MODE_MOVABLE_RIGHT);
+                CVarSetInteger(hudEditorElements[HUD_EDITOR_ELEMENT_START].modeCvar, HUD_EDITOR_ELEMENT_MODE_MOVABLE_RIGHT);
+                CVarSetInteger(hudEditorElements[HUD_EDITOR_ELEMENT_MAGIC_METER].modeCvar, HUD_EDITOR_ELEMENT_MODE_MOVABLE_LEFT);
+                CVarSetInteger(hudEditorElements[HUD_EDITOR_ELEMENT_HEARTS].modeCvar, HUD_EDITOR_ELEMENT_MODE_MOVABLE_LEFT);
+                CVarSetInteger(hudEditorElements[HUD_EDITOR_ELEMENT_RUPEE_COUNTER].modeCvar, HUD_EDITOR_ELEMENT_MODE_MOVABLE_LEFT);
+                break;
+            }
+        }
+    }
+
+    for (int i = HUD_EDITOR_ELEMENT_B; i < HUD_EDITOR_ELEMENT_MAX; i++) {
+        ImGui::PushID(hudEditorElements[i].name);
+        ImGui::SeparatorText(hudEditorElements[i].name);
+        float color[3] = {  (float)hudEditorElements[i].defaultR / 255, (float)hudEditorElements[i].defaultG / 255, (float)hudEditorElements[i].defaultB / 255 };
+        // This color picker currently doesn't do anything other than serve as a visual indicator. Eventually it will be used to set the color of the element.
+        ImGui::ColorEdit3("Color", color, ImGuiColorEditFlags_NoInputs | ImGuiColorEditFlags_NoLabel);
+        ImGui::SameLine();
+        if (UIWidgets::CVarCombobox("Mode", hudEditorElements[i].modeCvar, modeNames, {
+            .labelPosition = UIWidgets::LabelPosition::None
+        })) {
+            CVarClear(hudEditorElements[i].xCvar);
+            CVarClear(hudEditorElements[i].yCvar);
+            CVarClear(hudEditorElements[i].scaleCvar);
+        }
+        if (CVarGetInteger(hudEditorElements[i].modeCvar, HUD_EDITOR_ELEMENT_MODE_VANILLA) >= HUD_EDITOR_ELEMENT_MODE_MOVABLE_43) {
+            ImGui::BeginTable("##table", 3, ImGuiTableFlags_NoSavedSettings | ImGuiTableFlags_NoBordersInBody);
+            ImGui::TableNextColumn();
+            UIWidgets::CVarSliderInt("X", hudEditorElements[i].xCvar, -10, 330, hudEditorElements[i].defaultX, {
+                .showButtons = false,
+                .format = "X: %d",
+                .labelPosition = UIWidgets::LabelPosition::None,
+            });
+            ImGui::TableNextColumn();
+            UIWidgets::CVarSliderInt("Y", hudEditorElements[i].yCvar, -10, 250, hudEditorElements[i].defaultY, {
+                .showButtons = false,
+                .format = "Y: %d",
+                .labelPosition = UIWidgets::LabelPosition::None,
+            });
+            ImGui::TableNextColumn();
+            UIWidgets::CVarSliderFloat("Scale", hudEditorElements[i].scaleCvar, 0.25f, 4.0f, 1.0f, {
+                .showButtons = false,
+                .format = "Scale: %.2f",
+                .labelPosition = UIWidgets::LabelPosition::None,
+            });
+            ImGui::EndTable();
+        }
+        ImGui::PopID();
+    }
+
+    ImGui::End();
+}

--- a/mm/2s2h/BenGui/HudEditor.h
+++ b/mm/2s2h/BenGui/HudEditor.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <libultraship/libultraship.h>
+
+#ifdef __cplusplus
+
+#include "UIWidgets.hpp"
+#include <unordered_map>
+
+class HudEditorWindow : public LUS::GuiWindow {
+    public:
+        using GuiWindow::GuiWindow;
+
+        void InitElement() override {};
+        void DrawElement() override;
+        void UpdateElement() override {};
+};
+
+extern "C" {
+#endif
+
+#include "z64.h"
+
+typedef enum {
+    HUD_EDITOR_ELEMENT_NONE = -1,
+    HUD_EDITOR_ELEMENT_B,
+    HUD_EDITOR_ELEMENT_C_LEFT,
+    HUD_EDITOR_ELEMENT_C_DOWN,
+    HUD_EDITOR_ELEMENT_C_RIGHT,
+    HUD_EDITOR_ELEMENT_A,
+    HUD_EDITOR_ELEMENT_C_UP,
+    HUD_EDITOR_ELEMENT_START,
+    HUD_EDITOR_ELEMENT_MAGIC_METER,
+    HUD_EDITOR_ELEMENT_HEARTS,
+    HUD_EDITOR_ELEMENT_RUPEE_COUNTER,
+    HUD_EDITOR_ELEMENT_MAX,
+} HudEditorElementID;
+
+typedef enum {
+    HUD_EDITOR_ELEMENT_MODE_VANILLA,
+    HUD_EDITOR_ELEMENT_MODE_HIDDEN,
+    HUD_EDITOR_ELEMENT_MODE_MOVABLE_43,
+    HUD_EDITOR_ELEMENT_MODE_MOVABLE_LEFT,
+    HUD_EDITOR_ELEMENT_MODE_MOVABLE_RIGHT,
+} HudEditorElementMode;
+
+void HudEditor_SetActiveElement(HudEditorElementID id);
+bool HudEditor_ShouldOverrideDraw();
+void HudEditor_ModifyDrawValues(s16* rectLeft, s16* rectTop, s16* rectWidth, s16* rectHeight, s16* dsdx, s16* dtdy);
+
+typedef struct {
+    HudEditorElementID id;
+    const char* name;
+    int32_t defaultX;
+    int32_t defaultY;
+    int32_t defaultR;
+    int32_t defaultG;
+    int32_t defaultB;
+    int32_t defaultA;
+    const char* xCvar;
+    const char* yCvar;
+    const char* scaleCvar;
+    const char* colorCvar;
+    const char* modeCvar;
+} HudEditorElement;
+
+#define HUD_EDITOR_ELEMENT(id, name, cvar, defaultX, defaultY, defaultR, defaultG, defaultB, defaultA) \
+    { \
+        id, name, defaultX, defaultY, defaultR, defaultG, defaultB, defaultA, \
+        "gHudEditor." cvar ".Position.X", "gHudEditor." cvar ".Position.Y", \
+        "gHudEditor." cvar ".Scale", \
+        "gHudEditor." cvar ".Color.Value", \
+        "gHudEditor." cvar ".Mode" \
+    }
+
+extern HudEditorElementID hudEditorActiveElement;
+
+extern HudEditorElement hudEditorElements[HUD_EDITOR_ELEMENT_MAX];
+
+#ifdef __cplusplus
+}
+#endif

--- a/mm/src/code/z_parameter.c
+++ b/mm/src/code/z_parameter.c
@@ -16,6 +16,7 @@
 #include "BenPort.h"
 #include <string.h>
 #include "libultraship/libultraship.h"
+#include "BenGui/HudEditor.h"
 
 // #region 2S2H [Port] Asset tables we can pull from instead of from ROM
 #define dgEmptyTexture "__OTR__textures/virtual/gEmptyTexture"
@@ -299,7 +300,21 @@ Gfx* Gfx_DrawTexRectIA8(Gfx* gfx, TexturePtr texture, s16 textureWidth, s16 text
                         G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD,
                         G_TX_NOLOD);
 
-    gSPTextureRectangle(gfx++, rectLeft << 2, rectTop << 2, (rectLeft + rectWidth) << 2, (rectTop + rectHeight) << 2,
+    // #region 2S2H [Cosmetic] Hud Editor
+    if (HudEditor_ShouldOverrideDraw()) {
+        if (CVarGetInteger(hudEditorElements[hudEditorActiveElement].modeCvar, HUD_EDITOR_ELEMENT_MODE_VANILLA) == HUD_EDITOR_ELEMENT_MODE_HIDDEN) {
+            hudEditorActiveElement = HUD_EDITOR_ELEMENT_NONE;
+            return gfx;
+        }
+
+        HudEditor_ModifyDrawValues(&rectLeft, &rectTop, &rectWidth, &rectHeight, &dsdx, &dtdy);
+
+        hudEditorActiveElement = HUD_EDITOR_ELEMENT_NONE;
+    }
+    // #endregion
+
+    // 2S2H [Cosmetic] Changed to Wide variant to support widescreen
+    gSPWideTextureRectangle(gfx++, rectLeft << 2, rectTop << 2, (rectLeft + rectWidth) << 2, (rectTop + rectHeight) << 2,
                         G_TX_RENDERTILE, 0, 0, dsdx, dtdy);
 
     return gfx;
@@ -340,13 +355,27 @@ Gfx* Gfx_DrawTexRectIA8_DropShadow(Gfx* gfx, TexturePtr texture, s16 textureWidt
                         G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD,
                         G_TX_NOLOD);
 
-    gSPTextureRectangle(gfx++, (rectLeft + 2) * 4, (rectTop + 2) * 4, (rectLeft + rectWidth + 2) * 4,
+    // #region 2S2H [Cosmetic] Hud Editor
+    if (HudEditor_ShouldOverrideDraw()) {
+        if (CVarGetInteger(hudEditorElements[hudEditorActiveElement].modeCvar, HUD_EDITOR_ELEMENT_MODE_VANILLA) == HUD_EDITOR_ELEMENT_MODE_HIDDEN) {
+            hudEditorActiveElement = HUD_EDITOR_ELEMENT_NONE;
+            return gfx;
+        }
+
+        HudEditor_ModifyDrawValues(&rectLeft, &rectTop, &rectWidth, &rectHeight, &dsdx, &dtdy);
+
+        hudEditorActiveElement = HUD_EDITOR_ELEMENT_NONE;
+    }
+    // #endregion
+
+    // 2S2H [Cosmetic] Changed to Wide variant to support widescreen
+    gSPWideTextureRectangle(gfx++, (rectLeft + 2) * 4, (rectTop + 2) * 4, (rectLeft + rectWidth + 2) * 4,
                         (rectTop + rectHeight + 2) * 4, G_TX_RENDERTILE, 0, 0, dsdx, dtdy);
 
     gDPPipeSync(gfx++);
     gDPSetPrimColor(gfx++, 0, 0, r, g, b, a);
-
-    gSPTextureRectangle(gfx++, rectLeft * 4, rectTop * 4, (rectLeft + rectWidth) * 4, (rectTop + rectHeight) * 4,
+    // 2S2H [Cosmetic] Changed to Wide variant to support widescreen
+    gSPWideTextureRectangle(gfx++, rectLeft * 4, rectTop * 4, (rectLeft + rectWidth) * 4, (rectTop + rectHeight) * 4,
                         G_TX_RENDERTILE, 0, 0, dsdx, dtdy);
 
     return gfx;
@@ -376,15 +405,29 @@ Gfx* Gfx_DrawRect_DropShadow(Gfx* gfx, s16 rectLeft, s16 rectTop, s16 rectWidth,
         dropShadowAlpha = 100;
     }
 
+    // #region 2S2H [Cosmetic] Hud Editor
+    if (HudEditor_ShouldOverrideDraw()) {
+        if (CVarGetInteger(hudEditorElements[hudEditorActiveElement].modeCvar, HUD_EDITOR_ELEMENT_MODE_VANILLA) == HUD_EDITOR_ELEMENT_MODE_HIDDEN) {
+            hudEditorActiveElement = HUD_EDITOR_ELEMENT_NONE;
+            return gfx;
+        }
+
+        HudEditor_ModifyDrawValues(&rectLeft, &rectTop, &rectWidth, &rectHeight, &dsdx, &dtdy);
+
+        hudEditorActiveElement = HUD_EDITOR_ELEMENT_NONE;
+    }
+    // #endregion
+
     gDPPipeSync(gfx++);
     gDPSetPrimColor(gfx++, 0, 0, 0, 0, 0, dropShadowAlpha);
-    gSPTextureRectangle(gfx++, (rectLeft + 2) * 4, (rectTop + 2) * 4, (rectLeft + rectWidth + 2) * 4,
+    // 2S2H [Cosmetic] Changed to Wide variant to support widescreen
+    gSPWideTextureRectangle(gfx++, (rectLeft + 2) * 4, (rectTop + 2) * 4, (rectLeft + rectWidth + 2) * 4,
                         (rectTop + rectHeight + 2) * 4, G_TX_RENDERTILE, 0, 0, dsdx, dtdy);
 
     gDPPipeSync(gfx++);
     gDPSetPrimColor(gfx++, 0, 0, r, g, b, a);
-
-    gSPTextureRectangle(gfx++, rectLeft * 4, rectTop * 4, (rectLeft + rectWidth) * 4, (rectTop + rectHeight) * 4,
+    // 2S2H [Cosmetic] Changed to Wide variant to support widescreen
+    gSPWideTextureRectangle(gfx++, rectLeft * 4, rectTop * 4, (rectLeft + rectWidth) * 4, (rectTop + rectHeight) * 4,
                         G_TX_RENDERTILE, 0, 0, dsdx, dtdy);
 
     return gfx;
@@ -426,13 +469,28 @@ Gfx* Gfx_DrawTexRectIA8_DropShadowOffset(Gfx* gfx, TexturePtr texture, s16 textu
     gDPLoadTextureBlock(gfx++, texture, G_IM_FMT_IA, G_IM_SIZ_8b, textureWidth, textureHeight, 0,
                         G_TX_MIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, masks, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
 
-    gSPTextureRectangle(gfx++, (rectLeft + 2) * 4, (rectTop + 2) * 4, (rectLeft + rectWidth + 2) * 4,
+    // #region 2S2H [Cosmetic] Hud Editor
+    if (HudEditor_ShouldOverrideDraw()) {
+        if (CVarGetInteger(hudEditorElements[hudEditorActiveElement].modeCvar, HUD_EDITOR_ELEMENT_MODE_VANILLA) == HUD_EDITOR_ELEMENT_MODE_HIDDEN) {
+            hudEditorActiveElement = HUD_EDITOR_ELEMENT_NONE;
+            return gfx;
+        }
+
+        HudEditor_ModifyDrawValues(&rectLeft, &rectTop, &rectWidth, &rectHeight, &dsdx, &dtdy);
+
+        hudEditorActiveElement = HUD_EDITOR_ELEMENT_NONE;
+    }
+    // #endregion
+
+    // 2S2H [Cosmetic] Changed to Wide variant to support widescreen
+    gSPWideTextureRectangle(gfx++, (rectLeft + 2) * 4, (rectTop + 2) * 4, (rectLeft + rectWidth + 2) * 4,
                         (rectTop + rectHeight + 2) * 4, G_TX_RENDERTILE, rects, 0, dsdx, dtdy);
 
     gDPPipeSync(gfx++);
     gDPSetPrimColor(gfx++, 0, 0, r, g, b, a);
 
-    gSPTextureRectangle(gfx++, rectLeft * 4, rectTop * 4, (rectLeft + rectWidth) * 4, (rectTop + rectHeight) * 4,
+    // 2S2H [Cosmetic] Changed to Wide variant to support widescreen
+    gSPWideTextureRectangle(gfx++, rectLeft * 4, rectTop * 4, (rectLeft + rectWidth) * 4, (rectTop + rectHeight) * 4,
                         G_TX_RENDERTILE, rects, 0, dsdx, dtdy);
 
     return gfx;
@@ -459,7 +517,21 @@ Gfx* Gfx_DrawTexRectI8(Gfx* gfx, TexturePtr texture, s16 textureWidth, s16 textu
                         G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD,
                         G_TX_NOLOD);
 
-    gSPTextureRectangle(gfx++, rectLeft << 2, rectTop << 2, (rectLeft + rectWidth) << 2, (rectTop + rectHeight) << 2,
+    // #region 2S2H [Cosmetic] Hud Editor
+    if (HudEditor_ShouldOverrideDraw()) {
+        if (CVarGetInteger(hudEditorElements[hudEditorActiveElement].modeCvar, HUD_EDITOR_ELEMENT_MODE_VANILLA) == HUD_EDITOR_ELEMENT_MODE_HIDDEN) {
+            hudEditorActiveElement = HUD_EDITOR_ELEMENT_NONE;
+            return gfx;
+        }
+
+        HudEditor_ModifyDrawValues(&rectLeft, &rectTop, &rectWidth, &rectHeight, &dsdx, &dtdy);
+
+        hudEditorActiveElement = HUD_EDITOR_ELEMENT_NONE;
+    }
+    // #endregion
+
+    // 2S2H [Cosmetic] Changed to Wide variant to support widescreen
+    gSPWideTextureRectangle(gfx++, rectLeft << 2, rectTop << 2, (rectLeft + rectWidth) << 2, (rectTop + rectHeight) << 2,
                         G_TX_RENDERTILE, 0, 0, dsdx, dtdy);
 
     return gfx;
@@ -3942,13 +4014,16 @@ void Magic_DrawMeter(PlayState* play) {
 
         gDPSetEnvColor(OVERLAY_DISP++, 100, 50, 50, 255);
 
+        HudEditor_SetActiveElement(HUD_EDITOR_ELEMENT_MAGIC_METER);
         OVERLAY_DISP = Gfx_DrawTexRectIA8_DropShadow(
             OVERLAY_DISP, gMagicMeterEndTex, 8, 16, 18, magicBarY, 8, 16, 1 << 10, 1 << 10, sMagicMeterOutlinePrimRed,
             sMagicMeterOutlinePrimGreen, sMagicMeterOutlinePrimBlue, interfaceCtx->magicAlpha);
+        HudEditor_SetActiveElement(HUD_EDITOR_ELEMENT_MAGIC_METER);
         OVERLAY_DISP = Gfx_DrawTexRectIA8_DropShadow(OVERLAY_DISP, gMagicMeterMidTex, 24, 16, 26, magicBarY,
                                                      ((void)0, gSaveContext.magicCapacity), 16, 1 << 10, 1 << 10,
                                                      sMagicMeterOutlinePrimRed, sMagicMeterOutlinePrimGreen,
                                                      sMagicMeterOutlinePrimBlue, interfaceCtx->magicAlpha);
+        HudEditor_SetActiveElement(HUD_EDITOR_ELEMENT_MAGIC_METER);
         OVERLAY_DISP = Gfx_DrawTexRectIA8_DropShadowOffset(
             OVERLAY_DISP, gMagicMeterEndTex, 8, 16, ((void)0, gSaveContext.magicCapacity) + 26, magicBarY, 8, 16,
             1 << 10, 1 << 10, sMagicMeterOutlinePrimRed, sMagicMeterOutlinePrimGreen, sMagicMeterOutlinePrimBlue,
@@ -3995,9 +4070,35 @@ void Magic_DrawMeter(PlayState* play) {
 
             gDPLoadTextureBlock_4b(OVERLAY_DISP++, gMagicMeterFillTex, G_IM_FMT_I, 16, 16, 0, G_TX_NOMIRROR | G_TX_WRAP,
                                    G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
-            gSPTextureRectangle(OVERLAY_DISP++, 104, (magicBarY + 3) << 2,
-                                (((void)0, gSaveContext.save.saveInfo.playerData.magic) + 26) << 2,
-                                (magicBarY + 10) << 2, G_TX_RENDERTILE, 0, 0, 1 << 10, 1 << 10);
+
+            // #region 2S2H [Cosmetic] Hud Editor
+            HudEditor_SetActiveElement(HUD_EDITOR_ELEMENT_MAGIC_METER);
+            if (HudEditor_ShouldOverrideDraw()) {
+                if (CVarGetInteger(hudEditorElements[hudEditorActiveElement].modeCvar, HUD_EDITOR_ELEMENT_MODE_VANILLA) == HUD_EDITOR_ELEMENT_MODE_HIDDEN) {
+                    hudEditorActiveElement = HUD_EDITOR_ELEMENT_NONE;
+                } else {
+                    // All of this information was derived from the original call to gSPTextureRectangle below
+                    s16 rectLeft = 26;
+                    s16 rectTop = magicBarY + 3;
+                    s16 rectWidth = gSaveContext.save.saveInfo.playerData.magic;
+                    s16 rectHeight = 7;
+                    s16 dsdx = 512;
+                    s16 dtdy = 512;
+
+                    HudEditor_ModifyDrawValues(&rectLeft, &rectTop, &rectWidth, &rectHeight, &dsdx, &dtdy);
+
+                    hudEditorActiveElement = HUD_EDITOR_ELEMENT_NONE;
+
+                    gSPWideTextureRectangle(OVERLAY_DISP++, rectLeft << 2, rectTop << 2,
+                                    (rectLeft + rectWidth) << 2, (rectTop + rectHeight) << 2,
+                                    G_TX_RENDERTILE, 0, 0, dsdx << 1, dtdy << 1);
+                }
+            // #endregion
+            } else {
+                gSPTextureRectangle(OVERLAY_DISP++, 104, (magicBarY + 3) << 2,
+                                    (((void)0, gSaveContext.save.saveInfo.playerData.magic) + 26) << 2,
+                                    (magicBarY + 10) << 2, G_TX_RENDERTILE, 0, 0, 1 << 10, 1 << 10);
+            }
         }
     }
 
@@ -4020,8 +4121,37 @@ void Interface_SetPerspectiveView(PlayState* play, s32 topY, s32 bottomY, s32 le
 
     interfaceCtx->viewport.topY = topY;
     interfaceCtx->viewport.bottomY = bottomY;
+    // 2S2H [Cosmetic] These are originally relative to screen size, but by default we want them to instead be relative to the 4:3 HUD size, to match the rest of the HUD
     interfaceCtx->viewport.leftX = OTRConvertHUDXToScreenX(leftX);
     interfaceCtx->viewport.rightX = OTRConvertHUDXToScreenX(rightX);
+
+    // #region 2S2H [Cosmetic] Hud Editor
+    HudEditor_SetActiveElement(HUD_EDITOR_ELEMENT_A);
+    if (HudEditor_ShouldOverrideDraw()) {
+        if (CVarGetInteger(hudEditorElements[hudEditorActiveElement].modeCvar, HUD_EDITOR_ELEMENT_MODE_VANILLA) == HUD_EDITOR_ELEMENT_MODE_HIDDEN) {
+            interfaceCtx->viewport.leftX = 0;
+            interfaceCtx->viewport.rightX = 0;
+            hudEditorActiveElement = HUD_EDITOR_ELEMENT_NONE;
+        } else {
+            // All of this information was derived from the original call to gSPTextureRectangle below
+            s16 rectLeft = leftX;
+            s16 rectTop = topY;
+            s16 rectWidth = rightX - leftX;
+            s16 rectHeight = bottomY - topY;
+            s16 dsdx = 512;
+            s16 dtdy = 512;
+
+            HudEditor_ModifyDrawValues(&rectLeft, &rectTop, &rectWidth, &rectHeight, &dsdx, &dtdy);
+            hudEditorActiveElement = HUD_EDITOR_ELEMENT_NONE;
+
+            interfaceCtx->viewport.leftX = OTRConvertHUDXToScreenX(rectLeft);
+            interfaceCtx->viewport.rightX = OTRConvertHUDXToScreenX(rectLeft + rectWidth);
+            interfaceCtx->viewport.topY = rectTop;
+            interfaceCtx->viewport.bottomY = rectTop + rectHeight;
+        }
+    }
+    // #endregion
+
     View_SetViewport(&interfaceCtx->view, &interfaceCtx->viewport);
 
     View_SetPerspective(&interfaceCtx->view, 60.0f, 10.0f, 60.0f);
@@ -4060,6 +4190,7 @@ void Interface_DrawItemButtons(PlayState* play) {
     gDPSetCombineMode(OVERLAY_DISP++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
 
     // B Button Color & Texture
+    HudEditor_SetActiveElement(HUD_EDITOR_ELEMENT_B);
     OVERLAY_DISP = Gfx_DrawTexRectIA8_DropShadow(
         OVERLAY_DISP, gButtonBackgroundTex, 0x20, 0x20, D_801BF9D4[EQUIP_SLOT_B], D_801BF9DC[EQUIP_SLOT_B],
         D_801BFAF4[EQUIP_SLOT_B], D_801BFAF4[EQUIP_SLOT_B], D_801BF9E4[EQUIP_SLOT_B] * 2, D_801BF9E4[EQUIP_SLOT_B] * 2,
@@ -4067,16 +4198,19 @@ void Interface_DrawItemButtons(PlayState* play) {
     gDPPipeSync(OVERLAY_DISP++);
 
     // C-Left Button Color & Texture
+    HudEditor_SetActiveElement(HUD_EDITOR_ELEMENT_C_LEFT);
     OVERLAY_DISP = Gfx_DrawRect_DropShadow(OVERLAY_DISP, D_801BF9D4[EQUIP_SLOT_C_LEFT], D_801BF9DC[EQUIP_SLOT_C_LEFT],
                                            D_801BFAF4[EQUIP_SLOT_C_LEFT], D_801BFAF4[EQUIP_SLOT_C_LEFT],
                                            D_801BF9E4[EQUIP_SLOT_C_LEFT] * 2, D_801BF9E4[EQUIP_SLOT_C_LEFT] * 2, 255,
                                            240, 0, interfaceCtx->cLeftAlpha);
     // C-Down Button Color & Texture
+    HudEditor_SetActiveElement(HUD_EDITOR_ELEMENT_C_DOWN);
     OVERLAY_DISP = Gfx_DrawRect_DropShadow(OVERLAY_DISP, D_801BF9D4[EQUIP_SLOT_C_DOWN], D_801BF9DC[EQUIP_SLOT_C_DOWN],
                                            D_801BFAF4[EQUIP_SLOT_C_DOWN], D_801BFAF4[EQUIP_SLOT_C_DOWN],
                                            D_801BF9E4[EQUIP_SLOT_C_DOWN] * 2, D_801BF9E4[EQUIP_SLOT_C_DOWN] * 2, 255,
                                            240, 0, interfaceCtx->cDownAlpha);
     // C-Right Button Color & Texture
+    HudEditor_SetActiveElement(HUD_EDITOR_ELEMENT_C_RIGHT);
     OVERLAY_DISP = Gfx_DrawRect_DropShadow(OVERLAY_DISP, D_801BF9D4[EQUIP_SLOT_C_RIGHT], D_801BF9DC[EQUIP_SLOT_C_RIGHT],
                                            D_801BFAF4[EQUIP_SLOT_C_RIGHT], D_801BFAF4[EQUIP_SLOT_C_RIGHT],
                                            D_801BF9E4[EQUIP_SLOT_C_RIGHT] * 2, D_801BF9E4[EQUIP_SLOT_C_RIGHT] * 2, 255,
@@ -4084,6 +4218,7 @@ void Interface_DrawItemButtons(PlayState* play) {
 
     if (!IS_PAUSE_STATE_GAMEOVER) {
         if ((play->pauseCtx.state != PAUSE_STATE_OFF) || (play->pauseCtx.debugEditor != DEBUG_EDITOR_NONE)) {
+            HudEditor_SetActiveElement(HUD_EDITOR_ELEMENT_START);
             OVERLAY_DISP = Gfx_DrawRect_DropShadow(OVERLAY_DISP, 0x88, 0x11, 0x16, 0x16, 0x5B6, 0x5B6, 0xFF, 0x82, 0x3C,
                                                    interfaceCtx->startAlpha);
             // Start Button Texture, Color & Label
@@ -4095,7 +4230,32 @@ void Interface_DrawItemButtons(PlayState* play) {
             gDPLoadTextureBlock_4b(OVERLAY_DISP++, interfaceCtx->doActionSegment[DO_ACTION_SEG_START].mainTex,
                                    G_IM_FMT_IA, DO_ACTION_TEX_WIDTH, DO_ACTION_TEX_HEIGHT, 0, G_TX_NOMIRROR | G_TX_WRAP,
                                    G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
-            gSPTextureRectangle(OVERLAY_DISP++, 0x01F8, 0x0054, 0x02D4, 0x009C, G_TX_RENDERTILE, 0, 0, 0x04A6, 0x04A6);
+            // #region 2S2H [Cosmetic] Hud Editor
+            HudEditor_SetActiveElement(HUD_EDITOR_ELEMENT_START);
+            if (HudEditor_ShouldOverrideDraw()) {
+                if (CVarGetInteger(hudEditorElements[hudEditorActiveElement].modeCvar, HUD_EDITOR_ELEMENT_MODE_VANILLA) == HUD_EDITOR_ELEMENT_MODE_HIDDEN) {
+                    hudEditorActiveElement = HUD_EDITOR_ELEMENT_NONE;
+                } else {
+                    // All of this information was derived from the original call to gSPTextureRectangle below
+                    s16 rectLeft = 0x01F8 >> 2;
+                    s16 rectTop = 0x0054 >> 2;
+                    s16 rectWidth = (0x02D4 >> 2) - rectLeft;
+                    s16 rectHeight = (0x009C >> 2) - rectTop;
+                    s16 dsdx = 0x04A6 >> 1;
+                    s16 dtdy = 0x04A6 >> 1;
+
+                    HudEditor_ModifyDrawValues(&rectLeft, &rectTop, &rectWidth, &rectHeight, &dsdx, &dtdy);
+
+                    hudEditorActiveElement = HUD_EDITOR_ELEMENT_NONE;
+
+                    gSPWideTextureRectangle(OVERLAY_DISP++, rectLeft << 2, rectTop << 2,
+                                    (rectLeft + rectWidth) << 2, (rectTop + rectHeight) << 2,
+                                    G_TX_RENDERTILE, 0, 0, dsdx << 1, dtdy << 1);
+                }
+            // #endregion
+            } else {
+                gSPTextureRectangle(OVERLAY_DISP++, 0x01F8, 0x0054, 0x02D4, 0x009C, G_TX_RENDERTILE, 0, 0, 0x04A6, 0x04A6);
+            }
         }
     }
 
@@ -4117,6 +4277,7 @@ void Interface_DrawItemButtons(PlayState* play) {
                 temp = interfaceCtx->aAlpha;
             }
 
+            HudEditor_SetActiveElement(HUD_EDITOR_ELEMENT_C_UP);
             OVERLAY_DISP =
                 Gfx_DrawRect_DropShadow(OVERLAY_DISP, 0xFE, 0x10, 0x10, 0x10, 0x800, 0x800, 0xFF, 0xF0, 0, temp);
 
@@ -4151,6 +4312,7 @@ void Interface_DrawItemButtons(PlayState* play) {
             } else { // EQUIP_SLOT_C_RIGHT
                 gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 240, 0, interfaceCtx->cRightAlpha);
             }
+            HudEditor_SetActiveElement(temp);
             OVERLAY_DISP =
                 Gfx_DrawTexRectIA8(OVERLAY_DISP, emptyCButtonArrows[temp - 1], 0x20, 0x20, D_801BF9D4[temp], D_801BF9DC[temp],
                                    D_801BFAF4[temp], D_801BFAF4[temp], D_801BF9E4[temp] * 2, D_801BF9E4[temp] * 2);
@@ -4168,9 +4330,34 @@ void Interface_DrawItemIconTexture(PlayState* play, TexturePtr texture, s16 butt
     gDPLoadTextureBlock(OVERLAY_DISP++, texture, G_IM_FMT_RGBA, G_IM_SIZ_32b, 32, 32, 0, G_TX_NOMIRROR | G_TX_WRAP,
                         G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
 
-    gSPTextureRectangle(OVERLAY_DISP++, D_801BF9D4[button] << 2, D_801BF9DC[button] << 2,
-                        (D_801BF9D4[button] + D_801BFAFC[button]) << 2, (D_801BF9DC[button] + D_801BFAFC[button]) << 2,
-                        G_TX_RENDERTILE, 0, 0, D_801BF9BC[button] << 1, D_801BF9BC[button] << 1);
+    // #region 2S2H [Cosmetic] Hud Editor
+    HudEditor_SetActiveElement(button);
+    if (HudEditor_ShouldOverrideDraw()) {
+        if (CVarGetInteger(hudEditorElements[hudEditorActiveElement].modeCvar, HUD_EDITOR_ELEMENT_MODE_VANILLA) == HUD_EDITOR_ELEMENT_MODE_HIDDEN) {
+            hudEditorActiveElement = HUD_EDITOR_ELEMENT_NONE;
+        } else {
+            // All of this information was derived from the original call to gSPTextureRectangle below
+            s16 rectLeft = D_801BF9D4[button];
+            s16 rectTop = D_801BF9DC[button];
+            s16 rectWidth = D_801BFAFC[button];
+            s16 rectHeight = D_801BFAFC[button];
+            s16 dsdx = D_801BF9BC[button];
+            s16 dtdy = D_801BF9BC[button];
+
+            HudEditor_ModifyDrawValues(&rectLeft, &rectTop, &rectWidth, &rectHeight, &dsdx, &dtdy);
+
+            hudEditorActiveElement = HUD_EDITOR_ELEMENT_NONE;
+
+            gSPWideTextureRectangle(OVERLAY_DISP++, rectLeft << 2, rectTop << 2,
+                            (rectLeft + rectWidth) << 2, (rectTop + rectHeight) << 2,
+                            G_TX_RENDERTILE, 0, 0, dsdx << 1, dtdy << 1);
+        }
+    // #endregion
+    } else {
+        gSPTextureRectangle(OVERLAY_DISP++, D_801BF9D4[button] << 2, D_801BF9DC[button] << 2,
+                            (D_801BF9D4[button] + D_801BFAFC[button]) << 2, (D_801BF9DC[button] + D_801BFAFC[button]) << 2,
+                            G_TX_RENDERTILE, 0, 0, D_801BF9BC[button] << 1, D_801BF9BC[button] << 1);
+    }
 
     CLOSE_DISPS(play->state.gfxCtx);
 }
@@ -4229,11 +4416,13 @@ void Interface_DrawAmmoCount(PlayState* play, s16 button, s16 alpha) {
 
         // Draw upper digit (tens)
         if ((u32)i != 0) {
+            HudEditor_SetActiveElement(button);
             OVERLAY_DISP = Gfx_DrawTexRectIA8(OVERLAY_DISP, gAmmoDigitTextures[i], 8, 8,
                                               D_801BFB04[button], D_801BFB0C[button], 8, 8, 1 << 10, 1 << 10);
         }
 
         // Draw lower digit (ones)
+        HudEditor_SetActiveElement(button);
         OVERLAY_DISP = Gfx_DrawTexRectIA8(OVERLAY_DISP, gAmmoDigitTextures[ammo], 8, 8,
                                           D_801BFB04[button] + 6, D_801BFB0C[button], 8, 8, 1 << 10, 1 << 10);
     }
@@ -4297,10 +4486,35 @@ void Interface_DrawBButtonIcons(PlayState* play) {
 
         D_801BF9B0 = 1024.0f / (D_801BF9B4[gSaveContext.options.language] / 100.0f);
 
-        gSPTextureRectangle(
-            OVERLAY_DISP++, (D_801BF9C4[gSaveContext.options.language] * 4),
-            (D_801BF9C8[gSaveContext.options.language] * 4), ((D_801BF9C4[gSaveContext.options.language] + 0x30) << 2),
-            ((D_801BF9C8[gSaveContext.options.language] + 0x10) << 2), G_TX_RENDERTILE, 0, 0, D_801BF9B0, D_801BF9B0);
+        // #region 2S2H [Cosmetic] Hud Editor
+        HudEditor_SetActiveElement(HUD_EDITOR_ELEMENT_B);
+        if (HudEditor_ShouldOverrideDraw()) {
+            if (CVarGetInteger(hudEditorElements[hudEditorActiveElement].modeCvar, HUD_EDITOR_ELEMENT_MODE_VANILLA) == HUD_EDITOR_ELEMENT_MODE_HIDDEN) {
+                hudEditorActiveElement = HUD_EDITOR_ELEMENT_NONE;
+            } else {
+                // All of this information was derived from the original call to gSPTextureRectangle below
+                s16 rectLeft = D_801BF9C4[gSaveContext.options.language];
+                s16 rectTop = D_801BF9C8[gSaveContext.options.language];
+                s16 rectWidth = 0x30;
+                s16 rectHeight = 0x10;
+                s16 dsdx = D_801BF9B0 >> 1;
+                s16 dtdy = D_801BF9B0 >> 1;
+
+                HudEditor_ModifyDrawValues(&rectLeft, &rectTop, &rectWidth, &rectHeight, &dsdx, &dtdy);
+
+                hudEditorActiveElement = HUD_EDITOR_ELEMENT_NONE;
+
+                gSPWideTextureRectangle(OVERLAY_DISP++, rectLeft << 2, rectTop << 2,
+                                (rectLeft + rectWidth) << 2, (rectTop + rectHeight) << 2,
+                                G_TX_RENDERTILE, 0, 0, dsdx << 1, dtdy << 1);
+            }
+        // #endregion
+        } else {
+            gSPTextureRectangle(
+                OVERLAY_DISP++, (D_801BF9C4[gSaveContext.options.language] * 4),
+                (D_801BF9C8[gSaveContext.options.language] * 4), ((D_801BF9C4[gSaveContext.options.language] + 0x30) << 2),
+                ((D_801BF9C8[gSaveContext.options.language] + 0x10) << 2), G_TX_RENDERTILE, 0, 0, D_801BF9B0, D_801BF9B0);
+        }
     } else if (interfaceCtx->bButtonDoAction != DO_ACTION_NONE) {
         gDPPipeSync(OVERLAY_DISP++);
         gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0,
@@ -4312,10 +4526,35 @@ void Interface_DrawBButtonIcons(PlayState* play) {
 
         D_801BF9B0 = 1024.0f / (D_801BF9B4[gSaveContext.options.language] / 100.0f);
 
-        gSPTextureRectangle(
-            OVERLAY_DISP++, (D_801BF9C4[gSaveContext.options.language] * 4),
-            (D_801BF9C8[gSaveContext.options.language] * 4), ((D_801BF9C4[gSaveContext.options.language] + 0x30) << 2),
-            ((D_801BF9C8[gSaveContext.options.language] + 0x10) << 2), G_TX_RENDERTILE, 0, 0, D_801BF9B0, D_801BF9B0);
+        // #region 2S2H [Cosmetic] Hud Editor
+        HudEditor_SetActiveElement(HUD_EDITOR_ELEMENT_B);
+        if (HudEditor_ShouldOverrideDraw()) {
+            if (CVarGetInteger(hudEditorElements[hudEditorActiveElement].modeCvar, HUD_EDITOR_ELEMENT_MODE_VANILLA) == HUD_EDITOR_ELEMENT_MODE_HIDDEN) {
+                hudEditorActiveElement = HUD_EDITOR_ELEMENT_NONE;
+            } else {
+                // All of this information was derived from the original call to gSPTextureRectangle below
+                s16 rectLeft = D_801BF9C4[gSaveContext.options.language];
+                s16 rectTop = D_801BF9C8[gSaveContext.options.language];
+                s16 rectWidth = 0x30;
+                s16 rectHeight = 0x10;
+                s16 dsdx = D_801BF9B0 >> 1;
+                s16 dtdy = D_801BF9B0 >> 1;
+
+                HudEditor_ModifyDrawValues(&rectLeft, &rectTop, &rectWidth, &rectHeight, &dsdx, &dtdy);
+
+                hudEditorActiveElement = HUD_EDITOR_ELEMENT_NONE;
+
+                gSPWideTextureRectangle(OVERLAY_DISP++, rectLeft << 2, rectTop << 2,
+                                (rectLeft + rectWidth) << 2, (rectTop + rectHeight) << 2,
+                                G_TX_RENDERTILE, 0, 0, dsdx << 1, dtdy << 1);
+            }
+        // #endregion
+        } else {
+            gSPTextureRectangle(
+                OVERLAY_DISP++, (D_801BF9C4[gSaveContext.options.language] * 4),
+                (D_801BF9C8[gSaveContext.options.language] * 4), ((D_801BF9C4[gSaveContext.options.language] + 0x30) << 2),
+                ((D_801BF9C8[gSaveContext.options.language] + 0x10) << 2), G_TX_RENDERTILE, 0, 0, D_801BF9B0, D_801BF9B0);
+        }
     }
 
     CLOSE_DISPS(play->state.gfxCtx);
@@ -6433,6 +6672,7 @@ void Interface_Draw(PlayState* play) {
         gDPSetEnvColor(OVERLAY_DISP++, sRupeeCounterIconEnvColors[CUR_UPG_VALUE(UPG_WALLET)].r,
                        sRupeeCounterIconEnvColors[CUR_UPG_VALUE(UPG_WALLET)].g,
                        sRupeeCounterIconEnvColors[CUR_UPG_VALUE(4)].b, 255);
+        HudEditor_SetActiveElement(HUD_EDITOR_ELEMENT_RUPEE_COUNTER);
         OVERLAY_DISP =
             Gfx_DrawTexRectIA8(OVERLAY_DISP, gRupeeCounterIconTex, 16, 16, 26, 206, 16, 16, 1 << 10, 1 << 10);
 
@@ -6584,6 +6824,7 @@ void Interface_Draw(PlayState* play) {
             gDPPipeSync(OVERLAY_DISP++);
             gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 0, 0, 0, magicAlpha);
 
+            HudEditor_SetActiveElement(HUD_EDITOR_ELEMENT_RUPEE_COUNTER);
             OVERLAY_DISP = Gfx_DrawTexRectI8(OVERLAY_DISP, sCounterTextures[counterDigits[sp2CC]], 8, 16, sp2CA + 1, 207,
                                              8, 16, 1 << 10, 1 << 10);
 
@@ -6597,8 +6838,33 @@ void Interface_Draw(PlayState* play) {
                 gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 100, 100, 100, interfaceCtx->magicAlpha);
             }
 
-            gSPTextureRectangle(OVERLAY_DISP++, sp2CA * 4, 824, (sp2CA * 4) + 0x20, 888, G_TX_RENDERTILE, 0, 0, 1 << 10,
-                                1 << 10);
+            // #region 2S2H [Cosmetic] Hud Editor
+            HudEditor_SetActiveElement(HUD_EDITOR_ELEMENT_RUPEE_COUNTER);
+            if (HudEditor_ShouldOverrideDraw()) {
+                if (CVarGetInteger(hudEditorElements[hudEditorActiveElement].modeCvar, HUD_EDITOR_ELEMENT_MODE_VANILLA) == HUD_EDITOR_ELEMENT_MODE_HIDDEN) {
+                    hudEditorActiveElement = HUD_EDITOR_ELEMENT_NONE;
+                } else {
+                    // All of this information was derived from the original call to gSPTextureRectangle below
+                    s16 rectLeft = sp2CA;
+                    s16 rectTop = 824 / 4;
+                    s16 rectWidth = 0x20 / 4;
+                    s16 rectHeight = (888 / 4) - rectTop;
+                    s16 dsdx = 512;
+                    s16 dtdy = 512;
+
+                    HudEditor_ModifyDrawValues(&rectLeft, &rectTop, &rectWidth, &rectHeight, &dsdx, &dtdy);
+
+                    hudEditorActiveElement = HUD_EDITOR_ELEMENT_NONE;
+
+                    gSPWideTextureRectangle(OVERLAY_DISP++, rectLeft << 2, rectTop << 2,
+                                    (rectLeft + rectWidth) << 2, (rectTop + rectHeight) << 2,
+                                    G_TX_RENDERTILE, 0, 0, dsdx << 1, dtdy << 1);
+                }
+            // #endregion
+            } else {
+                gSPTextureRectangle(OVERLAY_DISP++, sp2CA * 4, 824, (sp2CA * 4) + 0x20, 888, G_TX_RENDERTILE, 0, 0, 1 << 10,
+                                    1 << 10);
+            }
         }
 
         Magic_DrawMeter(play);


### PR DESCRIPTION
Low priority, as this doesn't introduce anything necessary.

Introduces a simple Hud Editor window, with widescreen support for most of the hud elements in z_parameter.

This is not exhaustive, as it doesn't touch the timers, minigame related stuff, or the clock, but it's fine for a v1, and lays the groundwork for the rest.