### PR TITLE
Make clearFillRect fill ful height

### DIFF
--- a/mm/src/code/z_rcp.c
+++ b/mm/src/code/z_rcp.c
@@ -1513,8 +1513,9 @@ void func_8012CF0C(GraphicsContext* gfxCtx, s32 clearFb, s32 clearZb, u8 r, u8 g
 
     // #region 2S2H [Cosmetic] Account for different aspect ratios than 4:3
     // WideRectangle consumes two instructions and requires ++ for the macro to work
+    // Remove `- 1` on the sizes so the rectangle fills the whole screen like `fillRect`
     Gfx* tmpGfx = masterGfx;
-    gDPFillWideRectangle(tmpGfx++, OTRGetRectDimensionFromLeftEdge(0), 0, OTRGetRectDimensionFromRightEdge(gCfbWidth), gCfbHeight - 1);
+    gDPFillWideRectangle(tmpGfx++, OTRGetRectDimensionFromLeftEdge(0), 0, OTRGetRectDimensionFromRightEdge(gCfbWidth), gCfbHeight);
     gDPPipeSync(&masterGfx[2]);
     gSPEndDisplayList(&masterGfx[3]);
     // #endregion


### PR DESCRIPTION
Continues #161 on adjusting the `clearFillRect` size so it consumes the fill screen