### PR TITLE
Add ability to configure motion blur

### DIFF
--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -7,6 +7,7 @@
 #include <unordered_map>
 #include <string>
 #include "2s2h/Enhancements/Enhancements.h"
+#include "2s2h/Enhancements/Graphics/MotionBlur.h"
 #include "2s2h/DeveloperTools/DeveloperTools.h"
 #include "HudEditor.h"
 
@@ -294,6 +295,11 @@ void DrawEnhancementsMenu() {
                 .tooltip = "Allow using Fierce Deity's mask outside of boss rooms."
             });
 
+            ImGui::EndMenu();
+        }
+
+        if (UIWidgets::BeginMenu("Graphics")) {
+            MotionBlur_RenderMenuOptions();
             ImGui::EndMenu();
         }
         

--- a/mm/2s2h/Enhancements/Graphics/MotionBlur.cpp
+++ b/mm/2s2h/Enhancements/Graphics/MotionBlur.cpp
@@ -1,0 +1,39 @@
+#include "MotionBlur.h"
+#include <libultraship/bridge.h>
+
+#include "2s2h/BenGui/UIWidgets.hpp"
+
+extern "C" {
+#include "z64.h"
+}
+
+const char* motionBlurOptions[] = { "Dynamic (default)", "Always Off", "Always On" };
+
+void MotionBlur_RenderMenuOptions() {
+    ImGui::SeparatorText("Motion Blur");
+    UIWidgets::CVarCombobox("Motion Blur Mode", "gEnhancements.Graphics.MotionBlur.Mode", motionBlurOptions, {
+        .labelPosition = UIWidgets::LabelPosition::None,
+    });
+    if (CVarGetInteger("gEnhancements.Graphics.MotionBlur.Mode", 0) == 0) {
+        UIWidgets::Checkbox("On/Off", (bool*)&R_MOTION_BLUR_ENABLED);
+        if (R_MOTION_BLUR_ENABLED) {
+            int32_t motionBlurStrength = R_MOTION_BLUR_ALPHA;
+            if (UIWidgets::SliderInt("Strength", &motionBlurStrength, 0, 255)) {
+                R_MOTION_BLUR_ALPHA = motionBlurStrength;
+            }
+        }
+    }
+    if (CVarGetInteger("gEnhancements.Graphics.MotionBlur.Mode", 0) == 2) {
+        UIWidgets::CVarSliderInt("Strength", "gEnhancements.Graphics.MotionBlur.Strength", 0, 255, 180);
+    }
+}
+
+extern "C" void MotionBlur_Override(u8* status, s32* alpha) {
+    if (CVarGetInteger("gEnhancements.Graphics.MotionBlur.Mode", 0) == 1) {
+        *status = 0;
+        *alpha = 0;
+    } else if (CVarGetInteger("gEnhancements.Graphics.MotionBlur.Mode", 0) == 2) {
+        if (*status == 0) *status = 2;
+        *alpha = CVarGetInteger("gEnhancements.Graphics.MotionBlur.Strength", 180);
+    }
+}

--- a/mm/2s2h/Enhancements/Graphics/MotionBlur.h
+++ b/mm/2s2h/Enhancements/Graphics/MotionBlur.h
@@ -1,0 +1,19 @@
+#ifndef MOTION_BLUR_H
+#define MOTION_BLUR_H
+
+void MotionBlur_RenderMenuOptions();
+
+#ifdef __cplusplus
+#include <libultraship/libultraship.h>
+
+extern "C" {
+#endif
+
+
+void MotionBlur_Override(u8* status, s32* alpha);
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif // MOTION_BLUR_H

--- a/mm/src/code/z_play.c
+++ b/mm/src/code/z_play.c
@@ -36,6 +36,7 @@ u8 sMotionBlurStatus;
 #include "debug.h"
 #include "2s2h/Enhancements/GameInteractor/GameInteractor.h"
 #include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
+#include "2s2h/Enhancements/Graphics/MotionBlur.h"
 #include "2s2h/DeveloperTools/CollisionViewer.h"
 #include "2s2h/framebuffer_effects.h"
 #include <string.h>
@@ -84,6 +85,8 @@ void Play_DrawMotionBlur(PlayState* this) {
         alpha = 0;
         sMotionBlurStatus = MOTION_BLUR_OFF;
     }
+
+    MotionBlur_Override(&sMotionBlurStatus, &alpha);
 
     if (sMotionBlurStatus != MOTION_BLUR_OFF) {
         OPEN_DISPS(gfxCtx);


### PR DESCRIPTION
<img width="201" alt="Screenshot 2024-04-29 at 6 30 54 PM" src="https://github.com/HarbourMasters/2ship2harkinian/assets/7316699/26f2c43d-14ac-4db4-8003-728374a37e10">

Options:
- Dynamic (default): this is the vanilla game behavior, driven by REGs. Displays a checkbox and slider bound to the REGs
- Always off: Prevents all motion blur
- Always on: Forces motion blur on with the alpha set to a cvar value from a slider