### PR TITLE
Increase audio seq cmd queue size

### DIFF
--- a/mm/include/variables.h
+++ b/mm/include/variables.h
@@ -1742,7 +1742,7 @@ extern u8 sVoiceMaskPattern[];
 extern ActiveSfx gActiveSfx[7][3];
 extern SeqRequest sSeqRequests[][5];
 extern u8 sNumSeqRequests[5];
-extern u32 sAudioSeqCmds[0xB0];
+extern u32 sAudioSeqCmds[0x100];
 extern ActiveSequence gActiveSeqs[];
 extern u8 sResetAudioHeapTimer;
 extern u16 sResetAudioHeapFadeReverbVolume;

--- a/mm/src/code/stubs.c
+++ b/mm/src/code/stubs.c
@@ -55,7 +55,7 @@ u64 aspMainDataStart[100];
 u64 aspMainDataEnd[100];
 
 u8 sNumSeqRequests[5];
-u32 sAudioSeqCmds[0xB0];
+u32 sAudioSeqCmds[0x100];
 ActiveSequence gActiveSeqs[5];
 u8 sResetAudioHeapTimer;
 u16 sResetAudioHeapFadeReverbVolume;


### PR DESCRIPTION
`sAudioSeqCmds` is indexed by `sSeqCmdWritePos` and `sSeqCmdReadPos` values. The behavior of these values is that they are only ever increased and will eventually roll over. This pattern is the same as OOT decomp.

MM decomp seems to have incorrectly set the size of `sAudioSeqCmds` to `0xB0` instead of `0x100`, meaning that as the position values are increased they eventually index OOB.

Increasing this value to `0x100` still produces a matching rom in MM decomp, so this is probably the proper size to use.

Fixes #140 