### PR TITLE
Fix song of double time camera spline data

### DIFF
--- a/mm/include/command_macros_base.h
+++ b/mm/include/command_macros_base.h
@@ -6,6 +6,9 @@
  * Each macro packs bytes (B), halfwords (H) and words (W, for consistency) into a single word
  */
 
+// 2S2H [Port] Order B and H variables for endianness
+#ifdef IS_BIGENDIAN
+
 #define CMD_BBBB(a, b, c, d) (_SHIFTL(a, 24, 8) | _SHIFTL(b, 16, 8) | _SHIFTL(c, 8, 8) | _SHIFTL(d, 0, 8))
 
 #define CMD_BBH(a, b, c) (_SHIFTL(a, 24, 8) | _SHIFTL(b, 16, 8) | _SHIFTL(c, 0, 16))
@@ -13,6 +16,18 @@
 #define CMD_HBB(a, b, c) (_SHIFTL(a, 16, 16) | _SHIFTL(b, 8, 8) | _SHIFTL(c, 0, 8))
 
 #define CMD_HH(a, b) (_SHIFTL(a, 16, 16) | _SHIFTL(b, 0, 16))
+
+#else
+
+#define CMD_BBBB(a, b, c, d) (_SHIFTL(a, 0, 8) | _SHIFTL(b, 8, 8) | _SHIFTL(c, 16, 8) | _SHIFTL(d, 24, 8))
+
+#define CMD_BBH(a, b, c) (_SHIFTL(a, 0, 8) | _SHIFTL(b, 8, 8) | _SHIFTL(c, 16, 16))
+
+#define CMD_HBB(a, b, c) (_SHIFTL(a, 0, 16) | _SHIFTL(b, 16, 8) | _SHIFTL(c, 24, 8))
+
+#define CMD_HH(a, b) (_SHIFTL(a, 0, 16) | _SHIFTL(b, 16, 16))
+
+#endif
 
 #define CMD_W(a) (a)
 


### PR DESCRIPTION
Song of Double Time cutscene uses camera spline data defined in the source rather than a resource. The macros used for the data assume BIG_ENDIAN. This PR adds LITTLE_ENDIAN alternates for these macros so the camera spline data is correct.

Fixes #187 