### PR TITLE
Tweaks to logging

### DIFF
--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -349,6 +349,16 @@ extern std::shared_ptr<ActorViewerWindow> mActorViewerWindow;
 extern std::shared_ptr<CollisionViewerWindow> mCollisionViewerWindow;
 extern std::shared_ptr<EventLogWindow> mEventLogWindow;
 
+const char* logLevels[] = {
+    "trace",
+    "debug",
+    "info",
+    "warn",
+    "error",
+    "critical",
+    "off",
+};
+
 void DrawDeveloperToolsMenu() {
     if (UIWidgets::BeginMenu("Developer Tools", UIWidgets::Colors::Yellow)) {
         UIWidgets::CVarCheckbox("Debug Mode", "gDeveloperTools.DebugEnabled", {
@@ -364,6 +374,12 @@ void DrawDeveloperToolsMenu() {
         }
         if (UIWidgets::CVarCheckbox("Prevent Actor Init", "gDeveloperTools.PreventActorInit")) {
             RegisterPreventActorInitHooks();
+        }
+        if (UIWidgets::CVarCombobox("Log Level", "gDeveloperTools.LogLevel", logLevels, {
+            .tooltip = "The log level determines which messages are printed to the console. This does not affect the log file output",
+            .defaultIndex = 1,
+        })) {
+            LUS::Context::GetInstance()->GetLogger()->set_level((spdlog::level::level_enum)CVarGetInteger("gDeveloperTools.LogLevel", 1));
         }
         
         if (gPlayState != NULL) {

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -130,6 +130,11 @@ OTRGlobals::OTRGlobals() {
                                                  OOT_PAL_GC,     OOT_PAL_GC_DBG1,   OOT_PAL_GC_DBG2 };
     // tell LUS to reserve 3 SoH specific threads (Game, Audio, Save)
     context = LUS::Context::CreateInstance("2 Ship 2 Harkinian", appShortName, "shipofharkinian.json", OTRFiles, {}, 3);
+
+    // Override LUS defaults
+    LUS::Context::GetInstance()->GetLogger()->set_level((spdlog::level::level_enum)CVarGetInteger("gDeveloperTools.LogLevel", 1));
+    LUS::Context::GetInstance()->GetLogger()->set_pattern("[%H:%M:%S.%e] [%s:%#] [%l] %v");
+
     //context = LUS::Context::CreateUninitializedInstance("Ship of Harkinian", appShortName, "shipofharkinian.json");
     auto loader = context->GetResourceManager()->GetResourceLoader();
     loader->RegisterResourceFactory(std::make_shared<SOH::ResourceFactoryBinaryAnimationV0>(), RESOURCE_FORMAT_BINARY,

--- a/mm/src/audio/lib/thread.c
+++ b/mm/src/audio/lib/thread.c
@@ -270,8 +270,6 @@ void AudioThread_QueueCmd(AudioCmd cmdData) {
     AudioCmd* cmd = &gAudioCtx.threadCmdBuf[gAudioCtx.threadCmdWritePos & 0xFF];
     *cmd = cmdData;
 
-    LUSLOG_TRACE("Queueing Command: %s", cmd_op_to_str(cmd->op));
-
     gAudioCtx.threadCmdWritePos++;
 
     if (gAudioCtx.threadCmdWritePos == gAudioCtx.threadCmdReadPos) {
@@ -467,7 +465,7 @@ void AudioThread_ProcessCmds(u32 msg) {
         }
 
         cmd = &gAudioCtx.threadCmdBuf[sCurCmdRdPos++ & 0xFF];
-        LUSLOG_TRACE("Process Command: %s", cmd_op_to_str(cmd->op));
+
         if (cmd->op == AUDIOCMD_OP_GLOBAL_STOP_AUDIOCMDS) {
             gAudioCtx.threadCmdQueueFinished = true;
             break;


### PR DESCRIPTION
Arguably this could be a LUS_CVAR thing, but it's already exposed for us to change at will, with the caveat that the logs emitted in the `LUS::Context::CreateInstance` do not account for the overrides yet, which emits a dozen or so logs.

Log level defaults to `debug`, and modified the pattern to remove the date and the absolute file path, now just uses the file name. (this is subjective, but depending on where you put your repository, this absolute file path could take up more than half of the screen)

Also removed two traces from the audio code. They do more harm than good staying around.