### PR TITLE
Fix Song of Time frustum

### DIFF
--- a/mm/assets/xml/overlays/ovl_Oceff_Wipe.xml
+++ b/mm/assets/xml/overlays/ovl_Oceff_Wipe.xml
@@ -1,7 +1,7 @@
 <Root>
     <File Name="ovl_Oceff_Wipe" BaseAddress="0x809764B0" RangeStart="0x4F0" RangeEnd="0xCB0">
         <Texture Name="sSongOfTimeEffectTex" OutName="song_of_time_effect" Format="i8" Width="32" Height="32" Offset="0x4F0"/>
-        <Array Name="sSongOfTimeFrustumVtx" Count="32" Offset="0x8F0">
+        <Array Name="sSongOfTimeFrustumVtx" Count="40" Offset="0x8F0">
             <Vtx/>
         </Array>
         <DList Name="sSongOfTimeFrustumMaterialDL" Offset="0xB70"/>

--- a/mm/src/overlays/actors/ovl_Oceff_Wipe/z_oceff_wipe.c
+++ b/mm/src/overlays/actors/ovl_Oceff_Wipe/z_oceff_wipe.c
@@ -93,10 +93,11 @@ void OceffWipe_Draw(Actor* thisx, PlayState* play) {
         alphaTable[2] = 255;
     }
 
+    // 2S2H [Port] Originally this was just a pointer to the vertices, now it's the OTR path so we need to grab it's actual address
+    // and move out of loop as we don't need to load the resource each iteration
+    vtxPtr = ResourceMgr_LoadVtxByName(sSongOfTimeFrustumVtx);
+
     for (i = 0; i < 20; i++) {
-        // #region 2S2H [Port] Originally this was just a pointer to the vertices, now it's the OTR path so we need to grab it's actual address
-        vtxPtr = ResourceMgr_LoadVtxByName(sSongOfTimeFrustumVtx);
-        // #endregion
         vtxPtr[i * 2 + 0].v.cn[3] = alphaTable[(sAlphaIndices[i] & 0xF0) >> 4];
         vtxPtr[i * 2 + 1].v.cn[3] = alphaTable[sAlphaIndices[i] & 0xF];
     }


### PR DESCRIPTION
The song of time frustum vtx data was incorrectly sized. Comparing ZAPD output shows an additional 8 Vtx points after this one which is loaded by the same DL. A size of 40 also aligns with the for loop that sets the alpha values as is `i < 20` where it does `i * 2`