### PR TITLE
TWEAK: Restoration menu duplication

### DIFF
--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -355,14 +355,6 @@ void DrawEnhancementsMenu() {
             ImGui::EndMenu();
         }
 
-        if (UIWidgets::BeginMenu("Restorations")) {
-            UIWidgets::CVarCheckbox("Power Crouch Stab", "gEnhancements.Restorations.PowerCrouchStab", {
-                .tooltip = "Crouch stabs will use the power of Link's previous melee attack, as is in MM JP 1.0 and OOT."
-            });
-
-            ImGui::EndMenu();
-        }
-
         if (UIWidgets::BeginMenu("Graphics")) {
             MotionBlur_RenderMenuOptions();
             ImGui::SeparatorText("Other");
@@ -400,6 +392,9 @@ void DrawEnhancementsMenu() {
         }
 
         if (UIWidgets::BeginMenu("Restorations")) {
+            UIWidgets::CVarCheckbox("Power Crouch Stab", "gEnhancements.Restorations.PowerCrouchStab", {
+                .tooltip = "Crouch stabs will use the power of Link's previous melee attack, as is in MM JP 1.0 and OOT."
+            });
             UIWidgets::CVarCheckbox("Side Rolls", "gEnhancements.Restorations.SideRoll", {
                 .tooltip = "Restores side rolling from OOT."
             });


### PR DESCRIPTION
Theres was two "Restorations" enhancements menu, merged them into one (alphabetically)

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1488626251.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1488626960.zip)
<!--- section:artifacts:end -->