### PR TITLE
Fix talk animation crash

### DIFF
--- a/mm/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/mm/src/overlays/actors/ovl_player_actor/z_player.c
@@ -20733,6 +20733,14 @@ s32 func_8085B930(PlayState* play, PlayerAnimationHeader* talkAnim, AnimationMod
         return false;
     }
 
+    // 2S2H [Port] We are setting the result of func_8082ED20 to talkAnim ahead of time
+    // so that Animation_GetLastframe returns a real value
+    if (talkAnim == NULL) {
+        talkAnim = func_8082ED20(player);
+    }
+
+    //! @bug When func_8082ED20 is used to get a wait animation, NULL is still passed to Animation_GetLastFrame,
+    // causing it to read the frame count from address 0x80000000 which returns 15385
     PlayerAnimation_Change(play, &player->skelAnime, (talkAnim == NULL) ? func_8082ED20(player) : talkAnim, 2.0f / 3.0f,
                            0.0f, Animation_GetLastFrame(talkAnim), animMode, -6.0f);
     return true;


### PR DESCRIPTION
This documents an authentic bug observed in a animation change during dialog. A NULL anim is used to lookup a "wait" animation based on the players form or current mask. This animation is passed to the change func, but NULL is still sent to `Animation_GetLastFrame` which causes an exception due to NULL resource.

On console, `LibSegmentedTopVirtual` will turn NULL into address `0x80000000` which when casted as `AnimationHeaderCommon*` will return `15385` as the last frame value.

If elected to fix the bug by reassigning `talkAnim` to the new animation so that we get the real last frame count.

The crash can be observed when talking to the milk bar man in the afternoon for the second time.