### PR TITLE
Fix z-targetting camera snap

### DIFF
--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -331,6 +331,11 @@ void DrawEnhancementsMenu() {
     if (UIWidgets::BeginMenu("Enhancements")) {
 
         if (UIWidgets::BeginMenu("Camera")) {
+            ImGui::SeparatorText("Fixes");
+            UIWidgets::CVarCheckbox(
+                "Fix Targetting Camera Snap", "gEnhancements.Camera.FixTargettingCameraSnap",
+                { .tooltip =
+                      "Fixes the camera snap that occurs when you are moving and press the targetting button." });
             ImGui::SeparatorText("Right Stick Camera");
             UIWidgets::CVarCheckbox("Invert Camera X Axis", "gEnhancements.Camera.RightStick.InvertXAxis",
                                     { .tooltip = "Inverts the Camera X Axis in Free Look." });

--- a/mm/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/mm/src/overlays/actors/ovl_player_actor/z_player.c
@@ -4808,7 +4808,8 @@ void func_80832888(Player* this, PlayState* play) {
         } else {
             this->unk_738--;
         }
-    } else if (this->stateFlags1 & PLAYER_STATE1_20000) {
+    } else if (this->stateFlags1 & PLAYER_STATE1_20000 &&
+               !CVarGetInteger("gEnhancements.Camera.FixTargettingCameraSnap", 0)) {
         this->unk_738 = 0;
     } else if (this->unk_738 != 0) {
         this->unk_738--;


### PR DESCRIPTION
This is not the "proper fix" of back-porting oot camera behavior. In fact this same line that we are overriding exists in it's same form on OoT, but this gets us 90% of the way there for this fix in terms of behavior.