### PR TITLE
Fix DL indexing on resources in draw code

### DIFF
--- a/mm/src/overlays/actors/ovl_Obj_Kinoko/z_obj_kinoko.c
+++ b/mm/src/overlays/actors/ovl_Obj_Kinoko/z_obj_kinoko.c
@@ -75,15 +75,21 @@ void ObjKinoko_Draw(Actor* thisx, PlayState* play) {
 
     Gfx_SetupDL25_Xlu(play->state.gfxCtx);
 
+    // #region 2S2H [Port]
+    // We need to first load the DL before we can index it on the port
+    Gfx* gameplay_keep_DL_029D10_Data = ResourceMgr_LoadGfxByName(gameplay_keep_DL_029D10);
+
     gfx = POLY_XLU_DISP;
     gDPSetPrimColor(&gfx[0], 0, 0, 169, 63, 186, (u8)thisx->speed);
     gDPSetEnvColor(&gfx[1], 110, 44, 200, 100);
     gDPSetRenderMode(&gfx[2], G_RM_PASS, G_RM_ZB_CLD_SURF2);
     gSPMatrix(&gfx[3], Matrix_NewMtx(play->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-    gSPDisplayList(&gfx[4], &gameplay_keep_DL_029D10[2]);
+    // Index adjust 2 -> 4 (for gsDPPipeSync) to account for our extraction size changes
+    gSPDisplayList(&gfx[4], &gameplay_keep_DL_029D10_Data[4]);
     Matrix_RotateXS(-0x4000, MTXMODE_APPLY);
     gSPMatrix(&gfx[5], Matrix_NewMtx(play->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-    gSPDisplayList(&gfx[6], &gameplay_keep_DL_029D10[2]);
+    gSPDisplayList(&gfx[6], &gameplay_keep_DL_029D10_Data[4]);
+    // #endregion
     POLY_XLU_DISP = &gfx[7];
 
     CLOSE_DISPS(play->state.gfxCtx);

--- a/mm/src/overlays/actors/ovl_Oceff_Wipe4/z_oceff_wipe4.c
+++ b/mm/src/overlays/actors/ovl_Oceff_Wipe4/z_oceff_wipe4.c
@@ -121,7 +121,8 @@ void OceffWipe4_Draw(Actor* thisx, PlayState* play) {
     gSPDisplayList(POLY_XLU_DISP++, scarecrowSongModelDL);
     gSPDisplayList(POLY_XLU_DISP++, Gfx_TwoTexScroll(play->state.gfxCtx, G_TX_RENDERTILE, scroll * 2, scroll * -2, 32,
                                                      64, 1, scroll * -1, scroll, 32, 32));
-    gSPDisplayList(POLY_XLU_DISP++, &scarecrowSongModelDL[11]);
+    // Index adjust 11 -> 14 (for gsSPVertex) to account for our extraction size changes
+    gSPDisplayList(POLY_XLU_DISP++, &scarecrowSongModelDL[14]);
     // #endregion
 
     CLOSE_DISPS(play->state.gfxCtx);


### PR DESCRIPTION
Continues #271 by correctly indexing to the instruction expected on console. This is because our DL from resources have markers at the front and some instructions are double sized (HASH/FILEPATH).

Also provide a similar fix for mask of scents mushroom smoke.

Fixes #270 