### PR TITLE
Fix: Maintain Three-Day clock scissor box size

### DIFF
--- a/mm/src/code/z_parameter.c
+++ b/mm/src/code/z_parameter.c
@@ -5048,8 +5048,9 @@ void Interface_DrawClock(PlayState* play) {
              * Section: Cuts off Three-Day Clock's Sun and Moon when they dip below the clock
              */
             gDPPipeSync(OVERLAY_DISP++);
-            gDPSetScissorFrac(OVERLAY_DISP++, G_SC_NON_INTERLACE, 400, 620, 880,
-                              R_THREE_DAY_CLOCK_SUN_MOON_CUTOFF * 4.0f);
+            // 2S2H [Cosmetic] Adjust the x values so the scissor stays the same size regardless of widescreen
+            gDPSetScissor(OVERLAY_DISP++, G_SC_NON_INTERLACE, OTRConvertHUDXToScreenX(400 / 4), 620 / 4,
+                          OTRConvertHUDXToScreenX(880 / 4), R_THREE_DAY_CLOCK_SUN_MOON_CUTOFF);
 
             // determines the current hour
             for (sp1C6 = 0; sp1C6 <= 24; sp1C6++) {
@@ -5108,8 +5109,9 @@ void Interface_DrawClock(PlayState* play) {
              * Section: Cuts off Three-Day Clock's Hour Digits when they dip below the clock
              */
             gDPPipeSync(OVERLAY_DISP++);
-            gDPSetScissorFrac(OVERLAY_DISP++, G_SC_NON_INTERLACE, 400, 620, 880,
-                              R_THREE_DAY_CLOCK_HOUR_DIGIT_CUTOFF * 4.0f);
+            // 2S2H [Cosmetic] Adjust the x values so the scissor stays the same size regardless of widescreen
+            gDPSetScissor(OVERLAY_DISP++, G_SC_NON_INTERLACE, OTRConvertHUDXToScreenX(400 / 4), (620 / 4),
+                          OTRConvertHUDXToScreenX(880 / 4), R_THREE_DAY_CLOCK_SUN_MOON_CUTOFF);
 
             /**
              * Section: Draws Three-Day Clock's Hour Digit Above the Sun


### PR DESCRIPTION
The scissor box that is responsible for cutting off the sun/moon and hour digit on the Three-day clock was getting scaled for different aspect ratios. This would lead to the box being larger than necessary on widescreen and too small for ratios <4:3.

This updates the scissor calls to adjust the x values using the `OTRConvertHUDXToScreenX` so that the stretching performed in the renderer matches the original 4:3 HUD effect.

(Render code adjusted to only draw the contents of the scissor box for demonstration)
Before:
![image](https://github.com/HarbourMasters/2ship2harkinian/assets/13861068/a56297e9-3a7a-46a7-81f4-bed88140440d)

After:
![image](https://github.com/HarbourMasters/2ship2harkinian/assets/13861068/0e13bb34-d159-4462-89c1-22f239a3cc42)
