### PR TITLE
Fix save corruption from non null-terminated cstrings

### DIFF
--- a/mm/2s2h/BenJsonConversions.hpp
+++ b/mm/2s2h/BenJsonConversions.hpp
@@ -17,11 +17,9 @@ void to_json(json& j, const ItemEquips& itemEquips) {
 void from_json(const json& j, ItemEquips& itemEquips) {
     j.at("equipment").get_to(itemEquips.equipment);
     // buttonItems and cButtonSlots are arrays of arrays, so we need to manually parse them
-    for (int x = 0; x < 4; x++) {
-        for (int y = 0; y < 4; y++) {
-            itemEquips.buttonItems[x][y] = j.at("buttonItems")[x][y].get<u8>();
-            itemEquips.cButtonSlots[x][y] = j.at("cButtonSlots")[x][y].get<u8>();
-        }
+    for (int i = 0; i < ARRAY_COUNT(itemEquips.buttonItems); i++) {
+        j.at("buttonItems").at(i).get_to(itemEquips.buttonItems[i]);
+        j.at("cButtonSlots").at(i).get_to(itemEquips.cButtonSlots[i]);
     }
 }
 
@@ -48,12 +46,9 @@ void from_json(const json& j, Inventory& inventory) {
     j.at("dungeonKeys").get_to(inventory.dungeonKeys);
     j.at("defenseHearts").get_to(inventory.defenseHearts);
     j.at("strayFairies").get_to(inventory.strayFairies);
-    // dekuPlaygroundPlayerName is an array of char arrays, so we need to manually parse it
-    for (int i = 0; i < 3; i++) {
-        std::string name = j.at("dekuPlaygroundPlayerName")[i].get<std::string>();
-        for (int j = 0; j < 8; j++) {
-            inventory.dekuPlaygroundPlayerName[i][j] = name[j];
-        }
+    // dekuPlaygroundPlayerName is an array of uint, so we need to manually parse it
+    for (int i = 0; i < ARRAY_COUNT(inventory.dekuPlaygroundPlayerName); i++) {
+        j.at("dekuPlaygroundPlayerName").at(i).get_to(inventory.dekuPlaygroundPlayerName[i]);
     }
 }
 
@@ -103,16 +98,9 @@ void to_json(json& j, const SavePlayerData& savePlayerData) {
 }
 
 void from_json(const json& j, SavePlayerData& savePlayerData) {
-    // newf is an array of chars, so we need to manually parse it
-    std::string newf = j.at("newf").get<std::string>();
-    for (int i = 0; i < 6; i++) {
-        savePlayerData.newf[i] = newf[i];
-    }
+    j.at("newf").get_to(savePlayerData.newf);
     j.at("threeDayResetCount").get_to(savePlayerData.threeDayResetCount);
-    std::string playerName = j.at("playerName").get<std::string>();
-    for (int i = 0; i < 8; i++) {
-        savePlayerData.playerName[i] = playerName[i];
-    }
+    j.at("playerName").get_to(savePlayerData.playerName);
     j.at("healthCapacity").get_to(savePlayerData.healthCapacity);
     j.at("health").get_to(savePlayerData.health);
     j.at("magicLevel").get_to(savePlayerData.magicLevel);
@@ -224,10 +212,8 @@ void from_json(const json& j, SaveInfo& saveInfo) {
     j.at("bombersCaughtNum").get_to(saveInfo.bombersCaughtNum);
     j.at("bombersCaughtOrder").get_to(saveInfo.bombersCaughtOrder);
     // lotteryCodes is an array of arrays, so we need to manually parse it
-    for (int x = 0; x < 3; x++) {
-        for (int y = 0; y < 3; y++) {
-            saveInfo.lotteryCodes[x][y] = j.at("lotteryCodes")[x][y].get<s8>();
-        }
+    for (int i = 0; i < ARRAY_COUNT(saveInfo.lotteryCodes); i++) {
+        j.at("lotteryCodes").at(i).get_to(saveInfo.lotteryCodes[i]);
     }
     j.at("spiderHouseMaskOrder").get_to(saveInfo.spiderHouseMaskOrder);
     j.at("bomberCode").get_to(saveInfo.bomberCode);

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -1587,18 +1587,17 @@ extern "C" void BenSysFlashrom_WriteData(u8* saveBuffer, u32 pageNum, u32 pageCo
     FlashSlotFile flashSlotFile = FLASH_SLOT_FILE_UNAVAILABLE;
     bool isBackup = false;
     for (u32 i = 0; i < ARRAY_COUNT(gFlashSaveStartPages) - 1; i++) {
-        if (pageNum == gFlashSaveStartPages[i]) {
+        // Verify that the requested pages align with expected values
+        if (pageNum == (u32)gFlashSaveStartPages[i] &&
+            (pageCount == (u32)gFlashSaveNumPages[i] || pageCount == (u32)gFlashSpecialSaveNumPages[i])) {
             flashSlotFile = static_cast<FlashSlotFile>(i);
             break;
         }
     }
 
-    // Exclude debug file from saving
-    if (flashSlotFile == FLASH_SLOT_FILE_UNAVAILABLE || gSaveContext.fileNum == 255) {
-        return;
-    }
-
     switch (flashSlotFile) {
+        case FLASH_SLOT_FILE_UNAVAILABLE:
+            return;
         case FLASH_SLOT_FILE_1_NEW_CYCLE_BACKUP:
         case FLASH_SLOT_FILE_2_NEW_CYCLE_BACKUP:
             isBackup = true;
@@ -1653,17 +1652,17 @@ extern "C" s32 BenSysFlashrom_ReadData(void* saveBuffer, u32 pageNum, u32 pageCo
     FlashSlotFile flashSlotFile = FLASH_SLOT_FILE_UNAVAILABLE;
     bool isBackup = false;
     for (u32 i = 0; i < ARRAY_COUNT(gFlashSaveStartPages) - 1; i++) {
-        if (pageNum == gFlashSaveStartPages[i]) {
+        // Verify that the requested pages align with expected values
+        if (pageNum == (u32)gFlashSaveStartPages[i] &&
+            (pageCount == (u32)gFlashSaveNumPages[i] || pageCount == (u32)gFlashSpecialSaveNumPages[i])) {
             flashSlotFile = static_cast<FlashSlotFile>(i);
             break;
         }
     }
 
-    if (flashSlotFile == FLASH_SLOT_FILE_UNAVAILABLE) {
-        return -1;
-    }
-
     switch (flashSlotFile) {
+        case FLASH_SLOT_FILE_UNAVAILABLE:
+            return -1;
         case FLASH_SLOT_FILE_1_NEW_CYCLE_BACKUP:
         case FLASH_SLOT_FILE_2_NEW_CYCLE_BACKUP:
             isBackup = true;
@@ -1712,7 +1711,6 @@ extern "C" s32 BenSysFlashrom_ReadData(void* saveBuffer, u32 pageNum, u32 pageCo
 
             memcpy(saveBuffer, &saveOptions, sizeof(SaveOptions));
             return 0;
-            break;
         }
     }
 }

--- a/mm/include/z64save.h
+++ b/mm/include/z64save.h
@@ -214,7 +214,8 @@ typedef struct Inventory {
     /* 0x5A */ s8 dungeonKeys[9];                       // "key_register"
     /* 0x63 */ s8 defenseHearts;
     /* 0x64 */ s8 strayFairies[10];                     // "orange_fairy"
-    /* 0x6E */ char dekuPlaygroundPlayerName[3][8];     // "degnuts_memory_name" Stores playerName (8 char) over (3 days) when getting a new high score
+    // 2S2H [Port] Switch type from char to u8 to avoid dealing with non-terminated strings
+    /* 0x6E */ u8 dekuPlaygroundPlayerName[3][8];       // "degnuts_memory_name" Stores playerName (8 char) over (3 days) when getting a new high score
 } Inventory; // size = 0x88
 
 typedef struct HorseData {
@@ -262,9 +263,11 @@ typedef struct SaveOptions {
 } SaveOptions; // size = 0x6
 
 typedef struct SavePlayerData {
-    /* 0x00 */ char newf[6];                          // "newf"               Will always be "ZELDA3 for a valid save
+    // 2S2H [Port] Switch type from char to u8 to avoid dealing with non-terminated strings
+    /* 0x00 */ u8 newf[6];                            // "newf"               Will always be "ZELDA3 for a valid save
     /* 0x06 */ u16 threeDayResetCount;                // "savect"
-    /* 0x08 */ char playerName[8];                    // "player_name"
+    // 2S2H [Port] Switch type from char to u8 to avoid dealing with non-terminated strings
+    /* 0x08 */ u8 playerName[8];                      // "player_name"
     /* 0x10 */ s16 healthCapacity;                    // "max_life"
     /* 0x12 */ s16 health;                            // "now_life"
     /* 0x14 */ s8 magicLevel; // 0 for no magic/new load, 1 for magic, 2 for double magic "magic_max"


### PR DESCRIPTION
There are a few fields in the save context that are typed as char arrays, but are not null-terminated. The way we were using the to_json / from_json would interpret and deal with these fields like real strings. Because they aren't terminated, overflowed data would end up in the final string, leading to garbage data in the json output, or worse a thrown exception causing an incomplete json.

At first I was going to try to copy the values to a temp string and ensure it is terminated properly, but the player name treats `\0` as the number 0. We could potentially create intermediary types that use `u8` instead for the save/read operations, then just memcpy the values into/out-of the save context, but that feels kinda messy.

Ultimately I think it would be better to just modify the save context types to just use `u8` instead. This has the same `sizeof` as `char`, so the save context is not changing size as a whole. This allows the json implementation to be quite clean.

---

I've also adjusted the way we validate if a save slot is valid, as strictly checking for fileNum 255 was preventing `global.sav` from being created/updated.