### PR TITLE
Fix ImGui BeginTable not wrapped in if statements

### DIFF
--- a/mm/2s2h/BenGui/HudEditor.cpp
+++ b/mm/2s2h/BenGui/HudEditor.cpp
@@ -168,26 +168,27 @@ void HudEditorWindow::DrawElement() {
             CVarClear(hudEditorElements[i].scaleCvar);
         }
         if (CVarGetInteger(hudEditorElements[i].modeCvar, HUD_EDITOR_ELEMENT_MODE_VANILLA) >= HUD_EDITOR_ELEMENT_MODE_MOVABLE_43) {
-            ImGui::BeginTable("##table", 3, ImGuiTableFlags_NoSavedSettings | ImGuiTableFlags_NoBordersInBody);
-            ImGui::TableNextColumn();
-            UIWidgets::CVarSliderInt("X", hudEditorElements[i].xCvar, -10, 330, hudEditorElements[i].defaultX, {
-                .showButtons = false,
-                .format = "X: %d",
-                .labelPosition = UIWidgets::LabelPosition::None,
-            });
-            ImGui::TableNextColumn();
-            UIWidgets::CVarSliderInt("Y", hudEditorElements[i].yCvar, -10, 250, hudEditorElements[i].defaultY, {
-                .showButtons = false,
-                .format = "Y: %d",
-                .labelPosition = UIWidgets::LabelPosition::None,
-            });
-            ImGui::TableNextColumn();
-            UIWidgets::CVarSliderFloat("Scale", hudEditorElements[i].scaleCvar, 0.25f, 4.0f, 1.0f, {
-                .showButtons = false,
-                .format = "Scale: %.2f",
-                .labelPosition = UIWidgets::LabelPosition::None,
-            });
-            ImGui::EndTable();
+            if (ImGui::BeginTable("##table", 3, ImGuiTableFlags_NoSavedSettings | ImGuiTableFlags_NoBordersInBody)) {
+                ImGui::TableNextColumn();
+                UIWidgets::CVarSliderInt("X", hudEditorElements[i].xCvar, -10, 330, hudEditorElements[i].defaultX, {
+                    .showButtons = false,
+                    .format = "X: %d",
+                    .labelPosition = UIWidgets::LabelPosition::None,
+                });
+                ImGui::TableNextColumn();
+                UIWidgets::CVarSliderInt("Y", hudEditorElements[i].yCvar, -10, 250, hudEditorElements[i].defaultY, {
+                    .showButtons = false,
+                    .format = "Y: %d",
+                    .labelPosition = UIWidgets::LabelPosition::None,
+                });
+                ImGui::TableNextColumn();
+                UIWidgets::CVarSliderFloat("Scale", hudEditorElements[i].scaleCvar, 0.25f, 4.0f, 1.0f, {
+                    .showButtons = false,
+                    .format = "Scale: %.2f",
+                    .labelPosition = UIWidgets::LabelPosition::None,
+                });
+                ImGui::EndTable();
+            }
         }
         ImGui::PopID();
     }

--- a/mm/2s2h/DeveloperTools/SaveEditor.cpp
+++ b/mm/2s2h/DeveloperTools/SaveEditor.cpp
@@ -911,6 +911,8 @@ void DrawPlayerTab() {
     ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.0f, 1.0f, 1.0f, 0.0f));
     ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 3.0f);
     ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(8.0f, 8.0f));
+    ImGui::BeginChild("playerTab", ImVec2(0, 0), true);
+
     if (gPlayState) {
         Player* player = GET_PLAYER(gPlayState);
         ImGui::BeginChild("playerLocation", ImVec2(INV_GRID_WIDTH * 8 + INV_GRID_PADDING * 2, INV_GRID_HEIGHT * 1.75f + INV_GRID_PADDING * 2 + INV_GRID_TOP_MARGIN), ImGuiChildFlags_Border);
@@ -1039,28 +1041,29 @@ void DrawPlayerTab() {
         ImGui::Text("Player States");
         uint32_t states[4] = { player->stateFlags1, player->stateFlags2, player->stateFlags3, player->meleeWeaponState };
 
-        ImGui::BeginTable("stateTable", 4);
-        GetPlayerForm(GET_PLAYER_FORM);
-        ImGui::PushStyleVar(ImGuiTableColumnFlags_WidthFixed, 15.0f);
-        ImGui::PushStyleColor(ImGuiCol_TableHeaderBg, formColor);
-        ImGui::TableSetupColumn("State 1");
-        ImGui::TableSetupColumn("State 2");
-        ImGui::TableSetupColumn("State 3");
-        ImGui::TableSetupColumn("Sword State");
-        ImGui::TableHeadersRow();
-        ImGui::TableNextColumn();
-
-        for (int i = 0; i <= 3; i++) {
-            ImGui::Text(std::to_string(states[i]).c_str());
+        if (ImGui::BeginTable("stateTable", 4)) {
+            GetPlayerForm(GET_PLAYER_FORM);
+            ImGui::PushStyleVar(ImGuiTableColumnFlags_WidthFixed, 15.0f);
+            ImGui::PushStyleColor(ImGuiCol_TableHeaderBg, formColor);
+            ImGui::TableSetupColumn("State 1");
+            ImGui::TableSetupColumn("State 2");
+            ImGui::TableSetupColumn("State 3");
+            ImGui::TableSetupColumn("Sword State");
+            ImGui::TableHeadersRow();
             ImGui::TableNextColumn();
+
+            for (int i = 0; i <= 3; i++) {
+                ImGui::Text(std::to_string(states[i]).c_str());
+                ImGui::TableNextColumn();
+            }
+
+            ImGui::PopStyleColor(1);
+            ImGui::PopStyleVar(1);
+            ImGui::EndTable();
         }
-
-        ImGui::PopStyleColor(1);
-        ImGui::PopStyleVar(1);
-        ImGui::EndTable();
         ImGui::EndChild();
-
     }
+    ImGui::EndChild();
     ImGui::PopStyleVar(2);
     ImGui::PopStyleColor(1);
 }


### PR DESCRIPTION
ImGui tables need to be wrapped in if blocks so that table setup methods aren't called if the table is off screen/not rendered. Without it trips debug asserts.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1494552063.zip?h=20a00267c7ffeb2eb80ab31f356f2ba5f120f43c)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1494552307.zip?h=20a00267c7ffeb2eb80ab31f356f2ba5f120f43c)
<!--- section:artifacts:end -->