### PR TITLE
Fix snowhead pillar memcpy

### DIFF
--- a/mm/src/overlays/actors/ovl_Bg_Hakugin_Post/z_bg_hakugin_post.c
+++ b/mm/src/overlays/actors/ovl_Bg_Hakugin_Post/z_bg_hakugin_post.c
@@ -149,7 +149,7 @@ void func_80A9AFB4(BgHakuginPost* this, PlayState* play, BgHakuginPostUnkStruct*
             if ((unkStruct->unk_0000[i].unk_34 == 0) ||
                 (this->dyna.actor.world.pos.y < unkStruct->unk_0000[i].unk_08.y)) {
                 for (j = 10; j >= i; j--) {
-                    memcpy(&unkStruct->unk_0000[j + 1], &unkStruct->unk_0000[j], 0x38);
+                    memcpy(&unkStruct->unk_0000[j + 1], &unkStruct->unk_0000[j], sizeof(BgHakuginPostUnkStruct1));
                 }
                 break;
             }


### PR DESCRIPTION
The snowhead pillar was using a memcpy with a hardcoded size for n64 hardware instead of a `sizeof` for the underlying struct.