### PR TITLE
Correctly set final object entries count based on last slot index

### DIFF
--- a/mm/2s2h/z_scene_2SH.cpp
+++ b/mm/2s2h/z_scene_2SH.cpp
@@ -176,9 +176,11 @@ void Scene_CommandObjectList(PlayState* play, SOH::ISceneCommand* cmd) {
     }
 
     // Continuing from the last index, add the remaining object ids from the command object list
-    for (; k < objList->objects.size(); k++) {
-        play->objectCtx.slots[play->objectCtx.numEntries++].id = -objList->objects[k];
+    for (; k < objList->objects.size(); i++, k++) {
+        play->objectCtx.slots[i].id = -objList->objects[k];
     }
+
+    play->objectCtx.numEntries = i;
 
     // #endregion
 


### PR DESCRIPTION
Our simplified loop replacement for the original `CommandObjectList` was incrementing the `play->objectCtx.numEntries` incorrectly which would cause it to prevent objects from loading in areas with a lot of room transitions.

Instead, the `numEntries` should be set by the last slot index `i` which matches more with what the original while loop was doing.