### PR TITLE
[Cheat] Longer Deku Flower Gliding

### DIFF
--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -542,6 +542,9 @@ void DrawCheatsMenu() {
             RegisterMoonJumpOnL();
         }
         UIWidgets::CVarCheckbox("No Clip", "gCheats.NoClip");
+        UIWidgets::CVarCheckbox(
+            "Longer Deku Flower Glide", "gCheats.LongerFlowerGlide",
+            { .tooltip = "Allows Deku Link to glide longer, no longer dropping after a certain distance" });
 
         ImGui::EndMenu();
     }

--- a/mm/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/mm/src/overlays/actors/ovl_player_actor/z_player.c
@@ -18821,7 +18821,7 @@ void Player_Action_94(Player* this, PlayState* play) {
         temp_fv1 = D_8085D958[this->av1.actionVar1] - Math_Vec3f_DistXZ(&this->actor.world.pos, this->unk_AF0);
         PlayerAnimation_Update(play, &this->skelAnime);
 
-        if ((this->av2.actionVar2 != 0) && (temp_fv1 > 300.0f)) {
+        if (((this->av2.actionVar2 != 0) && (temp_fv1 > 300.0f)) || (CVarGetInteger("gCheats.LongerFlowerGlide", 0))) {
             sp76 = 0x1770;
             if (!BEN_ANIM_EQUAL(this->skelAnime.animation, gPlayerAnim_pn_kakku)) {
                 func_8082E5EC(play, this, &gPlayerAnim_pn_kakkufinish);


### PR DESCRIPTION
Bypasses the struggling and dropping after a certain distance and allows you to glide majestically until you either slowly reach the ground or press A to cancel the glide.