### PR TITLE
clearFillRect fix

### DIFF
--- a/mm/src/code/z_rcp.c
+++ b/mm/src/code/z_rcp.c
@@ -1514,7 +1514,7 @@ void func_8012CF0C(GraphicsContext* gfxCtx, s32 clearFb, s32 clearZb, u8 r, u8 g
     // #region 2S2H [Cosmetic] Account for different aspect ratios than 4:3
     // WideRectangle consumes two instructions and requires ++ for the macro to work
     Gfx* tmpGfx = masterGfx;
-    gDPFillWideRectangle(tmpGfx++, OTRGetRectDimensionFromLeftEdge(0), 0, OTRGetRectDimensionFromRightEdge(gCfbWidth - 1), gCfbHeight - 1);
+    gDPFillWideRectangle(tmpGfx++, OTRGetRectDimensionFromLeftEdge(0), 0, OTRGetRectDimensionFromRightEdge(gCfbWidth), gCfbHeight - 1);
     gDPPipeSync(&masterGfx[2]);
     gSPEndDisplayList(&masterGfx[3]);
     // #endregion


### PR DESCRIPTION
This fixes #118 but i'm not sure on it being that correct. It makes more sense to me for this to just use `gCfbHeight` and `gCfbWidth` instead of `gCfbHeight - 1` and `gCfbWidth - 1`

If others agree with my guess on what would be the appropriate fix i can change `gCfbHeight - 1` to `gCfbHeight` also, but for now just leaving it to what fixes the cutscene only