### PR TITLE
Fix UB in the texture animation factory

### DIFF
--- a/mm/2s2h/resource/importer/TextureAnimationFactory.cpp
+++ b/mm/2s2h/resource/importer/TextureAnimationFactory.cpp
@@ -2,6 +2,7 @@
 #include "2s2h/resource/type/TextureAnimation.h"
 #include <libultraship/libultraship.h>
 #include "spdlog/spdlog.h"
+#include <malloc.h>
 
 namespace SOH {
 
@@ -15,6 +16,7 @@ std::shared_ptr<Ship::IResource> ResourceFactoryBinaryTextureAnimationV0::ReadRe
 
     const size_t numEntries = reader->ReadUInt32();
 
+    // `e` is a void* and must be allocated and freed with malloc/free
     for (size_t i = 0; i < numEntries; i++) {
         AnimatedMaterial anim;
         anim.segment = reader->ReadInt8();
@@ -22,7 +24,13 @@ std::shared_ptr<Ship::IResource> ResourceFactoryBinaryTextureAnimationV0::ReadRe
 
         switch ((TextureAnimationParamsType)anim.type) {
             case TextureAnimationParamsType::SingleScroll: {
-                auto* e = new AnimatedMatTexScrollParams;
+                auto* e = (AnimatedMatTexScrollParams*)malloc(sizeof(AnimatedMatTexScrollParams));
+                if (e == nullptr) {
+                    SPDLOG_CRITICAL("Failed to allocate memory for AnimatedMatTexScrollParams");
+                    std::bad_alloc ex;
+                    throw ex;
+                }
+
                 e->xStep = reader->ReadInt8();
                 e->yStep = reader->ReadInt8();
                 e->width = reader->ReadUByte();
@@ -31,7 +39,13 @@ std::shared_ptr<Ship::IResource> ResourceFactoryBinaryTextureAnimationV0::ReadRe
                 break;
             }
             case TextureAnimationParamsType::DualScroll: {
-                auto* e = new AnimatedMatTexScrollParams[2];
+                auto* e = (AnimatedMatTexScrollParams*)malloc(sizeof(AnimatedMatTexScrollParams) * 2);
+                if (e == nullptr) {
+                    SPDLOG_CRITICAL("Failed to allocate memory for AnimatedMatTexScrollParams");
+                    std::bad_alloc ex;
+                    throw ex;
+                }
+
                 e[0].xStep = reader->ReadInt8();
                 e[0].yStep = reader->ReadInt8();
                 e[0].width = reader->ReadUByte();
@@ -46,7 +60,13 @@ std::shared_ptr<Ship::IResource> ResourceFactoryBinaryTextureAnimationV0::ReadRe
             case TextureAnimationParamsType::ColorChange:
             case TextureAnimationParamsType::ColorChangeLERP:
             case TextureAnimationParamsType::ColorChangeLagrange: {
-                auto* e = new AnimatedMatColorParams;
+                auto* e = (AnimatedMatColorParams*)malloc(sizeof(AnimatedMatColorParams));
+                if (e == nullptr) {
+                    SPDLOG_CRITICAL("Failed to allocate memory for AnimatedMatColorParams");
+                    std::bad_alloc ex;
+                    throw ex;
+                }
+
                 e->keyFrameLength = reader->ReadUInt16();
                 e->keyFrameCount = reader->ReadUInt16();
 
@@ -91,8 +111,12 @@ std::shared_ptr<Ship::IResource> ResourceFactoryBinaryTextureAnimationV0::ReadRe
                 break;
             }
             case TextureAnimationParamsType::TextureCycle: {
-                auto* e = new AnimatedMatTexCycleParams;
-
+                auto* e = (AnimatedMatTexCycleParams*)malloc(sizeof(AnimatedMatTexCycleParams));
+                if (e == nullptr) {
+                    SPDLOG_CRITICAL("Failed to allocate memory for AnimatedMatTexCycleParams");
+                    std::bad_alloc ex;
+                    throw ex;
+                }
                 e->keyFrameLength = reader->ReadUInt16();
                 uint32_t textureListSize = reader->ReadUInt32();
                 e->textureList = new void*[textureListSize];

--- a/mm/2s2h/resource/type/TextureAnimation.cpp
+++ b/mm/2s2h/resource/type/TextureAnimation.cpp
@@ -5,10 +5,11 @@ TextureAnimation::~TextureAnimation() {
     for (auto& a : anims) {
         switch ((TextureAnimationParamsType)a.type) {
             case TextureAnimationParamsType::SingleScroll:
-                delete a.params;
+                // a.params is a void* and must be allocated and freed with malloc/free
+                free(a.params);
                 break;
             case TextureAnimationParamsType::DualScroll:
-                delete[] a.params;
+                free(a.params);
                 break;
             case TextureAnimationParamsType::ColorChange:
             case TextureAnimationParamsType::ColorChangeLERP:
@@ -16,13 +17,13 @@ TextureAnimation::~TextureAnimation() {
                 delete[] ((AnimatedMatColorParams*)a.params)->keyFrames;
                 delete[] ((AnimatedMatColorParams*)a.params)->primColors;
                 delete[] ((AnimatedMatColorParams*)a.params)->envColors;
-                delete a.params;
+                free(a.params);
                 break;
             case TextureAnimationParamsType::TextureCycle:
                 // BENTODO free the textures
                 delete[] ((AnimatedMatTexCycleParams*)a.params)->textureIndexList;
                 delete[] ((AnimatedMatTexCycleParams*)a.params)->textureList;
-                delete a.params;
+                free(a.params);
                 break;
         }
     }


### PR DESCRIPTION
It is UB to call delete on a `void*`. Replace `new`/`delete` with `malloc`/`free`

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1489792469.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1489792767.zip)
<!--- section:artifacts:end -->