### PR TITLE
Fix ocarina effects

### DIFF
--- a/mm/src/overlays/actors/ovl_Oceff_Storm/z_oceff_storm.c
+++ b/mm/src/overlays/actors/ovl_Oceff_Storm/z_oceff_storm.c
@@ -188,8 +188,10 @@ void OceffStorm_Draw2(Actor* thisx, PlayState* play) {
     gSPDisplayList(POLY_XLU_DISP++, &sSongOfStormsMaterialDL);
     gSPDisplayList(POLY_XLU_DISP++, Gfx_TwoTexScroll(play->state.gfxCtx, G_TX_RENDERTILE, scroll * 8, scroll * 4, 64,
                                                      64, 1, scroll * 4, scroll * 4, 64, 64));
-    gSPTextureRectangle(POLY_XLU_DISP++, 0, 0, SCREEN_WIDTH << 2, SCREEN_HEIGHT << 2, G_TX_RENDERTILE, 0, 0,
-                        (s32)(0.13671875 * (1 << 10)), (s32)(-0.13671875 * (1 << 10)));
+    // 2S2H [Cosmetic] Changed to Wide variant to support widescreen
+    gSPWideTextureRectangle(POLY_XLU_DISP++, OTRGetRectDimensionFromLeftEdge(0) << 2, 0,
+                            OTRGetRectDimensionFromRightEdge(SCREEN_WIDTH) << 2, SCREEN_HEIGHT << 2, G_TX_RENDERTILE, 0,
+                            0, (s32)(0.13671875 * (1 << 10)), (s32)(-0.13671875 * (1 << 10)));
 
     CLOSE_DISPS(play->state.gfxCtx);
 }

--- a/mm/src/overlays/actors/ovl_Oceff_Wipe2/z_oceff_wipe2.c
+++ b/mm/src/overlays/actors/ovl_Oceff_Wipe2/z_oceff_wipe2.c
@@ -69,7 +69,7 @@ void OceffWipe2_Draw(Actor* thisx, PlayState* play) {
 
     quakeOffset = Camera_GetQuakeOffset(GET_ACTIVE_CAM(play));
 
-    vtxPtr = sEponaSongFrustumVtx;
+    vtxPtr = ResourceMgr_LoadVtxByName(sEponaSongFrustumVtx);
 
     if (this->timer < 32) {
         z = Math_SinS(this->timer * 0x200) * 1220.0f;

--- a/mm/src/overlays/actors/ovl_Oceff_Wipe3/z_oceff_wipe3.c
+++ b/mm/src/overlays/actors/ovl_Oceff_Wipe3/z_oceff_wipe3.c
@@ -70,7 +70,7 @@ void OceffWipe3_Draw(Actor* thisx, PlayState* play) {
 
     quakeOffset = Camera_GetQuakeOffset(GET_ACTIVE_CAM(play));
 
-    vtxPtr = sSariaSongFrustumVtx;
+    vtxPtr = ResourceMgr_LoadVtxByName(sSariaSongFrustumVtx);
 
     if (this->counter < 32) {
         z = Math_SinS(this->counter * 512) * 1220.0f;

--- a/mm/src/overlays/actors/ovl_Oceff_Wipe4/z_oceff_wipe4.c
+++ b/mm/src/overlays/actors/ovl_Oceff_Wipe4/z_oceff_wipe4.c
@@ -75,7 +75,8 @@ void OceffWipe4_Draw(Actor* thisx, PlayState* play) {
         z = 1220.0f;
     }
 
-    vtxPtr = sScarecrowSongFrustumVtx;
+    vtxPtr = ResourceMgr_LoadVtxByName(sScarecrowSongFrustumVtx);
+
     if (this->counter >= 30) {
         alpha = 12 * (50 - this->counter);
     } else {

--- a/mm/src/overlays/actors/ovl_Oceff_Wipe5/z_oceff_wipe5.c
+++ b/mm/src/overlays/actors/ovl_Oceff_Wipe5/z_oceff_wipe5.c
@@ -35,7 +35,7 @@ static Vtx* gOceff5VtxData;
 void OceffWipe5_Init(Actor* thisx, PlayState* play) {
     OceffWipe5* this = THIS;
 
-    gOceff5VtxData = ResourceMgr_LoadArrayByName(gOceff5Vtx);
+    gOceff5VtxData = ResourceMgr_LoadVtxByName(gOceff5Vtx);
 
     Actor_SetScale(&this->actor, 1.0f);
     this->counter = 0;
@@ -44,7 +44,6 @@ void OceffWipe5_Init(Actor* thisx, PlayState* play) {
 
 void OceffWipe5_Destroy(Actor* thisx, PlayState* play) {
     OceffWipe5* this = THIS;
-    gOceff5VtxData = ResourceMgr_LoadArrayByName(gOceff5Vtx);
 
     Magic_Reset(play);
     play->msgCtx.ocarinaSongEffectActive = false;
@@ -107,7 +106,7 @@ void OceffWipe5_Draw(Actor* thisx, PlayState* play) {
         alpha = 255;
     }
 
-    for (i = 1; i < ResourceMgr_GetArraySizeByName(gOceff5Vtx); i += 2) {
+    for (i = 1; i < ResourceMgr_GetVtxArraySizeByName(gOceff5Vtx); i += 2) {
         gOceff5VtxData[i].v.cn[3] = alpha;
     }
 

--- a/mm/src/overlays/actors/ovl_Oceff_Wipe6/z_oceff_wipe6.c
+++ b/mm/src/overlays/actors/ovl_Oceff_Wipe6/z_oceff_wipe6.c
@@ -29,12 +29,13 @@ ActorInit Oceff_Wipe6_InitVars = {
 };
 
 #include "overlays/ovl_Oceff_Wipe6/ovl_Oceff_Wipe6.h"
-Vtx* gOceff6VtxData;
+
+static Vtx* gOceff6VtxData;
 
 void OceffWipe6_Init(Actor* thisx, PlayState* play) {
     OceffWipe6* this = THIS;
 
-    gOceff6VtxData = ResourceMgr_LoadArrayByName(gOceff6Vtx);
+    gOceff6VtxData = ResourceMgr_LoadVtxByName(gOceff6Vtx);
 
     Actor_SetScale(&this->actor, 1.0f);
     this->counter = 0;
@@ -84,7 +85,7 @@ void OceffWipe6_Draw(Actor* thisx, PlayState* play) {
         alpha = 255;
     }
 
-    for (i = 1; i < ResourceMgr_GetArraySizeByName(gOceff6Vtx); i += 2) {
+    for (i = 1; i < ResourceMgr_GetVtxArraySizeByName(gOceff6Vtx); i += 2) {
         gOceff6VtxData[i].v.cn[3] = alpha;
     }
 

--- a/mm/src/overlays/actors/ovl_Oceff_Wipe7/z_oceff_wipe7.c
+++ b/mm/src/overlays/actors/ovl_Oceff_Wipe7/z_oceff_wipe7.c
@@ -86,7 +86,7 @@ void OceffWipe7_Draw(Actor* thisx, PlayState* play) {
         alpha = 255;
     }
 
-    for (i = 1; i < ResourceMgr_GetArraySizeByName(sSongofHealingEffectFrustrumVtx); i += 2) {
+    for (i = 1; i < ResourceMgr_GetVtxArraySizeByName(sSongofHealingEffectFrustrumVtx); i += 2) {
         sSongofHealingEffectFrustrumVtxData[i].v.cn[3] = alpha;
     }
 


### PR DESCRIPTION
Fix remainder of ocarina effects not loading Vtx data correctly or using the wrong size method. Also makes song of storms support widescreen.