### PR TITLE
Bump lus with packages, new namespace, and global factories

### DIFF
--- a/.github/workflows/apt-deps.txt
+++ b/.github/workflows/apt-deps.txt
@@ -1,1 +1,1 @@
-libusb-dev libusb-1.0-0-dev libsdl2-dev libsdl2-net-dev libpng-dev libglew-dev libzip-dev zipcmp zipmerge ziptool nlohmann-json3-dev ninja-build
+libusb-dev libusb-1.0-0-dev libsdl2-dev libsdl2-net-dev libpng-dev libglew-dev libzip-dev zipcmp zipmerge ziptool nlohmann-json3-dev libtinyxml2-dev libspdlog-dev ninja-build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ elseif ("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "x64")
 	set(VCPKG_TARGET_TRIPLET x64-windows-static)
 endif()
 vcpkg_bootstrap()
-vcpkg_install_packages(zlib bzip2 libzip libpng sdl2 sdl2-net glew glfw3 nlohmann-json)
+vcpkg_install_packages(zlib bzip2 libzip libpng sdl2 sdl2-net glew glfw3 nlohmann-json tinyxml2 spdlog)
 endif()
 
 ################################################################################

--- a/mm/2s2h/BenGui/BenGui.cpp
+++ b/mm/2s2h/BenGui/BenGui.cpp
@@ -27,10 +27,10 @@ namespace BenGui {
 
     std::shared_ptr<BenMenuBar> mBenMenuBar;
 
-    std::shared_ptr<LUS::GuiWindow> mConsoleWindow;
-    std::shared_ptr<LUS::GuiWindow> mStatsWindow;
-    std::shared_ptr<LUS::GuiWindow> mInputEditorWindow;
-    std::shared_ptr<LUS::GuiWindow> mGfxDebuggerWindow;
+    std::shared_ptr<Ship::GuiWindow> mConsoleWindow;
+    std::shared_ptr<Ship::GuiWindow> mStatsWindow;
+    std::shared_ptr<Ship::GuiWindow> mInputEditorWindow;
+    std::shared_ptr<Ship::GuiWindow> mGfxDebuggerWindow;
 
     std::shared_ptr<SaveEditorWindow> mSaveEditorWindow;
     std::shared_ptr<HudEditorWindow> mHudEditorWindow;
@@ -39,7 +39,7 @@ namespace BenGui {
     std::shared_ptr<EventLogWindow> mEventLogWindow;
 
     void SetupGuiElements() {
-        auto gui = LUS::Context::GetInstance()->GetWindow()->GetGui();
+        auto gui = Ship::Context::GetInstance()->GetWindow()->GetGui();
 
         auto& style = ImGui::GetStyle();
         style.FramePadding = ImVec2(4.0f, 6.0f);
@@ -47,7 +47,7 @@ namespace BenGui {
         style.Colors[ImGuiCol_MenuBarBg] = UIWidgets::Colors::DarkGray;
 
         mBenMenuBar = std::make_shared<BenMenuBar>("gOpenMenuBar", CVarGetInteger("gOpenMenuBar", 0));
-        gui->SetMenuBar(std::reinterpret_pointer_cast<LUS::GuiMenuBar>(mBenMenuBar));
+        gui->SetMenuBar(std::reinterpret_pointer_cast<Ship::GuiMenuBar>(mBenMenuBar));
 
         if (gui->GetMenuBar() && !gui->GetMenuBar()->IsVisible()) {
 #if defined(__SWITCH__) || defined(__WIIU__)

--- a/mm/2s2h/BenGui/BenGui.cpp
+++ b/mm/2s2h/BenGui/BenGui.cpp
@@ -1,9 +1,9 @@
 #include "BenGui.hpp"
 
 #include <spdlog/spdlog.h>
-#include <ImGui/imgui.h>
+#include <imgui.h>
 #define IMGUI_DEFINE_MATH_OPERATORS
-#include <ImGui/imgui_internal.h>
+#include <imgui_internal.h>
 #include <libultraship/libultraship.h>
 #include <Fast3D/gfx_pc.h>
 #include "UIWidgets.hpp"

--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -26,16 +26,16 @@ static const std::unordered_map<int32_t, const char*> textureFilteringMap = {
     { FILTER_NONE, "None" },
 };
 
-static const std::unordered_map<LUS::AudioBackend, const char*> audioBackendsMap = {
-    { LUS::AudioBackend::WASAPI, "Windows Audio Session API" },
-    { LUS::AudioBackend::SDL, "SDL" },
+static const std::unordered_map<Ship::AudioBackend, const char*> audioBackendsMap = {
+    { Ship::AudioBackend::WASAPI, "Windows Audio Session API" },
+    { Ship::AudioBackend::SDL, "SDL" },
 };
 
-static std::unordered_map<LUS::WindowBackend, const char*> windowBackendsMap = {
-    { LUS::WindowBackend::DX11, "DirectX" },
-    { LUS::WindowBackend::SDL_OPENGL, "OpenGL" },
-    { LUS::WindowBackend::SDL_METAL, "Metal" },
-    { LUS::WindowBackend::GX2, "GX2" }
+static std::unordered_map<Ship::WindowBackend, const char*> windowBackendsMap = {
+    { Ship::WindowBackend::DX11, "DirectX" },
+    { Ship::WindowBackend::SDL_OPENGL, "OpenGL" },
+    { Ship::WindowBackend::SDL_METAL, "Metal" },
+    { Ship::WindowBackend::GX2, "GX2" }
 };
 
 namespace BenGui {
@@ -43,11 +43,11 @@ namespace BenGui {
 void DrawMenuBarIcon() {
     static bool gameIconLoaded = false;
     if (!gameIconLoaded) {
-        LUS::Context::GetInstance()->GetWindow()->GetGui()->LoadTextureFromRawImage("Game_Icon", "textures/icons/g2ShipIcon.png");
+        Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadTextureFromRawImage("Game_Icon", "textures/icons/g2ShipIcon.png");
         gameIconLoaded = true;
     }
 
-    if (LUS::Context::GetInstance()->GetWindow()->GetGui()->HasTextureByName("Game_Icon")) {
+    if (Ship::Context::GetInstance()->GetWindow()->GetGui()->HasTextureByName("Game_Icon")) {
 #ifdef __SWITCH__
         ImVec2 iconSize = ImVec2(20.0f, 20.0f);
         float posScale = 1.0f;
@@ -59,7 +59,7 @@ void DrawMenuBarIcon() {
         float posScale = 1.0f;
 #endif
         ImGui::SetCursorPos(ImVec2(5, 5) * posScale);
-        ImGui::Image(LUS::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName("Game_Icon"), iconSize);
+        ImGui::Image(Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName("Game_Icon"), iconSize);
         ImGui::SameLine();
         ImGui::SetCursorPos(ImVec2(25, 0) * posScale);
     }
@@ -74,11 +74,11 @@ void DrawBenMenu() {
             "[-]"
 #endif
         )) {
-            LUS::Context::GetInstance()->GetWindow()->GetGui()->GetMenuBar()->ToggleVisibility();
+            Ship::Context::GetInstance()->GetWindow()->GetGui()->GetMenuBar()->ToggleVisibility();
         }
 #if !defined(__SWITCH__) && !defined(__WIIU__)
         if (UIWidgets::MenuItem("Toggle Fullscreen", "F11")) {
-            LUS::Context::GetInstance()->GetWindow()->ToggleFullscreen();
+            Ship::Context::GetInstance()->GetWindow()->ToggleFullscreen();
         }
 #endif
         if (UIWidgets::MenuItem("Reset",
@@ -90,25 +90,25 @@ void DrawBenMenu() {
             ""
 #endif
         )) {
-            std::reinterpret_pointer_cast<LUS::ConsoleWindow>(
-                LUS::Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Console"))
+            std::reinterpret_pointer_cast<Ship::ConsoleWindow>(
+                Ship::Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Console"))
                 ->Dispatch("reset");
         }
 #if !defined(__SWITCH__) && !defined(__WIIU__)
         if (UIWidgets::MenuItem("Open App Files Folder")) {
-            std::string filesPath = LUS::Context::GetInstance()->GetAppDirectoryPath();
+            std::string filesPath = Ship::Context::GetInstance()->GetAppDirectoryPath();
             SDL_OpenURL(std::string("file:///" + std::filesystem::absolute(filesPath).string()).c_str());
         }
 
         if (UIWidgets::MenuItem("Quit")) {
-            LUS::Context::GetInstance()->GetWindow()->Close();
+            Ship::Context::GetInstance()->GetWindow()->Close();
         }
 #endif
         ImGui::EndMenu();
     }
 }
 
-extern std::shared_ptr<LUS::GuiWindow> mInputEditorWindow;
+extern std::shared_ptr<Ship::GuiWindow> mInputEditorWindow;
 
 void DrawSettingsMenu() {
     if (UIWidgets::BeginMenu("Settings")) {
@@ -131,13 +131,13 @@ void DrawSettingsMenu() {
                 AudioSeq_SetPortVolumeScale(SEQ_PLAYER_AMBIENCE, CVarGetFloat("gSettings.Audio.AmbienceVolume", 1.0f));
             }
 
-            auto currentAudioBackend = LUS::Context::GetInstance()->GetAudio()->GetAudioBackend();
+            auto currentAudioBackend = Ship::Context::GetInstance()->GetAudio()->GetAudioBackend();
             if (UIWidgets::Combobox("Audio API", &currentAudioBackend, audioBackendsMap, {
                 .tooltip = "Sets the audio API used by the game. Requires a relaunch to take effect.",
-                .disabled = LUS::Context::GetInstance()->GetAudio()->GetAvailableAudioBackends()->size() <= 1,
+                .disabled = Ship::Context::GetInstance()->GetAudio()->GetAvailableAudioBackends()->size() <= 1,
                 .disabledTooltip = "Only one audio API is available on this platform."
             })) {
-                LUS::Context::GetInstance()->GetAudio()->SetAudioBackend(currentAudioBackend);
+                Ship::Context::GetInstance()->GetAudio()->SetAudioBackend(currentAudioBackend);
             }
 
             ImGui::EndMenu();
@@ -147,13 +147,13 @@ void DrawSettingsMenu() {
             
     #ifndef __APPLE__
             if (UIWidgets::CVarSliderFloat("Internal Resolution: %d %%", "gInternalResolution", 0.5f, 2.0f, 1.0f)) {
-                LUS::Context::GetInstance()->GetWindow()->SetResolutionMultiplier(CVarGetFloat("gInternalResolution", 1));
+                Ship::Context::GetInstance()->GetWindow()->SetResolutionMultiplier(CVarGetFloat("gInternalResolution", 1));
             };
             UIWidgets::Tooltip("Multiplies your output resolution by the value inputted, as a more intensive but effective " "form of anti-aliasing");
 #endif 
 #ifndef __WIIU__ 
             if (UIWidgets::CVarSliderInt("MSAA: %d","gMSAAValue", 1, 8, 1)) {
-                LUS::Context::GetInstance()->GetWindow()->SetMsaaLevel(CVarGetInteger("gMSAAValue", 1));
+                Ship::Context::GetInstance()->GetWindow()->SetMsaaLevel(CVarGetInteger("gMSAAValue", 1));
             };
             UIWidgets::Tooltip("Activates multi-sample anti-aliasing when above 1x up to 8x for 8 samples for every pixel");
 #endif
@@ -161,18 +161,18 @@ void DrawSettingsMenu() {
             { // FPS Slider
                 constexpr unsigned int minFps = 20;
                 static unsigned int maxFps;
-                if (LUS::Context::GetInstance()->GetWindow()->GetWindowBackend() == LUS::WindowBackend::DX11) {
+                if (Ship::Context::GetInstance()->GetWindow()->GetWindowBackend() == Ship::WindowBackend::DX11) {
                     maxFps = 360;
                 } else {
-                    maxFps = LUS::Context::GetInstance()->GetWindow()->GetCurrentRefreshRate();
+                    maxFps = Ship::Context::GetInstance()->GetWindow()->GetCurrentRefreshRate();
                 }
                 unsigned int currentFps = std::max(std::min(OTRGlobals::Instance->GetInterpolationFPS(), maxFps), minFps);
                 bool matchingRefreshRate =
                     CVarGetInteger("gMatchRefreshRate", 0) &&
-                    LUS::Context::GetInstance()->GetWindow()->GetWindowBackend() != LUS::WindowBackend::DX11;
+                    Ship::Context::GetInstance()->GetWindow()->GetWindowBackend() != Ship::WindowBackend::DX11;
                 UIWidgets::CVarSliderInt((currentFps == 20) ? "FPS: Original (20)" : "FPS: %d", "gInterpolationFPS",
                                          minFps, maxFps, 20, {.disabled = matchingRefreshRate} );
-                if (LUS::Context::GetInstance()->GetWindow()->GetWindowBackend() == LUS::WindowBackend::DX11) {
+                if (Ship::Context::GetInstance()->GetWindow()->GetWindowBackend() == Ship::WindowBackend::DX11) {
                     UIWidgets::Tooltip(
                         "Uses Matrix Interpolation to create extra frames, resulting in smoother graphics. This is purely visual and does not impact game logic, execution of glitches etc.\n\n A higher target FPS than your monitor's refresh rate will waste resources, and might give a worse result."); 
                 } else { 
@@ -180,13 +180,13 @@ void DrawSettingsMenu() {
                 }
             } // END FPS Slider
 
-            if (LUS::Context::GetInstance()->GetWindow()->GetWindowBackend() == LUS::WindowBackend::DX11) {
+            if (Ship::Context::GetInstance()->GetWindow()->GetWindowBackend() == Ship::WindowBackend::DX11) {
                 //UIWidgets::Spacer(0);
                 if (ImGui::Button("Match Refresh Rate")) {
-                    int hz = LUS::Context::GetInstance()->GetWindow()->GetCurrentRefreshRate();
+                    int hz = Ship::Context::GetInstance()->GetWindow()->GetCurrentRefreshRate();
                     if (hz >= 20 && hz <= 360) {
                         CVarSetInteger("gInterpolationFPS", hz);
-                        LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
+                        Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
                     }
                 }
             } else {
@@ -194,7 +194,7 @@ void DrawSettingsMenu() {
             }
             UIWidgets::Tooltip("Matches interpolation value to the current game's window refresh rate");
 
-            if (LUS::Context::GetInstance()->GetWindow()->GetWindowBackend() == LUS::WindowBackend::DX11) {
+            if (Ship::Context::GetInstance()->GetWindow()->GetWindowBackend() == Ship::WindowBackend::DX11) {
                 UIWidgets::CVarSliderInt(CVarGetInteger("gExtraLatencyThreshold", 80) == 0 ? "Jitter fix: Off" : "Jitter fix: >= %d FPS",
                     "gExtraLatencyThreshold", 0, 360, 80);
                 UIWidgets::Tooltip("When Interpolation FPS setting is at least this threshold, add one frame of input lag (e.g. 16.6 ms for 60 FPS) in order to avoid jitter. This setting allows the CPU to work on one frame while GPU works on the previous frame.\nThis setting should be used when your computer is too slow to do CPU + GPU work in time.");
@@ -203,18 +203,18 @@ void DrawSettingsMenu() {
             //UIWidgets::PaddedSeparator(true, true, 3.0f, 3.0f);
             // #endregion */
 
-            LUS::WindowBackend runningWindowBackend = LUS::Context::GetInstance()->GetWindow()->GetWindowBackend();
-            LUS::WindowBackend configWindowBackend;
-            int32_t configWindowBackendId = LUS::Context::GetInstance()->GetConfig()->GetInt("Window.Backend.Id", -1);
+            Ship::WindowBackend runningWindowBackend = Ship::Context::GetInstance()->GetWindow()->GetWindowBackend();
+            Ship::WindowBackend configWindowBackend;
+            int32_t configWindowBackendId = Ship::Context::GetInstance()->GetConfig()->GetInt("Window.Backend.Id", -1);
             if (configWindowBackendId != -1 &&
-                configWindowBackendId < static_cast<int>(LUS::WindowBackend::BACKEND_COUNT)) {
-                configWindowBackend = static_cast<LUS::WindowBackend>(configWindowBackendId);
+                configWindowBackendId < static_cast<int>(Ship::WindowBackend::BACKEND_COUNT)) {
+                configWindowBackend = static_cast<Ship::WindowBackend>(configWindowBackendId);
             } else {
                 configWindowBackend = runningWindowBackend;
             }
 
-            auto availableWindowBackends = LUS::Context::GetInstance()->GetWindow()->GetAvailableWindowBackends();
-            std::unordered_map<LUS::WindowBackend, const char*> availableWindowBackendsMap;
+            auto availableWindowBackends = Ship::Context::GetInstance()->GetWindow()->GetAvailableWindowBackends();
+            std::unordered_map<Ship::WindowBackend, const char*> availableWindowBackendsMap;
             for (auto& backend : *availableWindowBackends) {
                 availableWindowBackendsMap[backend] = windowBackendsMap[backend];
             }
@@ -222,24 +222,24 @@ void DrawSettingsMenu() {
             if (UIWidgets::Combobox(
                     "Renderer API (Needs reload)", &configWindowBackend, availableWindowBackendsMap,
                     { .tooltip = "Sets the renderer API used by the game. Requires a relaunch to take effect.",
-                      .disabled = LUS::Context::GetInstance()->GetWindow()->GetAvailableWindowBackends()->size() <= 1,
+                      .disabled = Ship::Context::GetInstance()->GetWindow()->GetAvailableWindowBackends()->size() <= 1,
                       .disabledTooltip = "Only one renderer API is available on this platform." })) {
-                LUS::Context::GetInstance()->GetConfig()->SetInt("Window.Backend.Id",
+                Ship::Context::GetInstance()->GetConfig()->SetInt("Window.Backend.Id",
                                                                  static_cast<int32_t>(configWindowBackend));
-                LUS::Context::GetInstance()->GetConfig()->SetString("Window.Backend.Name",
+                Ship::Context::GetInstance()->GetConfig()->SetString("Window.Backend.Name",
                                                                     windowBackendsMap.at(configWindowBackend));
-                LUS::Context::GetInstance()->GetConfig()->Save();
+                Ship::Context::GetInstance()->GetConfig()->Save();
             }
 
-            if (LUS::Context::GetInstance()->GetWindow()->CanDisableVerticalSync()) {
+            if (Ship::Context::GetInstance()->GetWindow()->CanDisableVerticalSync()) {
                 UIWidgets::CVarCheckbox("Enable Vsync", "gVsyncEnabled");
             }
 
-            if (LUS::Context::GetInstance()->GetWindow()->SupportsWindowedFullscreen()) {
+            if (Ship::Context::GetInstance()->GetWindow()->SupportsWindowedFullscreen()) {
                 UIWidgets::CVarCheckbox("Windowed fullscreen", "gSdlWindowedFullscreen");
             }
 
-            if (LUS::Context::GetInstance()->GetWindow()->GetGui()->SupportsViewports()) {
+            if (Ship::Context::GetInstance()->GetWindow()->GetGui()->SupportsViewports()) {
                 UIWidgets::CVarCheckbox(
                     "Allow multi-windows", "gEnableMultiViewports",
                     { .tooltip = "Allows multiple windows to be opened at once. Requires a reload to take effect." });
@@ -248,7 +248,7 @@ void DrawSettingsMenu() {
             UIWidgets::CVarCombobox("Texture Filter (Needs reload)", "gTextureFilter", textureFilteringMap);
 
             // Currently this only has "Overlays Text Font", it doesn't use our new UIWidgets so it stands out
-            // LUS::Context::GetInstance()->GetWindow()->GetGui()->GetGameOverlay()->DrawSettings();
+            // Ship::Context::GetInstance()->GetWindow()->GetGui()->GetGameOverlay()->DrawSettings();
 
             ImGui::EndMenu();
         }
@@ -367,9 +367,9 @@ void DrawCheatsMenu() {
     }
 }
 
-extern std::shared_ptr<LUS::GuiWindow> mStatsWindow;
-extern std::shared_ptr<LUS::GuiWindow> mConsoleWindow;
-extern std::shared_ptr<LUS::GuiWindow> mGfxDebuggerWindow;
+extern std::shared_ptr<Ship::GuiWindow> mStatsWindow;
+extern std::shared_ptr<Ship::GuiWindow> mConsoleWindow;
+extern std::shared_ptr<Ship::GuiWindow> mGfxDebuggerWindow;
 extern std::shared_ptr<SaveEditorWindow> mSaveEditorWindow;
 extern std::shared_ptr<ActorViewerWindow> mActorViewerWindow;
 extern std::shared_ptr<CollisionViewerWindow> mCollisionViewerWindow;
@@ -405,7 +405,7 @@ void DrawDeveloperToolsMenu() {
             .tooltip = "The log level determines which messages are printed to the console. This does not affect the log file output",
             .defaultIndex = 1,
         })) {
-            LUS::Context::GetInstance()->GetLogger()->set_level((spdlog::level::level_enum)CVarGetInteger("gDeveloperTools.LogLevel", 1));
+            Ship::Context::GetInstance()->GetLogger()->set_level((spdlog::level::level_enum)CVarGetInteger("gDeveloperTools.LogLevel", 1));
         }
         
         if (gPlayState != NULL) {

--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -1,6 +1,6 @@
 #include "BenMenuBar.h"
 #include "BenPort.h"
-#include "ImGui/imgui.h"
+#include <imgui.h>
 #include "public/bridge/consolevariablebridge.h"
 #include <libultraship/libultraship.h>
 #include "UIWidgets.hpp"

--- a/mm/2s2h/BenGui/BenMenuBar.h
+++ b/mm/2s2h/BenGui/BenMenuBar.h
@@ -9,9 +9,9 @@
 #include "DeveloperTools/EventLog.h"
 
 namespace BenGui {
-class BenMenuBar : public LUS::GuiMenuBar {
+class BenMenuBar : public Ship::GuiMenuBar {
   public:
-    using LUS::GuiMenuBar::GuiMenuBar;
+    using Ship::GuiMenuBar::GuiMenuBar;
   protected:
     void DrawElement() override;
     void InitElement() override {};

--- a/mm/2s2h/BenGui/HudEditor.h
+++ b/mm/2s2h/BenGui/HudEditor.h
@@ -7,7 +7,7 @@
 #include "UIWidgets.hpp"
 #include <unordered_map>
 
-class HudEditorWindow : public LUS::GuiWindow {
+class HudEditorWindow : public Ship::GuiWindow {
     public:
         using GuiWindow::GuiWindow;
 

--- a/mm/2s2h/BenGui/UIWidgets.cpp
+++ b/mm/2s2h/BenGui/UIWidgets.cpp
@@ -1,6 +1,6 @@
 #include "UIWidgets.hpp"
 #define IMGUI_DEFINE_MATH_OPERATORS
-#include <ImGui/imgui_internal.h>
+#include <imgui_internal.h>
 #include <libultraship/libultraship.h>
 #include <string>
 #include <unordered_map>

--- a/mm/2s2h/BenGui/UIWidgets.cpp
+++ b/mm/2s2h/BenGui/UIWidgets.cpp
@@ -119,7 +119,7 @@ namespace UIWidgets {
         return dirty;
     }
 
-    bool WindowButton(const char* label, const char* cvarName, std::shared_ptr<LUS::GuiWindow> windowPtr, const ButtonOptions& options) {
+    bool WindowButton(const char* label, const char* cvarName, std::shared_ptr<Ship::GuiWindow> windowPtr, const ButtonOptions& options) {
         ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(0, 0));
         std::string buttonText = label;
         bool dirty = false;
@@ -209,7 +209,7 @@ namespace UIWidgets {
         bool value = (bool)CVarGetInteger(cvarName, options.defaultValue);
         if (Checkbox(label, &value, options)) {
             CVarSetInteger(cvarName, value);
-            LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
+            Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
             dirty = true;
         }
         return dirty;
@@ -277,7 +277,7 @@ namespace UIWidgets {
             if (Button("-", { .color = options.color, .size = Sizes::Inline }) && *value > min) {
                 *value -= options.step;
                 if (*value < min) *value = min;
-                LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
+                Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
                 dirty = true;
             }
             ImGui::SameLine(0, 3.0f);
@@ -286,7 +286,7 @@ namespace UIWidgets {
             ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
         }
         if (ImGui::SliderScalar(invisibleLabel, ImGuiDataType_S32, value, &min, &max, options.format, options.flags)) {
-            LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
+            Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
             dirty = true;
         }
         if (options.showButtons) {
@@ -295,7 +295,7 @@ namespace UIWidgets {
             if (Button("+", { .color = options.color, .size = Sizes::Inline }) && *value < max) {
                 *value += options.step;
                 if (*value > max) *value = max;
-                LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
+                Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
                 dirty = true;
             }
         }
@@ -316,7 +316,7 @@ namespace UIWidgets {
         int32_t value = CVarGetInteger(cvarName, defaultValue);
         if (SliderInt(label, &value, min, max, options)) {
             CVarSetInteger(cvarName, value);
-            LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
+            Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
             dirty = true;
         }
         return dirty;
@@ -348,7 +348,7 @@ namespace UIWidgets {
             if (Button("-", { .color = options.color, .size = Sizes::Inline }) && *value > min) {
                 *value -= options.step;
                 if (*value < min) *value = min;
-                LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
+                Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
                 dirty = true;
             }
             ImGui::SameLine(0, 3.0f);
@@ -358,7 +358,7 @@ namespace UIWidgets {
         }
         if (ImGui::SliderScalar(invisibleLabel, ImGuiDataType_Float, &valueToDisplay, &minToDisplay, &maxToDisplay, options.format, options.flags)) {
             *value = options.isPercentage ? valueToDisplay / 100.0f : valueToDisplay;
-            LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
+            Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
             dirty = true;
         }
         if (options.showButtons) {
@@ -367,7 +367,7 @@ namespace UIWidgets {
             if (Button("+", { .color = options.color, .size = Sizes::Inline }) && *value < max) {
                 *value += options.step;
                 if (*value > max) *value = max;
-                LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
+                Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
                 dirty = true;
             }
         }
@@ -388,7 +388,7 @@ namespace UIWidgets {
         float value = CVarGetFloat(cvarName, defaultValue);
         if (SliderFloat(label, &value, min, max, options)) {
             CVarSetFloat(cvarName, value);
-            LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
+            Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
             dirty = true;
         }
         return dirty;
@@ -405,7 +405,7 @@ namespace UIWidgets {
             color.b = (uint8_t)(colorVec.z * 255.0f);
             color.a = (uint8_t)(colorVec.w * 255.0f);
             CVarSetColor(cvarName, color);
-            LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
+            Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
             changed = true;
         }
         PopStyleCombobox();

--- a/mm/2s2h/BenGui/UIWidgets.hpp
+++ b/mm/2s2h/BenGui/UIWidgets.hpp
@@ -83,7 +83,7 @@ namespace UIWidgets {
     void PushStyleButton(const ImVec4& color = Colors::Gray);
     void PopStyleButton();
     bool Button(const char* label, const ButtonOptions& options = {});
-    bool WindowButton(const char* label, const char* cvarName, std::shared_ptr<LUS::GuiWindow> windowPtr, const ButtonOptions& options = {});
+    bool WindowButton(const char* label, const char* cvarName, std::shared_ptr<Ship::GuiWindow> windowPtr, const ButtonOptions& options = {});
 
     struct CheckboxOptions {
         const ImVec4 color = Colors::Indigo;
@@ -346,7 +346,7 @@ namespace UIWidgets {
         int32_t value = CVarGetInteger(cvarName, options.defaultIndex);
         if (Combobox<T>(label, &value, comboMap, options)) {
             CVarSetInteger(cvarName, value);
-            LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
+            Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
             dirty = true;
         }
         return dirty;
@@ -358,7 +358,7 @@ namespace UIWidgets {
         int32_t value = CVarGetInteger(cvarName, options.defaultIndex);
         if (Combobox<T>(label, &value, comboVector, options)) {
             CVarSetInteger(cvarName, value);
-            LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
+            Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
             dirty = true;
         }
         return dirty;
@@ -370,7 +370,7 @@ namespace UIWidgets {
         int32_t value = CVarGetInteger(cvarName, options.defaultIndex);
         if (Combobox<T>(label, &value, comboArray, options)) {
             CVarSetInteger(cvarName, value);
-            LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
+            Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
             dirty = true;
         }
         return dirty;

--- a/mm/2s2h/BenGui/UIWidgets.hpp
+++ b/mm/2s2h/BenGui/UIWidgets.hpp
@@ -6,7 +6,7 @@
 #include <span>
 #include <stdint.h>
 #define IMGUI_DEFINE_MATH_OPERATORS
-#include <ImGui/imgui.h>
+#include <imgui.h>
 #include <libultraship/libultraship.h>
 #include <unordered_map>
 

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -61,7 +61,13 @@ CrowdControl* CrowdControl::Instance;
 #include "2s2h/DeveloperTools/DeveloperTools.h"
 
 // Resource Types/Factories
-#include "2s2h/resource//type/2shResourceType.h"
+#include "resource/type/Array.h"
+#include "resource/type/Blob.h"
+#include "resource/type/DisplayList.h"
+#include "resource/type/Matrix.h"
+#include "resource/type/Texture.h"
+#include "resource/type/Vertex.h"
+#include "2s2h/resource/type/2shResourceType.h"
 #include "2s2h/resource/type/Animation.h"
 #include "2s2h/resource/type/AudioSample.h"
 #include "2s2h/resource/type/AudioSequence.h"
@@ -73,6 +79,12 @@ CrowdControl* CrowdControl::Instance;
 #include "2s2h/resource/type/Scene.h"
 #include "2s2h/resource/type/Skeleton.h"
 #include "2s2h/resource/type/SkeletonLimb.h"
+#include "resource/factory/ArrayFactory.h"
+#include "resource/factory/BlobFactory.h"
+#include "resource/factory/DisplayListFactory.h"
+#include "resource/factory/MatrixFactory.h"
+#include "resource/factory/TextureFactory.h"
+#include "resource/factory/VertexFactory.h"
 #include "2s2h/resource/importer/AnimationFactory.h"
 #include "2s2h/resource/importer/AudioSampleFactory.h"
 #include "2s2h/resource/importer/AudioSequenceFactory.h"
@@ -143,6 +155,24 @@ OTRGlobals::OTRGlobals() {
     overlay->SetCurrentFont(CVarGetString("gOverlayFont", "Press Start 2P"));
 
     auto loader = context->GetResourceManager()->GetResourceLoader();
+    loader->RegisterResourceFactory(std::make_shared<LUS::ResourceFactoryBinaryTextureV0>(), RESOURCE_FORMAT_BINARY,
+                                    "Texture", static_cast<uint32_t>(LUS::ResourceType::Texture), 0);
+    loader->RegisterResourceFactory(std::make_shared<LUS::ResourceFactoryBinaryTextureV1>(), RESOURCE_FORMAT_BINARY,
+                                    "Texture", static_cast<uint32_t>(LUS::ResourceType::Texture), 1);
+    loader->RegisterResourceFactory(std::make_shared<LUS::ResourceFactoryBinaryVertexV0>(), RESOURCE_FORMAT_BINARY,
+                                    "Vertex", static_cast<uint32_t>(LUS::ResourceType::Vertex), 0);
+    loader->RegisterResourceFactory(std::make_shared<LUS::ResourceFactoryXMLVertexV0>(), RESOURCE_FORMAT_XML, "Vertex",
+                                    static_cast<uint32_t>(LUS::ResourceType::Vertex), 0);
+    loader->RegisterResourceFactory(std::make_shared<LUS::ResourceFactoryBinaryDisplayListV0>(), RESOURCE_FORMAT_BINARY,
+                                    "DisplayList", static_cast<uint32_t>(LUS::ResourceType::DisplayList), 0);
+    loader->RegisterResourceFactory(std::make_shared<LUS::ResourceFactoryXMLDisplayListV0>(), RESOURCE_FORMAT_XML,
+                                    "DisplayList", static_cast<uint32_t>(LUS::ResourceType::DisplayList), 0);
+    loader->RegisterResourceFactory(std::make_shared<LUS::ResourceFactoryBinaryMatrixV0>(), RESOURCE_FORMAT_BINARY,
+                                    "Matrix", static_cast<uint32_t>(LUS::ResourceType::Matrix), 0);
+    loader->RegisterResourceFactory(std::make_shared<LUS::ResourceFactoryBinaryArrayV0>(), RESOURCE_FORMAT_BINARY,
+                                    "Array", static_cast<uint32_t>(LUS::ResourceType::Array), 0);
+    loader->RegisterResourceFactory(std::make_shared<LUS::ResourceFactoryBinaryBlobV0>(), RESOURCE_FORMAT_BINARY,
+                                    "Blob", static_cast<uint32_t>(LUS::ResourceType::Blob), 0);
     loader->RegisterResourceFactory(std::make_shared<SOH::ResourceFactoryBinaryAnimationV0>(), RESOURCE_FORMAT_BINARY,
                                     "Animation", static_cast<uint32_t>(SOH::ResourceType::SOH_Animation), 0);
     loader->RegisterResourceFactory(std::make_shared<SOH::ResourceFactoryBinaryPlayerAnimationV0>(),

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -29,7 +29,7 @@
 #include "variables.h"
 #include "z64.h"
 #include "macros.h"
-#include <Utils/StringHelper.h>
+#include <utils/StringHelper.h>
 #include <nlohmann/json.hpp>
 
 #include <Fast3D/gfx_pc.h>

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -102,19 +102,19 @@ Color_RGB8 zoraColor = { 0x00, 0xEC, 0x64 };
 
 OTRGlobals::OTRGlobals() {
     std::vector<std::string> OTRFiles;
-    //std::string mqPath = LUS::Context::LocateFileAcrossAppDirs("oot-mq.otr", appShortName);
+    //std::string mqPath = Ship::Context::LocateFileAcrossAppDirs("oot-mq.otr", appShortName);
     //if (std::filesystem::exists(mqPath)) {
     //    OTRFiles.push_back(mqPath);
     //}
-    std::string ootPath = LUS::Context::LocateFileAcrossAppDirs("mm.otr", appShortName);
+    std::string ootPath = Ship::Context::LocateFileAcrossAppDirs("mm.otr", appShortName);
     if (std::filesystem::exists(ootPath)) {
         OTRFiles.push_back(ootPath);
     }
-    std::string sohOtrPath = LUS::Context::GetPathRelativeToAppBundle("soh.otr");
+    std::string sohOtrPath = Ship::Context::GetPathRelativeToAppBundle("soh.otr");
     if (std::filesystem::exists(sohOtrPath)) {
         OTRFiles.push_back(sohOtrPath);
     }
-    std::string patchesPath = LUS::Context::LocateFileAcrossAppDirs("mods", appShortName);
+    std::string patchesPath = Ship::Context::LocateFileAcrossAppDirs("mods", appShortName);
     if (patchesPath.length() > 0 && std::filesystem::exists(patchesPath)) {
         if (std::filesystem::is_directory(patchesPath)) {
             for (const auto& p : std::filesystem::recursive_directory_iterator(patchesPath)) {
@@ -129,18 +129,18 @@ OTRGlobals::OTRGlobals() {
                                                  OOT_PAL_11,     OOT_NTSC_JP_GC_CE, OOT_NTSC_JP_GC, OOT_NTSC_US_GC,
                                                  OOT_PAL_GC,     OOT_PAL_GC_DBG1,   OOT_PAL_GC_DBG2 };
     // tell LUS to reserve 3 SoH specific threads (Game, Audio, Save)
-    context = LUS::Context::CreateInstance("2 Ship 2 Harkinian", appShortName, "shipofharkinian.json", OTRFiles, {}, 3);
+    context = Ship::Context::CreateInstance("2 Ship 2 Harkinian", appShortName, "shipofharkinian.json", OTRFiles, {}, 3);
 
     // Override LUS defaults
-    LUS::Context::GetInstance()->GetLogger()->set_level((spdlog::level::level_enum)CVarGetInteger("gDeveloperTools.LogLevel", 1));
-    LUS::Context::GetInstance()->GetLogger()->set_pattern("[%H:%M:%S.%e] [%s:%#] [%l] %v");
+    Ship::Context::GetInstance()->GetLogger()->set_level((spdlog::level::level_enum)CVarGetInteger("gDeveloperTools.LogLevel", 1));
+    Ship::Context::GetInstance()->GetLogger()->set_pattern("[%H:%M:%S.%e] [%s:%#] [%l] %v");
 
-    //context = LUS::Context::CreateUninitializedInstance("Ship of Harkinian", appShortName, "shipofharkinian.json");
+    //context = Ship::Context::CreateUninitializedInstance("Ship of Harkinian", appShortName, "shipofharkinian.json");
 
     auto overlay = context->GetInstance()->GetWindow()->GetGui()->GetGameOverlay();
     overlay->LoadFont("Press Start 2P", "fonts/PressStart2P-Regular.ttf", 12.0f);
     overlay->LoadFont("Fipps", "fonts/Fipps-Regular.otf", 32.0f);
-    overlay->SetCurrentFont(CVarGetString(CVAR_GAME_OVERLAY_FONT, "Press Start 2P"));
+    overlay->SetCurrentFont(CVarGetString("gOverlayFont", "Press Start 2P"));
 
     auto loader = context->GetResourceManager()->GetResourceLoader();
     loader->RegisterResourceFactory(std::make_shared<SOH::ResourceFactoryBinaryAnimationV0>(), RESOURCE_FORMAT_BINARY,
@@ -204,7 +204,7 @@ OTRGlobals::OTRGlobals() {
 #if defined(__SWITCH__)
             SPDLOG_ERROR("Invalid OTR File!");
 #elif defined(__WIIU__)
-            LUS::WiiU::ThrowInvalidOTR();
+            Ship::WiiU::ThrowInvalidOTR();
 #else
             SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Invalid OTR File",
                                      "Attempted to load an invalid OTR file. Try regenerating.", nullptr);
@@ -251,15 +251,15 @@ bool OTRGlobals::HasOriginal() {
 }
 
 uint32_t OTRGlobals::GetInterpolationFPS() {
-    if (LUS::Context::GetInstance()->GetWindow()->GetWindowBackend() == LUS::WindowBackend::DX11) {
+    if (Ship::Context::GetInstance()->GetWindow()->GetWindowBackend() == Ship::WindowBackend::DX11) {
         return CVarGetInteger("gInterpolationFPS", 20);
     }
 
     if (CVarGetInteger("gMatchRefreshRate", 0)) {
-        return LUS::Context::GetInstance()->GetWindow()->GetCurrentRefreshRate();
+        return Ship::Context::GetInstance()->GetWindow()->GetCurrentRefreshRate();
     }
 
-    return std::min<uint32_t>(LUS::Context::GetInstance()->GetWindow()->GetCurrentRefreshRate(),
+    return std::min<uint32_t>(Ship::Context::GetInstance()->GetWindow()->GetCurrentRefreshRate(),
                               CVarGetInteger("gInterpolationFPS", 20));
 }
 
@@ -358,7 +358,7 @@ extern "C" void OTRAudio_Exit() {
 }
 
 extern "C" void OTRExtScanner() {
-    auto lst = *LUS::Context::GetInstance()->GetResourceManager()->GetArchiveManager()->ListFiles("*").get();
+    auto lst = *Ship::Context::GetInstance()->GetResourceManager()->GetArchiveManager()->ListFiles("*").get();
 
     for (auto& rPath : lst) {
         std::vector<std::string> raw = StringHelper::Split(rPath, ".");
@@ -372,8 +372,8 @@ extern "C" void OTRExtScanner() {
 
 extern "C" void InitOTR() {
 #if not defined(__SWITCH__) && not defined(__WIIU__)
-    if (!std::filesystem::exists(LUS::Context::LocateFileAcrossAppDirs("mm.otr", appShortName))) {
-        std::string installPath = LUS::Context::GetAppBundlePath();
+    if (!std::filesystem::exists(Ship::Context::LocateFileAcrossAppDirs("mm.otr", appShortName))) {
+        std::string installPath = Ship::Context::GetAppBundlePath();
         if (!std::filesystem::exists(installPath + "/assets/extractor")) {
             Extractor::ShowErrorBox(
                 "Extractor assets not found",
@@ -388,7 +388,7 @@ extern "C" void InitOTR() {
                 Extractor::ShowErrorBox("Error", "An error occured, no OTR file was generated. Exiting...");
                 exit(1);
             }
-            extract.CallZapd(installPath, LUS::Context::GetAppDirectoryPath(appShortName));
+            extract.CallZapd(installPath, Ship::Context::GetAppDirectoryPath(appShortName));
             generatedOtrIsMQ = extract.IsMasterQuest();
         } else {
             exit(1);
@@ -397,9 +397,9 @@ extern "C" void InitOTR() {
 #endif
 
 #ifdef __SWITCH__
-    LUS::Switch::Init(LUS::PreInitPhase);
+    Ship::Switch::Init(Ship::PreInitPhase);
 #elif defined(__WIIU__)
-    LUS::WiiU::Init("soh");
+    Ship::WiiU::Init("soh");
 #endif
 
     OTRGlobals::Instance = new OTRGlobals();
@@ -433,7 +433,7 @@ extern "C" void InitOTR() {
     }
 #endif
 
-    std::shared_ptr<LUS::Config> conf = OTRGlobals::Instance->context->GetConfig();
+    std::shared_ptr<Ship::Config> conf = OTRGlobals::Instance->context->GetConfig();
 
 }
 
@@ -504,7 +504,7 @@ extern bool ShouldClearTextureCacheAtEndOfFrame;
 
 extern "C" void Graph_StartFrame() {
 #ifndef __WIIU__
-    using LUS::KbScancode;
+    using Ship::KbScancode;
     int32_t dwScancode = OTRGlobals::Instance->context->GetWindow()->GetLastScancode();
     OTRGlobals::Instance->context->GetWindow()->SetLastScancode(-1);
 
@@ -512,7 +512,7 @@ extern "C" void Graph_StartFrame() {
         #if 0
         case KbScancode::LUS_KB_F5: {
             if (CVarGetInteger("gSaveStatesEnabled", 0) == 0) {
-                LUS::Context::GetInstance()->GetWindow()->GetGui()->GetGameOverlay()->TextDrawNotification(
+                Ship::Context::GetInstance()->GetWindow()->GetGui()->GetGameOverlay()->TextDrawNotification(
                     6.0f, true, "Save states not enabled. Check Cheats Menu.");
                 return;
             }
@@ -533,7 +533,7 @@ extern "C" void Graph_StartFrame() {
         }
         case KbScancode::LUS_KB_F6: {
             if (CVarGetInteger("gSaveStatesEnabled", 0) == 0) {
-                LUS::Context::GetInstance()->GetWindow()->GetGui()->GetGameOverlay()->TextDrawNotification(
+                Ship::Context::GetInstance()->GetWindow()->GetGui()->GetGameOverlay()->TextDrawNotification(
                     6.0f, true, "Save states not enabled. Check Cheats Menu.");
                 return;
             }
@@ -548,7 +548,7 @@ extern "C" void Graph_StartFrame() {
         }
         case KbScancode::LUS_KB_F7: {
             if (CVarGetInteger("gSaveStatesEnabled", 0) == 0) {
-                LUS::Context::GetInstance()->GetWindow()->GetGui()->GetGameOverlay()->TextDrawNotification(
+                Ship::Context::GetInstance()->GetWindow()->GetGui()->GetGameOverlay()->TextDrawNotification(
                     6.0f, true, "Save states not enabled. Check Cheats Menu.");
                 return;
             }
@@ -664,7 +664,7 @@ extern "C" void Graph_ProcessGfxCommands(Gfx* commands) {
     //
     //if (ShouldClearTextureCacheAtEndOfFrame) {
     //    gfx_texture_cache_clear();
-    //    LUS::SkeletonPatcher::UpdateSkeletons();
+    //    Ship::SkeletonPatcher::UpdateSkeletons();
     //    ShouldClearTextureCacheAtEndOfFrame = false;
     //}
 
@@ -689,15 +689,15 @@ extern "C" uint16_t OTRGetPixelDepth(float x, float y) {
 }
 
 extern "C" uint32_t ResourceMgr_GetNumGameVersions() {
-    return LUS::Context::GetInstance()->GetResourceManager()->GetArchiveManager()->GetGameVersions().size();
+    return Ship::Context::GetInstance()->GetResourceManager()->GetArchiveManager()->GetGameVersions().size();
 }
 
 extern "C" uint32_t ResourceMgr_GetGameVersion(int index) {
-    return LUS::Context::GetInstance()->GetResourceManager()->GetArchiveManager()->GetGameVersions()[index];
+    return Ship::Context::GetInstance()->GetResourceManager()->GetArchiveManager()->GetGameVersions()[index];
 }
 
 extern "C" uint32_t ResourceMgr_GetGamePlatform(int index) {
-    uint32_t version = LUS::Context::GetInstance()->GetResourceManager()->GetArchiveManager()->GetGameVersions()[index];
+    uint32_t version = Ship::Context::GetInstance()->GetResourceManager()->GetArchiveManager()->GetGameVersions()[index];
 
     switch (version) {
         case OOT_NTSC_US_10:
@@ -722,7 +722,7 @@ extern "C" uint32_t ResourceMgr_GetGamePlatform(int index) {
 }
 
 extern "C" uint32_t ResourceMgr_GetGameRegion(int index) {
-    uint32_t version = LUS::Context::GetInstance()->GetResourceManager()->GetArchiveManager()->GetGameVersions()[index];
+    uint32_t version = Ship::Context::GetInstance()->GetResourceManager()->GetArchiveManager()->GetGameVersions()[index];
 
     switch (version) {
         case OOT_NTSC_US_10:
@@ -794,16 +794,16 @@ extern "C" uint32_t ResourceMgr_IsGameMasterQuest() {
 }
 
 extern "C" void ResourceMgr_LoadDirectory(const char* resName) {
-    LUS::Context::GetInstance()->GetResourceManager()->LoadDirectory(resName);
+    Ship::Context::GetInstance()->GetResourceManager()->LoadDirectory(resName);
 }
 extern "C" void ResourceMgr_DirtyDirectory(const char* resName) {
-    LUS::Context::GetInstance()->GetResourceManager()->DirtyDirectory(resName);
+    Ship::Context::GetInstance()->GetResourceManager()->DirtyDirectory(resName);
 }
 
 // OTRTODO: There is probably a more elegant way to go about this...
 // Kenix: This is definitely leaking memory when it's called.
 extern "C" char** ResourceMgr_ListFiles(const char* searchMask, int* resultSize) {
-    auto lst = LUS::Context::GetInstance()->GetResourceManager()->GetArchiveManager()->ListFiles(searchMask);
+    auto lst = Ship::Context::GetInstance()->GetResourceManager()->GetArchiveManager()->ListFiles(searchMask);
     char** result = (char**)malloc(lst->size() * sizeof(char*));
 
     for (size_t i = 0; i < lst->size(); i++) {
@@ -827,10 +827,10 @@ extern "C" uint8_t ResourceMgr_FileExists(const char* filePath) {
 }
 
 extern "C" void ResourceMgr_LoadFile(const char* resName) {
-    LUS::Context::GetInstance()->GetResourceManager()->LoadResource(resName);
+    Ship::Context::GetInstance()->GetResourceManager()->LoadResource(resName);
 }
 
-std::shared_ptr<LUS::IResource> GetResourceByNameHandlingMQ(const char* path) {
+std::shared_ptr<Ship::IResource> GetResourceByNameHandlingMQ(const char* path) {
     std::string Path = path;
     if (ResourceMgr_IsGameMasterQuest()) {
         size_t pos = 0;
@@ -838,7 +838,7 @@ std::shared_ptr<LUS::IResource> GetResourceByNameHandlingMQ(const char* path) {
             Path.replace(pos, 7, "/mq/");
         }
     }
-    return LUS::Context::GetInstance()->GetResourceManager()->LoadResource(Path.c_str());
+    return Ship::Context::GetInstance()->GetResourceManager()->LoadResource(Path.c_str());
 }
 
 extern "C" char* GetResourceDataByNameHandlingMQ(const char* path) {
@@ -962,7 +962,7 @@ std::unordered_map<std::string, std::unordered_map<std::string, GfxPatch>> origi
 // using OTRs instead (When that is available). Index can be found using the commented out section below.
 extern "C" void ResourceMgr_PatchGfxByName(const char* path, const char* patchName, int index, Gfx instruction) {
     auto res = std::static_pointer_cast<LUS::DisplayList>(
-        LUS::Context::GetInstance()->GetResourceManager()->LoadResource(path));
+        Ship::Context::GetInstance()->GetResourceManager()->LoadResource(path));
 
     // Leaving this here for people attempting to find the correct Dlist index to patch
     /*if (strcmp("__OTR__objects/object_gi_longsword/gGiBiggoronSwordDL", path) == 0) {
@@ -1000,7 +1000,7 @@ extern "C" void ResourceMgr_PatchGfxByName(const char* path, const char* patchNa
 extern "C" void ResourceMgr_PatchGfxCopyCommandByName(const char* path, const char* patchName, int destinationIndex,
                                                       int sourceIndex) {
     auto res = std::static_pointer_cast<LUS::DisplayList>(
-        LUS::Context::GetInstance()->GetResourceManager()->LoadResource(path));
+        Ship::Context::GetInstance()->GetResourceManager()->LoadResource(path));
 
     // Do not patch custom assets as they most likely do not have the same instructions as authentic assets
     if (res->GetInitData()->IsCustom) {
@@ -1020,7 +1020,7 @@ extern "C" void ResourceMgr_PatchGfxCopyCommandByName(const char* path, const ch
 extern "C" void ResourceMgr_UnpatchGfxByName(const char* path, const char* patchName) {
     if (originalGfx.contains(path) && originalGfx[path].contains(patchName)) {
         auto res = std::static_pointer_cast<LUS::DisplayList>(
-            LUS::Context::GetInstance()->GetResourceManager()->LoadResource(path));
+            Ship::Context::GetInstance()->GetResourceManager()->LoadResource(path));
 
         Gfx* gfx = (Gfx*)&res->Instructions[originalGfx[path][patchName].index];
         *gfx = originalGfx[path][patchName].instruction;
@@ -1108,7 +1108,7 @@ extern "C" SoundFontSample* ReadCustomSample(const char* path) {
 
         ExtensionEntry entry = ExtensionCache[path];
 
-        auto sampleRaw = LUS::Context::GetInstance()->GetResourceManager()->LoadFile(entry.path);
+        auto sampleRaw = Ship::Context::GetInstance()->GetResourceManager()->LoadFile(entry.path);
         uint32_t* strem = (uint32_t*)sampleRaw->Buffer.get();
         uint8_t* strem2 = (uint8_t*)strem;
 
@@ -1196,7 +1196,7 @@ extern "C" SkeletonHeader* ResourceMgr_LoadSkeletonByName(const char* path, Skel
     bool isAlt = CVarGetInteger("gAltAssets", 0);
 
     if (isAlt) {
-        pathStr = LUS::IResource::gAltAssetPrefix + pathStr;
+        pathStr = Ship::IResource::gAltAssetPrefix + pathStr;
     }
 
     SkeletonHeader* skelHeader = (SkeletonHeader*)ResourceGetDataByName(pathStr.c_str());
@@ -1210,7 +1210,7 @@ extern "C" SkeletonHeader* ResourceMgr_LoadSkeletonByName(const char* path, Skel
     // Therefore we can take this oppurtunity to take note of the Skeleton that is created...
     if (skelAnime != nullptr) {
         auto stringPath = std::string(path);
-        //LUS::SkeletonPatcher::RegisterSkeleton(stringPath, skelAnime);
+        //Ship::SkeletonPatcher::RegisterSkeleton(stringPath, skelAnime);
     }
 
     return skelHeader;
@@ -1230,9 +1230,9 @@ extern "C" s32* ResourceMgr_LoadCSByName(const char* path) {
     return (s32*)GetResourceDataByNameHandlingMQ(path);
 }
 
-std::filesystem::path GetSaveFile(std::shared_ptr<LUS::Config> Conf) {
+std::filesystem::path GetSaveFile(std::shared_ptr<Ship::Config> Conf) {
     const std::string fileName =
-        Conf->GetString("Game.SaveName", LUS::Context::GetPathRelativeToAppDirectory("oot_save.sav"));
+        Conf->GetString("Game.SaveName", Ship::Context::GetPathRelativeToAppDirectory("oot_save.sav"));
     std::filesystem::path saveFile = std::filesystem::absolute(fileName);
 
     if (!exists(saveFile.parent_path())) {
@@ -1243,13 +1243,13 @@ std::filesystem::path GetSaveFile(std::shared_ptr<LUS::Config> Conf) {
 }
 
 std::filesystem::path GetSaveFile() {
-    const std::shared_ptr<LUS::Config> pConf = OTRGlobals::Instance->context->GetConfig();
+    const std::shared_ptr<Ship::Config> pConf = OTRGlobals::Instance->context->GetConfig();
 
     return GetSaveFile(pConf);
 }
 
 void OTRGlobals::CheckSaveFile(size_t sramSize) const {
-    const std::shared_ptr<LUS::Config> pConf = Instance->context->GetConfig();
+    const std::shared_ptr<Ship::Config> pConf = Instance->context->GetConfig();
 
     std::filesystem::path savePath = GetSaveFile(pConf);
     std::fstream saveFile(savePath, std::fstream::in | std::fstream::out | std::fstream::binary);
@@ -1425,13 +1425,13 @@ Color_RGB8 GetColorForControllerLED() {
 extern "C" void OTRControllerCallback(uint8_t rumble) {
     // We call this every tick, SDL accounts for this use and prevents driver spam
     // https://github.com/libsdl-org/SDL/blob/f17058b562c8a1090c0c996b42982721ace90903/src/joystick/SDL_joystick.c#L1114-L1144
-    LUS::Context::GetInstance()->GetControlDeck()->GetControllerByPort(0)->GetLED()->SetLEDColor(
+    Ship::Context::GetInstance()->GetControlDeck()->GetControllerByPort(0)->GetLED()->SetLEDColor(
         GetColorForControllerLED());
 
-    static std::shared_ptr<LUS::InputEditorWindow> controllerConfigWindow = nullptr;
+    static std::shared_ptr<Ship::InputEditorWindow> controllerConfigWindow = nullptr;
     if (controllerConfigWindow == nullptr) {
-        controllerConfigWindow = std::dynamic_pointer_cast<LUS::InputEditorWindow>(
-            LUS::Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Input Editor"));
+        controllerConfigWindow = std::dynamic_pointer_cast<Ship::InputEditorWindow>(
+            Ship::Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Input Editor"));
     // TODO: Add SoH Controller Config window rumble testing to upstream LUS config window
     //       note: the current implementation may not be desired in LUS, as "true" rumble support
     //             using osMotor calls is planned: https://github.com/Kenix3/libultraship/issues/9
@@ -1441,9 +1441,9 @@ extern "C" void OTRControllerCallback(uint8_t rumble) {
     }
 
     if (rumble) {
-        LUS::Context::GetInstance()->GetControlDeck()->GetControllerByPort(0)->GetRumble()->StartRumble();
+        Ship::Context::GetInstance()->GetControlDeck()->GetControllerByPort(0)->GetRumble()->StartRumble();
     } else {
-        LUS::Context::GetInstance()->GetControlDeck()->GetControllerByPort(0)->GetRumble()->StopRumble();
+        Ship::Context::GetInstance()->GetControlDeck()->GetControllerByPort(0)->GetRumble()->StopRumble();
     }
 }
 
@@ -1550,7 +1550,7 @@ extern "C" void AudioPlayer_Play(const uint8_t* buf, uint32_t len) {
 }
 
 extern "C" int Controller_ShouldRumble(size_t slot) {
-    for (auto [id, mapping] : LUS::Context::GetInstance()
+    for (auto [id, mapping] : Ship::Context::GetInstance()
                                   ->GetControlDeck()
                                   ->GetControllerByPort(static_cast<uint8_t>(slot))
                                   ->GetRumble()
@@ -1585,7 +1585,7 @@ typedef enum FlashSlotFile {
      (GET_NEWF(save, 2) == 'L') && (GET_NEWF(save, 3) == 'D') && \
      (GET_NEWF(save, 4) == 'A') && (GET_NEWF(save, 5) == '3'))
 
-const std::filesystem::path savesFolderPath(LUS::Context::GetPathRelativeToAppDirectory("Save"));
+const std::filesystem::path savesFolderPath(Ship::Context::GetPathRelativeToAppDirectory("Save"));
 
 void WriteSaveFile(std::filesystem::path fileName, nlohmann::json j) {
     const std::filesystem::path filePath = savesFolderPath / fileName;

--- a/mm/2s2h/BenPort.h
+++ b/mm/2s2h/BenPort.h
@@ -25,7 +25,7 @@ class OTRGlobals {
   public:
     static OTRGlobals* Instance;
 
-    std::shared_ptr<LUS::Context> context;
+    std::shared_ptr<Ship::Context> context;
 
     OTRGlobals();
     ~OTRGlobals();

--- a/mm/2s2h/DeveloperTools/ActorViewer.h
+++ b/mm/2s2h/DeveloperTools/ActorViewer.h
@@ -2,7 +2,7 @@
 
 #include <libultraship/libultraship.h>
 
-class ActorViewerWindow : public LUS::GuiWindow {
+class ActorViewerWindow : public Ship::GuiWindow {
     public:
         using GuiWindow::GuiWindow;
 

--- a/mm/2s2h/DeveloperTools/CollisionViewer.cpp
+++ b/mm/2s2h/DeveloperTools/CollisionViewer.cpp
@@ -69,7 +69,7 @@ void CollisionViewerWindow::DrawElement() {
         CVarClear("gCollisionViewer.ATCollisionColor");
         CVarClear("gCollisionViewer.SpecialSurfaceColor");
         CVarClear("gCollisionViewer.InteractableColor");
-        LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
+        Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
     }
 
     ImGui::SeparatorText("Collision Types");

--- a/mm/2s2h/DeveloperTools/CollisionViewer.h
+++ b/mm/2s2h/DeveloperTools/CollisionViewer.h
@@ -11,7 +11,7 @@ void DrawCollisionViewer();
 #ifdef __cplusplus
 }
 
-class CollisionViewerWindow : public LUS::GuiWindow {
+class CollisionViewerWindow : public Ship::GuiWindow {
   public:
     using GuiWindow::GuiWindow;
 

--- a/mm/2s2h/DeveloperTools/DebugConsole.cpp
+++ b/mm/2s2h/DeveloperTools/DebugConsole.cpp
@@ -15,18 +15,18 @@ extern "C" {
 #include "overlays/gamestates/ovl_title/z_title.h"
 }
 
-#define CMD_REGISTER LUS::Context::GetInstance()->GetConsole()->AddCommand
+#define CMD_REGISTER Ship::Context::GetInstance()->GetConsole()->AddCommand
 // TODO: Commands should be using the output passed in.
 #define ERROR_MESSAGE                                                                \
-    std::reinterpret_pointer_cast<LUS::ConsoleWindow>(                               \
-        LUS::Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Console")) \
+    std::reinterpret_pointer_cast<Ship::ConsoleWindow>(                               \
+        Ship::Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Console")) \
         ->SendErrorMessage
 #define INFO_MESSAGE                                                                 \
-    std::reinterpret_pointer_cast<LUS::ConsoleWindow>(                               \
-        LUS::Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Console")) \
+    std::reinterpret_pointer_cast<Ship::ConsoleWindow>(                               \
+        Ship::Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Console")) \
         ->SendInfoMessage
 
-static bool ActorSpawnHandler(std::shared_ptr<LUS::Console> Console, const std::vector<std::string>& args,
+static bool ActorSpawnHandler(std::shared_ptr<Ship::Console> Console, const std::vector<std::string>& args,
                               std::string* output) {
     if ((args.size() != 9) && (args.size() != 3) && (args.size() != 6)) {
         ERROR_MESSAGE("Not enough arguments passed to actorspawn");
@@ -83,7 +83,7 @@ static bool ActorSpawnHandler(std::shared_ptr<LUS::Console> Console, const std::
     return 0;
 }
 
-static bool LoadSceneHandler(std::shared_ptr<LUS::Console> Console, const std::vector<std::string>&,
+static bool LoadSceneHandler(std::shared_ptr<Ship::Console> Console, const std::vector<std::string>&,
                              std::string* output) {
     gSaveContext.respawnFlag = 0;
     gSaveContext.seqId = 0xFF;
@@ -92,7 +92,7 @@ static bool LoadSceneHandler(std::shared_ptr<LUS::Console> Console, const std::v
     return 0;
 }
 
-static bool SetPosHandler(std::shared_ptr<LUS::Console> Console, const std::vector<std::string> args,
+static bool SetPosHandler(std::shared_ptr<Ship::Console> Console, const std::vector<std::string> args,
                           std::string* output) {
     if (gPlayState == nullptr) {
         ERROR_MESSAGE("PlayState == nullptr");
@@ -118,7 +118,7 @@ static bool SetPosHandler(std::shared_ptr<LUS::Console> Console, const std::vect
     return 0;
 }
 
-static bool ResetHandler(std::shared_ptr<LUS::Console> Console, std::vector<std::string> args, std::string* output) {
+static bool ResetHandler(std::shared_ptr<Ship::Console> Console, std::vector<std::string> args, std::string* output) {
     if (gPlayState == nullptr) {
         ERROR_MESSAGE("PlayState == nullptr");
         return 1;
@@ -132,7 +132,7 @@ static bool ResetHandler(std::shared_ptr<LUS::Console> Console, std::vector<std:
     return 0;
 }
 
-static bool BHandler(std::shared_ptr<LUS::Console> Console, const std::vector<std::string>& args, std::string* output) {
+static bool BHandler(std::shared_ptr<Ship::Console> Console, const std::vector<std::string>& args, std::string* output) {
     if (args.size() < 2) {
         ERROR_MESSAGE("[2S2H] Unexpected arguments passed");
         return 1;
@@ -156,7 +156,7 @@ static bool BHandler(std::shared_ptr<LUS::Console> Console, const std::vector<st
     return 0;
 }
 
-static bool GiveItemHandler(std::shared_ptr<LUS::Console> Console, const std::vector<std::string> args,
+static bool GiveItemHandler(std::shared_ptr<Ship::Console> Console, const std::vector<std::string> args,
                             std::string* output) {
     if (args.size() < 2) {
         ERROR_MESSAGE("[2S2H] Unexpected arguments passed");
@@ -191,7 +191,7 @@ static bool GiveItemHandler(std::shared_ptr<LUS::Console> Console, const std::ve
     return 0;
 }
 
-static bool EntranceHandler(std::shared_ptr<LUS::Console> Console, const std::vector<std::string>& args,
+static bool EntranceHandler(std::shared_ptr<Ship::Console> Console, const std::vector<std::string>& args,
                             std::string* output) {
     if (args.size() < 2) {
         ERROR_MESSAGE("[2S2H] Unexpected arguments passed");
@@ -213,7 +213,7 @@ static bool EntranceHandler(std::shared_ptr<LUS::Console> Console, const std::ve
     gSaveContext.nextTransitionType = TRANS_TYPE_INSTANT;
 }
 
-static bool VoidHandler(std::shared_ptr<LUS::Console> Console, const std::vector<std::string>& args,
+static bool VoidHandler(std::shared_ptr<Ship::Console> Console, const std::vector<std::string>& args,
                         std::string* output) {
     if (gPlayState != nullptr) {
         func_80169EFC(&gPlayState->state);
@@ -224,7 +224,7 @@ static bool VoidHandler(std::shared_ptr<LUS::Console> Console, const std::vector
     return 0;
 }
 
-static bool ReloadHandler(std::shared_ptr<LUS::Console> Console, const std::vector<std::string>& args,
+static bool ReloadHandler(std::shared_ptr<Ship::Console> Console, const std::vector<std::string>& args,
                           std::string* output) {
     if (gPlayState != nullptr) {
         gPlayState->nextEntrance = gSaveContext.save.entrance;
@@ -238,7 +238,7 @@ static bool ReloadHandler(std::shared_ptr<LUS::Console> Console, const std::vect
     return 0;
 }
 
-static bool FileSelectHandler(std::shared_ptr<LUS::Console> Console, const std::vector<std::string>& args,
+static bool FileSelectHandler(std::shared_ptr<Ship::Console> Console, const std::vector<std::string>& args,
                               std::string* output) {
     if (gPlayState != nullptr) {
         STOP_GAMESTATE(&gPlayState->state);
@@ -250,9 +250,9 @@ static bool FileSelectHandler(std::shared_ptr<LUS::Console> Console, const std::
     return 0;
 }
 
-static bool QuitHandler(std::shared_ptr<LUS::Console> Console, const std::vector<std::string>& args,
+static bool QuitHandler(std::shared_ptr<Ship::Console> Console, const std::vector<std::string>& args,
                         std::string* output) {
-    LUS::Context::GetInstance()->GetWindow()->Close();
+    Ship::Context::GetInstance()->GetWindow()->Close();
     return 0;
 }
 
@@ -267,30 +267,30 @@ void DebugConsole_Init(void) {
     CMD_REGISTER("reload", { ReloadHandler, "Reloads the current map." });
     CMD_REGISTER("entrance", { EntranceHandler,
                                "Sends player to the entered entrance (hex)",
-                               { { "entrance", LUS::ArgumentType::NUMBER } } });
+                               { { "entrance", Ship::ArgumentType::NUMBER } } });
 
     // Gameplay
     CMD_REGISTER("give_item", { GiveItemHandler,
                                 "Gives an item to the player as if it was given from an actor",
-                                { { "giveItemID", LUS::ArgumentType::NUMBER } } });
+                                { { "giveItemID", Ship::ArgumentType::NUMBER } } });
 
-    CMD_REGISTER("bItem", { BHandler, "Set an item to the B button.", { { "Item ID", LUS::ArgumentType::NUMBER } } });
+    CMD_REGISTER("bItem", { BHandler, "Set an item to the B button.", { { "Item ID", Ship::ArgumentType::NUMBER } } });
 
     CMD_REGISTER("spawn",
                  { ActorSpawnHandler,
                    "Spawn an actor.",
-                   { { "actor id", LUS::ArgumentType::NUMBER },
-                     { "data", LUS::ArgumentType::NUMBER },
-                     { "x", LUS::ArgumentType::NUMBER, true },
-                     { "y", LUS::ArgumentType::NUMBER, true },
-                     { "z", LUS::ArgumentType::NUMBER, true },
-                     { "rx", LUS::ArgumentType::NUMBER, true },
-                     { "ry", LUS::ArgumentType::NUMBER, true },
-                     { "rz", LUS::ArgumentType::NUMBER, true } } });
+                   { { "actor id", Ship::ArgumentType::NUMBER },
+                     { "data", Ship::ArgumentType::NUMBER },
+                     { "x", Ship::ArgumentType::NUMBER, true },
+                     { "y", Ship::ArgumentType::NUMBER, true },
+                     { "z", Ship::ArgumentType::NUMBER, true },
+                     { "rx", Ship::ArgumentType::NUMBER, true },
+                     { "ry", Ship::ArgumentType::NUMBER, true },
+                     { "rz", Ship::ArgumentType::NUMBER, true } } });
 
     CMD_REGISTER("pos", { SetPosHandler,
                           "Sets the position of the player.",
-                          { { "x", LUS::ArgumentType::NUMBER, true },
-                            { "y", LUS::ArgumentType::NUMBER, true },
-                            { "z", LUS::ArgumentType::NUMBER, true } } });
+                          { { "x", Ship::ArgumentType::NUMBER, true },
+                            { "y", Ship::ArgumentType::NUMBER, true },
+                            { "z", Ship::ArgumentType::NUMBER, true } } });
 }

--- a/mm/2s2h/DeveloperTools/EventLog.cpp
+++ b/mm/2s2h/DeveloperTools/EventLog.cpp
@@ -327,7 +327,7 @@ void EventLogWindow::DrawElement() {
                 CVarSetInteger("gEventLog.Filter.OpenText", 0);
                 CVarSetInteger("gEventLog.Filter.ItemGive", 0);
             }
-            LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
+            Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
         }
         g->CurrentItemFlags = backup_item_flags;
 
@@ -356,7 +356,7 @@ void EventLogWindow::DrawElement() {
     s32 maxEntries = CVarGetInteger("gEventLog.MaxEntries", 1000);
     if (ImGui::InputScalar("##maxEntriesInput", ImGuiDataType_S32, &maxEntries)) {
         CVarSetInteger("gEventLog.MaxEntries", MAX(0, maxEntries));
-        LUS::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
+        Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
         TrimEventLog();
     }
     ImGui::PopItemWidth();

--- a/mm/2s2h/DeveloperTools/EventLog.h
+++ b/mm/2s2h/DeveloperTools/EventLog.h
@@ -2,7 +2,7 @@
 
 #include <libultraship/libultraship.h>
 
-class EventLogWindow : public LUS::GuiWindow {
+class EventLogWindow : public Ship::GuiWindow {
     public:
         using GuiWindow::GuiWindow;
 

--- a/mm/2s2h/DeveloperTools/SaveEditor.cpp
+++ b/mm/2s2h/DeveloperTools/SaveEditor.cpp
@@ -483,10 +483,10 @@ void DrawSlot(InventorySlot slot) {
     }
     ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 2.0f);
 
-    ImTextureID textureId = LUS::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName((const char*)gItemIcons[safeItemsForInventorySlot[slot][0]]);
+    ImTextureID textureId = Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName((const char*)gItemIcons[safeItemsForInventorySlot[slot][0]]);
 
     if (currentItemId != ITEM_NONE) {
-        textureId = LUS::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName((const char*)gItemIcons[currentItemId]);
+        textureId = Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName((const char*)gItemIcons[currentItemId]);
     }
 
     if (ImGui::ImageButton(textureId, ImVec2(INV_GRID_ICON_SIZE, INV_GRID_ICON_SIZE), ImVec2(0, 0), ImVec2(1, 1), 0, ImVec4(0, 0, 0, 0), ImVec4(1, 1, 1, currentItemId == ITEM_NONE ? 0.4f : 1.0f))) {
@@ -517,7 +517,7 @@ void DrawSlot(InventorySlot slot) {
                 ImGui::SameLine();
             }
             ItemId id = safeMode ? safeItemsForInventorySlot[selectedInventorySlot][pickerIndex] : static_cast<ItemId>(pickerIndex);
-            if (ImGui::ImageButton(LUS::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName((const char*)gItemIcons[id]), ImVec2(INV_GRID_ICON_SIZE, INV_GRID_ICON_SIZE), ImVec2(0, 0), ImVec2(1, 1), 0)) {
+            if (ImGui::ImageButton(Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName((const char*)gItemIcons[id]), ImVec2(INV_GRID_ICON_SIZE, INV_GRID_ICON_SIZE), ImVec2(0, 0), ImVec2(1, 1), 0)) {
                 gSaveContext.save.saveInfo.inventory.items[selectedInventorySlot] = id;
                 ImGui::CloseCurrentPopup();
             }
@@ -1136,6 +1136,6 @@ void SaveEditorWindow::InitElement() {
 
     for (TexturePtr entry : gItemIcons) {
         const char* path = static_cast<const char*>(entry);
-        LUS::Context::GetInstance()->GetWindow()->GetGui()->LoadGuiTexture(path, path, ImVec4(1, 1, 1, 1));
+        Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadGuiTexture(path, path, ImVec4(1, 1, 1, 1));
     }
 }

--- a/mm/2s2h/DeveloperTools/SaveEditor.h
+++ b/mm/2s2h/DeveloperTools/SaveEditor.h
@@ -2,7 +2,7 @@
 
 #include <libultraship/libultraship.h>
 
-class SaveEditorWindow : public LUS::GuiWindow {
+class SaveEditorWindow : public Ship::GuiWindow {
     public:
         using GuiWindow::GuiWindow;
 

--- a/mm/2s2h/Extractor/Extract.cpp
+++ b/mm/2s2h/Extractor/Extract.cpp
@@ -6,7 +6,7 @@
 #endif
 #include "Extract.h"
 #include "portable-file-dialogs.h"
-#include <Utils/BitConverter.h>
+#include <utils/binarytools/BitConverter.h>
 #include "build.h"
 
 #ifdef unix

--- a/mm/2s2h/resource/importer/AnimationFactory.cpp
+++ b/mm/2s2h/resource/importer/AnimationFactory.cpp
@@ -5,14 +5,14 @@
 #include "spdlog/spdlog.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource>
-ResourceFactoryBinaryAnimationV0::ReadResource(std::shared_ptr<LUS::File> file) {
+std::shared_ptr<Ship::IResource>
+ResourceFactoryBinaryAnimationV0::ReadResource(std::shared_ptr<Ship::File> file) {
     if (!FileHasValidFormatAndReader(file)) {
         return nullptr;
     }
 
     auto animation = std::make_shared<Animation>(file->InitData);
-    auto reader = std::get<std::shared_ptr<LUS::BinaryReader>>(file->Reader);
+    auto reader = std::get<std::shared_ptr<Ship::BinaryReader>>(file->Reader);
 
     AnimationType animType = (AnimationType)reader->ReadUInt32();
     animation->type = animType;
@@ -82,7 +82,7 @@ ResourceFactoryBinaryAnimationV0::ReadResource(std::shared_ptr<LUS::File> file) 
 
         // Read the segment pointer (always 32 bit, doesn't adjust for system pointer size)
         std::string path = reader->ReadString();
-        const auto animData = std::static_pointer_cast<Animation>(LUS::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(path.c_str()));
+        const auto animData = std::static_pointer_cast<Animation>(Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(path.c_str()));
 
         animation->animationData.linkAnimationHeader.segment = animData->GetPointer();
     } else if (animType == AnimationType::Legacy) {

--- a/mm/2s2h/resource/importer/AnimationFactory.h
+++ b/mm/2s2h/resource/importer/AnimationFactory.h
@@ -4,8 +4,8 @@
 #include "ResourceFactoryBinary.h"
 
 namespace SOH {
-class ResourceFactoryBinaryAnimationV0 : public LUS::ResourceFactoryBinary {
+class ResourceFactoryBinaryAnimationV0 : public Ship::ResourceFactoryBinary {
   public:
-    std::shared_ptr<LUS::IResource> ReadResource(std::shared_ptr<LUS::File> file) override;
+    std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::File> file) override;
 };
 }; // namespace LUS

--- a/mm/2s2h/resource/importer/AudioSampleFactory.cpp
+++ b/mm/2s2h/resource/importer/AudioSampleFactory.cpp
@@ -3,13 +3,13 @@
 #include "spdlog/spdlog.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource> ResourceFactoryBinaryAudioSampleV2::ReadResource(std::shared_ptr<LUS::File> file) {
+std::shared_ptr<Ship::IResource> ResourceFactoryBinaryAudioSampleV2::ReadResource(std::shared_ptr<Ship::File> file) {
     if (!FileHasValidFormatAndReader(file)) {
         return nullptr;
     }
 
     auto audioSample = std::make_shared<AudioSample>(file->InitData);
-    auto reader = std::get<std::shared_ptr<LUS::BinaryReader>>(file->Reader);
+    auto reader = std::get<std::shared_ptr<Ship::BinaryReader>>(file->Reader);
 
     audioSample->sample.codec = reader->ReadUByte();
     audioSample->sample.medium = reader->ReadUByte();
@@ -71,7 +71,7 @@ extern "C" SoundFontSample* ReadCustomSample(const char* path) {
 
     ExtensionEntry entry = ExtensionCache[path];
 
-    auto sampleRaw = LUS::Context::GetInstance()->GetResourceManager()->LoadFile(entry.path);
+    auto sampleRaw = Ship::Context::GetInstance()->GetResourceManager()->LoadFile(entry.path);
     uint32_t* strem = (uint32_t*)sampleRaw->Buffer.get();
     uint8_t* strem2 = (uint8_t*)strem;
 

--- a/mm/2s2h/resource/importer/AudioSampleFactory.h
+++ b/mm/2s2h/resource/importer/AudioSampleFactory.h
@@ -4,8 +4,8 @@
 #include "ResourceFactoryBinary.h"
 
 namespace SOH {
-class ResourceFactoryBinaryAudioSampleV2 : public LUS::ResourceFactoryBinary {
+class ResourceFactoryBinaryAudioSampleV2 : public Ship::ResourceFactoryBinary {
   public:
-    std::shared_ptr<LUS::IResource> ReadResource(std::shared_ptr<LUS::File> file) override;
+    std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::File> file) override;
 };
 } // namespace SOH

--- a/mm/2s2h/resource/importer/AudioSequenceFactory.cpp
+++ b/mm/2s2h/resource/importer/AudioSequenceFactory.cpp
@@ -3,13 +3,13 @@
 #include "spdlog/spdlog.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource> ResourceFactoryBinaryAudioSequenceV2::ReadResource(std::shared_ptr<LUS::File> file) {
+std::shared_ptr<Ship::IResource> ResourceFactoryBinaryAudioSequenceV2::ReadResource(std::shared_ptr<Ship::File> file) {
     if (!FileHasValidFormatAndReader(file)) {
         return nullptr;
     }
 
     auto audioSequence = std::make_shared<AudioSequence>(file->InitData);
-    auto reader = std::get<std::shared_ptr<LUS::BinaryReader>>(file->Reader);
+    auto reader = std::get<std::shared_ptr<Ship::BinaryReader>>(file->Reader);
 
     audioSequence->sequence.seqDataSize = reader->ReadInt32();
     audioSequence->sequenceData.reserve(audioSequence->sequence.seqDataSize);

--- a/mm/2s2h/resource/importer/AudioSequenceFactory.h
+++ b/mm/2s2h/resource/importer/AudioSequenceFactory.h
@@ -4,8 +4,8 @@
 #include "ResourceFactoryBinary.h"
 
 namespace SOH {
-class ResourceFactoryBinaryAudioSequenceV2 : public LUS::ResourceFactoryBinary {
+class ResourceFactoryBinaryAudioSequenceV2 : public Ship::ResourceFactoryBinary {
   public:
-    std::shared_ptr<LUS::IResource> ReadResource(std::shared_ptr<LUS::File> file) override;
+    std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::File> file) override;
 };
 } // namespace SOH

--- a/mm/2s2h/resource/importer/AudioSoundFontFactory.cpp
+++ b/mm/2s2h/resource/importer/AudioSoundFontFactory.cpp
@@ -4,13 +4,13 @@
 #include "libultraship/libultraship.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource> ResourceFactoryBinaryAudioSoundFontV2::ReadResource(std::shared_ptr<LUS::File> file) {
+std::shared_ptr<Ship::IResource> ResourceFactoryBinaryAudioSoundFontV2::ReadResource(std::shared_ptr<Ship::File> file) {
     if (!FileHasValidFormatAndReader(file)) {
         return nullptr;
     }
 
     auto audioSoundFont = std::make_shared<AudioSoundFont>(file->InitData);
-    auto reader = std::get<std::shared_ptr<LUS::BinaryReader>>(file->Reader);
+    auto reader = std::get<std::shared_ptr<Ship::BinaryReader>>(file->Reader);
 
     audioSoundFont->soundFont.fntIndex = reader->ReadInt32();
     audioSoundFont->medium = reader->ReadInt8();
@@ -67,7 +67,7 @@ std::shared_ptr<LUS::IResource> ResourceFactoryBinaryAudioSoundFontV2::ReadResou
         if (sampleFileName.empty()) {
             drum.sound.sample = nullptr;
         } else {
-            auto res = LUS::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(sampleFileName.c_str());
+            auto res = Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(sampleFileName.c_str());
             drum.sound.sample = static_cast<Sample*>(res ? res->GetRawPointer() : nullptr);
         }
 
@@ -116,7 +116,7 @@ std::shared_ptr<LUS::IResource> ResourceFactoryBinaryAudioSoundFontV2::ReadResou
             bool hasSampleRef = reader->ReadInt8();
             std::string sampleFileName = reader->ReadString();
             instrument.lowNotesSound.tuning = reader->ReadFloat();
-            auto res = LUS::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(sampleFileName.c_str());
+            auto res = Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(sampleFileName.c_str());
             instrument.lowNotesSound.sample = static_cast<Sample*>(res ? res->GetRawPointer() : nullptr);
         } else {
             instrument.lowNotesSound.sample = nullptr;
@@ -128,7 +128,7 @@ std::shared_ptr<LUS::IResource> ResourceFactoryBinaryAudioSoundFontV2::ReadResou
             bool hasSampleRef = reader->ReadInt8();
             std::string sampleFileName = reader->ReadString();
             instrument.normalNotesSound.tuning = reader->ReadFloat();
-            auto res = LUS::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(sampleFileName.c_str());
+            auto res = Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(sampleFileName.c_str());
             instrument.normalNotesSound.sample = static_cast<Sample*>(res ? res->GetRawPointer() : nullptr);
         } else {
             instrument.normalNotesSound.sample = nullptr;
@@ -140,7 +140,7 @@ std::shared_ptr<LUS::IResource> ResourceFactoryBinaryAudioSoundFontV2::ReadResou
             bool hasSampleRef = reader->ReadInt8();
             std::string sampleFileName = reader->ReadString();
             instrument.highNotesSound.tuning = reader->ReadFloat();
-            auto res = LUS::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(sampleFileName.c_str());
+            auto res = Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(sampleFileName.c_str());
             instrument.highNotesSound.sample = static_cast<Sample*>(res ? res->GetRawPointer() : nullptr);
         } else {
             instrument.highNotesSound.sample = nullptr;
@@ -165,7 +165,7 @@ std::shared_ptr<LUS::IResource> ResourceFactoryBinaryAudioSoundFontV2::ReadResou
             bool hasSampleRef = reader->ReadInt8();
             std::string sampleFileName = reader->ReadString();
             soundEffect.tuning = reader->ReadFloat();
-            auto res = LUS::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(sampleFileName.c_str());
+            auto res = Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(sampleFileName.c_str());
             soundEffect.sample = static_cast<Sample*>(res ? res->GetRawPointer() : nullptr);
         }
         

--- a/mm/2s2h/resource/importer/AudioSoundFontFactory.h
+++ b/mm/2s2h/resource/importer/AudioSoundFontFactory.h
@@ -4,8 +4,8 @@
 #include "ResourceFactoryBinary.h"
 
 namespace SOH {
-class ResourceFactoryBinaryAudioSoundFontV2 : public LUS::ResourceFactoryBinary {
+class ResourceFactoryBinaryAudioSoundFontV2 : public Ship::ResourceFactoryBinary {
   public:
-    std::shared_ptr<LUS::IResource> ReadResource(std::shared_ptr<LUS::File> file) override;
+    std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::File> file) override;
 };
 } // namespace SOH

--- a/mm/2s2h/resource/importer/AudioSoundFontFactory.h.1
+++ b/mm/2s2h/resource/importer/AudioSoundFontFactory.h.1
@@ -4,8 +4,8 @@
 #include "ResourceFactoryBinary.h"
 
 namespace SOH {
-class ResourceFactoryBinaryAudioSoundFontV2 : public LUS::ResourceFactoryBinary {
+class ResourceFactoryBinaryAudioSoundFontV2 : public Ship::ResourceFactoryBinary {
   public:
-    std::shared_ptr<LUS::IResource> ReadResource(std::shared_ptr<LUS::File> file) override;
+    std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::File> file) override;
 };
 } // namespace SOH

--- a/mm/2s2h/resource/importer/BackgroundFactory.cpp
+++ b/mm/2s2h/resource/importer/BackgroundFactory.cpp
@@ -3,13 +3,13 @@
 #include "spdlog/spdlog.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource> ResourceFactoryBinaryBackgroundV0::ReadResource(std::shared_ptr<LUS::File> file) {
+std::shared_ptr<Ship::IResource> ResourceFactoryBinaryBackgroundV0::ReadResource(std::shared_ptr<Ship::File> file) {
     if (!FileHasValidFormatAndReader(file)) {
         return nullptr;
     }
 
     auto background = std::make_shared<Background>(file->InitData);
-    auto reader = std::get<std::shared_ptr<LUS::BinaryReader>>(file->Reader);
+    auto reader = std::get<std::shared_ptr<Ship::BinaryReader>>(file->Reader);
 
     uint32_t dataSize = reader->ReadUInt32();
 

--- a/mm/2s2h/resource/importer/BackgroundFactory.h
+++ b/mm/2s2h/resource/importer/BackgroundFactory.h
@@ -4,8 +4,8 @@
 #include "resource/ResourceFactoryBinary.h"
 
 namespace SOH {
-class ResourceFactoryBinaryBackgroundV0 : public LUS::ResourceFactoryBinary {
+class ResourceFactoryBinaryBackgroundV0 : public Ship::ResourceFactoryBinary {
   public:
-    std::shared_ptr<LUS::IResource> ReadResource(std::shared_ptr<LUS::File> file) override;
+    std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::File> file) override;
 };
 } // namespace SOH

--- a/mm/2s2h/resource/importer/CollisionHeaderFactory.cpp
+++ b/mm/2s2h/resource/importer/CollisionHeaderFactory.cpp
@@ -3,13 +3,13 @@
 #include "spdlog/spdlog.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource> ResourceFactoryBinaryCollisionHeaderV0::ReadResource(std::shared_ptr<LUS::File> file) {
+std::shared_ptr<Ship::IResource> ResourceFactoryBinaryCollisionHeaderV0::ReadResource(std::shared_ptr<Ship::File> file) {
     if (!FileHasValidFormatAndReader(file)) {
         return nullptr;
     }
 
     auto collisionHeader = std::make_shared<CollisionHeader>(file->InitData);
-    auto reader = std::get<std::shared_ptr<LUS::BinaryReader>>(file->Reader);
+    auto reader = std::get<std::shared_ptr<Ship::BinaryReader>>(file->Reader);
 
     collisionHeader->collisionHeaderData.minBounds.x = reader->ReadInt16();
     collisionHeader->collisionHeaderData.minBounds.y = reader->ReadInt16();
@@ -123,7 +123,7 @@ std::shared_ptr<LUS::IResource> ResourceFactoryBinaryCollisionHeaderV0::ReadReso
     return collisionHeader;
 }
 
-std::shared_ptr<LUS::IResource> ResourceFactoryXMLCollisionHeaderV0::ReadResource(std::shared_ptr<LUS::File> file) {
+std::shared_ptr<Ship::IResource> ResourceFactoryXMLCollisionHeaderV0::ReadResource(std::shared_ptr<Ship::File> file) {
     if (!FileHasValidFormatAndReader(file)) {
         return nullptr;
     }

--- a/mm/2s2h/resource/importer/CollisionHeaderFactory.h
+++ b/mm/2s2h/resource/importer/CollisionHeaderFactory.h
@@ -5,13 +5,13 @@
 #include "ResourceFactoryXML.h"
 
 namespace SOH {
-class ResourceFactoryBinaryCollisionHeaderV0 : public LUS::ResourceFactoryBinary {
+class ResourceFactoryBinaryCollisionHeaderV0 : public Ship::ResourceFactoryBinary {
   public:
-    std::shared_ptr<LUS::IResource> ReadResource(std::shared_ptr<LUS::File> file) override;
+    std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::File> file) override;
 };
 
-class ResourceFactoryXMLCollisionHeaderV0 : public LUS::ResourceFactoryXML {
+class ResourceFactoryXMLCollisionHeaderV0 : public Ship::ResourceFactoryXML {
   public:
-    std::shared_ptr<LUS::IResource> ReadResource(std::shared_ptr<LUS::File> file) override;
+    std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::File> file) override;
 };
 } // namespace SOH

--- a/mm/2s2h/resource/importer/CutsceneFactory.cpp
+++ b/mm/2s2h/resource/importer/CutsceneFactory.cpp
@@ -245,19 +245,19 @@ typedef enum {
 
 namespace SOH {
 
-static inline uint32_t read_CMD_BBBB(std::shared_ptr<LUS::BinaryReader> reader) {
+static inline uint32_t read_CMD_BBBB(std::shared_ptr<Ship::BinaryReader> reader) {
     uint32_t v;
     reader->Read((char*)&v, sizeof(uint32_t));
 
     return v;
 }
 
-static inline uint32_t read_CMD_BBH(std::shared_ptr<LUS::BinaryReader> reader) {
+static inline uint32_t read_CMD_BBH(std::shared_ptr<Ship::BinaryReader> reader) {
     uint32_t v;
     reader->Read((char*)&v, sizeof(uint32_t));
 
     // swap the half word to match endianness
-    if (reader->GetEndianness() != LUS::Endianness::Native) {
+    if (reader->GetEndianness() != Ship::Endianness::Native) {
         uint8_t* b = (uint8_t*)&v;
         uint8_t tmp = b[2];
         b[2] = b[3];
@@ -267,12 +267,12 @@ static inline uint32_t read_CMD_BBH(std::shared_ptr<LUS::BinaryReader> reader) {
     return v;
 }
 
-static inline uint32_t read_CMD_HBB(std::shared_ptr<LUS::BinaryReader> reader) {
+static inline uint32_t read_CMD_HBB(std::shared_ptr<Ship::BinaryReader> reader) {
     uint32_t v;
     reader->Read((char*)&v, sizeof(uint32_t));
 
     // swap the half word to match endianness
-    if (reader->GetEndianness() != LUS::Endianness::Native) {
+    if (reader->GetEndianness() != Ship::Endianness::Native) {
         uint8_t* b = (uint8_t*)&v;
         uint8_t tmp = b[0];
         b[0] = b[1];
@@ -282,12 +282,12 @@ static inline uint32_t read_CMD_HBB(std::shared_ptr<LUS::BinaryReader> reader) {
     return v;
 }
 
-static inline uint32_t read_CMD_HH(std::shared_ptr<LUS::BinaryReader> reader) {
+static inline uint32_t read_CMD_HH(std::shared_ptr<Ship::BinaryReader> reader) {
     uint32_t v;
     reader->Read((char*)&v, sizeof(uint32_t));
 
     // swap the half words to match endianness
-    if (reader->GetEndianness() != LUS::Endianness::Native) {
+    if (reader->GetEndianness() != Ship::Endianness::Native) {
         uint8_t* b = (uint8_t*)&v;
         uint8_t tmp = b[0];
         b[0] = b[1];
@@ -300,13 +300,13 @@ static inline uint32_t read_CMD_HH(std::shared_ptr<LUS::BinaryReader> reader) {
     return v;
 }
 
-std::shared_ptr<LUS::IResource> ResourceFactoryBinaryCutsceneV0::ReadResource(std::shared_ptr<LUS::File> file) {
+std::shared_ptr<Ship::IResource> ResourceFactoryBinaryCutsceneV0::ReadResource(std::shared_ptr<Ship::File> file) {
     if (!FileHasValidFormatAndReader(file)) {
         return nullptr;
     }
 
     auto cutscene = std::make_shared<Cutscene>(file->InitData);
-    auto reader = std::get<std::shared_ptr<LUS::BinaryReader>>(file->Reader);
+    auto reader = std::get<std::shared_ptr<Ship::BinaryReader>>(file->Reader);
 
     uint32_t numEntries = reader->ReadUInt32();
     cutscene->commands.reserve(numEntries);
@@ -473,7 +473,7 @@ std::shared_ptr<LUS::IResource> ResourceFactoryBinaryCutsceneV0::ReadResource(st
 }
 
 #if 0
-void LUS::CutsceneFactoryV0::ParseFileBinaryOoT(std::shared_ptr<BinaryReader> reader,
+void Ship::CutsceneFactoryV0::ParseFileBinaryOoT(std::shared_ptr<BinaryReader> reader,
                                                 std::shared_ptr<Cutscene> cutscene) {
     while (true) {
         uint32_t commandId = reader->ReadUInt32();

--- a/mm/2s2h/resource/importer/CutsceneFactory.h
+++ b/mm/2s2h/resource/importer/CutsceneFactory.h
@@ -5,8 +5,8 @@
 
 
 namespace SOH {
-class ResourceFactoryBinaryCutsceneV0 : public LUS::ResourceFactoryBinary {
+class ResourceFactoryBinaryCutsceneV0 : public Ship::ResourceFactoryBinary {
   public:
-    std::shared_ptr<LUS::IResource> ReadResource(std::shared_ptr<LUS::File> file) override;
+    std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::File> file) override;
 };
 }; // namespace LUS

--- a/mm/2s2h/resource/importer/KeyFrameFactory.cpp
+++ b/mm/2s2h/resource/importer/KeyFrameFactory.cpp
@@ -2,7 +2,6 @@
 #include "2s2h/resource/type/KeyFrame.h"
 #include <libultraship/libultraship.h>
 #include "spdlog/spdlog.h"
-#include "../ZAPDTR/ZAPD/ZCKeyFrame.h"
 
 namespace SOH {
 std::shared_ptr<Ship::IResource> ResourceFactoryBinaryKeyFrameSkel::ReadResource(std::shared_ptr<Ship::File> file) {
@@ -15,10 +14,10 @@ std::shared_ptr<Ship::IResource> ResourceFactoryBinaryKeyFrameSkel::ReadResource
 
     skel->skelData.limbCount = reader->ReadUByte();
     skel->skelData.dListCount = reader->ReadUByte();
-    ZKeyframeSkelType skelType = (ZKeyframeSkelType)reader->ReadUByte();
+    KeyframeSkelType skelType = (KeyframeSkelType)reader->ReadUByte();
     uint8_t numLimbs = reader->ReadUByte();
 
-    if (skelType == ZKeyframeSkelType::Normal) {
+    if (skelType == KeyframeSkelType::Normal) {
         KeyFrameStandardLimb* limbs = new KeyFrameStandardLimb[numLimbs];
 
         for (uint32_t i = 0; i < numLimbs; i++) {
@@ -63,10 +62,10 @@ std::shared_ptr<Ship::IResource> ResourceFactoryBinaryKeyFrameAnim::ReadResource
     auto anim = std::make_shared<KeyFrameAnim>(file->InitData);
     auto reader = std::get<std::shared_ptr<Ship::BinaryReader>>(file->Reader);
 
-    const ZKeyframeSkelType skelType = (ZKeyframeSkelType)reader->ReadUByte();
+    const KeyframeSkelType skelType = (KeyframeSkelType)reader->ReadUByte();
     const uint32_t numBitFlags = reader->ReadUInt32();
 
-    if (skelType == ZKeyframeSkelType::Normal) {
+    if (skelType == KeyframeSkelType::Normal) {
         anim->animData.bitFlags = new u8[numBitFlags];
         for (uint32_t i = 0; i < numBitFlags; i++) {
             anim->animData.bitFlags[i] = reader->ReadUByte();

--- a/mm/2s2h/resource/importer/KeyFrameFactory.cpp
+++ b/mm/2s2h/resource/importer/KeyFrameFactory.cpp
@@ -5,13 +5,13 @@
 #include "../ZAPDTR/ZAPD/ZCKeyFrame.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource> ResourceFactoryBinaryKeyFrameSkel::ReadResource(std::shared_ptr<LUS::File> file) {
+std::shared_ptr<Ship::IResource> ResourceFactoryBinaryKeyFrameSkel::ReadResource(std::shared_ptr<Ship::File> file) {
     if (!FileHasValidFormatAndReader(file)) {
         return nullptr;
     }
 
     auto skel = std::make_shared<KeyFrameSkel>(file->InitData);
-    auto reader = std::get<std::shared_ptr<LUS::BinaryReader>>(file->Reader);
+    auto reader = std::get<std::shared_ptr<Ship::BinaryReader>>(file->Reader);
 
     skel->skelData.limbCount = reader->ReadUByte();
     skel->skelData.dListCount = reader->ReadUByte();
@@ -23,7 +23,7 @@ std::shared_ptr<LUS::IResource> ResourceFactoryBinaryKeyFrameSkel::ReadResource(
 
         for (uint32_t i = 0; i < numLimbs; i++) {
             std::string dlStr = reader->ReadString();
-            auto dl = LUS::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(dlStr.c_str());
+            auto dl = Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(dlStr.c_str());
             limbs[i].dList = nullptr;
             if (dl != nullptr) {
                 limbs[i].dList = dl->GetRawPointer();
@@ -40,7 +40,7 @@ std::shared_ptr<LUS::IResource> ResourceFactoryBinaryKeyFrameSkel::ReadResource(
 
         for (uint32_t i = 0; i < numLimbs; i++) {
             std::string dlStr = reader->ReadString();
-            auto dl = LUS::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(dlStr.c_str());
+            auto dl = Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(dlStr.c_str());
             limbs[i].dList = nullptr;
             if (dl != nullptr) {
                 limbs[i].dList = dl->GetRawPointer();
@@ -55,13 +55,13 @@ std::shared_ptr<LUS::IResource> ResourceFactoryBinaryKeyFrameSkel::ReadResource(
     return skel;
 }
 
-std::shared_ptr<LUS::IResource> ResourceFactoryBinaryKeyFrameAnim::ReadResource(std::shared_ptr<LUS::File> file) {
+std::shared_ptr<Ship::IResource> ResourceFactoryBinaryKeyFrameAnim::ReadResource(std::shared_ptr<Ship::File> file) {
     if (!FileHasValidFormatAndReader(file)) {
         return nullptr;
     }
 
     auto anim = std::make_shared<KeyFrameAnim>(file->InitData);
-    auto reader = std::get<std::shared_ptr<LUS::BinaryReader>>(file->Reader);
+    auto reader = std::get<std::shared_ptr<Ship::BinaryReader>>(file->Reader);
 
     const ZKeyframeSkelType skelType = (ZKeyframeSkelType)reader->ReadUByte();
     const uint32_t numBitFlags = reader->ReadUInt32();

--- a/mm/2s2h/resource/importer/KeyFrameFactory.h
+++ b/mm/2s2h/resource/importer/KeyFrameFactory.h
@@ -4,14 +4,14 @@
 #include "ResourceFactoryBinary.h"
 
 namespace SOH {
-class ResourceFactoryBinaryKeyFrameSkel : public LUS::ResourceFactoryBinary {
+class ResourceFactoryBinaryKeyFrameSkel : public Ship::ResourceFactoryBinary {
   public:
-    std::shared_ptr<LUS::IResource> ReadResource(std::shared_ptr<LUS::File> file) override;
+    std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::File> file) override;
 };
 
-class ResourceFactoryBinaryKeyFrameAnim : public LUS::ResourceFactoryBinary {
+class ResourceFactoryBinaryKeyFrameAnim : public Ship::ResourceFactoryBinary {
   public:
-    std::shared_ptr<LUS::IResource> ReadResource(std::shared_ptr<LUS::File> file) override;
+    std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::File> file) override;
 };
 
 };

--- a/mm/2s2h/resource/importer/PathFactory.cpp
+++ b/mm/2s2h/resource/importer/PathFactory.cpp
@@ -3,13 +3,13 @@
 #include "spdlog/spdlog.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource> ResourceFactoryBinaryPathMMV0::ReadResource(std::shared_ptr<LUS::File> file) {
+std::shared_ptr<Ship::IResource> ResourceFactoryBinaryPathMMV0::ReadResource(std::shared_ptr<Ship::File> file) {
     if (!FileHasValidFormatAndReader(file)) {
         return nullptr;
     }
 
     auto path = std::make_shared<PathMM>(file->InitData);
-    auto reader = std::get<std::shared_ptr<LUS::BinaryReader>>(file->Reader);
+    auto reader = std::get<std::shared_ptr<Ship::BinaryReader>>(file->Reader);
 
     path->numPaths = reader->ReadUInt32();
     path->paths.reserve(path->numPaths);

--- a/mm/2s2h/resource/importer/PathFactory.h
+++ b/mm/2s2h/resource/importer/PathFactory.h
@@ -4,8 +4,8 @@
 #include "ResourceFactoryBinary.h"
 
 namespace SOH {
-class ResourceFactoryBinaryPathMMV0 : public LUS::ResourceFactoryBinary {
+class ResourceFactoryBinaryPathMMV0 : public Ship::ResourceFactoryBinary {
   public:
-    std::shared_ptr<LUS::IResource> ReadResource(std::shared_ptr<LUS::File> file) override;
+    std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::File> file) override;
 };
 } // namespace SOH

--- a/mm/2s2h/resource/importer/PlayerAnimationFactory.cpp
+++ b/mm/2s2h/resource/importer/PlayerAnimationFactory.cpp
@@ -3,14 +3,14 @@
 #include "spdlog/spdlog.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource>
-ResourceFactoryBinaryPlayerAnimationV0::ReadResource(std::shared_ptr<LUS::File> file) {
+std::shared_ptr<Ship::IResource>
+ResourceFactoryBinaryPlayerAnimationV0::ReadResource(std::shared_ptr<Ship::File> file) {
     if (!FileHasValidFormatAndReader(file)) {
         return nullptr;
     }
 
     auto playerAnimation = std::make_shared<PlayerAnimation>(file->InitData);
-    auto reader = std::get<std::shared_ptr<LUS::BinaryReader>>(file->Reader);
+    auto reader = std::get<std::shared_ptr<Ship::BinaryReader>>(file->Reader);
 
     uint32_t numEntries = reader->ReadUInt32();
     playerAnimation->limbRotData.reserve(numEntries);

--- a/mm/2s2h/resource/importer/PlayerAnimationFactory.h
+++ b/mm/2s2h/resource/importer/PlayerAnimationFactory.h
@@ -4,8 +4,8 @@
 #include "ResourceFactoryBinary.h"
 
 namespace SOH {
-class ResourceFactoryBinaryPlayerAnimationV0 : public LUS::ResourceFactoryBinary {
+class ResourceFactoryBinaryPlayerAnimationV0 : public Ship::ResourceFactoryBinary {
   public:
-    std::shared_ptr<LUS::IResource> ReadResource(std::shared_ptr<LUS::File> file) override;
+    std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::File> file) override;
 };
 }; // namespace LUS

--- a/mm/2s2h/resource/importer/SceneFactory.cpp
+++ b/mm/2s2h/resource/importer/SceneFactory.cpp
@@ -69,7 +69,7 @@ ResourceFactoryBinarySceneV0::ResourceFactoryBinarySceneV0() {
 }
 
 void ResourceFactoryBinarySceneV0::ParseSceneCommands(std::shared_ptr<Scene> scene,
-                                                      std::shared_ptr<LUS::BinaryReader> reader) {
+                                                      std::shared_ptr<Ship::BinaryReader> reader) {
     uint32_t commandCount = reader->ReadUInt32();
     scene->commands.reserve(commandCount);
 
@@ -79,17 +79,17 @@ void ResourceFactoryBinarySceneV0::ParseSceneCommands(std::shared_ptr<Scene> sce
 }
 
 std::shared_ptr<ISceneCommand>
-ResourceFactoryBinarySceneV0::ParseSceneCommand(std::shared_ptr<Scene> scene, std::shared_ptr<LUS::BinaryReader> reader,
+ResourceFactoryBinarySceneV0::ParseSceneCommand(std::shared_ptr<Scene> scene, std::shared_ptr<Ship::BinaryReader> reader,
                                                 uint32_t index) {
     SceneCommandID cmdID = (SceneCommandID)reader->ReadInt32();
 
-    reader->Seek(-sizeof(int32_t), LUS::SeekOffsetType::Current);
+    reader->Seek(-sizeof(int32_t), Ship::SeekOffsetType::Current);
 
     std::shared_ptr<ISceneCommand> result = nullptr;
     auto commandFactory = ResourceFactoryBinarySceneV0::sceneCommandFactories[cmdID];
 
     if (commandFactory != nullptr) {
-        auto initData = std::make_shared<LUS::ResourceInitData>();
+        auto initData = std::make_shared<Ship::ResourceInitData>();
         initData->Id = scene->GetInitData()->Id;
         initData->Type = static_cast<uint32_t>(ResourceType::SOH_SceneCommand);
         initData->Path = scene->GetInitData()->Path + "/SceneCommand" + std::to_string(index);
@@ -106,13 +106,13 @@ ResourceFactoryBinarySceneV0::ParseSceneCommand(std::shared_ptr<Scene> scene, st
     return result;
 }
 
-std::shared_ptr<LUS::IResource> ResourceFactoryBinarySceneV0::ReadResource(std::shared_ptr<LUS::File> file) {
+std::shared_ptr<Ship::IResource> ResourceFactoryBinarySceneV0::ReadResource(std::shared_ptr<Ship::File> file) {
     if (!FileHasValidFormatAndReader(file)) {
         return nullptr;
     }
 
     auto scene = std::make_shared<Scene>(file->InitData);
-    auto reader = std::get<std::shared_ptr<LUS::BinaryReader>>(file->Reader);
+    auto reader = std::get<std::shared_ptr<Ship::BinaryReader>>(file->Reader);
 
     ParseSceneCommands(scene, reader);
 

--- a/mm/2s2h/resource/importer/SceneFactory.h
+++ b/mm/2s2h/resource/importer/SceneFactory.h
@@ -7,12 +7,12 @@
 #include "ResourceFactoryBinary.h"
 
 namespace SOH {
-class ResourceFactoryBinarySceneV0 : public LUS::ResourceFactoryBinary {
+class ResourceFactoryBinarySceneV0 : public Ship::ResourceFactoryBinary {
   public:
     ResourceFactoryBinarySceneV0();
 
-    std::shared_ptr<LUS::IResource> ReadResource(std::shared_ptr<LUS::File> file) override;
-    void ParseSceneCommands(std::shared_ptr<Scene> scene, std::shared_ptr<LUS::BinaryReader> reader);
+    std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::File> file) override;
+    void ParseSceneCommands(std::shared_ptr<Scene> scene, std::shared_ptr<Ship::BinaryReader> reader);
 
     // Doing something very similar to what we do on the ResourceLoader.
     // Eventually, scene commands should be moved up to the ResourceLoader as well.
@@ -23,6 +23,6 @@ class ResourceFactoryBinarySceneV0 : public LUS::ResourceFactoryBinary {
 
   protected:
     std::shared_ptr<ISceneCommand> ParseSceneCommand(std::shared_ptr<Scene> scene,
-                                                     std::shared_ptr<LUS::BinaryReader> reader, uint32_t index);
+                                                     std::shared_ptr<Ship::BinaryReader> reader, uint32_t index);
 };
 } // namespace SOH

--- a/mm/2s2h/resource/importer/SkeletonFactory.cpp
+++ b/mm/2s2h/resource/importer/SkeletonFactory.cpp
@@ -4,13 +4,13 @@
 #include <libultraship/libultraship.h>
 
 namespace SOH {
-std::shared_ptr<LUS::IResource> ResourceFactoryBinarySkeletonV0::ReadResource(std::shared_ptr<LUS::File> file) {
+std::shared_ptr<Ship::IResource> ResourceFactoryBinarySkeletonV0::ReadResource(std::shared_ptr<Ship::File> file) {
     if (!FileHasValidFormatAndReader(file)) {
         return nullptr;
     }
 
     auto skeleton = std::make_shared<Skeleton>(file->InitData);
-    auto reader = std::get<std::shared_ptr<LUS::BinaryReader>>(file->Reader);
+    auto reader = std::get<std::shared_ptr<Ship::BinaryReader>>(file->Reader);
 
     skeleton->type = (SkeletonType)reader->ReadInt8();
     skeleton->limbType = (LimbType)reader->ReadInt8();
@@ -43,7 +43,7 @@ std::shared_ptr<LUS::IResource> ResourceFactoryBinarySkeletonV0::ReadResource(st
 
     for (size_t i = 0; i < skeleton->limbTable.size(); i++) {
         std::string limbStr = skeleton->limbTable[i];
-        auto limb = LUS::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(limbStr.c_str());
+        auto limb = Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(limbStr.c_str());
         skeleton->skeletonHeaderSegments.push_back(limb ? limb->GetRawPointer() : nullptr);
     }
 
@@ -62,7 +62,7 @@ std::shared_ptr<LUS::IResource> ResourceFactoryBinarySkeletonV0::ReadResource(st
     return skeleton;
 }
 
-std::shared_ptr<LUS::IResource> ResourceFactoryXMLSkeletonV0::ReadResource(std::shared_ptr<LUS::File> file) {
+std::shared_ptr<Ship::IResource> ResourceFactoryXMLSkeletonV0::ReadResource(std::shared_ptr<Ship::File> file) {
     if (!FileHasValidFormatAndReader(file)) {
         return nullptr;
     }
@@ -112,7 +112,7 @@ std::shared_ptr<LUS::IResource> ResourceFactoryXMLSkeletonV0::ReadResource(std::
             std::string limbName = child->Attribute("Path");
             skel->limbTable.push_back(limbName);
 
-            auto limb = LUS::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(limbName.c_str());
+            auto limb = Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(limbName.c_str());
             skel->skeletonHeaderSegments.push_back(limb ? limb->GetRawPointer() : nullptr);
         }
 

--- a/mm/2s2h/resource/importer/SkeletonFactory.h
+++ b/mm/2s2h/resource/importer/SkeletonFactory.h
@@ -5,13 +5,13 @@
 #include "ResourceFactoryXML.h"
 
 namespace SOH {
-class ResourceFactoryBinarySkeletonV0 : public LUS::ResourceFactoryBinary {
+class ResourceFactoryBinarySkeletonV0 : public Ship::ResourceFactoryBinary {
   public:
-    std::shared_ptr<LUS::IResource> ReadResource(std::shared_ptr<LUS::File> file) override;
+    std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::File> file) override;
 };
 
-class ResourceFactoryXMLSkeletonV0 : public LUS::ResourceFactoryXML {
+class ResourceFactoryXMLSkeletonV0 : public Ship::ResourceFactoryXML {
   public:
-    std::shared_ptr<LUS::IResource> ReadResource(std::shared_ptr<LUS::File> file) override;  
+    std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::File> file) override;  
 };
 } // namespace SOH

--- a/mm/2s2h/resource/importer/SkeletonLimbFactory.cpp
+++ b/mm/2s2h/resource/importer/SkeletonLimbFactory.cpp
@@ -4,13 +4,13 @@
 #include "libultraship/libultraship.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource> ResourceFactoryBinarySkeletonLimbV0::ReadResource(std::shared_ptr<LUS::File> file) {
+std::shared_ptr<Ship::IResource> ResourceFactoryBinarySkeletonLimbV0::ReadResource(std::shared_ptr<Ship::File> file) {
     if (!FileHasValidFormatAndReader(file)) {
         return nullptr;
     }
 
     auto skeletonLimb = std::make_shared<SkeletonLimb>(file->InitData);
-    auto reader = std::get<std::shared_ptr<LUS::BinaryReader>>(file->Reader);
+    auto reader = std::get<std::shared_ptr<Ship::BinaryReader>>(file->Reader);
 
     skeletonLimb->limbType = (LimbType)reader->ReadInt8();
     skeletonLimb->skinSegmentType = (ZLimbSkinType)reader->ReadInt8();
@@ -184,7 +184,7 @@ std::shared_ptr<LUS::IResource> ResourceFactoryBinarySkeletonLimbV0::ReadResourc
     return skeletonLimb;
 }
 
-std::shared_ptr<LUS::IResource> ResourceFactoryXMLSkeletonLimbV0::ReadResource(std::shared_ptr<LUS::File> file) {
+std::shared_ptr<Ship::IResource> ResourceFactoryXMLSkeletonLimbV0::ReadResource(std::shared_ptr<Ship::File> file) {
     if (!FileHasValidFormatAndReader(file)) {
         return nullptr;
     }

--- a/mm/2s2h/resource/importer/SkeletonLimbFactory.h
+++ b/mm/2s2h/resource/importer/SkeletonLimbFactory.h
@@ -5,13 +5,13 @@
 #include "ResourceFactoryXML.h"
 
 namespace SOH {
-class ResourceFactoryBinarySkeletonLimbV0 : public LUS::ResourceFactoryBinary {
+class ResourceFactoryBinarySkeletonLimbV0 : public Ship::ResourceFactoryBinary {
   public:
-    std::shared_ptr<LUS::IResource> ReadResource(std::shared_ptr<LUS::File> file) override;
+    std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::File> file) override;
 };
 
-class ResourceFactoryXMLSkeletonLimbV0 : public LUS::ResourceFactoryXML {
+class ResourceFactoryXMLSkeletonLimbV0 : public Ship::ResourceFactoryXML {
   public:
-    std::shared_ptr<LUS::IResource> ReadResource(std::shared_ptr<LUS::File> file) override;  
+    std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::File> file) override;  
 };
 } // namespace SOH

--- a/mm/2s2h/resource/importer/TextMMFactory.cpp
+++ b/mm/2s2h/resource/importer/TextMMFactory.cpp
@@ -3,13 +3,13 @@
 #include "spdlog/spdlog.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource> ResourceFactoryBinaryTextMMV0::ReadResource(std::shared_ptr<LUS::File> file) {
+std::shared_ptr<Ship::IResource> ResourceFactoryBinaryTextMMV0::ReadResource(std::shared_ptr<Ship::File> file) {
     if (!FileHasValidFormatAndReader(file)) {
         return nullptr;
     }
 
     auto text = std::make_shared<TextMM>(file->InitData);
-    auto reader = std::get<std::shared_ptr<LUS::BinaryReader>>(file->Reader);
+    auto reader = std::get<std::shared_ptr<Ship::BinaryReader>>(file->Reader);
 
     const uint32_t msgCount = reader->ReadUInt32();
     text->messages.reserve(msgCount);
@@ -32,7 +32,7 @@ std::shared_ptr<LUS::IResource> ResourceFactoryBinaryTextMMV0::ReadResource(std:
     return text;
 }
 
-std::shared_ptr<LUS::IResource> ResourceFactoryXMLTextMMV0::ReadResource(std::shared_ptr<LUS::File> file) {
+std::shared_ptr<Ship::IResource> ResourceFactoryXMLTextMMV0::ReadResource(std::shared_ptr<Ship::File> file) {
     if (!FileHasValidFormatAndReader(file)) {
         return nullptr;
     }

--- a/mm/2s2h/resource/importer/TextMMFactory.h
+++ b/mm/2s2h/resource/importer/TextMMFactory.h
@@ -5,18 +5,18 @@
 #include "ResourceFactoryXML.h"
 
 namespace SOH {
-class ResourceFactoryBinaryTextMMV0 : public LUS::ResourceFactoryBinary {
+class ResourceFactoryBinaryTextMMV0 : public Ship::ResourceFactoryBinary {
   public:
-    std::shared_ptr<LUS::IResource> ReadResource(std::shared_ptr<LUS::File> file) override;
+    std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::File> file) override;
 };
 
-class ResourceFactoryXMLTextMMV0 : public LUS::ResourceFactoryXML {
+class ResourceFactoryXMLTextMMV0 : public Ship::ResourceFactoryXML {
   public:
-    std::shared_ptr<LUS::IResource> ReadResource(std::shared_ptr<LUS::File> file) override;
+    std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::File> file) override;
 };
 
 #if 0
-class TextMMFactory : public LUS::ResourceFactoryBinary
+class TextMMFactory : public Ship::ResourceFactoryBinary
 {
   public:
     std::shared_ptr<IResource>
@@ -26,4 +26,3 @@ class TextMMFactory : public LUS::ResourceFactoryBinary
 };
 #endif
 }; // namespace LUS
-

--- a/mm/2s2h/resource/importer/TextureAnimationFactory.cpp
+++ b/mm/2s2h/resource/importer/TextureAnimationFactory.cpp
@@ -5,13 +5,13 @@
 
 namespace SOH {
 
-std::shared_ptr<LUS::IResource> ResourceFactoryBinaryTextureAnimationV0::ReadResource(std::shared_ptr<LUS::File> file) {
+std::shared_ptr<Ship::IResource> ResourceFactoryBinaryTextureAnimationV0::ReadResource(std::shared_ptr<Ship::File> file) {
     if (!FileHasValidFormatAndReader(file)) {
         return nullptr;
     }
 
     auto tAnim = std::make_shared<TextureAnimation>(file->InitData);
-    auto reader = std::get<std::shared_ptr<LUS::BinaryReader>>(file->Reader);
+    auto reader = std::get<std::shared_ptr<Ship::BinaryReader>>(file->Reader);
 
     const size_t numEntries = reader->ReadUInt32();
 

--- a/mm/2s2h/resource/importer/TextureAnimationFactory.h
+++ b/mm/2s2h/resource/importer/TextureAnimationFactory.h
@@ -4,9 +4,9 @@
 #include "ResourceFactoryBinary.h"
 
 namespace SOH {
-class ResourceFactoryBinaryTextureAnimationV0 : public LUS::ResourceFactoryBinary {
+class ResourceFactoryBinaryTextureAnimationV0 : public Ship::ResourceFactoryBinary {
   public:
-    std::shared_ptr<LUS::IResource> ReadResource(std::shared_ptr<LUS::File> file) override;
+    std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::File> file) override;
 
 };
 

--- a/mm/2s2h/resource/importer/scenecommand/EndMarkerFactory.cpp
+++ b/mm/2s2h/resource/importer/scenecommand/EndMarkerFactory.cpp
@@ -3,8 +3,8 @@
 #include "spdlog/spdlog.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource>
-EndMarkerFactory::ReadResource(std::shared_ptr<LUS::ResourceInitData> initData, std::shared_ptr<LUS::BinaryReader> reader) {
+std::shared_ptr<Ship::IResource>
+EndMarkerFactory::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData, std::shared_ptr<Ship::BinaryReader> reader) {
     auto endMarker = std::make_shared<EndMarker>(initData);
 
     ReadCommandId(endMarker, reader);

--- a/mm/2s2h/resource/importer/scenecommand/EndMarkerFactory.h
+++ b/mm/2s2h/resource/importer/scenecommand/EndMarkerFactory.h
@@ -5,6 +5,6 @@
 namespace SOH {
 class EndMarkerFactory : public SceneCommandFactoryBinaryV0 {
   public:
-    std::shared_ptr<LUS::IResource> ReadResource(std::shared_ptr<LUS::ResourceInitData> initData, std::shared_ptr<LUS::BinaryReader> reader) override;
+    std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::ResourceInitData> initData, std::shared_ptr<Ship::BinaryReader> reader) override;
 };
 } // namespace SOH

--- a/mm/2s2h/resource/importer/scenecommand/SceneCommandFactory.cpp
+++ b/mm/2s2h/resource/importer/scenecommand/SceneCommandFactory.cpp
@@ -4,7 +4,7 @@
 
 namespace SOH {
 void SceneCommandFactoryBinaryV0::ReadCommandId(std::shared_ptr<SOH::ISceneCommand> command,
-                                                std::shared_ptr<LUS::BinaryReader> reader) {
+                                                std::shared_ptr<Ship::BinaryReader> reader) {
     command->cmdId = (SceneCommandID)reader->ReadInt32();
 }
 }

--- a/mm/2s2h/resource/importer/scenecommand/SceneCommandFactory.h
+++ b/mm/2s2h/resource/importer/scenecommand/SceneCommandFactory.h
@@ -8,10 +8,10 @@
 namespace SOH {
 class SceneCommandFactoryBinaryV0 {
   public:
-    virtual std::shared_ptr<LUS::IResource> ReadResource(std::shared_ptr<LUS::ResourceInitData> initData,
-                                                         std::shared_ptr<LUS::BinaryReader> reader) = 0;
+    virtual std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::ResourceInitData> initData,
+                                                         std::shared_ptr<Ship::BinaryReader> reader) = 0;
 
   protected:
-    void ReadCommandId(std::shared_ptr<ISceneCommand> command, std::shared_ptr<LUS::BinaryReader> reader);
+    void ReadCommandId(std::shared_ptr<ISceneCommand> command, std::shared_ptr<Ship::BinaryReader> reader);
 };
 } // namespace SOH

--- a/mm/2s2h/resource/importer/scenecommand/SetActorCutsceneListFactory.cpp
+++ b/mm/2s2h/resource/importer/scenecommand/SetActorCutsceneListFactory.cpp
@@ -3,8 +3,8 @@
 #include "spdlog/spdlog.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource> SetActorCutsceneListFactory::ReadResource(std::shared_ptr<LUS::ResourceInitData> initData,
-                                                                     std::shared_ptr<LUS::BinaryReader> reader) {
+std::shared_ptr<Ship::IResource> SetActorCutsceneListFactory::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData,
+                                                                     std::shared_ptr<Ship::BinaryReader> reader) {
     auto setActorCsList = std::make_shared<SetActorCutsceneList>(initData);
     ReadCommandId(setActorCsList, reader);
 

--- a/mm/2s2h/resource/importer/scenecommand/SetActorCutsceneListFactory.h
+++ b/mm/2s2h/resource/importer/scenecommand/SetActorCutsceneListFactory.h
@@ -4,7 +4,7 @@
 
 namespace SOH {
 class SetActorCutsceneListFactory : public SceneCommandFactoryBinaryV0 {
-    std::shared_ptr<LUS::IResource> ReadResource(std::shared_ptr<LUS::ResourceInitData> initData,
-                                            std::shared_ptr<LUS::BinaryReader> reader) override;
+    std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::ResourceInitData> initData,
+                                            std::shared_ptr<Ship::BinaryReader> reader) override;
 };
 }

--- a/mm/2s2h/resource/importer/scenecommand/SetActorListFactory.cpp
+++ b/mm/2s2h/resource/importer/scenecommand/SetActorListFactory.cpp
@@ -3,8 +3,8 @@
 #include "spdlog/spdlog.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource>
-SetActorListFactory::ReadResource(std::shared_ptr<LUS::ResourceInitData> initData, std::shared_ptr<LUS::BinaryReader> reader) {
+std::shared_ptr<Ship::IResource>
+SetActorListFactory::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData, std::shared_ptr<Ship::BinaryReader> reader) {
     auto setActorList = std::make_shared<SetActorList>(initData);
 
     ReadCommandId(setActorList, reader);

--- a/mm/2s2h/resource/importer/scenecommand/SetActorListFactory.h
+++ b/mm/2s2h/resource/importer/scenecommand/SetActorListFactory.h
@@ -5,7 +5,7 @@
 namespace SOH {
 class SetActorListFactory : public SceneCommandFactoryBinaryV0 {
   public:
-    std::shared_ptr<LUS::IResource>
-    ReadResource(std::shared_ptr<LUS::ResourceInitData> initData, std::shared_ptr<LUS::BinaryReader> reader) override;
+    std::shared_ptr<Ship::IResource>
+    ReadResource(std::shared_ptr<Ship::ResourceInitData> initData, std::shared_ptr<Ship::BinaryReader> reader) override;
 };
 } // namespace SOH

--- a/mm/2s2h/resource/importer/scenecommand/SetAlternateHeadersFactory.cpp
+++ b/mm/2s2h/resource/importer/scenecommand/SetAlternateHeadersFactory.cpp
@@ -3,8 +3,8 @@
 #include "libultraship/libultraship.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource> SetAlternateHeadersFactory::ReadResource(std::shared_ptr<LUS::ResourceInitData> initData,
-                                                                   std::shared_ptr<LUS::BinaryReader> reader) {
+std::shared_ptr<Ship::IResource> SetAlternateHeadersFactory::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData,
+                                                                   std::shared_ptr<Ship::BinaryReader> reader) {
     auto setAlternateHeaders = std::make_shared<SetAlternateHeaders>(initData);
 
     ReadCommandId(setAlternateHeaders, reader);
@@ -14,7 +14,7 @@ std::shared_ptr<LUS::IResource> SetAlternateHeadersFactory::ReadResource(std::sh
     for (uint32_t i = 0; i < setAlternateHeaders->numHeaders; i++) {
         auto headerName = reader->ReadString();
         if (!headerName.empty()) {
-            setAlternateHeaders->headers.push_back(std::static_pointer_cast<Scene>(LUS::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(headerName.c_str())));
+            setAlternateHeaders->headers.push_back(std::static_pointer_cast<Scene>(Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(headerName.c_str())));
         } else {
             setAlternateHeaders->headers.push_back(nullptr);
         }

--- a/mm/2s2h/resource/importer/scenecommand/SetAlternateHeadersFactory.h
+++ b/mm/2s2h/resource/importer/scenecommand/SetAlternateHeadersFactory.h
@@ -5,7 +5,7 @@
 namespace SOH {
 class SetAlternateHeadersFactory : public SceneCommandFactoryBinaryV0 {
   public:
-    std::shared_ptr<LUS::IResource>
-    ReadResource(std::shared_ptr<LUS::ResourceInitData> initData, std::shared_ptr<LUS::BinaryReader> reader) override;
+    std::shared_ptr<Ship::IResource>
+    ReadResource(std::shared_ptr<Ship::ResourceInitData> initData, std::shared_ptr<Ship::BinaryReader> reader) override;
 };
 } // namespace SOH

--- a/mm/2s2h/resource/importer/scenecommand/SetAnimatedMaterialListFactory.cpp
+++ b/mm/2s2h/resource/importer/scenecommand/SetAnimatedMaterialListFactory.cpp
@@ -5,15 +5,15 @@
 
 namespace SOH {
 
-std::shared_ptr<LUS::IResource> SetAnimatedMaterialListFactory::ReadResource(std::shared_ptr<LUS::ResourceInitData> initData,
-                                                                             std::shared_ptr<LUS::BinaryReader> reader) {
+std::shared_ptr<Ship::IResource> SetAnimatedMaterialListFactory::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData,
+                                                                             std::shared_ptr<Ship::BinaryReader> reader) {
     auto setAnimatedMat = std::make_shared<SetAnimatedMaterialList>(initData);
     
     ReadCommandId(setAnimatedMat, reader);
 
     std::string str = reader->ReadString();
     const auto data = std::static_pointer_cast<TextureAnimation>(
-        LUS::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(str.c_str()));
+        Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(str.c_str()));
 
     AnimatedMaterial* res = data->GetPointer();
     setAnimatedMat->mat = res;

--- a/mm/2s2h/resource/importer/scenecommand/SetAnimatedMaterialListFactory.h
+++ b/mm/2s2h/resource/importer/scenecommand/SetAnimatedMaterialListFactory.h
@@ -5,7 +5,7 @@
 namespace SOH {
 class SetAnimatedMaterialListFactory : public SceneCommandFactoryBinaryV0 {
   public:
-    std::shared_ptr<LUS::IResource> ReadResource(std::shared_ptr<LUS::ResourceInitData> initData,
-                                            std::shared_ptr<LUS::BinaryReader> reader) override;
+    std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::ResourceInitData> initData,
+                                            std::shared_ptr<Ship::BinaryReader> reader) override;
 };
 }

--- a/mm/2s2h/resource/importer/scenecommand/SetCameraSettingsFactory.cpp
+++ b/mm/2s2h/resource/importer/scenecommand/SetCameraSettingsFactory.cpp
@@ -3,8 +3,8 @@
 #include "spdlog/spdlog.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource> SetCameraSettingsFactory::ReadResource(std::shared_ptr<LUS::ResourceInitData> initData,
-                                                                 std::shared_ptr<LUS::BinaryReader> reader) {
+std::shared_ptr<Ship::IResource> SetCameraSettingsFactory::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData,
+                                                                 std::shared_ptr<Ship::BinaryReader> reader) {
     auto setCameraSettings = std::make_shared<SetCameraSettings>(initData);
 
     ReadCommandId(setCameraSettings, reader);

--- a/mm/2s2h/resource/importer/scenecommand/SetCameraSettingsFactory.h
+++ b/mm/2s2h/resource/importer/scenecommand/SetCameraSettingsFactory.h
@@ -5,7 +5,7 @@
 namespace SOH {
 class SetCameraSettingsFactory : public SceneCommandFactoryBinaryV0 {
   public:
-    std::shared_ptr<LUS::IResource>
-    ReadResource(std::shared_ptr<LUS::ResourceInitData> initData, std::shared_ptr<LUS::BinaryReader> reader) override;
+    std::shared_ptr<Ship::IResource>
+    ReadResource(std::shared_ptr<Ship::ResourceInitData> initData, std::shared_ptr<Ship::BinaryReader> reader) override;
 };
 }; // namespace LUS

--- a/mm/2s2h/resource/importer/scenecommand/SetCollisionHeaderFactory.cpp
+++ b/mm/2s2h/resource/importer/scenecommand/SetCollisionHeaderFactory.cpp
@@ -4,14 +4,14 @@
 #include "spdlog/spdlog.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource> SetCollisionHeaderFactory::ReadResource(std::shared_ptr<LUS::ResourceInitData> initData,
-                                                                  std::shared_ptr<LUS::BinaryReader> reader) {
+std::shared_ptr<Ship::IResource> SetCollisionHeaderFactory::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData,
+                                                                  std::shared_ptr<Ship::BinaryReader> reader) {
     auto setCollisionHeader = std::make_shared<SetCollisionHeader>(initData);
 
     ReadCommandId(setCollisionHeader, reader);
     
     setCollisionHeader->fileName = reader->ReadString();
-    setCollisionHeader->collisionHeader = std::static_pointer_cast<CollisionHeader>(LUS::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(setCollisionHeader->fileName.c_str()));
+    setCollisionHeader->collisionHeader = std::static_pointer_cast<CollisionHeader>(Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(setCollisionHeader->fileName.c_str()));
 
     return setCollisionHeader;
 }

--- a/mm/2s2h/resource/importer/scenecommand/SetCollisionHeaderFactory.h
+++ b/mm/2s2h/resource/importer/scenecommand/SetCollisionHeaderFactory.h
@@ -5,7 +5,7 @@
 namespace SOH {
 class SetCollisionHeaderFactory : public SceneCommandFactoryBinaryV0 {
   public:
-    std::shared_ptr<LUS::IResource>
-    ReadResource(std::shared_ptr<LUS::ResourceInitData> initData, std::shared_ptr<LUS::BinaryReader> reader) override;
+    std::shared_ptr<Ship::IResource>
+    ReadResource(std::shared_ptr<Ship::ResourceInitData> initData, std::shared_ptr<Ship::BinaryReader> reader) override;
 };
 } // namespace SOH

--- a/mm/2s2h/resource/importer/scenecommand/SetCsCameraFactory.cpp
+++ b/mm/2s2h/resource/importer/scenecommand/SetCsCameraFactory.cpp
@@ -3,8 +3,8 @@
 #include "spdlog/spdlog.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource>
-SetCsCameraFactory::ReadResource(std::shared_ptr<LUS::ResourceInitData> initData, std::shared_ptr<LUS::BinaryReader> reader) {
+std::shared_ptr<Ship::IResource>
+SetCsCameraFactory::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData, std::shared_ptr<Ship::BinaryReader> reader) {
     auto setCsCamera = std::make_shared<SetCsCamera>(initData);
     
     ReadCommandId(setCsCamera, reader);

--- a/mm/2s2h/resource/importer/scenecommand/SetCsCameraFactory.h
+++ b/mm/2s2h/resource/importer/scenecommand/SetCsCameraFactory.h
@@ -5,7 +5,7 @@
 namespace SOH {
 class SetCsCameraFactory : public SceneCommandFactoryBinaryV0 {
   public:
-    std::shared_ptr<LUS::IResource>
-    ReadResource(std::shared_ptr<LUS::ResourceInitData> initData, std::shared_ptr<LUS::BinaryReader> reader) override;
+    std::shared_ptr<Ship::IResource>
+    ReadResource(std::shared_ptr<Ship::ResourceInitData> initData, std::shared_ptr<Ship::BinaryReader> reader) override;
 };
 }; // namespace LUS

--- a/mm/2s2h/resource/importer/scenecommand/SetCutscenesFactory.cpp
+++ b/mm/2s2h/resource/importer/scenecommand/SetCutscenesFactory.cpp
@@ -4,8 +4,8 @@
 #include "spdlog/spdlog.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource> SetCutsceneFactoryMM::ReadResource(std::shared_ptr<LUS::ResourceInitData> initData,
-                                                             std::shared_ptr<LUS::BinaryReader> reader) {
+std::shared_ptr<Ship::IResource> SetCutsceneFactoryMM::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData,
+                                                             std::shared_ptr<Ship::BinaryReader> reader) {
     auto setCutscenes = std::make_shared<SetCutscenesMM>(initData);
 
     ReadCommandId(setCutscenes, reader);
@@ -20,7 +20,7 @@ std::shared_ptr<LUS::IResource> SetCutsceneFactoryMM::ReadResource(std::shared_p
         entry.entrance = reader->ReadUByte();
         entry.flag = reader->ReadUByte();
         entry.data = std::static_pointer_cast<Cutscene>(
-            LUS::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(path.c_str()))->GetPointer();
+            Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(path.c_str()))->GetPointer();
         setCutscenes->entries.emplace_back(entry);
     }
 

--- a/mm/2s2h/resource/importer/scenecommand/SetCutscenesFactory.h
+++ b/mm/2s2h/resource/importer/scenecommand/SetCutscenesFactory.h
@@ -5,8 +5,8 @@
 namespace SOH {
 class SetCutsceneFactoryMM : public SceneCommandFactoryBinaryV0 {
   public:
-    std::shared_ptr<LUS::IResource> ReadResource(std::shared_ptr<LUS::ResourceInitData> initData,
-                                            std::shared_ptr<LUS::BinaryReader> reader) override;
+    std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::ResourceInitData> initData,
+                                            std::shared_ptr<Ship::BinaryReader> reader) override;
 };
 
 }; // namespace LUS

--- a/mm/2s2h/resource/importer/scenecommand/SetEchoSettingsFactory.cpp
+++ b/mm/2s2h/resource/importer/scenecommand/SetEchoSettingsFactory.cpp
@@ -3,8 +3,8 @@
 #include "spdlog/spdlog.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource>
-SetEchoSettingsFactory::ReadResource(std::shared_ptr<LUS::ResourceInitData> initData, std::shared_ptr<LUS::BinaryReader> reader) {
+std::shared_ptr<Ship::IResource>
+SetEchoSettingsFactory::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData, std::shared_ptr<Ship::BinaryReader> reader) {
     auto setEchoSettings = std::make_shared<SetEchoSettings>(initData);
 
     ReadCommandId(setEchoSettings, reader);

--- a/mm/2s2h/resource/importer/scenecommand/SetEchoSettingsFactory.h
+++ b/mm/2s2h/resource/importer/scenecommand/SetEchoSettingsFactory.h
@@ -5,7 +5,7 @@
 namespace SOH {
 class SetEchoSettingsFactory : public SceneCommandFactoryBinaryV0 {
   public:
-    std::shared_ptr<LUS::IResource>
-    ReadResource(std::shared_ptr<LUS::ResourceInitData> initData, std::shared_ptr<LUS::BinaryReader> reader) override;
+    std::shared_ptr<Ship::IResource>
+    ReadResource(std::shared_ptr<Ship::ResourceInitData> initData, std::shared_ptr<Ship::BinaryReader> reader) override;
 };
 } // namespace SOH

--- a/mm/2s2h/resource/importer/scenecommand/SetEntranceListFactory.cpp
+++ b/mm/2s2h/resource/importer/scenecommand/SetEntranceListFactory.cpp
@@ -3,8 +3,8 @@
 #include "spdlog/spdlog.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource>
-SetEntranceListFactory::ReadResource(std::shared_ptr<LUS::ResourceInitData> initData, std::shared_ptr<LUS::BinaryReader> reader) {
+std::shared_ptr<Ship::IResource>
+SetEntranceListFactory::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData, std::shared_ptr<Ship::BinaryReader> reader) {
     auto setEntranceList = std::make_shared<SetEntranceList>(initData);
 
     ReadCommandId(setEntranceList, reader);

--- a/mm/2s2h/resource/importer/scenecommand/SetEntranceListFactory.h
+++ b/mm/2s2h/resource/importer/scenecommand/SetEntranceListFactory.h
@@ -5,7 +5,7 @@
 namespace SOH {
 class SetEntranceListFactory : public SceneCommandFactoryBinaryV0 {
   public:
-    std::shared_ptr<LUS::IResource>
-    ReadResource(std::shared_ptr<LUS::ResourceInitData> initData, std::shared_ptr<LUS::BinaryReader> reader) override;
+    std::shared_ptr<Ship::IResource>
+    ReadResource(std::shared_ptr<Ship::ResourceInitData> initData, std::shared_ptr<Ship::BinaryReader> reader) override;
 };
 } // namespace SOH

--- a/mm/2s2h/resource/importer/scenecommand/SetExitListFactory.cpp
+++ b/mm/2s2h/resource/importer/scenecommand/SetExitListFactory.cpp
@@ -3,9 +3,9 @@
 #include "spdlog/spdlog.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource>
-SetExitListFactory::ReadResource(std::shared_ptr<LUS::ResourceInitData> initData,
-                                         std::shared_ptr<LUS::BinaryReader> reader) {
+std::shared_ptr<Ship::IResource>
+SetExitListFactory::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData,
+                                         std::shared_ptr<Ship::BinaryReader> reader) {
     auto setExitList = std::make_shared<SetExitList>(initData);
 
     ReadCommandId(setExitList, reader);

--- a/mm/2s2h/resource/importer/scenecommand/SetExitListFactory.h
+++ b/mm/2s2h/resource/importer/scenecommand/SetExitListFactory.h
@@ -5,7 +5,7 @@
 namespace SOH {
 class SetExitListFactory : public SceneCommandFactoryBinaryV0 {
   public:
-    std::shared_ptr<LUS::IResource> ReadResource(std::shared_ptr<LUS::ResourceInitData> initData,
-                                                 std::shared_ptr<LUS::BinaryReader> reader) override;
+    std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::ResourceInitData> initData,
+                                                 std::shared_ptr<Ship::BinaryReader> reader) override;
 };
 } // namespace SOH

--- a/mm/2s2h/resource/importer/scenecommand/SetLightListFactory.cpp
+++ b/mm/2s2h/resource/importer/scenecommand/SetLightListFactory.cpp
@@ -3,8 +3,8 @@
 #include "spdlog/spdlog.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource>
-SetLightListFactory::ReadResource(std::shared_ptr<LUS::ResourceInitData> initData, std::shared_ptr<LUS::BinaryReader> reader) {
+std::shared_ptr<Ship::IResource>
+SetLightListFactory::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData, std::shared_ptr<Ship::BinaryReader> reader) {
     auto setLightList = std::make_shared<SetLightList>(initData);
 
     ReadCommandId(setLightList, reader);

--- a/mm/2s2h/resource/importer/scenecommand/SetLightListFactory.h
+++ b/mm/2s2h/resource/importer/scenecommand/SetLightListFactory.h
@@ -5,7 +5,7 @@
 namespace SOH {
 class SetLightListFactory : public SceneCommandFactoryBinaryV0 {
   public:
-    std::shared_ptr<LUS::IResource>
-    ReadResource(std::shared_ptr<LUS::ResourceInitData> initData, std::shared_ptr<LUS::BinaryReader> reader) override;
+    std::shared_ptr<Ship::IResource>
+    ReadResource(std::shared_ptr<Ship::ResourceInitData> initData, std::shared_ptr<Ship::BinaryReader> reader) override;
 };
 } // namespace SOH

--- a/mm/2s2h/resource/importer/scenecommand/SetLightingSettingsFactory.cpp
+++ b/mm/2s2h/resource/importer/scenecommand/SetLightingSettingsFactory.cpp
@@ -3,9 +3,9 @@
 #include "spdlog/spdlog.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource>
-SetLightingSettingsFactory::ReadResource(std::shared_ptr<LUS::ResourceInitData> initData,
-                                         std::shared_ptr<LUS::BinaryReader> reader) {
+std::shared_ptr<Ship::IResource>
+SetLightingSettingsFactory::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData,
+                                         std::shared_ptr<Ship::BinaryReader> reader) {
     auto setLightingSettings = std::make_shared<SetLightingSettings>(initData);
 
     ReadCommandId(setLightingSettings, reader);

--- a/mm/2s2h/resource/importer/scenecommand/SetLightingSettingsFactory.h
+++ b/mm/2s2h/resource/importer/scenecommand/SetLightingSettingsFactory.h
@@ -5,7 +5,7 @@
 namespace SOH {
 class SetLightingSettingsFactory : public SceneCommandFactoryBinaryV0 {
   public:
-    std::shared_ptr<LUS::IResource> ReadResource(std::shared_ptr<LUS::ResourceInitData> initData,
-                                                 std::shared_ptr<LUS::BinaryReader> reader) override;
+    std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::ResourceInitData> initData,
+                                                 std::shared_ptr<Ship::BinaryReader> reader) override;
 };
 } // namespace SOH

--- a/mm/2s2h/resource/importer/scenecommand/SetMeshFactory.cpp
+++ b/mm/2s2h/resource/importer/scenecommand/SetMeshFactory.cpp
@@ -4,8 +4,8 @@
 #include "libultraship/libultraship.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource>
-SetMeshFactory::ReadResource(std::shared_ptr<LUS::ResourceInitData> initData, std::shared_ptr<LUS::BinaryReader> reader) {
+std::shared_ptr<Ship::IResource>
+SetMeshFactory::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData, std::shared_ptr<Ship::BinaryReader> reader) {
     auto setMesh = std::make_shared<SetMesh>(initData);
 
     ReadCommandId(setMesh, reader);
@@ -41,8 +41,8 @@ SetMeshFactory::ReadResource(std::shared_ptr<LUS::ResourceInitData> initData, st
             std::string meshOpa = reader->ReadString();
             std::string meshXlu = reader->ReadString();
 
-            auto opaRes = LUS::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(meshOpa.c_str());
-            auto xluRes = LUS::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(meshXlu.c_str());
+            auto opaRes = Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(meshOpa.c_str());
+            auto xluRes = Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(meshXlu.c_str());
             dlist.opa = meshOpa != "" ? (Gfx*)(opaRes ? opaRes->GetRawPointer() : nullptr) : 0;
             dlist.xlu = meshXlu != "" ? (Gfx*)(xluRes ? xluRes->GetRawPointer() : nullptr) : 0;
 
@@ -54,8 +54,8 @@ SetMeshFactory::ReadResource(std::shared_ptr<LUS::ResourceInitData> initData, st
             std::string imgOpa = reader->ReadString();
             std::string imgXlu = reader->ReadString();
 
-            auto opaRes = LUS::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(imgOpa.c_str());
-            auto xluRes = LUS::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(imgXlu.c_str());
+            auto opaRes = Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(imgOpa.c_str());
+            auto xluRes = Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(imgXlu.c_str());
             pType.opa = imgOpa != "" ? (Gfx*)(opaRes ? opaRes->GetRawPointer() : nullptr) : 0;
             pType.xlu = imgXlu != "" ? (Gfx*)(xluRes ? xluRes->GetRawPointer() : nullptr) : 0;
 
@@ -103,8 +103,8 @@ SetMeshFactory::ReadResource(std::shared_ptr<LUS::ResourceInitData> initData, st
             std::string meshOpa = reader->ReadString();
             std::string meshXlu = reader->ReadString();
 
-            opaRes = LUS::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(meshOpa.c_str());
-            xluRes = LUS::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(meshXlu.c_str());
+            opaRes = Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(meshOpa.c_str());
+            xluRes = Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(meshXlu.c_str());
             pType.opa = meshOpa != "" ? (Gfx*)(opaRes ? opaRes->GetRawPointer() : nullptr) : 0;
             pType.xlu = meshXlu != "" ? (Gfx*)(xluRes ? xluRes->GetRawPointer() : nullptr) : 0;
 
@@ -121,8 +121,8 @@ SetMeshFactory::ReadResource(std::shared_ptr<LUS::ResourceInitData> initData, st
             std::string meshOpa = reader->ReadString();
             std::string meshXlu = reader->ReadString();
 
-            auto opaRes = LUS::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(meshOpa.c_str());
-            auto xluRes = LUS::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(meshXlu.c_str());
+            auto opaRes = Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(meshOpa.c_str());
+            auto xluRes = Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(meshXlu.c_str());
             dlist.opa = meshOpa != "" ? (Gfx*)(opaRes ? opaRes->GetRawPointer() : nullptr) : 0;
             dlist.xlu = meshXlu != "" ? (Gfx*)(xluRes ? xluRes->GetRawPointer() : nullptr) : 0;
 

--- a/mm/2s2h/resource/importer/scenecommand/SetMeshFactory.h
+++ b/mm/2s2h/resource/importer/scenecommand/SetMeshFactory.h
@@ -5,7 +5,7 @@
 namespace SOH {
 class SetMeshFactory : public SceneCommandFactoryBinaryV0 {
   public:
-    std::shared_ptr<LUS::IResource>
-    ReadResource(std::shared_ptr<LUS::ResourceInitData> initData, std::shared_ptr<LUS::BinaryReader> reader) override;
+    std::shared_ptr<Ship::IResource>
+    ReadResource(std::shared_ptr<Ship::ResourceInitData> initData, std::shared_ptr<Ship::BinaryReader> reader) override;
 };
 } // namespace SOH

--- a/mm/2s2h/resource/importer/scenecommand/SetMinimapChestsFactory.cpp
+++ b/mm/2s2h/resource/importer/scenecommand/SetMinimapChestsFactory.cpp
@@ -4,8 +4,8 @@
 
 namespace SOH {
 
-std::shared_ptr<LUS::IResource> SetMinimapChestsFactory::ReadResource(std::shared_ptr<LUS::ResourceInitData> initData,
-                                                                      std::shared_ptr<LUS::BinaryReader> reader) {
+std::shared_ptr<Ship::IResource> SetMinimapChestsFactory::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData,
+                                                                      std::shared_ptr<Ship::BinaryReader> reader) {
     auto chests = std::make_shared<SetMinimapChests>(initData);
 
     ReadCommandId(chests, reader);

--- a/mm/2s2h/resource/importer/scenecommand/SetMinimapChestsFactory.h
+++ b/mm/2s2h/resource/importer/scenecommand/SetMinimapChestsFactory.h
@@ -5,7 +5,7 @@
 namespace SOH {
 class SetMinimapChestsFactory : public SceneCommandFactoryBinaryV0 {
   public:
-    std::shared_ptr<LUS::IResource> ReadResource(std::shared_ptr<LUS::ResourceInitData> initData,
-                                            std::shared_ptr<LUS::BinaryReader> reader) override;
+    std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::ResourceInitData> initData,
+                                            std::shared_ptr<Ship::BinaryReader> reader) override;
 };
 }

--- a/mm/2s2h/resource/importer/scenecommand/SetMinimapListFactory.cpp
+++ b/mm/2s2h/resource/importer/scenecommand/SetMinimapListFactory.cpp
@@ -3,8 +3,8 @@
 #include "spdlog/spdlog.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource> SetMinimapListFactory::ReadResource(std::shared_ptr<LUS::ResourceInitData> initData,
-                                                               std::shared_ptr<LUS::BinaryReader> reader) {
+std::shared_ptr<Ship::IResource> SetMinimapListFactory::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData,
+                                                               std::shared_ptr<Ship::BinaryReader> reader) {
     auto mapList = std::make_shared<SetMinimapList>(initData);
 
     ReadCommandId(mapList, reader);

--- a/mm/2s2h/resource/importer/scenecommand/SetMinimapListFactory.h
+++ b/mm/2s2h/resource/importer/scenecommand/SetMinimapListFactory.h
@@ -5,7 +5,7 @@
 namespace SOH {
 class SetMinimapListFactory : public SceneCommandFactoryBinaryV0 {
   public:
-    std::shared_ptr<LUS::IResource> ReadResource(std::shared_ptr<LUS::ResourceInitData> initData,
-                                            std::shared_ptr<LUS::BinaryReader> reader) override;
+    std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::ResourceInitData> initData,
+                                            std::shared_ptr<Ship::BinaryReader> reader) override;
 };
 }; // namespace LUS

--- a/mm/2s2h/resource/importer/scenecommand/SetObjectListFactory.cpp
+++ b/mm/2s2h/resource/importer/scenecommand/SetObjectListFactory.cpp
@@ -3,8 +3,8 @@
 #include "spdlog/spdlog.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource>
-SetObjectListFactory::ReadResource(std::shared_ptr<LUS::ResourceInitData> initData, std::shared_ptr<LUS::BinaryReader> reader) {
+std::shared_ptr<Ship::IResource>
+SetObjectListFactory::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData, std::shared_ptr<Ship::BinaryReader> reader) {
     auto setObjectList = std::make_shared<SetObjectList>(initData);
 
     ReadCommandId(setObjectList, reader);

--- a/mm/2s2h/resource/importer/scenecommand/SetObjectListFactory.h
+++ b/mm/2s2h/resource/importer/scenecommand/SetObjectListFactory.h
@@ -5,7 +5,7 @@
 namespace SOH {
 class SetObjectListFactory : public SceneCommandFactoryBinaryV0 {
   public:
-    std::shared_ptr<LUS::IResource>
-    ReadResource(std::shared_ptr<LUS::ResourceInitData> initData, std::shared_ptr<LUS::BinaryReader> reader) override;
+    std::shared_ptr<Ship::IResource>
+    ReadResource(std::shared_ptr<Ship::ResourceInitData> initData, std::shared_ptr<Ship::BinaryReader> reader) override;
 };
 } // namespace SOH

--- a/mm/2s2h/resource/importer/scenecommand/SetPathwaysFactory.cpp
+++ b/mm/2s2h/resource/importer/scenecommand/SetPathwaysFactory.cpp
@@ -4,8 +4,8 @@
 #include <libultraship/libultraship.h>
 
 namespace SOH {
-std::shared_ptr<LUS::IResource> SetPathwaysMMFactory::ReadResource(std::shared_ptr<LUS::ResourceInitData> initData,
-                                                            std::shared_ptr<LUS::BinaryReader> reader) {
+std::shared_ptr<Ship::IResource> SetPathwaysMMFactory::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData,
+                                                            std::shared_ptr<Ship::BinaryReader> reader) {
     auto setPathways = std::make_shared<SetPathwaysMM>(initData);
     
     ReadCommandId(setPathways, reader);
@@ -15,7 +15,7 @@ std::shared_ptr<LUS::IResource> SetPathwaysMMFactory::ReadResource(std::shared_p
     for (uint32_t i = 0; i < setPathways->numPaths; i++) {
         std::string pathFileName = reader->ReadString();
         auto path = std::static_pointer_cast<PathMM>(
-            LUS::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(pathFileName.c_str()));
+            Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(pathFileName.c_str()));
         setPathways->paths.push_back(path->GetPointer());
     }
     return setPathways;

--- a/mm/2s2h/resource/importer/scenecommand/SetPathwaysFactory.h
+++ b/mm/2s2h/resource/importer/scenecommand/SetPathwaysFactory.h
@@ -5,7 +5,7 @@
 namespace SOH {
 class SetPathwaysMMFactory : public SceneCommandFactoryBinaryV0 {
   public:
-    std::shared_ptr<LUS::IResource> ReadResource(std::shared_ptr<LUS::ResourceInitData> initData,
-                                            std::shared_ptr<LUS::BinaryReader> reader) override;
+    std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::ResourceInitData> initData,
+                                            std::shared_ptr<Ship::BinaryReader> reader) override;
 };
 }; // namespace LUS

--- a/mm/2s2h/resource/importer/scenecommand/SetRoomBehaviorFactory.cpp
+++ b/mm/2s2h/resource/importer/scenecommand/SetRoomBehaviorFactory.cpp
@@ -3,8 +3,8 @@
 #include "spdlog/spdlog.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource> SetRoomBehaviorMMFactory::ReadResource(std::shared_ptr<LUS::ResourceInitData> initData,
-                                                                  std::shared_ptr<LUS::BinaryReader> reader) {
+std::shared_ptr<Ship::IResource> SetRoomBehaviorMMFactory::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData,
+                                                                  std::shared_ptr<Ship::BinaryReader> reader) {
     auto setRoomBehavior = std::make_shared<SetRoomBehaviorMM>(initData);
 
     ReadCommandId(setRoomBehavior, reader);

--- a/mm/2s2h/resource/importer/scenecommand/SetRoomBehaviorFactory.h
+++ b/mm/2s2h/resource/importer/scenecommand/SetRoomBehaviorFactory.h
@@ -5,7 +5,7 @@
 namespace SOH {
 class SetRoomBehaviorMMFactory : public SceneCommandFactoryBinaryV0 {
   public:
-    std::shared_ptr<LUS::IResource> ReadResource(std::shared_ptr<LUS::ResourceInitData> initData,
-                                            std::shared_ptr<LUS::BinaryReader> reader) override;
+    std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::ResourceInitData> initData,
+                                            std::shared_ptr<Ship::BinaryReader> reader) override;
 };
 }; // namespace SOH

--- a/mm/2s2h/resource/importer/scenecommand/SetRoomListFactory.cpp
+++ b/mm/2s2h/resource/importer/scenecommand/SetRoomListFactory.cpp
@@ -3,8 +3,8 @@
 #include "spdlog/spdlog.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource>
-SetRoomListFactory::ReadResource(std::shared_ptr<LUS::ResourceInitData> initData, std::shared_ptr<LUS::BinaryReader> reader) {
+std::shared_ptr<Ship::IResource>
+SetRoomListFactory::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData, std::shared_ptr<Ship::BinaryReader> reader) {
     auto setRoomList = std::make_shared<SetRoomList>(initData);
 
     ReadCommandId(setRoomList, reader);

--- a/mm/2s2h/resource/importer/scenecommand/SetRoomListFactory.h
+++ b/mm/2s2h/resource/importer/scenecommand/SetRoomListFactory.h
@@ -5,7 +5,7 @@
 namespace SOH {
 class SetRoomListFactory : public SceneCommandFactoryBinaryV0 {
   public:
-    std::shared_ptr<LUS::IResource>
-    ReadResource(std::shared_ptr<LUS::ResourceInitData> initData, std::shared_ptr<LUS::BinaryReader> reader) override;
+    std::shared_ptr<Ship::IResource>
+    ReadResource(std::shared_ptr<Ship::ResourceInitData> initData, std::shared_ptr<Ship::BinaryReader> reader) override;
 };
 } // namespace SOH

--- a/mm/2s2h/resource/importer/scenecommand/SetSkyboxModifierFactory.cpp
+++ b/mm/2s2h/resource/importer/scenecommand/SetSkyboxModifierFactory.cpp
@@ -3,8 +3,8 @@
 #include "spdlog/spdlog.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource> SetSkyboxModifierFactory::ReadResource(std::shared_ptr<LUS::ResourceInitData> initData,
-                                                                 std::shared_ptr<LUS::BinaryReader> reader) {
+std::shared_ptr<Ship::IResource> SetSkyboxModifierFactory::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData,
+                                                                 std::shared_ptr<Ship::BinaryReader> reader) {
     auto setSkyboxModifier = std::make_shared<SetSkyboxModifier>(initData);
 
 	ReadCommandId(setSkyboxModifier, reader);

--- a/mm/2s2h/resource/importer/scenecommand/SetSkyboxModifierFactory.h
+++ b/mm/2s2h/resource/importer/scenecommand/SetSkyboxModifierFactory.h
@@ -5,7 +5,7 @@
 namespace SOH {
 class SetSkyboxModifierFactory : public SceneCommandFactoryBinaryV0 {
   public:
-    std::shared_ptr<LUS::IResource>
-    ReadResource(std::shared_ptr<LUS::ResourceInitData> initData, std::shared_ptr<LUS::BinaryReader> reader) override;
+    std::shared_ptr<Ship::IResource>
+    ReadResource(std::shared_ptr<Ship::ResourceInitData> initData, std::shared_ptr<Ship::BinaryReader> reader) override;
 };
 } // namespace SOH

--- a/mm/2s2h/resource/importer/scenecommand/SetSkyboxSettingsFactory.cpp
+++ b/mm/2s2h/resource/importer/scenecommand/SetSkyboxSettingsFactory.cpp
@@ -3,8 +3,8 @@
 #include "spdlog/spdlog.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource> SetSkyboxSettingsFactory::ReadResource(std::shared_ptr<LUS::ResourceInitData> initData,
-                                                                 std::shared_ptr<LUS::BinaryReader> reader) {
+std::shared_ptr<Ship::IResource> SetSkyboxSettingsFactory::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData,
+                                                                 std::shared_ptr<Ship::BinaryReader> reader) {
     auto setSkyboxSettings = std::make_shared<SetSkyboxSettings>(initData);
 
     ReadCommandId(setSkyboxSettings, reader);

--- a/mm/2s2h/resource/importer/scenecommand/SetSkyboxSettingsFactory.h
+++ b/mm/2s2h/resource/importer/scenecommand/SetSkyboxSettingsFactory.h
@@ -5,7 +5,7 @@
 namespace SOH {
 class SetSkyboxSettingsFactory : public SceneCommandFactoryBinaryV0 {
   public:
-    std::shared_ptr<LUS::IResource>
-    ReadResource(std::shared_ptr<LUS::ResourceInitData> initData, std::shared_ptr<LUS::BinaryReader> reader) override;
+    std::shared_ptr<Ship::IResource>
+    ReadResource(std::shared_ptr<Ship::ResourceInitData> initData, std::shared_ptr<Ship::BinaryReader> reader) override;
 };
 } // namespace SOH

--- a/mm/2s2h/resource/importer/scenecommand/SetSoundSettingsFactory.cpp
+++ b/mm/2s2h/resource/importer/scenecommand/SetSoundSettingsFactory.cpp
@@ -3,8 +3,8 @@
 #include "spdlog/spdlog.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource> SetSoundSettingsFactory::ReadResource(std::shared_ptr<LUS::ResourceInitData> initData,
-                                                                std::shared_ptr<LUS::BinaryReader> reader) {
+std::shared_ptr<Ship::IResource> SetSoundSettingsFactory::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData,
+                                                                std::shared_ptr<Ship::BinaryReader> reader) {
     auto setSoundSettings = std::make_shared<SetSoundSettings>(initData);
 
     ReadCommandId(setSoundSettings, reader);

--- a/mm/2s2h/resource/importer/scenecommand/SetSoundSettingsFactory.h
+++ b/mm/2s2h/resource/importer/scenecommand/SetSoundSettingsFactory.h
@@ -5,7 +5,7 @@
 namespace SOH {
 class SetSoundSettingsFactory : public SceneCommandFactoryBinaryV0 {
   public:
-    std::shared_ptr<LUS::IResource>
-    ReadResource(std::shared_ptr<LUS::ResourceInitData> initData, std::shared_ptr<LUS::BinaryReader> reader) override;
+    std::shared_ptr<Ship::IResource>
+    ReadResource(std::shared_ptr<Ship::ResourceInitData> initData, std::shared_ptr<Ship::BinaryReader> reader) override;
 };
 } // namespace SOH

--- a/mm/2s2h/resource/importer/scenecommand/SetSpecialObjectsFactory.cpp
+++ b/mm/2s2h/resource/importer/scenecommand/SetSpecialObjectsFactory.cpp
@@ -3,8 +3,8 @@
 #include "spdlog/spdlog.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource> SetSpecialObjectsFactory::ReadResource(std::shared_ptr<LUS::ResourceInitData> initData,
-                                                                 std::shared_ptr<LUS::BinaryReader> reader) {
+std::shared_ptr<Ship::IResource> SetSpecialObjectsFactory::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData,
+                                                                 std::shared_ptr<Ship::BinaryReader> reader) {
     auto setSpecialObjects = std::make_shared<SetSpecialObjects>(initData);
 
     ReadCommandId(setSpecialObjects, reader);

--- a/mm/2s2h/resource/importer/scenecommand/SetSpecialObjectsFactory.h
+++ b/mm/2s2h/resource/importer/scenecommand/SetSpecialObjectsFactory.h
@@ -5,7 +5,7 @@
 namespace SOH {
 class SetSpecialObjectsFactory : public SceneCommandFactoryBinaryV0 {
   public:
-    std::shared_ptr<LUS::IResource>
-    ReadResource(std::shared_ptr<LUS::ResourceInitData> initData, std::shared_ptr<LUS::BinaryReader> reader) override;
+    std::shared_ptr<Ship::IResource>
+    ReadResource(std::shared_ptr<Ship::ResourceInitData> initData, std::shared_ptr<Ship::BinaryReader> reader) override;
 };
 } // namespace SOH

--- a/mm/2s2h/resource/importer/scenecommand/SetStartPositionListFactory.cpp
+++ b/mm/2s2h/resource/importer/scenecommand/SetStartPositionListFactory.cpp
@@ -3,8 +3,8 @@
 #include "spdlog/spdlog.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource> SetStartPositionListFactory::ReadResource(std::shared_ptr<LUS::ResourceInitData> initData,
-                                                                    std::shared_ptr<LUS::BinaryReader> reader) {
+std::shared_ptr<Ship::IResource> SetStartPositionListFactory::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData,
+                                                                    std::shared_ptr<Ship::BinaryReader> reader) {
     auto setStartPositionList = std::make_shared<SetStartPositionList>(initData);
 
     ReadCommandId(setStartPositionList, reader);

--- a/mm/2s2h/resource/importer/scenecommand/SetStartPositionListFactory.h
+++ b/mm/2s2h/resource/importer/scenecommand/SetStartPositionListFactory.h
@@ -5,7 +5,7 @@
 namespace SOH {
 class SetStartPositionListFactory : public SceneCommandFactoryBinaryV0 {
   public:
-    std::shared_ptr<LUS::IResource>
-    ReadResource(std::shared_ptr<LUS::ResourceInitData> initData, std::shared_ptr<LUS::BinaryReader> reader) override;
+    std::shared_ptr<Ship::IResource>
+    ReadResource(std::shared_ptr<Ship::ResourceInitData> initData, std::shared_ptr<Ship::BinaryReader> reader) override;
 };
 } // namespace SOH

--- a/mm/2s2h/resource/importer/scenecommand/SetTimeSettingsFactory.cpp
+++ b/mm/2s2h/resource/importer/scenecommand/SetTimeSettingsFactory.cpp
@@ -3,8 +3,8 @@
 #include "spdlog/spdlog.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource> SetTimeSettingsFactory::ReadResource(std::shared_ptr<LUS::ResourceInitData> initData,
-                                                                     std::shared_ptr<LUS::BinaryReader> reader) {
+std::shared_ptr<Ship::IResource> SetTimeSettingsFactory::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData,
+                                                                     std::shared_ptr<Ship::BinaryReader> reader) {
     auto setTimeSettings = std::make_shared<SetTimeSettings>(initData);
 
     ReadCommandId(setTimeSettings, reader);

--- a/mm/2s2h/resource/importer/scenecommand/SetTimeSettingsFactory.h
+++ b/mm/2s2h/resource/importer/scenecommand/SetTimeSettingsFactory.h
@@ -5,7 +5,7 @@
 namespace SOH {
 class SetTimeSettingsFactory : public SceneCommandFactoryBinaryV0 {
   public:
-    std::shared_ptr<LUS::IResource>
-    ReadResource(std::shared_ptr<LUS::ResourceInitData> initData, std::shared_ptr<LUS::BinaryReader> reader) override;
+    std::shared_ptr<Ship::IResource>
+    ReadResource(std::shared_ptr<Ship::ResourceInitData> initData, std::shared_ptr<Ship::BinaryReader> reader) override;
 };
 } // namespace LUS

--- a/mm/2s2h/resource/importer/scenecommand/SetTransitionActorListFactory.cpp
+++ b/mm/2s2h/resource/importer/scenecommand/SetTransitionActorListFactory.cpp
@@ -3,8 +3,8 @@
 #include "spdlog/spdlog.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource> SetTransitionActorListFactory::ReadResource(std::shared_ptr<LUS::ResourceInitData> initData,
-                                                                      std::shared_ptr<LUS::BinaryReader> reader) {
+std::shared_ptr<Ship::IResource> SetTransitionActorListFactory::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData,
+                                                                      std::shared_ptr<Ship::BinaryReader> reader) {
     auto setTransitionActorList = std::make_shared<SetTransitionActorList>(initData);
     
     ReadCommandId(setTransitionActorList, reader);

--- a/mm/2s2h/resource/importer/scenecommand/SetTransitionActorListFactory.h
+++ b/mm/2s2h/resource/importer/scenecommand/SetTransitionActorListFactory.h
@@ -5,7 +5,7 @@
 namespace SOH {
 class SetTransitionActorListFactory : public SceneCommandFactoryBinaryV0 {
   public:
-    std::shared_ptr<LUS::IResource>
-    ReadResource(std::shared_ptr<LUS::ResourceInitData> initData, std::shared_ptr<LUS::BinaryReader> reader) override;
+    std::shared_ptr<Ship::IResource>
+    ReadResource(std::shared_ptr<Ship::ResourceInitData> initData, std::shared_ptr<Ship::BinaryReader> reader) override;
 };
 } // namespace SOH

--- a/mm/2s2h/resource/importer/scenecommand/SetWindSettingsFactory.cpp
+++ b/mm/2s2h/resource/importer/scenecommand/SetWindSettingsFactory.cpp
@@ -3,8 +3,8 @@
 #include "spdlog/spdlog.h"
 
 namespace SOH {
-std::shared_ptr<LUS::IResource> SetWindSettingsFactory::ReadResource(std::shared_ptr<LUS::ResourceInitData> initData,
-                                                                     std::shared_ptr<LUS::BinaryReader> reader) {
+std::shared_ptr<Ship::IResource> SetWindSettingsFactory::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData,
+                                                                     std::shared_ptr<Ship::BinaryReader> reader) {
     auto setWind = std::make_shared<SetWindSettings>(initData);
 
     ReadCommandId(setWind, reader);

--- a/mm/2s2h/resource/importer/scenecommand/SetWindSettingsFactory.h
+++ b/mm/2s2h/resource/importer/scenecommand/SetWindSettingsFactory.h
@@ -5,7 +5,7 @@
 namespace SOH {
 class SetWindSettingsFactory : public SceneCommandFactoryBinaryV0 {
   public:
-    std::shared_ptr<LUS::IResource> ReadResource(std::shared_ptr<LUS::ResourceInitData> initData,
-                                                 std::shared_ptr<LUS::BinaryReader> reader) override;
+    std::shared_ptr<Ship::IResource> ReadResource(std::shared_ptr<Ship::ResourceInitData> initData,
+                                                 std::shared_ptr<Ship::BinaryReader> reader) override;
 };
 }; // namespace LUS

--- a/mm/2s2h/resource/type/Animation.h
+++ b/mm/2s2h/resource/type/Animation.h
@@ -63,11 +63,11 @@ namespace SOH {
     TransformUpdateIndex transformUpdateIndex;
   };
 
-  class Animation : public LUS::Resource<AnimationData> {
+  class Animation : public Ship::Resource<AnimationData> {
     public:
       using Resource::Resource;
 
-      Animation() : Resource(std::shared_ptr<LUS::ResourceInitData>()) {
+      Animation() : Resource(std::shared_ptr<Ship::ResourceInitData>()) {
       }
 
       AnimationData* GetPointer();

--- a/mm/2s2h/resource/type/AudioSample.h
+++ b/mm/2s2h/resource/type/AudioSample.h
@@ -39,11 +39,11 @@ namespace SOH {
         s32 sampleRate;           // For wav samples only...
     } Sample; // size = 0x10
 
-    class AudioSample : public LUS::Resource<Sample> {
+    class AudioSample : public Ship::Resource<Sample> {
         public:
             using Resource::Resource;
 
-        AudioSample() : Resource(std::shared_ptr<LUS::ResourceInitData>()) {}
+        AudioSample() : Resource(std::shared_ptr<Ship::ResourceInitData>()) {}
 
             Sample* GetPointer();
             size_t GetPointerSize();

--- a/mm/2s2h/resource/type/AudioSequence.h
+++ b/mm/2s2h/resource/type/AudioSequence.h
@@ -17,11 +17,11 @@ typedef struct {
     uint8_t fonts[16];
 } Sequence;
 
-class AudioSequence : public LUS::Resource<Sequence> {
+class AudioSequence : public Ship::Resource<Sequence> {
 public:
     using Resource::Resource;
 
-    AudioSequence() : Resource(std::shared_ptr<LUS::ResourceInitData>()) {}
+    AudioSequence() : Resource(std::shared_ptr<Ship::ResourceInitData>()) {}
 
     Sequence* GetPointer();
     size_t GetPointerSize();

--- a/mm/2s2h/resource/type/AudioSoundFont.h
+++ b/mm/2s2h/resource/type/AudioSoundFont.h
@@ -52,11 +52,11 @@ typedef struct {
     s32 fntIndex;
 } SoundFont; // size = 0x14
 
-class AudioSoundFont : public LUS::Resource<SoundFont> {
+class AudioSoundFont : public Ship::Resource<SoundFont> {
 public:
     using Resource::Resource;
 
-    AudioSoundFont() : Resource(std::shared_ptr<LUS::ResourceInitData>()) {}
+    AudioSoundFont() : Resource(std::shared_ptr<Ship::ResourceInitData>()) {}
 
     SoundFont* GetPointer();
     size_t GetPointerSize();

--- a/mm/2s2h/resource/type/Background.h
+++ b/mm/2s2h/resource/type/Background.h
@@ -3,11 +3,11 @@
 #include "resource/Resource.h"
 
 namespace SOH {
-class Background : public LUS::Resource<uint8_t> {
+class Background : public Ship::Resource<uint8_t> {
   public:
     using Resource::Resource;
 
-    Background() : Resource(std::shared_ptr<LUS::ResourceInitData>()) {}
+    Background() : Resource(std::shared_ptr<Ship::ResourceInitData>()) {}
 
     uint8_t* GetPointer();
     size_t GetPointerSize();

--- a/mm/2s2h/resource/type/CollisionHeader.h
+++ b/mm/2s2h/resource/type/CollisionHeader.h
@@ -67,11 +67,11 @@ typedef struct {
     size_t cameraDataListLen; // OTRTODO: Added to allow for bounds checking the cameraDataList.
 } CollisionHeaderData; // original name: BGDataInfo
 
-class CollisionHeader : public LUS::Resource<CollisionHeaderData> {
+class CollisionHeader : public Ship::Resource<CollisionHeaderData> {
 public:
     using Resource::Resource;
 
-    CollisionHeader() : Resource(std::shared_ptr<LUS::ResourceInitData>()) {}
+    CollisionHeader() : Resource(std::shared_ptr<Ship::ResourceInitData>()) {}
 
     CollisionHeaderData* GetPointer();
     size_t GetPointerSize();

--- a/mm/2s2h/resource/type/Cutscene.h
+++ b/mm/2s2h/resource/type/Cutscene.h
@@ -41,11 +41,11 @@ enum class CutsceneCommands {
     Error = 0xFEAF,
 };
 
-class Cutscene : public LUS::Resource<uint32_t> {
+class Cutscene : public Ship::Resource<uint32_t> {
   public:
     using Resource::Resource;
 
-    Cutscene() : Resource(std::shared_ptr<LUS::ResourceInitData>()) {}
+    Cutscene() : Resource(std::shared_ptr<Ship::ResourceInitData>()) {}
 
     uint32_t* GetPointer();
     size_t GetPointerSize();

--- a/mm/2s2h/resource/type/KeyFrame.h
+++ b/mm/2s2h/resource/type/KeyFrame.h
@@ -56,11 +56,11 @@ typedef struct {
     /* 0x12 */ s16 duration;
 } KeyFrameAnimationData; // Size = 0x14
 
-class KeyFrameSkel : public LUS::Resource<KeyFrameSkeletonData> {
+class KeyFrameSkel : public Ship::Resource<KeyFrameSkeletonData> {
   public:
     using Resource::Resource;
 
-    KeyFrameSkel() : Resource(std::shared_ptr<LUS::ResourceInitData>()) {
+    KeyFrameSkel() : Resource(std::shared_ptr<Ship::ResourceInitData>()) {
     }
     ~KeyFrameSkel();
 
@@ -70,11 +70,11 @@ class KeyFrameSkel : public LUS::Resource<KeyFrameSkeletonData> {
     KeyFrameSkeletonData skelData;
 };
 
-class KeyFrameAnim : public LUS::Resource<KeyFrameAnimationData> {
+class KeyFrameAnim : public Ship::Resource<KeyFrameAnimationData> {
   public:
     using Resource::Resource;
 
-    KeyFrameAnim() : Resource(std::shared_ptr<LUS::ResourceInitData>()) {
+    KeyFrameAnim() : Resource(std::shared_ptr<Ship::ResourceInitData>()) {
     }
     ~KeyFrameAnim();
 

--- a/mm/2s2h/resource/type/KeyFrame.h
+++ b/mm/2s2h/resource/type/KeyFrame.h
@@ -11,6 +11,12 @@ typedef struct Vec3s {
     s16 z;
 } Vec3s;
 
+enum class KeyframeSkelType {
+	Normal,
+	Flex,
+	Error,
+};
+
 // Keyframe limb?
 typedef struct {
     /* 0x00 */ void* dList;

--- a/mm/2s2h/resource/type/Path.h
+++ b/mm/2s2h/resource/type/Path.h
@@ -14,11 +14,11 @@ typedef struct {
     /* 0x4 */ Vec3s* points;   // Segment Address to the array of points
 } PathDataMM; // size = 0x8
 
-class PathMM : public LUS::Resource<PathDataMM> {
+class PathMM : public Ship::Resource<PathDataMM> {
   public:
     using Resource::Resource;
 
-    PathMM() : Resource(std::shared_ptr<LUS::ResourceInitData>()) {
+    PathMM() : Resource(std::shared_ptr<Ship::ResourceInitData>()) {
     }
 
     PathDataMM* GetPointer();

--- a/mm/2s2h/resource/type/PlayerAnimation.h
+++ b/mm/2s2h/resource/type/PlayerAnimation.h
@@ -6,11 +6,11 @@
 
 namespace SOH {
 
-class PlayerAnimation : public LUS::Resource<int16_t> {
+class PlayerAnimation : public Ship::Resource<int16_t> {
   public:
     using Resource::Resource;
 
-    PlayerAnimation() : Resource(std::shared_ptr<LUS::ResourceInitData>()) {}
+    PlayerAnimation() : Resource(std::shared_ptr<Ship::ResourceInitData>()) {}
 
     int16_t* GetPointer();
     size_t GetPointerSize();

--- a/mm/2s2h/resource/type/Scene.h
+++ b/mm/2s2h/resource/type/Scene.h
@@ -8,11 +8,11 @@
 
 namespace SOH {
 
-class Scene : public LUS::Resource<void> {
+class Scene : public Ship::Resource<void> {
 public:
   using Resource::Resource;
 
-    Scene() : Resource(std::shared_ptr<LUS::ResourceInitData>()) {}
+    Scene() : Resource(std::shared_ptr<Ship::ResourceInitData>()) {}
 
     void* GetPointer();
     size_t GetPointerSize();

--- a/mm/2s2h/resource/type/Skeleton.cpp
+++ b/mm/2s2h/resource/type/Skeleton.cpp
@@ -36,9 +36,9 @@ void SkeletonPatcher::RegisterSkeleton(std::string& path, SkelAnime* skelAnime) 
     }
 
     // Determine if we're using an alternate skeleton
-    if (path.starts_with(LUS::IResource::gAltAssetPrefix)) {
-        info.vanillaSkeletonPath = path.substr(LUS::IResource::gAltAssetPrefix.length(),
-                                               path.size() - LUS::IResource::gAltAssetPrefix.length());
+    if (path.starts_with(Ship::IResource::gAltAssetPrefix)) {
+        info.vanillaSkeletonPath = path.substr(Ship::IResource::gAltAssetPrefix.length(),
+                                               path.size() - Ship::IResource::gAltAssetPrefix.length());
     } else {
         info.vanillaSkeletonPath = path;
     }
@@ -68,8 +68,8 @@ void SkeletonPatcher::UpdateSkeletons() {
     bool isHD = CVarGetInteger("gAltAssets", 0);
     for (auto skel : skeletons) {
         Skeleton* newSkel =
-            (Skeleton*)LUS::Context::GetInstance()->GetResourceManager()
-                ->LoadResource((isHD ? LUS::IResource::gAltAssetPrefix : "") + skel.vanillaSkeletonPath, true)
+            (Skeleton*)Ship::Context::GetInstance()->GetResourceManager()
+                ->LoadResource((isHD ? Ship::IResource::gAltAssetPrefix : "") + skel.vanillaSkeletonPath, true)
                 .get();
 
         if (newSkel != nullptr) {

--- a/mm/2s2h/resource/type/Skeleton.h
+++ b/mm/2s2h/resource/type/Skeleton.h
@@ -50,11 +50,11 @@ union SkeletonData {
     SkelCurveLimbList skelCurveLimbList;
 };
 
-class Skeleton : public LUS::Resource<SkeletonData> {
+class Skeleton : public Ship::Resource<SkeletonData> {
   public:
     using Resource::Resource;
 
-    Skeleton() : Resource(std::shared_ptr<LUS::ResourceInitData>()) {}
+    Skeleton() : Resource(std::shared_ptr<Ship::ResourceInitData>()) {}
 
     SkeletonData* GetPointer();
     size_t GetPointerSize();

--- a/mm/2s2h/resource/type/SkeletonLimb.h
+++ b/mm/2s2h/resource/type/SkeletonLimb.h
@@ -97,11 +97,11 @@ union SkeletonLimbData {
   SkinLimb skinLimb;
 };
 
-class SkeletonLimb : public LUS::Resource<SkeletonLimbData> {
+class SkeletonLimb : public Ship::Resource<SkeletonLimbData> {
 public:
   using Resource::Resource;
 
-    SkeletonLimb() : Resource(std::shared_ptr<LUS::ResourceInitData>()) {
+    SkeletonLimb() : Resource(std::shared_ptr<Ship::ResourceInitData>()) {
   }
 
     SkeletonLimbData* GetPointer();

--- a/mm/2s2h/resource/type/TextMM.h
+++ b/mm/2s2h/resource/type/TextMM.h
@@ -22,11 +22,11 @@ class MessageEntryMM {
     std::string msg;
 };
 
-class TextMM : public LUS::Resource<MessageEntryMM> {
+class TextMM : public Ship::Resource<MessageEntryMM> {
 public:
   using Resource::Resource;
 
-    TextMM() : Resource(std::shared_ptr<LUS::ResourceInitData>()) {
+    TextMM() : Resource(std::shared_ptr<Ship::ResourceInitData>()) {
   }
 
     MessageEntryMM* GetPointer();

--- a/mm/2s2h/resource/type/TextureAnimation.h
+++ b/mm/2s2h/resource/type/TextureAnimation.h
@@ -88,12 +88,12 @@ typedef struct {
     /* 0x4 */ void* params;
 } AnimatedMaterial; // size = 0x8
 
-class TextureAnimation : public LUS::Resource<AnimatedMaterial> {
+class TextureAnimation : public Ship::Resource<AnimatedMaterial> {
   public:
     using Resource::Resource;
     ~TextureAnimation();
 
-    TextureAnimation() : Resource(std::shared_ptr<LUS::ResourceInitData>()) {
+    TextureAnimation() : Resource(std::shared_ptr<Ship::ResourceInitData>()) {
     }
 
     AnimatedMaterial* GetPointer();

--- a/mm/2s2h/resource/type/scenecommand/SceneCommand.h
+++ b/mm/2s2h/resource/type/scenecommand/SceneCommand.h
@@ -48,10 +48,10 @@ enum class SceneCommandID : uint8_t {
     Error = 0xFF
 };
 
-class ISceneCommand : public LUS::IResource {
+class ISceneCommand : public Ship::IResource {
 public:
     using IResource::IResource;
-    ISceneCommand() : IResource(std::shared_ptr<LUS::ResourceInitData>()) {}
+    ISceneCommand() : IResource(std::shared_ptr<Ship::ResourceInitData>()) {}
     SceneCommandID cmdId;
 };
 

--- a/mm/2s2h/z_message_OTR.cpp
+++ b/mm/2s2h/z_message_OTR.cpp
@@ -10,7 +10,7 @@
 //extern "C" MessageTableEntry* sStaffMessageEntryTablePtr;
 
 MessageTableEntry* OTRMessage_LoadTable(const char* filePath, bool isNES) {
-    auto file = std::static_pointer_cast<SOH::TextMM>(LUS::Context::GetInstance()->GetResourceManager()->LoadResource(filePath));
+    auto file = std::static_pointer_cast<SOH::TextMM>(Ship::Context::GetInstance()->GetResourceManager()->LoadResource(filePath));
 
     if (file == nullptr)
         return nullptr;
@@ -61,7 +61,7 @@ extern "C" void OTRMessage_Init(PlayState* play) {
 
     //if (play->msgCtx.messageTableStaff == NULL) {
         auto file2 =
-            std::static_pointer_cast<SOH::TextMM>(LUS::Context::GetInstance()->GetResourceManager()->LoadResource(
+            std::static_pointer_cast<SOH::TextMM>(Ship::Context::GetInstance()->GetResourceManager()->LoadResource(
                 "text/staff_message_data_static/staff_message_data_static"));
         // OTRTODO: Should not be malloc'ing here. It's fine for now since we check that the message table is already null.
         play->msgCtx.messageTableStaff = (MessageTableEntry*)malloc(sizeof(MessageTableEntry) * file2->messages.size());

--- a/mm/2s2h/z_message_OTR.cpp
+++ b/mm/2s2h/z_message_OTR.cpp
@@ -1,7 +1,7 @@
 #include "BenPort.h"
 #include <libultraship/libultraship.h>
 #include "2s2h/resource/type/Scene.h"
-#include <Utils/StringHelper.h>
+#include <utils/StringHelper.h>
 #include "global.h"
 #include "2s2h/resource/type/TextMM.h"
 #include <message_data_static.h>

--- a/mm/2s2h/z_play_2SH.cpp
+++ b/mm/2s2h/z_play_2SH.cpp
@@ -1,7 +1,7 @@
 #include "BenPort.h"
 #include <libultraship/libultraship.h>
 #include "2s2h/resource/type/Scene.h"
-#include <Utils/StringHelper.h>
+#include <utils/StringHelper.h>
 #include <Vertex.h>
 extern "C" {
 #include "global.h"

--- a/mm/2s2h/z_play_2SH.cpp
+++ b/mm/2s2h/z_play_2SH.cpp
@@ -8,8 +8,8 @@ extern "C" {
 extern uintptr_t gSegments[NUM_SEGMENTS];
 }
 
-LUS::IResource* OTRPlay_LoadFile(PlayState* play, const char* fileName) {
-    auto res = LUS::Context::GetInstance()->GetResourceManager()->LoadResource(fileName);
+Ship::IResource* OTRPlay_LoadFile(PlayState* play, const char* fileName) {
+    auto res = Ship::Context::GetInstance()->GetResourceManager()->LoadResource(fileName);
     return res.get();
 }
 

--- a/mm/2s2h/z_scene_2SH.cpp
+++ b/mm/2s2h/z_scene_2SH.cpp
@@ -488,7 +488,7 @@ s32 OTRScene_ExecuteCommands(PlayState* play, SOH::Scene* scene) {
 }
 
 
-std::shared_ptr<LUS::IResource> GetResourceByNameHandlingMQ(const char* path);
+std::shared_ptr<Ship::IResource> GetResourceByNameHandlingMQ(const char* path);
 
 extern "C" s32 OTRfunc_8009728C(PlayState* play, RoomContext* roomCtx, s32 roomNum) {
     

--- a/mm/2s2h/z_scene_2SH.cpp
+++ b/mm/2s2h/z_scene_2SH.cpp
@@ -4,7 +4,7 @@
 #include <Blob.h>
 #include <memory>
 #include <cassert>
-#include <Utils/StringHelper.h>
+#include <utils/StringHelper.h>
 #include <DisplayList.h>
 #include "2s2h/Enhancements/GameInteractor/GameInteractor.h"
 #include "2s2h/resource/type/Scene.h"

--- a/mm/CMakeLists.txt
+++ b/mm/CMakeLists.txt
@@ -92,10 +92,6 @@ if (NOT TARGET libultraship)
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../libultraship ${CMAKE_BINARY_DIR}/libultraship)
 endif()
 
-if (NOT TARGET ZAPDUtils)
-    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../ZAPDTR/ZAPDUtils ${CMAKE_BINARY_DIR}/ZAPDUtils)
-endif()
-
 if (NOT TARGET ZAPDLib)
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../ZAPDTR/ZAPD ${CMAKE_BINARY_DIR}/ZAPD)
 endif()
@@ -414,7 +410,6 @@ target_include_directories(${PROJECT_NAME} PRIVATE assets
 	${CMAKE_CURRENT_SOURCE_DIR}/../libultraship/libultraship/Lib/spdlog/include/
     ${CMAKE_CURRENT_SOURCE_DIR}/../libultraship/src/graphic/Fast3D/U64/PR
     ${CMAKE_CURRENT_SOURCE_DIR}/../libultraship/src/graphic
-	${CMAKE_CURRENT_SOURCE_DIR}/../ZAPDTR/ZAPDUtils
     ${CMAKE_CURRENT_SOURCE_DIR}/../ZAPDTR/ZAPD/resource/type
 	${CMAKE_CURRENT_SOURCE_DIR}
 	${CMAKE_CURRENT_SOURCE_DIR}/2s2h/
@@ -443,6 +438,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
 			"_UNICODE"
 			STORMLIB_NO_AUTO_LINK
 			"_CRT_SECURE_NO_WARNINGS;"
+			NOMINMAX
 		)
 	elseif("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "Win32")
 		target_compile_definitions(${PROJECT_NAME} PRIVATE
@@ -462,6 +458,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
 			"UNICODE;"
 			"_UNICODE"
 			STORMLIB_NO_AUTO_LINK
+			NOMINMAX
 		)
 	endif()
 elseif (CMAKE_SYSTEM_NAME STREQUAL "CafeOS")
@@ -695,7 +692,6 @@ endif()
 # Dependencies
 ################################################################################
 add_dependencies(${PROJECT_NAME}
-    ZAPDUtils
     libultraship
 )
 if(NOT CMAKE_SYSTEM_NAME MATCHES "NintendoSwitch|CafeOS")
@@ -709,7 +705,6 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
 	if("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "x64")
 		set(ADDITIONAL_LIBRARY_DEPENDENCIES
 			"libultraship;"
-			"ZAPDUtils;"
 			"ZAPDLib;"
 			"glu32;"
 			"SDL2::SDL2;"
@@ -724,7 +719,6 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
 	elseif("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "Win32")
 		set(ADDITIONAL_LIBRARY_DEPENDENCIES
 			"libultraship;"
-			"ZAPDUtils;"
 			"ZAPDLib;"
 			"glu32;"
 			"SDL2::SDL2;"
@@ -742,7 +736,6 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "NintendoSwitch")
     find_package(Threads REQUIRED)
     set(ADDITIONAL_LIBRARY_DEPENDENCIES
         "libultraship;"
-        "ZAPDUtils;"
         SDL2::SDL2
         -lglad
         Threads::Threads
@@ -764,7 +757,6 @@ else()
     find_package(Threads REQUIRED)
  	set(ADDITIONAL_LIBRARY_DEPENDENCIES
         "libultraship;"
-        "ZAPDUtils;"
 		"ZAPDLib;"
 		SDL2::SDL2
  #       "$<$<BOOL:${BUILD_CROWD_CONTROL}>:SDL2_net::SDL2_net>"

--- a/mm/src/code/z_play.c
+++ b/mm/src/code/z_play.c
@@ -1504,7 +1504,7 @@ void Play_DrawMain(PlayState* this) {
 
                     // Read the picto box framebuffer back as a rgba16 buffer
                     gDPReadFB(sp74++, gPictoBoxFrameBuffer, this->pauseBgPreRender.fbufSave, 0, 0, SCREEN_WIDTH,
-                              SCREEN_HEIGHT);
+                              SCREEN_HEIGHT, false);
 
                     gsSPResetFB(sp74++);
                     // #endregion


### PR DESCRIPTION
* needs upstream  https://github.com/HarbourMasters/ZAPDTR/pull/23
* needs https://github.com/louist103/ZAPDTR/pull/17
* needs https://github.com/louist103/OTRExporter/pull/23

---

* Brings over LUS -> Ship namespace changes
* Copy Keyframe enum to 2ship so we aren't including files from zapdtr
* Register LUS resource types directly