### PR TITLE
Fix UB in Goron Race

### DIFF
--- a/mm/src/overlays/actors/ovl_En_Mt_tag/z_en_mt_tag.c
+++ b/mm/src/overlays/actors/ovl_En_Mt_tag/z_en_mt_tag.c
@@ -40,6 +40,7 @@ ActorInit En_Mt_tag_InitVars = {
     /**/ NULL,
 };
 
+// 2S2H [Port] - Add extra checkpoint for scene exit "18 + 1" to avoid UB in the checkpointIterator loop
 static s32 sStartingCheckpointPerSceneExitIndex[] = {
     0, 0, 0, 0, 1, 9, 12, 16, 19, 22, 26, 29, 30, 32, 34, 36, 39, 42, 45, 45,
 };


### PR DESCRIPTION
`sStartingCheckpointPerSceneExitIndex[sceneExitIndex + 1]` would cause issues when sceneExitIndex was 18, causing checkpointIterator to increase too much leading to a crash on release builds #287 

This adds an extra value to sStartingCheckpointPerSceneExitIndex to account for that case, and removes some ugly array index formatting from decomp