### PR TITLE
Add time-moves-when-you-move mode

### DIFF
--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -10,6 +10,7 @@
 #include "2s2h/Enhancements/Enhancements.h"
 #include "2s2h/Enhancements/Graphics/MotionBlur.h"
 #include "2s2h/Enhancements/Graphics/PlayAsKafei.h"
+#include "2s2h/Enhancements/Modes/TimeMovesWhenYouMove.h"
 #include "2s2h/DeveloperTools/DeveloperTools.h"
 #include "2s2h/DeveloperTools/WarpPoint.h"
 #include "HudEditor.h"
@@ -475,6 +476,10 @@ void DrawEnhancementsMenu() {
                                         { .tooltip = "Requires scene reload to take effect." })) {
                 UpdatePlayAsKafeiSkeletons();
             }
+            if (UIWidgets::CVarCheckbox("Time Moves When You Move", "gModes.TimeMovesWhenYouMove")) {
+                RegisterTimeMovesWhenYouMove();
+            }
+
             ImGui::EndMenu();
         }
         if (UIWidgets::BeginMenu("Player Movement")) {

--- a/mm/2s2h/Enhancements/Enhancements.cpp
+++ b/mm/2s2h/Enhancements/Enhancements.cpp
@@ -37,6 +37,7 @@ void InitEnhancements() {
 
     // Modes
     RegisterPlayAsKafei();
+    RegisterTimeMovesWhenYouMove();
 
     // Player Movement
     RegisterClimbSpeed();

--- a/mm/2s2h/Enhancements/Enhancements.h
+++ b/mm/2s2h/Enhancements/Enhancements.h
@@ -19,6 +19,7 @@
 #include "Graphics/PlayAsKafei.h"
 #include "PlayerMovement/ClimbSpeed.h"
 #include "Songs/EnableSunsSong.h"
+#include "Modes/TimeMovesWhenYouMove.h"
 
 enum AlwaysWinDoggyRaceOptions {
     ALWAYS_WIN_DOGGY_RACE_OFF,

--- a/mm/2s2h/Enhancements/Modes/TimeMovesWhenYouMove.cpp
+++ b/mm/2s2h/Enhancements/Modes/TimeMovesWhenYouMove.cpp
@@ -1,0 +1,29 @@
+#include "TimeMovesWhenYouMove.h"
+#include "libultraship/libultraship.h"
+#include "2s2h/Enhancements/GameInteractor/GameInteractor.h"
+
+extern "C" {
+    #include "macros.h"
+    #include "z64.h"
+    extern PlayState* gPlayState;
+    extern SaveContext gSaveContext;
+}
+
+static HOOK_ID onActorUpdateHookId = 0;
+
+void RegisterTimeMovesWhenYouMove() {
+    GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::OnActorUpdate>(onActorUpdateHookId);
+    onActorUpdateHookId = 0;
+    gSaveContext.save.timeSpeedOffset = 0;
+
+    if (CVarGetInteger("gModes.TimeMovesWhenYouMove", 0)) {
+        onActorUpdateHookId = GameInteractor::Instance->RegisterGameHookForID<GameInteractor::OnActorUpdate>(ACTOR_PLAYER, [](Actor* actor) {
+            Player* player = GET_PLAYER(gPlayState);
+
+            gSaveContext.save.timeSpeedOffset = -R_TIME_SPEED;
+            if (player->linearVelocity != 0) {
+                gSaveContext.save.timeSpeedOffset = CLAMP(player->linearVelocity / 2 - R_TIME_SPEED, -R_TIME_SPEED, 10);
+            }
+        });
+    }
+}

--- a/mm/2s2h/Enhancements/Modes/TimeMovesWhenYouMove.h
+++ b/mm/2s2h/Enhancements/Modes/TimeMovesWhenYouMove.h
@@ -1,0 +1,6 @@
+#ifndef MODES_TIME_MOVES_WHEN_YOU_MOVE_H
+#define MODES_TIME_MOVES_WHEN_YOU_MOVE_H
+
+void RegisterTimeMovesWhenYouMove();
+
+#endif // MODES_TIME_MOVES_WHEN_YOU_MOVE_H


### PR DESCRIPTION
Time speed is based on link's linear velocity, with time stopped when link isn't moving, and progressing the fastest when rolling as goron link

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1491844256.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1491849128.zip)
<!--- section:artifacts:end -->