### PR TITLE
Fix: Great Bay storm effect

### DIFF
--- a/mm/src/overlays/actors/ovl_Bg_Breakwall/z_bg_breakwall.c
+++ b/mm/src/overlays/actors/ovl_Bg_Breakwall/z_bg_breakwall.c
@@ -369,7 +369,7 @@ void func_808B7B54(Actor* thisx, PlayState* play) {
 
     gDPSetPrimColor(POLY_XLU_DISP++, 0, 0x80, sp50.r, sp50.g, sp50.b, 255);
     gDPSetEnvColor(POLY_XLU_DISP++, sp4C.r, sp4C.g, sp4C.b, 255);
-    gSPDisplayList(POLY_XLU_DISP++, object_posthouse_obj_DL_000A50);
+    gSPDisplayList(POLY_XLU_DISP++, object_kumo30_DL_000A50);
 
     Environment_LerpSandstormColors(D_808B8320, &sp50);
     Environment_LerpSandstormColors(D_808B8340, &sp4C);


### PR DESCRIPTION
This fixes the Great Bay storm effect that was incorrectly rendering the postmans hat and backpack instead of the opaque storm effect.

This is a genuine error from decomp that I plan to upstream a fix for. The short is that both DLs have an offset of `0xA50`, and object DLs are always loaded into segment 0x6, so both DLs technically produce matching roms in decomps case (both compile to `0x06000A50`), but obviously doesn't work for our OTR assets.

Before - After
![image](https://github.com/HarbourMasters/2ship2harkinian/assets/13861068/a9f6b0ef-66d5-4c99-bee2-a1e395f40fc2)
