### PR TITLE
Add debug inventory editor check

### DIFF
--- a/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_scope_NES.c
+++ b/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_scope_NES.c
@@ -483,6 +483,13 @@ void KaleidoScope_HandlePageToggles(PlayState* play, Input* input) {
     PauseContext* pauseCtx = &play->pauseCtx;
     InterfaceContext* interfaceCtx = &play->interfaceCtx;
 
+    // 2S2H [Debug] Restoring input check for debug inventory editor based on OOT debug
+    if (CVarGetInteger("gDeveloperTools.DebugEnabled", 0) && (pauseCtx->debugEditor == DEBUG_EDITOR_NONE) &&
+        CHECK_BTN_ALL(input->press.button, BTN_L)) {
+        pauseCtx->debugEditor = DEBUG_EDITOR_INVENTORY_INIT;
+        return;
+    }
+
     //! FAKE
     if (1) {}
 


### PR DESCRIPTION
Add the check for L button in pause menu with debug mode enabled to toggle the debug inventory editor. This check is placed here based on OOT debug.