### PR TITLE
replace more hardcoded allocs

### DIFF
--- a/mm/src/overlays/actors/ovl_Dm_Sa/z_dm_sa.c
+++ b/mm/src/overlays/actors/ovl_Dm_Sa/z_dm_sa.c
@@ -93,7 +93,8 @@ void DmSa_TransformLimbDraw(PlayState* play, s32 limbIndex, Actor* thisx) {
 }
 
 Gfx* func_80A2EB58(GraphicsContext* gfxCtx, u32 alpha) {
-    Gfx* gfxHead = GRAPH_ALLOC(gfxCtx, 2 * sizeof(Gfx)); //! @bug this does not allocate enough for 3 Gfx commands;
+    // 2S2H [Port] Fixing allocation size
+    Gfx* gfxHead = GRAPH_ALLOC(gfxCtx, 3 * sizeof(Gfx)); //! @bug this does not allocate enough for 3 Gfx commands;
     Gfx* gfx = gfxHead;
 
     gDPSetRenderMode(gfx++, G_RM_FOG_SHADE_A, G_RM_AA_ZB_XLU_SURF2);

--- a/mm/src/overlays/actors/ovl_En_Zl4/z_en_zl4.c
+++ b/mm/src/overlays/actors/ovl_En_Zl4/z_en_zl4.c
@@ -97,7 +97,8 @@ Gfx* func_809A1DD0(GraphicsContext* gfxCtx, u32 alpha) {
 
     OPEN_DISPS(gfxCtx);
 
-    disp = GRAPH_ALLOC(gfxCtx, 0x10);
+    // 2S2H [Port] Fixing allocation size
+    disp = GRAPH_ALLOC(gfxCtx, 3 * sizeof(Gfx)); //! @bug this does not allocate enough for 3 Gfx commands;
     disp2 = disp;
 
     gDPSetRenderMode(disp++, G_RM_FOG_SHADE_A, G_RM_AA_ZB_XLU_SURF2);
@@ -116,7 +117,7 @@ Gfx* func_809A1E28(GraphicsContext* gfxCtx, u32 alpha) {
 
     OPEN_DISPS(gfxCtx);
 
-    disp = GRAPH_ALLOC(gfxCtx, 0x10);
+    disp = GRAPH_ALLOC(gfxCtx, 2 * sizeof(Gfx));
     disp2 = disp;
 
     gDPSetEnvColor(disp++, 0, 0, 0, alpha);


### PR DESCRIPTION
Noticed some more hardcoded allocs, or incorrect size (from authentic bugs). These actors are unused, but figured we should fix them anyways.