### PR TITLE
Implement pixel depth value reads from the renderer

### DIFF
--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -610,12 +610,17 @@ extern "C" void Graph_ProcessGfxCommands(Gfx* commands) {
 
 float divisor_num = 0.0f;
 
+// Batch a coordinate to have its depth read later by OTRGetPixelDepth
 extern "C" void OTRGetPixelDepthPrepare(float x, float y) {
-    OTRGlobals::Instance->context->GetWindow()->GetPixelDepthPrepare(x, y);
+    // Invert the Y value to match the origin values used in the renderer
+    float adjustedY = SCREEN_HEIGHT - y;
+    OTRGlobals::Instance->context->GetWindow()->GetPixelDepthPrepare(x, adjustedY);
 }
 
 extern "C" uint16_t OTRGetPixelDepth(float x, float y) {
-    return OTRGlobals::Instance->context->GetWindow()->GetPixelDepth(x, y);
+    // Invert the Y value to match the origin values used in the renderer
+    float adjustedY = SCREEN_HEIGHT - y;
+    return OTRGlobals::Instance->context->GetWindow()->GetPixelDepth(x, adjustedY);
 }
 
 extern "C" uint32_t ResourceMgr_GetNumGameVersions() {

--- a/mm/include/functions.h
+++ b/mm/include/functions.h
@@ -1323,6 +1323,9 @@ void osContGetReadData(OSContPad* pad);
 void PadMgr_ThreadEntry();
 void Heaps_Alloc(void);
 // #endregion
+// #region 2S2H [Port] New methods added for porting
+void Lights_GlowCheckPrepare(PlayState* play);
+// #endregion
 // #region 2S2H [Port] Stubbed methods
 void osSetThreadPri(OSThread* thread, OSPri p);
 OSPri osGetThreadPri(OSThread* t);

--- a/mm/src/code/sys_cfb.c
+++ b/mm/src/code/sys_cfb.c
@@ -121,6 +121,9 @@ void* SysCfb_GetWorkBuffer(void) {
 }
 
 u16 SysCfb_GetZBufferPixel(s32 x, s32 y) {
+    // 2S2H [Port] Get the zbuffer pixel value from the renderer directly
+    return OTRGetPixelDepth(x, y);
+#if 0
     u16* zBuff = SysCfb_GetZBuffer();
     u16 val;
 
@@ -130,8 +133,12 @@ u16 SysCfb_GetZBufferPixel(s32 x, s32 y) {
         val = 0;
     }
     return val;
+#endif
 }
 
 s32 SysCfb_GetZBufferInt(s32 x, s32 y) {
-    return Environment_ZBufValToFixedPoint(SysCfb_GetZBufferPixel(x, y) << 2) >> 3;
+    // 2S2H [Port] The value from the renderer does not need to be converted to a fixed point
+    // Simply shifting is all we need to get the proper value
+    return SysCfb_GetZBufferPixel(x, y) >> 1;
+    // return Environment_ZBufValToFixedPoint(SysCfb_GetZBufferPixel(x, y) << 2) >> 3;
 }

--- a/mm/src/code/z_kankyo.c
+++ b/mm/src/code/z_kankyo.c
@@ -490,6 +490,10 @@ void Environment_JumpForwardInTime(void);
 void Environment_GraphCallback(GraphicsContext* gfxCtx, void* arg) {
     PlayState* play = (PlayState*)arg;
 
+    // 2S2H [Port] Batch all the coordinates that need their depth checked by calling prepare
+    OTRGetPixelDepthPrepare(sSunDepthTestX, sSunDepthTestY);
+    Lights_GlowCheckPrepare(play);
+
     sSunScreenDepth = SysCfb_GetZBufferPixel(sSunDepthTestX, sSunDepthTestY);
     Lights_GlowCheck(play);
 }


### PR DESCRIPTION
This updates the sun lens flare and light glow sources to read their depth value from the Fast3D renderer depth buffer.

To help with performance, there is a prepare method that can batch up all the coordinates to be read so that only one framebuffer read is needed per frame instead of ping-ponging multiple times. A new `Lights_GlowCheckPrepare` is added that does the same as `Lights_GlowCheck` but strictly just prepares the coordinate to be read.

Unlike SoH, the y-coordinate produced by `PROJECTED_TO_SCREEN_Y` needs to be inverted so that it matches the domain space used by Fast3D.

Note: It seems that sometimes openGL does not give a correct depth value when there is only one light source. I think this was an optimization in Fast3D that was never confirmed if it works. A follow up PR to LUS will address this.