### PR TITLE
Skip first cycle reset cutscene on debug created saves

### DIFF
--- a/mm/2s2h/DeveloperTools/DeveloperTools.cpp
+++ b/mm/2s2h/DeveloperTools/DeveloperTools.cpp
@@ -41,6 +41,9 @@ void RegisterDebugSaveCreate() {
             gSaveContext.save.cutsceneIndex = 0;
             gSaveContext.save.saveInfo.checksum = 1;
 
+            // Prevent first Song of Time reset from forcing Deku Link and having to learn Song of Healing
+            gSaveContext.save.saveInfo.playerData.threeDayResetCount = 1;
+
             if (CVarGetInteger("gDeveloperTools.DebugSaveFileMode", DEBUG_SAVE_INFO_NONE) == DEBUG_SAVE_INFO_COMPLETE) {
                 gSaveContext.save.saveInfo.playerData.doubleDefense = true;
                 gSaveContext.save.saveInfo.playerData.health = 20 * 0x10;


### PR DESCRIPTION
Setting the `threeDayResetCount` to >= 0 prevents the "first reset" cutscene which reverts link into deku form. Applying to both types of debug inventory saves since those cutscenes are long and not needed for debug saves.