### PR TITLE
Couple HUD Editor fixes

### DIFF
--- a/mm/src/code/z_lifemeter.c
+++ b/mm/src/code/z_lifemeter.c
@@ -418,24 +418,16 @@ void LifeMeter_Draw(PlayState* play) {
                     hudEditorActiveElement = HUD_EDITOR_ELEMENT_NONE;
                     Mtx_SetTranslateScaleMtx(mtx, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
                 } else {
-                    // All of this information was derived from the original call to gSPTextureRectangle below
-                    s16 offsetFromBaseX = (-130.0f + offsetX) - hudEditorElements[hudEditorActiveElement].defaultX;
-                    s16 offsetFromBaseY = -(94.5f - offsetY) - hudEditorElements[hudEditorActiveElement].defaultY;
-                    // TODO: These scale offsets don't seem to be working correctly
-                    s16 rectLeft = CVarGetInteger(hudEditorElements[hudEditorActiveElement].xCvar, hudEditorElements[hudEditorActiveElement].defaultX) + (offsetFromBaseX / CVarGetFloat(hudEditorElements[hudEditorActiveElement].scaleCvar, 1.0f));
-                    s16 rectTop = CVarGetInteger(hudEditorElements[hudEditorActiveElement].yCvar, hudEditorElements[hudEditorActiveElement].defaultY) + (offsetFromBaseY / CVarGetFloat(hudEditorElements[hudEditorActiveElement].scaleCvar, 1.0f));
-                    float size = 1.0f - (0.32f * lifesize);
+                    // All of this information was derived from the original call to Mtx_SetTranslateScaleMtx below
+                    f32 transX = -130.0f + offsetX;
+                    f32 transY = 94.5f - offsetY;
+                    f32 size = 1.0f - (0.32f * lifesize);
 
-                    size *= CVarGetFloat(hudEditorElements[hudEditorActiveElement].scaleCvar, 1.0f);
-
-                    if (CVarGetInteger(hudEditorElements[hudEditorActiveElement].modeCvar, HUD_EDITOR_ELEMENT_MODE_VANILLA) == HUD_EDITOR_ELEMENT_MODE_MOVABLE_LEFT) {
-                        rectLeft = OTRGetRectDimensionFromLeftEdge(rectLeft);
-                    } else if (CVarGetInteger(hudEditorElements[hudEditorActiveElement].modeCvar, HUD_EDITOR_ELEMENT_MODE_VANILLA) == HUD_EDITOR_ELEMENT_MODE_MOVABLE_RIGHT) {
-                        rectLeft = OTRGetRectDimensionFromRightEdge(rectLeft);
-                    }
+                    size *= HudEditor_GetActiveElementScale();
+                    HudEditor_ModifyMatrixValues(&transX, &transY);
 
                     hudEditorActiveElement = HUD_EDITOR_ELEMENT_NONE;
-                    Mtx_SetTranslateScaleMtx(mtx, size, size, size, rectLeft, -rectTop, 0.0f);
+                    Mtx_SetTranslateScaleMtx(mtx, size, size, size, transX, transY, 0.0f);
                 }
             // #endregion
             } else {

--- a/mm/src/code/z_map_disp.c
+++ b/mm/src/code/z_map_disp.c
@@ -998,21 +998,23 @@ void MapDisp_Update(PlayState* play) {
     if ((sMapDisp.mapDataScene != NULL) && (sSceneNumRooms != 0)) {
         // #region 2S2H [Cosmetic] Hud Editor minimap base position
         // This value is used to determine the relative positioning for all the other elements
+        MapDataRoom* mapDataRoom = &sMapDisp.mapDataScene->rooms[sMapDisp.curRoom];
         HudEditor_SetActiveElement(HUD_EDITOR_ELEMENT_MINIMAP);
-        if (HudEditor_ShouldOverrideDraw()) {
+        if (mapDataRoom != NULL && mapDataRoom->mapId != MAP_DATA_NO_MAP) {
             s32 width;
             s32 height;
+            MapDisp_GetMapTexDim(mapDataRoom, &width, &height);
 
-            MapDataRoom* mapDataRoom = &sMapDisp.mapDataScene->rooms[sMapDisp.curRoom];
-            if (mapDataRoom != NULL && mapDataRoom->mapId != MAP_DATA_NO_MAP) {
-                MapDisp_GetMapTexDim(mapDataRoom, &width, &height);
-                sMapDisp.minimapBaseX = 295;
-                sMapDisp.minimapBaseY = 220;
-                HudEditor_ModifyRectPosValues(&sMapDisp.minimapBaseX, &sMapDisp.minimapBaseY);
+            sMapDisp.minimapBaseX = 295;
+            sMapDisp.minimapBaseY = 220;
+
+            if (HudEditor_ShouldOverrideDraw()) {
                 // We don't want to scale width/height here, it will happen later when the texture is drawn
-                sMapDisp.minimapBaseX -= width;
-                sMapDisp.minimapBaseY -= height;
+                HudEditor_ModifyRectPosValues(&sMapDisp.minimapBaseX, &sMapDisp.minimapBaseY);
             }
+
+            sMapDisp.minimapBaseX -= width;
+            sMapDisp.minimapBaseY -= height;
         }
         // #endregion
 
@@ -1098,8 +1100,8 @@ void MapDisp_SwapRooms(s16 nextRoom) {
             if (HudEditor_ShouldOverrideDraw()) {
                 sMapDisp.minimapBaseX = 295;
                 sMapDisp.minimapBaseY = 220;
-                HudEditor_ModifyRectPosValues(&sMapDisp.minimapBaseX, &sMapDisp.minimapBaseY);
                 // We don't want to scale width/height here, it will happen later when the texture is drawn
+                HudEditor_ModifyRectPosValues(&sMapDisp.minimapBaseX, &sMapDisp.minimapBaseY);
                 sMapDisp.minimapBaseX -= width;
                 sMapDisp.minimapBaseY -= height;
 

--- a/mm/src/code/z_parameter.c
+++ b/mm/src/code/z_parameter.c
@@ -5074,6 +5074,19 @@ void Interface_SetPerspectiveView(PlayState* play, s32 topY, s32 bottomY, s32 le
             HudEditor_ModifyDrawValues(&rectLeft, &rectTop, &rectWidth, &rectHeight, &dsdx, &dtdy);
             hudEditorActiveElement = HUD_EDITOR_ELEMENT_NONE;
 
+            // Clamp the values to the avialable screen space while preserving the shape
+            // to avoid undefined behavior like stretching or hiding of the A button
+            rectLeft = MAX(rectLeft, OTRGetRectDimensionFromLeftEdge(0));
+            rectTop = MAX(rectTop, 0);
+
+            if (rectLeft + rectWidth > OTRGetRectDimensionFromRightEdge(SCREEN_WIDTH)) {
+                rectLeft = OTRGetRectDimensionFromRightEdge(SCREEN_WIDTH) - rectWidth;
+            }
+
+            if (rectTop + rectHeight > SCREEN_HEIGHT) {
+                rectTop = SCREEN_HEIGHT - rectHeight;
+            }
+
             interfaceCtx->viewport.leftX = OTRConvertHUDXToScreenX(rectLeft);
             interfaceCtx->viewport.rightX = OTRConvertHUDXToScreenX(rectLeft + rectWidth);
             interfaceCtx->viewport.topY = rectTop;


### PR DESCRIPTION
* Fix A button sometimes stretching or disappearing due to UB when specifying a viewport out of bounds. We now clamp and preserve the viewport shape of the A button.
* Fix beating heart not scaling the correctly with the rest of the static hearts. Use new matrix modify func that handles matrix math properly.
* Fix minimap not reseting back to its original position when changing back to the vanilla mode. Requires updating the minimap values outside of the "should" so that it resets back with the vanilla values.