### PR TITLE
Add missing reset to doggy race

### DIFF
--- a/mm/src/overlays/actors/ovl_En_Racedog/z_en_racedog.c
+++ b/mm/src/overlays/actors/ovl_En_Racedog/z_en_racedog.c
@@ -81,6 +81,7 @@ ActorInit En_Racedog_InitVars = {
     /**/ EnRacedog_Destroy,
     /**/ EnRacedog_Update,
     /**/ EnRacedog_Draw,
+    /**/ EnRacedog_Reset,
 };
 
 static s16 sNumberOfDogsFinished = 0;


### PR DESCRIPTION
The reset function already existed and had all the right variables in it, but it just wasn't called.

Fixes repeat doggy race attempts.