### PR TITLE
Fix owl save crash by adjusting save buffer size

### DIFF
--- a/mm/include/z64save.h
+++ b/mm/include/z64save.h
@@ -32,7 +32,7 @@ typedef enum RespawnMode {
     /* 8 */ RESPAWN_MODE_MAX
 } RespawnMode;
 
-#define SAVE_BUFFER_SIZE 0x4000
+#define SAVE_BUFFER_SIZE 0x8000 // 2S2H [Port] Double the original size of 0x4000 for 64 bit support
 
 typedef enum {
     /* 0  */ MAGIC_STATE_IDLE, // Regular gameplay

--- a/mm/src/code/z_sram_NES.c
+++ b/mm/src/code/z_sram_NES.c
@@ -1937,7 +1937,7 @@ void Sram_UpdateWriteToFlashDefault(SramContext* sramCtx) {
                 sramCtx->status = 4;
             }
         }
-    } else if (OSTIME_TO_TIMER(osGetTime() - sramCtx->startWriteOsTime) >= SECONDS_TO_TIMER(2)) {
+    } else if (OSTIME_TO_TIMER(osGetTime() - sramCtx->startWriteOsTime) >= SECONDS_TO_TIMER(0 /*2*/)) { // 2S2H [Port] Remove arbitrary 2 second delay
         // Finished status is hardcoded to 2 seconds instead of when the task finishes
         sramCtx->status = 0;
     }
@@ -1975,7 +1975,7 @@ void Sram_UpdateWriteToFlashOwlSave(SramContext* sramCtx) {
                 sramCtx->status = 4;
             }
         }
-    } else if (OSTIME_TO_TIMER(osGetTime() - sramCtx->startWriteOsTime) >= SECONDS_TO_TIMER(2)) {
+    } else if (OSTIME_TO_TIMER(osGetTime() - sramCtx->startWriteOsTime) >= SECONDS_TO_TIMER(0 /*2*/)) {  // 2S2H [Port] Remove arbitrary 2 second delay
         // Finished status is hardcoded to 2 seconds instead of when the task finishes
         sramCtx->status = 0;
         memset(sramCtx->saveBuf, 0, SAVE_BUFFER_SIZE);


### PR DESCRIPTION
Fixes #139

also removes arbitrary 2 second delay on saving