### PR TITLE
Fix vertex copies for chimney smoke effects

### DIFF
--- a/mm/src/overlays/actors/ovl_Obj_Entotu/z_obj_entotu.c
+++ b/mm/src/overlays/actors/ovl_Obj_Entotu/z_obj_entotu.c
@@ -158,7 +158,7 @@ void ObjEntotu_Init(Actor* thisx, PlayState* play) {
     ovl_Obj_Entotu_Vtx_000D10Data = ResourceMgr_LoadVtxArrayByName(ovl_Obj_Entotu_Vtx_000D10);
 
     memcpy(this->unk_148, ovl_Obj_Entotu_Vtx_000D10Data,
-               ResourceMgr_GetArraySizeByName(ovl_Obj_Entotu_Vtx_000D10) * sizeof(Vtx));
+           sizeof(Vtx) * ResourceMgr_GetVtxArraySizeByName(ovl_Obj_Entotu_Vtx_000D10));
     this->unk_1C6 = Rand_S16Offset(0, 59);
     this->unk_1C4 = 0;
 }

--- a/mm/src/overlays/actors/ovl_Obj_Smork/z_obj_smork.c
+++ b/mm/src/overlays/actors/ovl_Obj_Smork/z_obj_smork.c
@@ -135,8 +135,8 @@ void ObjSmork_Init(Actor* thisx, PlayState* play) {
     ObjSmork* this = THIS;
     ovl_Obj_Smork_Vtx_000C10Data = ResourceMgr_LoadVtxArrayByName(ovl_Obj_Smork_Vtx_000C10);
 
-    memcpy(this->unk_148, ovl_Obj_Smork_Vtx_000C10,
-               sizeof(Vtx) * ResourceMgr_GetArraySizeByName(ovl_Obj_Smork_Vtx_000C10));
+    memcpy(this->unk_148, ovl_Obj_Smork_Vtx_000C10Data,
+           sizeof(Vtx) * ResourceMgr_GetVtxArraySizeByName(ovl_Obj_Smork_Vtx_000C10));
     this->unk_1C6 = Rand_S16Offset(0, 59);
     this->unk_1C4 = 0;
 }

--- a/mm/src/overlays/actors/ovl_Obj_Toudai/z_obj_toudai.c
+++ b/mm/src/overlays/actors/ovl_Obj_Toudai/z_obj_toudai.c
@@ -61,7 +61,7 @@ void func_80A33BB4(ObjToudai* this, PlayState* play) {
 
     this->unk_228 = CLAMP(this->unk_228, 0.0f, 1.0f);
 
-    for (i = 0; i < ResourceMgr_GetArraySizeByName(ovl_Obj_Toudai_Vtx_D_80A34590); i++) {
+    for (i = 0; i < ARRAY_COUNT(this->unk_148); i++) {
         this->unk_148[i].v.cn[3] = ovl_Obj_Toudai_Vtx_D_80A34590data[i].v.cn[3] * this->unk_228;
     }
 
@@ -105,9 +105,10 @@ u8 func_80A342F4(s16 arg0) {
 
 void ObjToudai_Init(Actor* thisx, PlayState* play) {
     ObjToudai* this = THIS;
-    ovl_Obj_Toudai_Vtx_D_80A34590data = ResourceMgr_LoadVtxByName(ovl_Obj_Toudai_Vtx_D_80A34590data);
+    ovl_Obj_Toudai_Vtx_D_80A34590data = ResourceMgr_LoadVtxByName(ovl_Obj_Toudai_Vtx_D_80A34590);
 
-    memcpy(this->unk_148, &ovl_Obj_Toudai_Vtx_D_80A34590, sizeof(ovl_Obj_Toudai_Vtx_D_80A34590));
+    memcpy(this->unk_148, ovl_Obj_Toudai_Vtx_D_80A34590data,
+           sizeof(Vtx) * ResourceMgr_GetVtxArraySizeByName(ovl_Obj_Toudai_Vtx_D_80A34590));
 }
 
 void ObjToudai_Destroy(Actor* thisx, PlayState* play) {


### PR DESCRIPTION
The memcpy being used for the various chimney smoke effects was incorrectly using `ResourceMgr_GetArraySizeByName` which reports `0` for specifically vertex lists. Instead, there is a separate method `ResourceMgr_GetVtxArraySizeByName` that should be used instead to get the size of the data.

Additionally, some of these memcpy were using the resource OTR path name as the source to copy, rather than the loaded data itself.

This address these copies so that the correct vtx data is being used in the renderer. A separate fix will be needed at the OTRExporter level to address the segment address `0x09` not being set in the display list for `gsSPVertex`.

Partially fixes #125 