### PR TITLE
Fix Various Equip D-pad Issues

### DIFF
--- a/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_item.c
+++ b/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_item.c
@@ -1597,9 +1597,7 @@ void KaleidoScope_UpdateItemEquip(PlayState* play) {
                     }
                 }
                 // #region 2S2H [Dpad]
-                else if (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0)) {
-                    KaleidoScope_SwapDpadItemToCItem(play, EQUIP_SLOT_C_LEFT);
-                }
+                KaleidoScope_SwapDpadItemToCItem(play, EQUIP_SLOT_C_LEFT);
                 // #endregion
 
                 // Special case for magic arrows
@@ -1624,28 +1622,26 @@ void KaleidoScope_UpdateItemEquip(PlayState* play) {
                     }
                     // #region 2S2H [Dpad]
                     // Note Only C-Left has the swap of 'slot equips' here
-                    else if (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0)) {
-                        if ((DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_RIGHT) >= ITEM_BOW_FIRE) &&
-                                (DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_RIGHT) <= ITEM_BOW_LIGHT)) {
-                            DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_RIGHT) = BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_C_LEFT);
-                            DPAD_SLOT_EQUIP(0, EQUIP_SLOT_D_RIGHT) = C_SLOT_EQUIP(0, EQUIP_SLOT_C_LEFT);
-                            Interface_Dpad_LoadItemIcon(play, EQUIP_SLOT_D_RIGHT);
-                        } else if ((DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_LEFT) >= ITEM_BOW_FIRE) &&
-                                (DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_LEFT) <= ITEM_BOW_LIGHT)) {
-                            DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_LEFT) = BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_C_LEFT);
-                            DPAD_SLOT_EQUIP(0, EQUIP_SLOT_D_LEFT) = C_SLOT_EQUIP(0, EQUIP_SLOT_C_LEFT);
-                            Interface_Dpad_LoadItemIcon(play, EQUIP_SLOT_D_LEFT);
-                        } else if ((DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_DOWN) >= ITEM_BOW_FIRE) &&
-                                (DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_DOWN) <= ITEM_BOW_LIGHT)) {
-                            DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_DOWN) = BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_C_LEFT);
-                            DPAD_SLOT_EQUIP(0, EQUIP_SLOT_D_DOWN) = C_SLOT_EQUIP(0, EQUIP_SLOT_C_LEFT);
-                            Interface_Dpad_LoadItemIcon(play, EQUIP_SLOT_D_DOWN);
-                        } else if ((DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_UP) >= ITEM_BOW_FIRE) &&
-                                (DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_UP) <= ITEM_BOW_LIGHT)) {
-                            DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_UP) = BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_C_LEFT);
-                            DPAD_SLOT_EQUIP(0, EQUIP_SLOT_D_UP) = C_SLOT_EQUIP(0, EQUIP_SLOT_C_LEFT);
-                            Interface_Dpad_LoadItemIcon(play, EQUIP_SLOT_D_UP);
-                        }
+                    if ((DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_RIGHT) >= ITEM_BOW_FIRE) &&
+                            (DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_RIGHT) <= ITEM_BOW_LIGHT)) {
+                        DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_RIGHT) = BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_C_LEFT);
+                        DPAD_SLOT_EQUIP(0, EQUIP_SLOT_D_RIGHT) = C_SLOT_EQUIP(0, EQUIP_SLOT_C_LEFT);
+                        Interface_Dpad_LoadItemIcon(play, EQUIP_SLOT_D_RIGHT);
+                    } else if ((DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_LEFT) >= ITEM_BOW_FIRE) &&
+                            (DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_LEFT) <= ITEM_BOW_LIGHT)) {
+                        DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_LEFT) = BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_C_LEFT);
+                        DPAD_SLOT_EQUIP(0, EQUIP_SLOT_D_LEFT) = C_SLOT_EQUIP(0, EQUIP_SLOT_C_LEFT);
+                        Interface_Dpad_LoadItemIcon(play, EQUIP_SLOT_D_LEFT);
+                    } else if ((DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_DOWN) >= ITEM_BOW_FIRE) &&
+                            (DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_DOWN) <= ITEM_BOW_LIGHT)) {
+                        DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_DOWN) = BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_C_LEFT);
+                        DPAD_SLOT_EQUIP(0, EQUIP_SLOT_D_DOWN) = C_SLOT_EQUIP(0, EQUIP_SLOT_C_LEFT);
+                        Interface_Dpad_LoadItemIcon(play, EQUIP_SLOT_D_DOWN);
+                    } else if ((DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_UP) >= ITEM_BOW_FIRE) &&
+                            (DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_UP) <= ITEM_BOW_LIGHT)) {
+                        DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_UP) = BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_C_LEFT);
+                        DPAD_SLOT_EQUIP(0, EQUIP_SLOT_D_UP) = C_SLOT_EQUIP(0, EQUIP_SLOT_C_LEFT);
+                        Interface_Dpad_LoadItemIcon(play, EQUIP_SLOT_D_UP);
                     }
                     // #endregion
                 }
@@ -1692,9 +1688,7 @@ void KaleidoScope_UpdateItemEquip(PlayState* play) {
                     }
                 }
                 // #region 2S2H [Dpad]
-                else if (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0)) {
-                    KaleidoScope_SwapDpadItemToCItem(play, EQUIP_SLOT_C_DOWN);
-                }
+                KaleidoScope_SwapDpadItemToCItem(play, EQUIP_SLOT_C_DOWN);
                 // #endregion
 
                 // Special case for magic arrows
@@ -1717,24 +1711,22 @@ void KaleidoScope_UpdateItemEquip(PlayState* play) {
                     }
                     // #region 2S2H [Dpad]
                     // Note Only C-Left has the swap of 'slot equips' here
-                    else if (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0)) {
-                        if ((DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_RIGHT) >= ITEM_BOW_FIRE) &&
-                                (DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_RIGHT) <= ITEM_BOW_LIGHT)) {
-                            DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_RIGHT) = BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_C_DOWN);
-                            Interface_Dpad_LoadItemIcon(play, EQUIP_SLOT_D_RIGHT);
-                        } else if ((DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_LEFT) >= ITEM_BOW_FIRE) &&
-                                (DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_LEFT) <= ITEM_BOW_LIGHT)) {
-                            DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_LEFT) = BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_C_DOWN);
-                            Interface_Dpad_LoadItemIcon(play, EQUIP_SLOT_D_LEFT);
-                        } else if ((DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_DOWN) >= ITEM_BOW_FIRE) &&
-                                (DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_DOWN) <= ITEM_BOW_LIGHT)) {
-                            DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_DOWN) = BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_C_DOWN);
-                            Interface_Dpad_LoadItemIcon(play, EQUIP_SLOT_D_DOWN);
-                        } else if ((DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_UP) >= ITEM_BOW_FIRE) &&
-                                (DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_UP) <= ITEM_BOW_LIGHT)) {
-                            DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_UP) = BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_C_DOWN);
-                            Interface_Dpad_LoadItemIcon(play, EQUIP_SLOT_D_UP);
-                        }
+                    if ((DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_RIGHT) >= ITEM_BOW_FIRE) &&
+                            (DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_RIGHT) <= ITEM_BOW_LIGHT)) {
+                        DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_RIGHT) = BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_C_DOWN);
+                        Interface_Dpad_LoadItemIcon(play, EQUIP_SLOT_D_RIGHT);
+                    } else if ((DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_LEFT) >= ITEM_BOW_FIRE) &&
+                            (DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_LEFT) <= ITEM_BOW_LIGHT)) {
+                        DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_LEFT) = BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_C_DOWN);
+                        Interface_Dpad_LoadItemIcon(play, EQUIP_SLOT_D_LEFT);
+                    } else if ((DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_DOWN) >= ITEM_BOW_FIRE) &&
+                            (DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_DOWN) <= ITEM_BOW_LIGHT)) {
+                        DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_DOWN) = BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_C_DOWN);
+                        Interface_Dpad_LoadItemIcon(play, EQUIP_SLOT_D_DOWN);
+                    } else if ((DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_UP) >= ITEM_BOW_FIRE) &&
+                            (DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_UP) <= ITEM_BOW_LIGHT)) {
+                        DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_UP) = BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_C_DOWN);
+                        Interface_Dpad_LoadItemIcon(play, EQUIP_SLOT_D_UP);
                     }
                     // #endregion
                 }
@@ -1781,9 +1773,7 @@ void KaleidoScope_UpdateItemEquip(PlayState* play) {
                     }
                 }
                 // #region 2S2H [Dpad]
-                else if (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0)) {
-                    KaleidoScope_SwapDpadItemToCItem(play, EQUIP_SLOT_C_RIGHT);
-                }
+                KaleidoScope_SwapDpadItemToCItem(play, EQUIP_SLOT_C_RIGHT);
                 // #endregion
 
                 // Special case for magic arrows
@@ -1806,24 +1796,22 @@ void KaleidoScope_UpdateItemEquip(PlayState* play) {
                     }
                     // #region 2S2H [Dpad]
                     // Note Only C-Left has the swap of 'slot equips' here
-                    else if (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0)) {
-                        if ((DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_RIGHT) >= ITEM_BOW_FIRE) &&
-                                (DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_RIGHT) <= ITEM_BOW_LIGHT)) {
-                            DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_RIGHT) = BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_C_RIGHT);
-                            Interface_Dpad_LoadItemIcon(play, EQUIP_SLOT_D_RIGHT);
-                        } else if ((DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_LEFT) >= ITEM_BOW_FIRE) &&
-                                (DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_LEFT) <= ITEM_BOW_LIGHT)) {
-                            DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_LEFT) = BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_C_RIGHT);
-                            Interface_Dpad_LoadItemIcon(play, EQUIP_SLOT_D_LEFT);
-                        } else if ((DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_DOWN) >= ITEM_BOW_FIRE) &&
-                                (DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_DOWN) <= ITEM_BOW_LIGHT)) {
-                            DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_DOWN) = BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_C_RIGHT);
-                            Interface_Dpad_LoadItemIcon(play, EQUIP_SLOT_D_DOWN);
-                        } else if ((DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_UP) >= ITEM_BOW_FIRE) &&
-                                (DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_UP) <= ITEM_BOW_LIGHT)) {
-                            DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_UP) = BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_C_RIGHT);
-                            Interface_Dpad_LoadItemIcon(play, EQUIP_SLOT_D_UP);
-                        }
+                    if ((DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_RIGHT) >= ITEM_BOW_FIRE) &&
+                            (DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_RIGHT) <= ITEM_BOW_LIGHT)) {
+                        DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_RIGHT) = BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_C_RIGHT);
+                        Interface_Dpad_LoadItemIcon(play, EQUIP_SLOT_D_RIGHT);
+                    } else if ((DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_LEFT) >= ITEM_BOW_FIRE) &&
+                            (DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_LEFT) <= ITEM_BOW_LIGHT)) {
+                        DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_LEFT) = BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_C_RIGHT);
+                        Interface_Dpad_LoadItemIcon(play, EQUIP_SLOT_D_LEFT);
+                    } else if ((DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_DOWN) >= ITEM_BOW_FIRE) &&
+                            (DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_DOWN) <= ITEM_BOW_LIGHT)) {
+                        DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_DOWN) = BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_C_RIGHT);
+                        Interface_Dpad_LoadItemIcon(play, EQUIP_SLOT_D_DOWN);
+                    } else if ((DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_UP) >= ITEM_BOW_FIRE) &&
+                            (DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_UP) <= ITEM_BOW_LIGHT)) {
+                        DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_UP) = BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_C_RIGHT);
+                        Interface_Dpad_LoadItemIcon(play, EQUIP_SLOT_D_UP);
                     }
                     // #endregion
                 }

--- a/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_mask.c
+++ b/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_mask.c
@@ -581,37 +581,39 @@ void KaleidoScope_UpdateMaskCursor(PlayState* play) {
                         }
                     }
                     // #region 2S2H [Dpad]
-                    else if (CHECK_BTN_ALL(input->press.button, BTN_DRIGHT)) {
-                        if (((Player_GetCurMaskItemId(play) != ITEM_NONE) &&
-                             (Player_GetCurMaskItemId(play) == DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_RIGHT))) ||
-                            ((sMaskPlayerFormItems[GET_PLAYER_FORM] != ITEM_NONE) &&
-                             (sMaskPlayerFormItems[GET_PLAYER_FORM] == DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_RIGHT)))) {
-                            Audio_PlaySfx(NA_SE_SY_ERROR);
-                            return;
-                        }
-                    } else if (CHECK_BTN_ALL(input->press.button, BTN_DLEFT)) {
-                        if (((Player_GetCurMaskItemId(play) != ITEM_NONE) &&
-                             (Player_GetCurMaskItemId(play) == DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_LEFT))) ||
-                            ((sMaskPlayerFormItems[GET_PLAYER_FORM] != ITEM_NONE) &&
-                             (sMaskPlayerFormItems[GET_PLAYER_FORM] == DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_LEFT)))) {
-                            Audio_PlaySfx(NA_SE_SY_ERROR);
-                            return;
-                        }
-                    } else if (CHECK_BTN_ALL(input->press.button, BTN_DDOWN)) {
-                        if (((Player_GetCurMaskItemId(play) != ITEM_NONE) &&
-                             (Player_GetCurMaskItemId(play) == DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_DOWN))) ||
-                            ((sMaskPlayerFormItems[GET_PLAYER_FORM] != ITEM_NONE) &&
-                             (sMaskPlayerFormItems[GET_PLAYER_FORM] == DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_DOWN)))) {
-                            Audio_PlaySfx(NA_SE_SY_ERROR);
-                            return;
-                        }
-                    } else if (CHECK_BTN_ALL(input->press.button, BTN_DUP)) {
-                        if (((Player_GetCurMaskItemId(play) != ITEM_NONE) &&
-                             (Player_GetCurMaskItemId(play) == DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_UP))) ||
-                            ((sMaskPlayerFormItems[GET_PLAYER_FORM] != ITEM_NONE) &&
-                             (sMaskPlayerFormItems[GET_PLAYER_FORM] == DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_UP)))) {
-                            Audio_PlaySfx(NA_SE_SY_ERROR);
-                            return;
+                    else if (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0)) {
+                        if (CHECK_BTN_ALL(input->press.button, BTN_DRIGHT)) {
+                            if (((Player_GetCurMaskItemId(play) != ITEM_NONE) &&
+                                (Player_GetCurMaskItemId(play) == DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_RIGHT))) ||
+                                ((sMaskPlayerFormItems[GET_PLAYER_FORM] != ITEM_NONE) &&
+                                (sMaskPlayerFormItems[GET_PLAYER_FORM] == DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_RIGHT)))) {
+                                Audio_PlaySfx(NA_SE_SY_ERROR);
+                                return;
+                            }
+                        } else if (CHECK_BTN_ALL(input->press.button, BTN_DLEFT)) {
+                            if (((Player_GetCurMaskItemId(play) != ITEM_NONE) &&
+                                (Player_GetCurMaskItemId(play) == DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_LEFT))) ||
+                                ((sMaskPlayerFormItems[GET_PLAYER_FORM] != ITEM_NONE) &&
+                                (sMaskPlayerFormItems[GET_PLAYER_FORM] == DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_LEFT)))) {
+                                Audio_PlaySfx(NA_SE_SY_ERROR);
+                                return;
+                            }
+                        } else if (CHECK_BTN_ALL(input->press.button, BTN_DDOWN)) {
+                            if (((Player_GetCurMaskItemId(play) != ITEM_NONE) &&
+                                (Player_GetCurMaskItemId(play) == DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_DOWN))) ||
+                                ((sMaskPlayerFormItems[GET_PLAYER_FORM] != ITEM_NONE) &&
+                                (sMaskPlayerFormItems[GET_PLAYER_FORM] == DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_DOWN)))) {
+                                Audio_PlaySfx(NA_SE_SY_ERROR);
+                                return;
+                            }
+                        } else if (CHECK_BTN_ALL(input->press.button, BTN_DUP)) {
+                            if (((Player_GetCurMaskItemId(play) != ITEM_NONE) &&
+                                (Player_GetCurMaskItemId(play) == DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_UP))) ||
+                                ((sMaskPlayerFormItems[GET_PLAYER_FORM] != ITEM_NONE) &&
+                                (sMaskPlayerFormItems[GET_PLAYER_FORM] == DPAD_BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_D_UP)))) {
+                                Audio_PlaySfx(NA_SE_SY_ERROR);
+                                return;
+                            }
                         }
                     }
                     // #endregion
@@ -1111,9 +1113,7 @@ void KaleidoScope_UpdateMaskEquip(PlayState* play) {
                     }
                 }
                 // #region 2S2H [Dpad]
-                else if (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0)) {
-                    KaleidoScope_SwapDpadMaskToCMask(play, EQUIP_SLOT_C_LEFT);
-                }
+                KaleidoScope_SwapDpadMaskToCMask(play, EQUIP_SLOT_C_LEFT);
                 // #endregion
 
                 // Equip mask on CLeft
@@ -1142,9 +1142,7 @@ void KaleidoScope_UpdateMaskEquip(PlayState* play) {
                     }
                 }
                 // #region 2S2H [Dpad]
-                else if (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0)) {
-                    KaleidoScope_SwapDpadMaskToCMask(play, EQUIP_SLOT_C_DOWN);
-                }
+                KaleidoScope_SwapDpadMaskToCMask(play, EQUIP_SLOT_C_DOWN);
                 // #endregion
 
                 // Equip mask on CDown
@@ -1173,9 +1171,7 @@ void KaleidoScope_UpdateMaskEquip(PlayState* play) {
                     }
                 }
                 // #region 2S2H [Dpad]
-                else if (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0)) {
-                    KaleidoScope_SwapDpadMaskToCMask(play, EQUIP_SLOT_C_RIGHT);
-                }
+                KaleidoScope_SwapDpadMaskToCMask(play, EQUIP_SLOT_C_RIGHT);
                 // #endregion
 
                 // Equip mask on CRight


### PR DESCRIPTION
Makes it so that swapping always occurs, and equipping over a mask slot when dpad is inactive doesn't play an error noise

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1488335894.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1488336211.zip)
<!--- section:artifacts:end -->