### PR TITLE
Fix animation morph detection

### DIFF
--- a/mm/src/code/z_skelanime.c
+++ b/mm/src/code/z_skelanime.c
@@ -1373,7 +1373,7 @@ void Animation_SetMorph(PlayState* play, SkelAnime* skelAnime, f32 morphFrames) 
  */
 void PlayerAnimation_Change(PlayState* play, SkelAnime* skelAnime, PlayerAnimationHeader* animation, f32 playSpeed,
                             f32 startFrame, f32 endFrame, u8 mode, f32 morphFrames) {
-    LinkAnimationHeader* ogAnim = animation;
+    PlayerAnimationHeader* ogAnim = animation;
 
     if (ResourceMgr_OTRSigCheck(animation) != 0)
         animation = ResourceMgr_LoadAnimByName(animation);
@@ -1383,7 +1383,7 @@ void PlayerAnimation_Change(PlayState* play, SkelAnime* skelAnime, PlayerAnimati
         currentAnimation = ResourceMgr_LoadAnimByName(currentAnimation);
 
     skelAnime->mode = mode;
-    if ((morphFrames != 0.0f) && ((animation != skelAnime->animation) || (startFrame != skelAnime->curFrame))) {
+    if ((morphFrames != 0.0f) && ((animation != currentAnimation) || (startFrame != skelAnime->curFrame))) {
         if (morphFrames < 0) {
             PlayerAnimation_SetUpdateFunction(skelAnime);
             SkelAnime_CopyFrameTable(skelAnime, skelAnime->morphTable, skelAnime->jointTable);
@@ -1401,7 +1401,7 @@ void PlayerAnimation_Change(PlayState* play, SkelAnime* skelAnime, PlayerAnimati
         skelAnime->morphWeight = 0.0f;
     }
 
-    // We need to restore the original animation because player does `this->skelAnime == &anim` type checks.
+    // 2S2H [Port] Set back the original animation to handle comparisons to other animation resources
     skelAnime->animation = ogAnim;
     skelAnime->curFrame = 0.0f;
     skelAnime->startFrame = startFrame;
@@ -1803,7 +1803,7 @@ s32 SkelAnime_Once(SkelAnime* skelAnime) {
  */
 void Animation_ChangeImpl(SkelAnime* skelAnime, AnimationHeader* animation, f32 playSpeed, f32 startFrame, f32 endFrame,
                           u8 mode, f32 morphFrames, s8 taper) {
-    LinkAnimationHeader* ogAnim = animation;
+    AnimationHeader* ogAnim = animation;
 
     if (ResourceMgr_OTRSigCheck(animation) != 0)
         animation = ResourceMgr_LoadAnimByName(animation);
@@ -1813,7 +1813,7 @@ void Animation_ChangeImpl(SkelAnime* skelAnime, AnimationHeader* animation, f32 
         currentAnimation = ResourceMgr_LoadAnimByName(currentAnimation);
 
     skelAnime->mode = mode;
-    if ((morphFrames != 0.0f) && ((animation != skelAnime->animation) || (startFrame != skelAnime->curFrame))) {
+    if ((morphFrames != 0.0f) && ((animation != currentAnimation) || (startFrame != skelAnime->curFrame))) {
         if (morphFrames < 0) {
             SkelAnime_SetUpdate(skelAnime);
             SkelAnime_CopyFrameTable(skelAnime, skelAnime->morphTable, skelAnime->jointTable);
@@ -1835,7 +1835,8 @@ void Animation_ChangeImpl(SkelAnime* skelAnime, AnimationHeader* animation, f32 
         skelAnime->morphWeight = 0.0f;
     }
 
-    skelAnime->animation = animation;
+    // 2S2H [Port] Set back the original animation to handle comparisons to other animation resources
+    skelAnime->animation = ogAnim;
     skelAnime->startFrame = startFrame;
     skelAnime->endFrame = endFrame;
     skelAnime->animLength = Animation_GetLength(&animation->common);
@@ -1863,7 +1864,6 @@ void Animation_Change(SkelAnime* skelAnime, AnimationHeader* animation, f32 play
     if (ResourceMgr_OTRSigCheck(animation) != 0)
         animation = ResourceMgr_LoadAnimByName(animation);
     Animation_ChangeImpl(skelAnime, animation, playSpeed, startFrame, endFrame, mode, morphFrames, ANIMTAPER_NONE);
-    skelAnime->animation = ogAnim;
 }
 
 /**


### PR DESCRIPTION
Implements https://github.com/HarbourMasters/Shipwright/pull/1748 for 2ship. We mostly had this in place, just missed a few pieces.

This fixes animation comparisons not detecting that they are the same animation, leading to them morphing unnecessarily.

Fixes #318 

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1482974094.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1482974505.zip)
<!--- section:artifacts:end -->