### PR TITLE
Fix Hess Crash's Next Crash

### DIFF
--- a/mm/src/code/z_player_lib.c
+++ b/mm/src/code/z_player_lib.c
@@ -1807,6 +1807,12 @@ void Player_DrawImpl(PlayState* play, void** skeleton, Vec3s* jointTable, s32 dL
 
     gfx = POLY_OPA_DISP;
 
+    if (CVarGetInteger("gEnhancements.Fixes.HessCrash", 1)) {
+        if (eyeIndex >= PLAYER_EYES_MAX) {
+            eyeIndex = 0;
+        }
+    }
+
     if (eyeIndex < 0) {
         eyeIndex = sPlayerFaces[face].eyeIndex;
     }
@@ -1820,6 +1826,12 @@ void Player_DrawImpl(PlayState* play, void** skeleton, Vec3s* jointTable, s32 dL
     }
 
     gSPSegment(&gfx[0], 0x08, Lib_SegmentedToVirtual(sPlayerEyesTextures[playerForm][eyeIndex]));
+
+    if (CVarGetInteger("gEnhancements.Fixes.HessCrash", 1)) {
+        if (mouthIndex >= PLAYER_MOUTH_MAX) {
+            mouthIndex = 0;
+        }
+    }
 
     if (mouthIndex < 0) {
         mouthIndex = sPlayerFaces[face].mouthIndex;


### PR DESCRIPTION
So basically the joint table gets messed up when you hess on a certain frame, causing the values which get read by that to be invalid. The game has a few checks to deal with this, but none on the right hand (already handled in the previous fix) and then the mouth and eyes need to be fixed too. This would not normally crash on console but does on PC