### PR TITLE
Fix actor inits happening too early

### DIFF
--- a/mm/src/code/z_scene.c
+++ b/mm/src/code/z_scene.c
@@ -35,6 +35,9 @@ s32 Object_SpawnPersistent(ObjectContext* objectCtx, s16 id) {
     return objectCtx->numEntries - 1;
 }
 
+// 2S2H [Port] Track when objects are first loaded for a scene
+static u8 sObjectFirstUpdateSkippedForScene = false;
+
 void Object_InitContext(GameState* gameState, ObjectContext* objectCtx) {
     PlayState* play = (PlayState*)gameState;
     s32 pad;
@@ -66,6 +69,8 @@ void Object_InitContext(GameState* gameState, ObjectContext* objectCtx) {
     objectCtx->mainKeepSlot = Object_SpawnPersistent(objectCtx, GAMEPLAY_KEEP);
 
     gSegments[4] = OS_K0_TO_PHYSICAL(objectCtx->slots[objectCtx->mainKeepSlot].segment);
+
+    sObjectFirstUpdateSkippedForScene = false;
 }
 
 void Object_UpdateEntries(ObjectContext* objectCtx) {
@@ -74,18 +79,25 @@ void Object_UpdateEntries(ObjectContext* objectCtx) {
     RomFile* objectFile;
     size_t size;
 
+    // 2S2H [Port] Skip the first object load after scene init so that actors have their init delayed by one frame
+    // This seems to mostly if not nearly resolve actors that depend on console DMA requests ending later
+    if (!sObjectFirstUpdateSkippedForScene) {
+        sObjectFirstUpdateSkippedForScene = true;
+        return;
+    }
+
     for (i = 0; i < objectCtx->numEntries; i++) {
         if (entry->id < 0) {
             s32 id = -entry->id;
 
-            // #region 2S2H [Port] We don't care to load the object from DMA, consider it already loaded
+            // 2S2H [Port] We don't care to load the object from DMA, consider it already loaded
             // There is a weird case handled below that accounts for RomFiles with a size of 0, but according
             // to object_table.h there is only one instance of this, along with a bunch of placeholder entries
             // so we _should_ be fine. Famous last words.
             entry->id = id;
         }
-        entry++;
 
+        entry++;
     }
 }
 


### PR DESCRIPTION
#240 made it so all objects are loaded at once, rather than one per frame. This fixed some crashes but introduced new issues. Basically "object dependency" type issues where actors where init-ing too soon that were expecting certain things to have already happened (cutscenes starting, check for object loads, etc).

To fix this I've opted to skip the first time objects are loaded after scene init. This basically adds one frame delay to actor inits so that one game update is processed before actors init. Persisted objects are unaffected, as they are always marked as loaded outside of this function.

This delay also ensures that all actors are spawned (added to the actor context actorLists), before any of them init, so if they do a search for another actor (like cucco chicks searching for grog), the search wont fail.

We may still find edge cases where one actor needs to specifically init after another actor, but when those pop up we can try to handle them independently.