### PR TITLE
build: remove `-fuse-ld=lld`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,11 +63,6 @@ set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
 set(CMAKE_OBJCXX_FLAGS_RELEASE "-O2 -DNDEBUG")
 endif()
 
-if (NOT CMAKE_SYSTEM_NAME MATCHES "Darwin")
-set(CMAKE_CXX_FLAGS_DEBUG "-fuse-ld=lld")
-set(CMAKE_LINKER_FLAGS_DEBUG "-fuse-ld=lld")
-endif()
-
 if(NOT CMAKE_BUILD_TYPE )
     set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Choose the type of build." FORCE)
 endif()


### PR DESCRIPTION
having this flag set led to vscode breakpoints not working in a lot of files when building using gcc on linux

### before
![image](https://github.com/HarbourMasters/2ship2harkinian/assets/70942617/2634cc7b-6147-4138-a65e-145dd4481451)

### after
![image](https://github.com/HarbourMasters/2ship2harkinian/assets/70942617/37dc8d74-3080-41c5-a677-00723e342819)
