### PR TITLE
Restore telescope controls

### DIFF
--- a/mm/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/mm/src/overlays/actors/ovl_player_actor/z_player.c
@@ -8201,8 +8201,7 @@ void func_8083A98C(Actor* thisx, PlayState* play2) {
 
         // Show controls overlay. SCENE_AYASHIISHOP does not have Zoom, so has a different one.
         if (this->av2.actionVar2 == 1) {
-            // BENTODO: crash when going back from telescope in astral observatory
-            // Message_StartTextbox(play, (play->sceneId == SCENE_AYASHIISHOP) ? 0x2A00 : 0x5E6, NULL);
+            Message_StartTextbox(play, (play->sceneId == SCENE_AYASHIISHOP) ? 0x2A00 : 0x5E6, NULL);
         }
     } else {
         sPlayerControlInput = play->state.input;


### PR DESCRIPTION
The telescope has a special textbox at the top of the screen that displays controls about moving/zooming. This was previously stubbed due to a crash, but is no longer crashing, so restoring it back.