### PR TITLE
Fixed interpolation issue in z_eff_dust related to post STT cutscene.

### DIFF
--- a/mm/src/overlays/actors/ovl_Eff_Dust/z_eff_dust.c
+++ b/mm/src/overlays/actors/ovl_Eff_Dust/z_eff_dust.c
@@ -7,6 +7,7 @@
 #include "z_eff_dust.h"
 #include "objects/gameplay_keep/gameplay_keep.h"
 #include "system_malloc.h"
+#include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
 
 #define FLAGS (ACTOR_FLAG_10 | ACTOR_FLAG_20)
 
@@ -290,6 +291,7 @@ void func_80919768(Actor* thisx, PlayState* play2) {
     gSPSegment(POLY_XLU_DISP++, 0x08, D_80919DB0);
 
     for (i = 0; i < ARRAY_COUNT(this->distanceTraveled); i++) {
+        FrameInterpolation_RecordOpenChild(this, i);
         if (*distanceTraveled < 1.0f) {
             aux = 1.0f - SQ(*distanceTraveled);
             Matrix_Translate(thisx->world.pos.x, thisx->world.pos.y, thisx->world.pos.z, MTXMODE_NEW);
@@ -309,6 +311,7 @@ void func_80919768(Actor* thisx, PlayState* play2) {
 
             gSPSetGeometryMode(POLY_XLU_DISP++, G_FOG | G_LIGHTING);
         }
+        FrameInterpolation_RecordCloseChild();
         initialPositions++;
         distanceTraveled++;
     }


### PR DESCRIPTION
During the cutscene after freeing the giant in Ikana Canyon.

For quick reference the object in question is the purple particles at `Ikana Canyon; Stage 1` from the debug menu.

Not sure if `this` is the best argument in this particular case or not however...but it seems to work fine, if it is not please let me know and ill correct it.