### PR TITLE
Fix environment lighting

### DIFF
--- a/mm/2s2h/z_scene_2SH.cpp
+++ b/mm/2s2h/z_scene_2SH.cpp
@@ -27,6 +27,7 @@ extern "C" {
 #include "2s2h/resource/type/scenecommand/SetMesh.h"
 #include "2s2h/resource/type/scenecommand/SetObjectList.h"
 #include "2s2h/resource/type/scenecommand/SetLightList.h"
+#include "2s2h/resource/type/scenecommand/SetLightingSettings.h"
 #include "2s2h/resource/type/scenecommand/SetPathways.h"
 #include "2s2h/resource/type/scenecommand/SetTransitionActorList.h"
 #include "2s2h/resource/type/scenecommand/SetSkyboxSettings.h"
@@ -261,7 +262,10 @@ void Scene_CommandTransiActorList(PlayState* play, LUS::ISceneCommand* cmd) {
 }
 
 void Scene_CommandEnvLightSettings(PlayState* play, LUS::ISceneCommand* cmd) {
-    play->envCtx.lightSettingsList = (EnvLightSettings*)cmd->GetRawPointer();
+    LUS::SetLightingSettings* lightSettings = (LUS::SetLightingSettings*)cmd;
+
+    play->envCtx.numLightSettings = lightSettings->settings.size();
+    play->envCtx.lightSettingsList = (EnvLightSettings*)lightSettings->GetRawPointer();
 }
 
 void Scene_CommandTimeSettings(PlayState* play, LUS::ISceneCommand* cmd) {


### PR DESCRIPTION
The number of environment lighting settings was not being set in our replaced scene command leading to the game using the default env lighting everywhere. This PR fixes that. Most notably, being underwater causes the underwater blue fog lighting to work.

Before and Afters
![termina-lighting](https://github.com/HarbourMasters/2ship2harkinian/assets/13861068/89fe7f58-54e1-450b-8fdf-94f808d6657a)
![woodfall-lighting](https://github.com/HarbourMasters/2ship2harkinian/assets/13861068/f96ec4cf-75d2-4d77-bcc3-becd416f6964)
![image](https://github.com/HarbourMasters/2ship2harkinian/assets/13861068/760124d0-5cf6-4a69-b35f-90b1d2036682)
![image](https://github.com/HarbourMasters/2ship2harkinian/assets/13861068/ef58c9d8-a901-4ebf-a48d-679a87e1d3ad)
![water-lighting](https://github.com/HarbourMasters/2ship2harkinian/assets/13861068/6b0378fb-74b4-4779-8750-d377685a9f55)
