### PR TITLE
Prevent owl statue text on loading pause save

### DIFF
--- a/mm/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/mm/src/overlays/actors/ovl_player_actor/z_player.c
@@ -10968,10 +10968,12 @@ void Player_Init(Actor* thisx, PlayState* play) {
         initMode = PLAYER_INITMODE_D;
     }
 
-    // When we have a pause save entrance, we need to override the init mode to ensure the loading is handled correctly
+    // 2S2H [Enhancement] When we have a pause save entrance, we need unset the values to prevent them from lingering
+    // Load into INITMODE_D for stationary Link spawn
     if (gSaveContext.save.shipSaveInfo.pauseSaveEntrance != -1) {
-        initMode = PLAYER_INITMODE_6;
+        initMode = PLAYER_INITMODE_D;
         gSaveContext.save.shipSaveInfo.pauseSaveEntrance = -1;
+        gSaveContext.save.isOwlSave = false;
     }
 
     D_8085D2CC[initMode](play, this);


### PR DESCRIPTION
Using INITMODE_6 properly unsets the `isOwlSave` flag, but also puts link into a talk state with the owl statue text. This behavior is strange, especially when link is loading into water.

Instead I've changed it so that pause saves use `INITMODE_D` which is a stationary link spawn, then we specifically unset the `isOwlSave` flag so that it doesn't linger/get persisted onto the main savefile.