### PR TITLE
Add Hud Editor support for timers

### DIFF
--- a/mm/2s2h/BenGui/HudEditor.cpp
+++ b/mm/2s2h/BenGui/HudEditor.cpp
@@ -34,7 +34,7 @@ extern "C" void HudEditor_SetActiveElement(HudEditorElementID id) {
     hudEditorActiveElement = id;
 }
 
-extern "C" void HudEditor_ModifyRectLeftRectTopValues(s16* rectLeft, s16* rectTop) {
+extern "C" void HudEditor_ModifyRectPosValues(s16* rectLeft, s16* rectTop) {
     s16 offsetFromBaseX = *rectLeft - hudEditorElements[hudEditorActiveElement].defaultX;
     s16 offsetFromBaseY = *rectTop - hudEditorElements[hudEditorActiveElement].defaultY;
     *rectLeft = CVarGetInteger(hudEditorElements[hudEditorActiveElement].xCvar,
@@ -58,7 +58,7 @@ extern "C" void HudEditor_ModifyKaleidoEquipAnimValues(s16* ulx, s16* uly, s16* 
     *ulx = (*ulx / 10) + (SCREEN_WIDTH / 2);
     *uly = (SCREEN_HEIGHT / 2) - (*uly / 10);
 
-    HudEditor_ModifyRectLeftRectTopValues(ulx, uly);
+    HudEditor_ModifyRectPosValues(ulx, uly);
 
     // Adjust the values to match the kaleido matrix (origin 0,0 at center of screen, +y going up)
     *ulx -= SCREEN_WIDTH / 2;
@@ -91,7 +91,7 @@ extern "C" void HudEditor_ModifyDrawValuesFromBase(s16 baseX, s16 baseY, s16* re
 
 extern "C" void HudEditor_ModifyDrawValues(s16* rectLeft, s16* rectTop, s16* rectWidth, s16* rectHeight, s16* dsdx,
                                            s16* dtdy) {
-    HudEditor_ModifyRectLeftRectTopValues(rectLeft, rectTop);
+    HudEditor_ModifyRectPosValues(rectLeft, rectTop);
 
     *rectWidth *= CVarGetFloat(hudEditorElements[hudEditorActiveElement].scaleCvar, 1.0f);
     *rectHeight *= CVarGetFloat(hudEditorElements[hudEditorActiveElement].scaleCvar, 1.0f);

--- a/mm/2s2h/BenGui/HudEditor.h
+++ b/mm/2s2h/BenGui/HudEditor.h
@@ -52,7 +52,7 @@ typedef enum {
 
 void HudEditor_SetActiveElement(HudEditorElementID id);
 bool HudEditor_ShouldOverrideDraw();
-void HudEditor_ModifyRectLeftRectTopValues(s16* rectLeft, s16* rectTop);
+void HudEditor_ModifyRectPosValues(s16* rectLeft, s16* rectTop);
 void HudEditor_ModifyKaleidoEquipAnimValues(s16* ulx, s16* uly, s16* shrinkRate);
 void HudEditor_ModifyDrawValuesFromBase(s16 baseX, s16 baseY, s16* rectLeft, s16* rectTop, s16* rectWidth, s16* rectHeight, s16* dsdx, s16* dtdy);
 void HudEditor_ModifyDrawValues(s16* rectLeft, s16* rectTop, s16* rectWidth, s16* rectHeight, s16* dsdx, s16* dtdy);

--- a/mm/src/code/z_parameter.c
+++ b/mm/src/code/z_parameter.c
@@ -7151,7 +7151,7 @@ void Interface_DrawTimers(PlayState* play) {
                 // #region 2S2H [Cosmetic] Hud editor values for postman timer
                 HudEditor_SetActiveElement(hudTimerElement);
                 if (HudEditor_ShouldOverrideDraw()) {
-                    HudEditor_ModifyRectLeftRectTopValues(&newTimerX, &newTimerY);
+                    HudEditor_ModifyRectPosValues(&newTimerX, &newTimerY);
                 } else {
                     newTimerX = 115;
                     newTimerY = 80;
@@ -7208,7 +7208,7 @@ void Interface_DrawTimers(PlayState* play) {
                         // #region 2S2H [Cosmetic] Hud editor values for static minigame timers
                         HudEditor_SetActiveElement(hudTimerElement);
                         if (HudEditor_ShouldOverrideDraw()) {
-                            HudEditor_ModifyRectLeftRectTopValues(&newTimerX, &newTimerY);
+                            HudEditor_ModifyRectPosValues(&newTimerX, &newTimerY);
                             modifiedTimerHudValues = true;
                             gSaveContext.timerX[sTimerId] = newTimerX;
                             gSaveContext.timerY[sTimerId] = newTimerY;
@@ -7247,7 +7247,7 @@ void Interface_DrawTimers(PlayState* play) {
                     // #region 2S2H [Cosmetic] Hud Editor values for timers animation position
                     HudEditor_SetActiveElement(hudTimerElement);
                     if (HudEditor_ShouldOverrideDraw()) {
-                        HudEditor_ModifyRectLeftRectTopValues(&newTimerX, &newTimerY);
+                        HudEditor_ModifyRectPosValues(&newTimerX, &newTimerY);
                         modifiedTimerHudValues = true;
                         j = ((((void)0, gSaveContext.timerX[sTimerId]) - newTimerX) / sTimerStateTimer);
                         gSaveContext.timerX[sTimerId] = ((void)0, gSaveContext.timerX[sTimerId]) - j;
@@ -7315,7 +7315,7 @@ void Interface_DrawTimers(PlayState* play) {
                         HudEditor_SetActiveElement(hudTimerElement);
                         // If we are in a fallthrough, we don't want to modify the values a second time
                         if (HudEditor_ShouldOverrideDraw() && !modifiedTimerHudValues) {
-                            HudEditor_ModifyRectLeftRectTopValues(&newTimerX, &newTimerY);
+                            HudEditor_ModifyRectPosValues(&newTimerX, &newTimerY);
                         }
                         gSaveContext.timerX[sTimerId] = newTimerX;
                         gSaveContext.timerY[sTimerId] = newTimerY;


### PR DESCRIPTION
This adds Hud Editor support for various timers. Because some timers animate their start/end positions, I had to introduce an alternate way of setting/applying the modified values (similar to kaleido equip animations).

First we call `HudEditor_ModifyDrawValues` with some dummy values so that we can get the modified starting position of the timer, then later when actually drawing the elements we call a new method `HudEditor_ModifyTimerDrawValues` which uses the passed in start positions as the value to operate offset logic off of.

4 types of timers are handled in the following ways:
* Skullkid timer (on clock tower rooftop) - This one animates to a different position than the other timers (bottom-center), so I created a separate hud option for this timer (worthy candidate of going behind an "advanced" mode in the future)
* Animated timers - These timers start in the center of the screen, then animate to the top-left
* Static timers - These timers start in their final location without moving
* Postman timer - This timer is placed in the top-center, but I opted to apply the regular timer modifications to it. So widescreen would place it on the left.

Both animated timers require incrementally stepping the values to the final position (like the kaleido animation).

Postman and SkullKid are the outliers.
I could see an argument of dropping the skull kid timer option and not applying movement to it or the postman timer.
I could also see an argument of dropping the skull kid timer option and just treat it like a regular modified timer.
I don't think its worth creating a dedicated option for the postman timer though (at least not without an advanced mode).

<!--- section:artifacts:start -->
### Build Artifacts
<!--- section:artifacts:end -->