### PR TITLE
Fix cremia text crash.

### DIFF
--- a/mm/include/z64message.h
+++ b/mm/include/z64message.h
@@ -195,7 +195,7 @@ typedef struct {
         u64 force_structure_alignment_font;
     };
     /* 0x11880 */ union {
-        char schar[1280]; // msgBuf
+        unsigned char schar[1280]; // msgBuf
         u16 wchar[640];   // msgBufWide
         u64 force_structure_alignment_msg;
     } msgBuf;

--- a/mm/src/code/z_message.c
+++ b/mm/src/code/z_message.c
@@ -2160,7 +2160,7 @@ void Message_SetupLoadItemIcon(PlayState* play) {
             msgCtx->itemId = (u8)font->msgBuf.schar[msgCtx->msgBufPos];
         }
         msgCtx->nextTextId = font->msgBuf.schar[++msgCtx->msgBufPos] << 8;
-        msgCtx->nextTextId |= font->msgBuf.schar[++msgCtx->msgBufPos];
+        msgCtx->nextTextId += font->msgBuf.schar[++msgCtx->msgBufPos];
 
         msgCtx->unk1206C = (u8)(font->msgBuf.schar[++msgCtx->msgBufPos] << 8);
         msgCtx->unk1206C |= font->msgBuf.schar[++msgCtx->msgBufPos];


### PR DESCRIPTION
It always comes back to signed/unsigned. Things seem to work with `schar` being `unsigned`