### PR TITLE
Add more time options to save editor

### DIFF
--- a/mm/2s2h/DeveloperTools/SaveEditor.cpp
+++ b/mm/2s2h/DeveloperTools/SaveEditor.cpp
@@ -149,7 +149,7 @@ void DrawGeneralTab() {
     std::string minutes = (curMinutes < 10 ? "0" : "") + std::to_string(curMinutes);
     std::string hours = "";
     std::string ampm = "";
-    // 2S2HTODO: Switch to CVar if we ever add 24 hour mode display
+    // BENTODO: Switch to CVar if we ever add 24 hour mode display
     if (false) {
         if (curHours < 10) {
             hours += "0";


### PR DESCRIPTION
This adds some extra time utilities to the save editor plus some minor tweaks for better scroll bar positions.
* Time slider now displays the time in human format (with support for 24 hour if we ever add an enhancement for that)
* Easy time skip buttons for going forward/backwards in increments
* A day slider which allows switching the day and reloads actors (this may not be fully loading/unloading things for all scenes)
* Time speed slider which sets `gSaveContext.save.timeSpeedOffset` instead of `R_TIME_SPEED` reg. This is what song of time inversion sets, but I increased the range. 0 will freeze time.

![image](https://github.com/HarbourMasters/2ship2harkinian/assets/13861068/f9720e5d-7d32-4f63-8bba-82cefc8b9fd5)

https://github.com/HarbourMasters/2ship2harkinian/assets/13861068/a0123639-b35e-42ba-92c2-106e5cdaeb9f

