### PR TITLE
Actor Reset for Milk Bar door and race dog held

### DIFF
--- a/mm/src/overlays/actors/ovl_En_Dg/z_en_dg.c
+++ b/mm/src/overlays/actors/ovl_En_Dg/z_en_dg.c
@@ -1443,4 +1443,5 @@ void EnDg_Draw(Actor* thisx, PlayState* play) {
 void EnDg_Reset(void) {
     sIsAnyDogHeld = false;
     sBremenMaskFollowerIndex = ENDG_INDEX_NO_BREMEN_MASK_FOLLOWER;
+    sSelectedRacetrackDogInfo.index = -1;
 }

--- a/mm/src/overlays/actors/ovl_En_Door/z_en_door.c
+++ b/mm/src/overlays/actors/ovl_En_Door/z_en_door.c
@@ -27,6 +27,7 @@ void EnDoor_Init(Actor* thisx, PlayState* play2);
 void EnDoor_Destroy(Actor* thisx, PlayState* play);
 void EnDoor_Update(Actor* thisx, PlayState* play);
 void EnDoor_Draw(Actor* thisx, PlayState* play);
+void EnDoor_Reset(void);
 
 void func_80866B20(EnDoor*, PlayState*);
 void func_8086704C(EnDoor*, PlayState*);
@@ -286,6 +287,7 @@ ActorInit En_Door_InitVars = {
     /**/ EnDoor_Destroy,
     /**/ EnDoor_Update,
     /**/ EnDoor_Draw,
+    /**/ EnDoor_Reset,
 };
 
 typedef struct {
@@ -497,8 +499,10 @@ void func_80866A5C(EnDoor* this, PlayState* play) {
     }
 }
 
+// 2S2H [Port] Moved static vars out of function scope so they can be cleared in actor reset
+static s32 D_80867BC0;
+
 void func_80866B20(EnDoor* this, PlayState* play) {
-    static s32 D_80867BC0;
     Player* player = GET_PLAYER(play);
 
     if (Actor_ProcessTalkRequest(&this->knobDoor.dyna.actor, &play->state) &&
@@ -712,4 +716,8 @@ void EnDoor_Draw(Actor* thisx, PlayState* play) {
 
         CLOSE_DISPS(play->state.gfxCtx);
     }
+}
+
+void EnDoor_Reset(void) {
+    D_80867BC0 = false;
 }


### PR DESCRIPTION
Reset func for doors so that the milk bar door doesn't continually make link walk through it with the mask on.

Rest selected race dog index in dog race so the "is link holding a dog" method returns false. Fixes #259 