### PR TITLE
Fix Zelda arena leak/overflow with gamestate not being freed

### DIFF
--- a/mm/src/code/graph.c
+++ b/mm/src/code/graph.c
@@ -426,7 +426,7 @@ void RunFrame() {
 
         runFrameContext.nextOvl = Graph_GetNextGameState(runFrameContext.gameState);
         GameState_Destroy(runFrameContext.gameState);
-        // System (runFrameContext.gameState);
+        SystemArena_Free(runFrameContext.gameState);
         Overlay_FreeGameState(runFrameContext.ovl);
     }
     Graph_Destroy(&runFrameContext.gfxCtx);


### PR DESCRIPTION
The gamestate was being alloced on the zelda arena, but nothing was ever freeing it. It looks like the statement that originally would have been responsible for it got left in the dust with the original mini-build.

This can also be compared with SoH where there is an equivalent free call being made.

Fixes #406 