### PR TITLE
Add draw distance enhancements for actors and scene geometry

### DIFF
--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -532,6 +532,37 @@ void DrawEnhancementsMenu() {
                              "minor visual glitches that were covered up by the black bars\nPlease disable this "
                              "setting before reporting a bug" });
 
+            ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(255, 255, 0, 255));
+            ImGui::SeparatorText("Unstable");
+            ImGui::PopStyleColor();
+            UIWidgets::CVarCheckbox(
+                "Disable Scene Geometry Distance Check", "gEnhancements.Graphics.DisableSceneGeometryDistanceCheck",
+                { .tooltip =
+                      "Disables the distance check for scene geometry, allowing it to be drawn no matter how far "
+                      "away it is from the player. This may have unintended side effects." });
+            // BENTODO: Not implemented yet
+            // UIWidgets::CVarCheckbox("Widescreen Actor Culling",
+            //                         "gEnhancements.Graphics.ActorCullingAccountsForWidescreen",
+            //                         { .tooltip = "Adjusts the culling planes to account for widescreen resolutions. "
+            //                                      "This may have unintended side effects." });
+            if (UIWidgets::CVarSliderInt(
+                    "Increase Actor Draw Distance: %dx", "gEnhancements.Graphics.IncreaseActorDrawDistance", 1, 5, 1,
+                    { .tooltip =
+                          "Increase the range in which Actors are drawn. This may have unintended side effects." })) {
+                CVarSetInteger("gEnhancements.Graphics.IncreaseActorUpdateDistance",
+                               MIN(CVarGetInteger("gEnhancements.Graphics.IncreaseActorDrawDistance", 1),
+                                   CVarGetInteger("gEnhancements.Graphics.IncreaseActorUpdateDistance", 1)));
+            }
+            if (UIWidgets::CVarSliderInt(
+                    "Increase Actor Update Distance: %dx", "gEnhancements.Graphics.IncreaseActorUpdateDistance", 1, 5,
+                    1,
+                    { .tooltip =
+                          "Increase the range in which Actors are updated. This may have unintended side effects." })) {
+                CVarSetInteger("gEnhancements.Graphics.IncreaseActorDrawDistance",
+                               MAX(CVarGetInteger("gEnhancements.Graphics.IncreaseActorDrawDistance", 1),
+                                   CVarGetInteger("gEnhancements.Graphics.IncreaseActorUpdateDistance", 1)));
+            }
+
             ImGui::EndMenu();
         }
 

--- a/mm/include/PR/gbi.h
+++ b/mm/include/PR/gbi.h
@@ -391,6 +391,7 @@
  * G_EXTRAGEOMETRY flags: set extra custom geometry modes
  */
 #define G_EX_INVERT_CULLING 0x00000001
+#define G_EX_ALWAYS_EXECUTE_BRANCH 0x00000002
 
 /* Need these defined for Sprite Microcode */
 #ifdef _LANGUAGE_ASSEMBLY

--- a/mm/src/code/z_play.c
+++ b/mm/src/code/z_play.c
@@ -1373,10 +1373,20 @@ void Play_DrawMain(PlayState* this) {
                 if (1) {
                     u32 roomDrawFlags = ((1) ? 1 : 0) | (((void)0, 1) ? 2 : 0); // FAKE:
 
+                    if (CVarGetInteger("gEnhancements.Graphics.DisableSceneGeometryDistanceCheck", 0)) {
+                        gSPSetExtraGeometryMode(POLY_OPA_DISP++, G_EX_ALWAYS_EXECUTE_BRANCH);
+                        gSPSetExtraGeometryMode(POLY_XLU_DISP++, G_EX_ALWAYS_EXECUTE_BRANCH);
+                    }
+
                     Scene_Draw(this);
                     if (this->roomCtx.unk78) {
                         Room_Draw(this, &this->roomCtx.curRoom, roomDrawFlags & 3);
                         Room_Draw(this, &this->roomCtx.prevRoom, roomDrawFlags & 3);
+                    }
+
+                    if (CVarGetInteger("gEnhancements.Graphics.DisableSceneGeometryDistanceCheck", 0)) {
+                        gSPClearExtraGeometryMode(POLY_OPA_DISP++, G_EX_ALWAYS_EXECUTE_BRANCH);
+                        gSPClearExtraGeometryMode(POLY_XLU_DISP++, G_EX_ALWAYS_EXECUTE_BRANCH);
                     }
                 }
 


### PR DESCRIPTION
Depends on https://github.com/Kenix3/libultraship/pull/605

- Adds a checkbox for disabling scene geometry culling
- Add slider for multiplying actor draw distance check
- Add slider for multiplying actor update distance check

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1561105079.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1561107971.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1561109836.zip)
<!--- section:artifacts:end -->