### PR TITLE
Fix malloc include on macos

### DIFF
--- a/mm/2s2h/resource/importer/TextureAnimationFactory.cpp
+++ b/mm/2s2h/resource/importer/TextureAnimationFactory.cpp
@@ -2,9 +2,6 @@
 #include "2s2h/resource/type/TextureAnimation.h"
 #include <libultraship/libultraship.h>
 #include "spdlog/spdlog.h"
-#ifndef __APPLE__
-#include <malloc.h>
-#endif
 #include <stdlib.h>
 
 namespace SOH {


### PR DESCRIPTION
Builds were borked on mac

Referenced from soh's `heaps.c`

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1491880764.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1491882431.zip)
<!--- section:artifacts:end -->