### PR TITLE
Fix Great Bay Turtle unfolding animation on init

### DIFF
--- a/mm/src/overlays/actors/ovl_Dm_Char08/z_dm_char08.c
+++ b/mm/src/overlays/actors/ovl_Dm_Char08/z_dm_char08.c
@@ -73,6 +73,9 @@ static AnimationInfo sAnimationInfo[TURTLE_ANIM_MAX] = {
     { &gTurtleYawnAnim, 1.0f, 0.0f, -1.0f, ANIMMODE_LOOP, -24.0f },   // TURTLE_ANIM_YAWN
 };
 
+// 2S2H [Port] Copy of TURTLE_ANIM_FLOAT with no moprh frames
+static AnimationInfo sAnimInfoFloatStartFix = { &gTurtleFloatAnim, 1.0f, 0.0f, -1.0f, ANIMMODE_LOOP, 0.0f };
+
 static InitChainEntry sInitChain[] = {
     ICHAIN_F32(uncullZoneForward, 4000, ICHAIN_CONTINUE),
     ICHAIN_F32(uncullZoneScale, 4000, ICHAIN_CONTINUE),
@@ -247,6 +250,17 @@ void DmChar08_Init(Actor* thisx, PlayState* play2) {
         default:
             break;
     }
+
+    // 2S2H [Port] The turtle incorrectly morphs from the starting skeleton position
+    // to the floating animation. Although the float animation uses negative morph frames,
+    // it still seems to strangely morph causing it to "unfold" after init.
+    // Here before changing to the float animation, we change to a copy of it that has
+    // no morph frames. This forces the frame table to be set immediately, fixing the
+    // "unfold" effect. Then we allow the original animation to be set after.
+    if (this->animIndex == TURTLE_ANIM_FLOAT) {
+        DmChar08_ChangeAnim(&this->skelAnime, &sAnimInfoFloatStartFix, 0);
+    }
+
     DmChar08_ChangeAnim(&this->skelAnime, &sAnimationInfo[this->animIndex], 0);
 }
 


### PR DESCRIPTION
For reasons I don't understand, the Great Bay Turtle seems to be morphing from the initial skeleton limb/joints to the float animation, even though negative morph frames are set. This appears to be similar-ish to https://github.com/HarbourMasters/Shipwright/pull/1714

I played around with some changes and found that I could prevent the unfolding by just settings the morph frames to 0. Thankfully this seems to set what ever needs to be set immediately, so I've implemented a fix that creates a copy of the float animation with 0 morph frames, then check during init if the float animation is requested. If it is we first load this modified animation, then immediately load the regular animation.

I wish I knew what the real issue is here. Maybe the exporter is setting the initial joint positions incorrectly? I'm not sure.. For now this fix feels non-invasive and gets the job done.

Fixes #318 

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1482922947.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1482923600.zip)
<!--- section:artifacts:end -->