### PR TITLE
Fix scene object unload bounds check crash

### DIFF
--- a/mm/2s2h/z_scene_2SH.cpp
+++ b/mm/2s2h/z_scene_2SH.cpp
@@ -170,7 +170,7 @@ void Scene_CommandObjectList(PlayState* play, LUS::ISceneCommand* cmd) {
     // Loop until a mismatch in the object lists
     // Then clear all object ids past that in the context object list and kill actors for those objects
     for (i = play->objectCtx.numPersistentEntries, k = 0; i < play->objectCtx.numEntries; i++, k++) {
-        if (play->objectCtx.slots[i].id != objList->objects[k]) {
+        if (k >= objList->objects.size() || play->objectCtx.slots[i].id != objList->objects[k]) {
             for (j = i; j < play->objectCtx.numEntries; j++) {
                 play->objectCtx.slots[j].id = 0;
             }


### PR DESCRIPTION
We were missing a bounds check on the scene command object size that lead to an OOB access crash. 