### PR TITLE
Fix THA allocation bar representation on the debug speed meter

### DIFF
--- a/mm/src/code/speed_meter.c
+++ b/mm/src/code/speed_meter.c
@@ -191,7 +191,7 @@ void SpeedMeter_DrawAllocEntry(SpeedMeterAllocEntry* this, GraphicsContext* gfxC
                             G_TD_CLAMP | G_TP_NONE | G_CYC_FILL | G_PM_NPRIMITIVE,
                         G_AC_NONE | G_ZS_PIXEL | G_RM_NOOP | G_RM_NOOP2);
 
-        usedOff = ((this->lrx - this->ulx) * this->val) / this->maxVal + this->ulx;
+        usedOff = ((s64)(this->lrx - this->ulx) * this->val) / this->maxVal + this->ulx;
         gDrawRect(gfx++, this->backColor, usedOff, this->uly, this->lrx, this->lry);
         gDrawRect(gfx++, this->foreColor, this->ulx, this->uly, usedOff, this->lry);
 


### PR DESCRIPTION
The THA allocation bar (green) would appear to be a random size and progressively get smaller till it went out of bounds (looking like it was negative), then later would overflow off the right side of the screen.

This was due to integer truncation when computing the rectangle size. `this->val` would be a large s32 value multiplying with `260`, before it would be divided by `this->maxVal`. Properly casting the multiplication to `s64` prevents the truncation and restores the THA bar.

In the case of a regular play state, the THA bar will always be 100% full as `Play_Init` takes the remaining THA size and allocates it completely for the ZeldaArena.

![image](https://github.com/HarbourMasters/2ship2harkinian/assets/13861068/f934936b-0390-4496-a20b-4303e265f2c5)
