### PR TITLE
Fix zora guitar scaling issue

### DIFF
--- a/mm/src/code/z_player_lib.c
+++ b/mm/src/code/z_player_lib.c
@@ -1175,6 +1175,12 @@ struct_80124618 D_801C0560[] = {
     { 2, { 95, 95, 100 } },
     { 3, { 105, 105, 100 } },
     { 5, { 102, 102, 102 } },
+    //! @bug When playing zora guitar, this is passed into func_80124618 with a curFrame of 6, and func_80124618
+    // will overflow it into the next struct until it hits the value with 9
+    // #region 2S2H [Port] We are adding the next two animation stop values here to prevent OOB reads
+    { 0, { 100, 100, 100 } },
+    { 9, { 100, 100, 100 } },
+    // #endregion
 };
 struct_80124618 D_801C0580[] = {
     { 0, { 100, 100, 100 } }, { 9, { 100, 100, 100 } }, { 10, { 150, 150, 150 } },


### PR DESCRIPTION
Document and fix an authentic OOB read with the zora guitar playing animation.

Fixes #243 