### PR TITLE
Fix: bigslime VTX data use for windup punch/throw

### DIFF
--- a/mm/src/overlays/actors/ovl_En_Bigslime/z_en_bigslime.c
+++ b/mm/src/overlays/actors/ovl_En_Bigslime/z_en_bigslime.c
@@ -1733,7 +1733,7 @@ void EnBigslime_WindupThrowPlayer(EnBigslime* this, PlayState* play) {
     // Deforming Bigslime during the final windup punch while grabbing player using vtxSurfacePerturbation
     for (i = 0; i < BIGSLIME_NUM_VTX; i++) {
         dynamicVtx = &sBigslimeDynamicVtxData[this->dynamicVtxState][i];
-        staticVtx = &sBigslimeStaticVtx[i];
+        staticVtx = &sBigslimeStaticVtxData[i];
         if (this->vtxSurfacePerturbation[i] != 0.0f) {
             if (this->windupPunchTimer > 0) {
                 // loop over x, y, z


### PR DESCRIPTION
Just another instance of using the OTR string resource for vtx calculation instead of the real vtx data.

Fixes #316 

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1480711824.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1480716786.zip)
<!--- section:artifacts:end -->