### PR TITLE
Prevent infinite loop in save migration

### DIFF
--- a/mm/2s2h/SaveManager/SaveManager.cpp
+++ b/mm/2s2h/SaveManager/SaveManager.cpp
@@ -56,7 +56,9 @@ const std::unordered_map<uint32_t, std::function<void(nlohmann::json&)>> migrati
 
 void SaveManager_MigrateSave(nlohmann::json& j) {
     int version = j.value("version", 0);
-    while (version != CURRENT_SAVE_VERSION) {
+
+    // BENTODO: what should we do if the version number is greater?
+    while (version < CURRENT_SAVE_VERSION) {
         if (migrations.contains(version)) {
             auto migration = migrations.at(version);
             migration(j);


### PR DESCRIPTION
The save migrations were not gracefully handling saves that had a "higher" version than the current version for the build. The while loop would execute forever due to a strict inequal.

For now I changed it to a less than to prevent the loop and just allow the code to continue.

We probably need to think of what we actually want to do when this occurs.
Do nothing and just tell users that using newer saves on older builds aren't expected to work?
Do we set the version number back and make saves gracefully load zero values for things missing?
Do we gray out the save on the file menu? (a la SoH MQ) (assuming loading the unknown json doesn't crash)