### PR TITLE
Fix: Bombers message exclamation icon

### DIFF
--- a/mm/src/code/z_message.c
+++ b/mm/src/code/z_message.c
@@ -8,7 +8,6 @@
 #include "BenPort.h"
 #include <libultraship/libultraship.h>
 #include "assets/archives/schedule_dma_static/schedule_dma_static_yar.h"
-#include "assets/interface/schedule_static/schedule_static.h"
 #include "assets/archives/icon_item_static/icon_item_static_yar.h"
 #include "assets/archives/icon_item_24_static/icon_item_24_static_yar.h"
 #include "assets/interface/message_static/message_static.h"
@@ -41,7 +40,7 @@ const char* gBombersNotebookPhotos[] = {
     gBombersNotebookPhotoGuruGuruTex,
     gBombersNotebookPhotoBombersTex,
     gBombersNotebookPhotoMadameAromaBrightTex,
-    gBombersNotebookEntryIconExclamationPointTex,
+    gBombersNotebookEntryIconExclamationPointLargeTex,
     gBombersNotebookEntryIconMaskTex,
     gBombersNotebookEntryIconRibbonTex,
 };


### PR DESCRIPTION
The bombers exclamation icon being used in z_message was the wrong one. It was the icon from `schedule_static` which is for the bombers menu, instead of `schedule_dma_static` which are the icons for z_message.

![image](https://github.com/HarbourMasters/2ship2harkinian/assets/13861068/56b72159-849d-4189-b53d-34a7b8144f1c)
