### PR TITLE
Increase render area for particles and effects on widescreens

### DIFF
--- a/mm/src/overlays/actors/ovl_Demo_Kankyo/z_demo_kankyo.c
+++ b/mm/src/overlays/actors/ovl_Demo_Kankyo/z_demo_kankyo.c
@@ -522,8 +522,17 @@ void DemoKakyo_DrawLostWoodsSparkle(Actor* thisx, PlayState* play2) {
 
             Play_GetScreenPos(play, &worldPos, &screenPos);
 
+            // #region 2S2H [Cosmetic] Increase particle render area for widescreen
+            f32 xMin = 0.0f;
+            f32 xMax = SCREEN_WIDTH;
+            if (OTRGetAspectRatio() > 4.0f / 3.0f) {
+                xMin = OTRGetDimensionFromLeftEdge(xMin);
+                xMax = OTRGetDimensionFromRightEdge(xMax);
+            }
+            // #pragma endregion
+
             // checking if particle is on screen
-            if ((screenPos.x >= 0.0f) && (screenPos.x < SCREEN_WIDTH) && (screenPos.y >= 0.0f) &&
+            if ((screenPos.x >= xMin) && (screenPos.x < xMax) && (screenPos.y >= 0.0f) &&
                 (screenPos.y < SCREEN_HEIGHT)) {
                 Matrix_Translate(worldPos.x, worldPos.y, worldPos.z, MTXMODE_NEW);
                 scaleAlpha = this->effects[i].alpha / 50.0f;
@@ -614,8 +623,17 @@ void DemoKankyo_DrawMoonAndGiant(Actor* thisx, PlayState* play2) {
 
             Play_GetScreenPos(play, &worldPos, &screenPos);
 
+            // #region 2S2H [Cosmetic] Increase effect render area for widescreen
+            f32 xMin = 0.0f;
+            f32 xMax = SCREEN_WIDTH;
+            if (OTRGetAspectRatio() > 4.0f / 3.0f) {
+                xMin = OTRGetDimensionFromLeftEdge(xMin);
+                xMax = OTRGetDimensionFromRightEdge(xMax);
+            }
+            // #pragma endregion
+
             // checking if effect is on screen
-            if ((screenPos.x >= 0.0f) && (screenPos.x < SCREEN_WIDTH) && (screenPos.y >= 0.0f) &&
+            if ((screenPos.x >= xMin) && (screenPos.x < xMax) && (screenPos.y >= 0.0f) &&
                 (screenPos.y < SCREEN_HEIGHT)) {
                 Matrix_Translate(worldPos.x, worldPos.y, worldPos.z, MTXMODE_NEW);
                 alphaScale = this->effects[i].alpha / 50.0f;

--- a/mm/src/overlays/actors/ovl_Object_Kankyo/z_object_kankyo.c
+++ b/mm/src/overlays/actors/ovl_Object_Kankyo/z_object_kankyo.c
@@ -543,8 +543,16 @@ void func_808DD3C8(Actor* thisx, PlayState* play2) {
         FrameInterpolation_RecordOpenChild(this, i);
         Play_GetScreenPos(play, &worldPos, &screenPos);
 
+        // #region 2S2H [Cosmetic] Increase snow render area for widescreen
+        f32 xMin = 0.0f;
+        f32 xMax = SCREEN_WIDTH;
+        if (OTRGetAspectRatio() > 4.0f / 3.0f) {
+            xMin = OTRGetDimensionFromLeftEdge(xMin);
+            xMax = OTRGetDimensionFromRightEdge(xMax);
+        }
+        // #pragma endregion
 
-        if ((screenPos.x >= 0.0f) && (screenPos.x < SCREEN_WIDTH) && (screenPos.y >= 0.0f) &&
+        if ((screenPos.x >= xMin) && (screenPos.x < xMax) && (screenPos.y >= 0.0f) &&
             (screenPos.y < SCREEN_HEIGHT)) {
             if (!spB4) {
                 spB4 = true;
@@ -619,7 +627,16 @@ void func_808DD970(Actor* thisx, PlayState* play2) {
         FrameInterpolation_RecordOpenChild(this, i);
         Play_GetScreenPos(play, &worldPos, &screenPos);
 
-        if ((screenPos.x >= 0.0f) && (screenPos.x < SCREEN_WIDTH) && (screenPos.y >= 0.0f) &&
+        // #region 2S2H [Cosmetic] Increase deep underwater dust render area for widescreen
+        f32 xMin = 0.0f;
+        f32 xMax = SCREEN_WIDTH;
+        if (OTRGetAspectRatio() > 4.0f / 3.0f) {
+            xMin = OTRGetDimensionFromLeftEdge(xMin);
+            xMax = OTRGetDimensionFromRightEdge(xMax);
+        }
+        // #pragma endregion
+
+        if ((screenPos.x >= xMin) && (screenPos.x < xMax) && (screenPos.y >= 0.0f) &&
             (screenPos.y < SCREEN_HEIGHT)) {
             Matrix_Translate(worldPos.x, worldPos.y, worldPos.z, MTXMODE_NEW);
             Matrix_Scale(0.03f, 0.03f, 0.03f, MTXMODE_APPLY);


### PR DESCRIPTION
This increases the render area that some particles and effects check for if a particle is "on screen"

* Falling snow
* Floating dust in deep underwater (e.g. pinacle rock)
* Lost wood sparkle/floating particles
* Giants cutscene bubbles and Moon particles