### PR TITLE
Add temple clears to save editor

### DIFF
--- a/mm/2s2h/DeveloperTools/SaveEditor.cpp
+++ b/mm/2s2h/DeveloperTools/SaveEditor.cpp
@@ -322,8 +322,7 @@ void DrawGeneralTab() {
         { WEEKEVENTREG_CLEARED_STONE_TOWER_TEMPLE, "Stone Tower Cleared" },
     } };
 
-    for (size_t i = 0; i < templeClears.size(); i++) {
-        const auto& temple = templeClears.at(i);
+    for (const auto& temple : templeClears) {
         bool cleared = CHECK_WEEKEVENTREG(temple.first);
         if (UIWidgets::Checkbox(temple.second, &cleared, { .color = UIWidgets::Colors::Gray })) {
             if (cleared) {


### PR DESCRIPTION
This adds some quick temple clear check boxes to the save editor in-leu of a real flag management section. I figure these would be good to have for quick debugging until then. The previous snowhead clear flag from the save context is unused so it wasn't doing anything in the save editor.