### PR TITLE
FIX: audio cutoff issues

### DIFF
--- a/mm/src/code/stubs.c
+++ b/mm/src/code/stubs.c
@@ -340,6 +340,7 @@ u32 __osProbeTLB(void* param_1) {
 void func_801A31EC(u16 seqId, s8 arg1, u8 arg2) {
 }
 s32 osAiSetFrequency(u32 frequency) {
+    return 1;
 }
 s32 osContStartQuery(OSMesgQueue* mq) {
 }


### PR DESCRIPTION
This fix the audio cutoff issues when building in release mode

Explaination from @garrettjoecox
The result of osAiSetFrequency was being used later on to multiply the length an audio sequence would play. In debug mode this stub was returning 1, whereas in release mode this would return whatever was passed in as the freq argument.