### PR TITLE
Fix Gfx debugger with interpolation on

### DIFF
--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -591,6 +591,12 @@ extern "C" void Graph_ProcessGfxCommands(Gfx* commands) {
     OTRGlobals::Instance->context->GetWindow()->SetMaximumFrameLatency(threshold > 0 && target_fps >= threshold ? 2
                                                                                                                 : 1);
 
+    // When the gfx debugger is active, only run with the final mtx
+    if (GfxDebuggerIsDebugging()) {
+        mtx_replacements.clear();
+        mtx_replacements.emplace_back();
+    }
+
     RunCommands(commands, mtx_replacements);
 
     last_fps = fps;


### PR DESCRIPTION
The Gfx debugger works by repeatedly running the current games graphics commands. With interpolation added now, when the graphics commands are run, they run multiple times for each matrix interpolated value sets. This results in the debugger jumping when interpolation is added.

Since the debugger is meant to just debug the graphics commands themselves, I added a check to only run the final matrix values when the debugger is active. This prevents the jumpiness and ensures no interpolated values are displayed in the debugger.