### PR TITLE
Implement VisMono with custom framebuffer effects

### DIFF
--- a/mm/2s2h/framebuffer_effects.c
+++ b/mm/2s2h/framebuffer_effects.c
@@ -5,7 +5,9 @@ int gfx_create_framebuffer(uint32_t width, uint32_t height);
 
 s32 gPauseFrameBuffer = -1;
 s32 gBlurFrameBuffer = -1;
-s32 gShrinkFrameBuffer = -1;
+// A framebuffer that should only be used for drawing in the same frame that it is copied too
+// i.e. the VisMono and VisFbuf effects
+s32 gReusableFrameBuffer = -1;
 
 void FB_CreateFramebuffers(void) {
     if (gPauseFrameBuffer == -1) {
@@ -16,8 +18,8 @@ void FB_CreateFramebuffers(void) {
         gBlurFrameBuffer = gfx_create_framebuffer(SCREEN_WIDTH, SCREEN_HEIGHT);
     }
 
-    if (gShrinkFrameBuffer == -1) {
-        gShrinkFrameBuffer = gfx_create_framebuffer(SCREEN_WIDTH, SCREEN_HEIGHT);
+    if (gReusableFrameBuffer == -1) {
+        gReusableFrameBuffer = gfx_create_framebuffer(SCREEN_WIDTH, SCREEN_HEIGHT);
     }
 }
 

--- a/mm/2s2h/framebuffer_effects.h
+++ b/mm/2s2h/framebuffer_effects.h
@@ -5,7 +5,7 @@
 
 extern s32 gPauseFrameBuffer;
 extern s32 gBlurFrameBuffer;
-extern s32 gShrinkFrameBuffer;
+extern s32 gReusableFrameBuffer;
 
 void FB_CreateFramebuffers(void);
 void FB_CopyToFramebuffer(Gfx** gfxp, s32 fb_src, s32 fb_dest, u8 oncePerFrame, u8* hasCopied);

--- a/mm/src/code/z_play.c
+++ b/mm/src/code/z_play.c
@@ -1276,8 +1276,13 @@ void Play_DrawMain(PlayState* this) {
 
             TransitionFade_Draw(&this->unk_18E48, &sp218);
             if (gVisMonoColor.a != 0) {
-                sPlayVisMono.primColor.rgba = gVisMonoColor.rgba;
-                VisMono_Draw(&sPlayVisMono, &sp218);
+                // 2S2H [Port] Implement VisMono by performing a framebuffer copy and redraw with an active
+                // grayscale command to set the mono color
+                FB_CopyToFramebuffer(&sp218, 0, gReusableFrameBuffer, false, NULL);
+                gDPSetGrayscaleColor(sp218++, gVisMonoColor.r, gVisMonoColor.g, gVisMonoColor.b, gVisMonoColor.a);
+                gSPGrayscale(sp218++, true);
+                FB_DrawFromFramebuffer(&sp218, gReusableFrameBuffer, 255);
+                gSPGrayscale(sp218++, false);
             }
 
             gSPEndDisplayList(sp218++);

--- a/mm/src/code/z_visfbuf.c
+++ b/mm/src/code/z_visfbuf.c
@@ -170,7 +170,7 @@ void VisFbuf_ApplyEffects(VisFbuf* this, Gfx** gfxP, void* source, void* img, s3
                     G_AD_PATTERN | G_CD_MAGICSQ | G_CK_NONE | G_TC_CONV | G_TF_POINT | G_TT_NONE | G_TL_TILE |
                         G_TD_CLAMP | G_TP_NONE | G_CYC_COPY | G_PM_NPRIMITIVE,
                     G_AC_NONE | G_ZS_PIXEL | G_RM_NOOP | G_RM_NOOP2);
-    FB_CopyToFramebuffer(&gfx, 0, gShrinkFrameBuffer, false, NULL);
+    FB_CopyToFramebuffer(&gfx, 0, gReusableFrameBuffer, false, NULL);
 
     gDPPipeSync(gfx++);
     // fill framebuffer with primColor
@@ -224,7 +224,7 @@ void VisFbuf_ApplyEffects(VisFbuf* this, Gfx** gfxP, void* source, void* img, s3
 
         // 2S2H [Port][Widescreen]
         // Draw shrunk window using an adjusted horizontal scale accounting for different aspect ratios
-        FB_DrawFromFramebufferScaled(&gfx, gShrinkFrameBuffer, 255,
+        FB_DrawFromFramebufferScaled(&gfx, gReusableFrameBuffer, 255,
                                      (1.0f - scale) * (OTRGetAspectRatio() / ((float)SCREEN_WIDTH / SCREEN_HEIGHT)),
                                      (1.0f - scale));
     }


### PR DESCRIPTION
This implements the VisMono effect by using the custom framebuffer copy/draw commands to take a copy of the game framebuffer, then uses our custom grayscale modifier to set the mono color before drawing back the framebuffer.

This implements the fullscreen grayscale and sepia filter effect.

I relabeled the shrink window framebuffer to indicate that it can be reusable in the same frame as it does not require drawing a retained copy from a previous game frame.

![image](https://github.com/HarbourMasters/2ship2harkinian/assets/13861068/f6033451-2e34-45a6-a792-f13a1a375d23)
