### PR TITLE
Fix macports cache

### DIFF
--- a/.github/workflows/gtar
+++ b/.github/workflows/gtar
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec sudo /opt/homebrew/bin/gtar.orig "$@"

--- a/.github/workflows/gtar
+++ b/.github/workflows/gtar
@@ -1,2 +1,4 @@
 #!/bin/sh
+
+# Call the original gtar executable with sudo for macports cache restoration to root folder
 exec sudo /opt/homebrew/bin/gtar.orig "$@"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -194,7 +194,9 @@ jobs:
           ${{ runner.os }}-14-macports-
     - name: Install MacPorts (if necessary)
       run: |
-        if [ -x "$(command -v port)" ]; then
+        command -v port
+        echo $?
+        if [ command -v port &>/dev/null ]; then
           echo "MacPorts already installed"
         else
           wget https://github.com/macports/macports-base/releases/download/v2.9.3/MacPorts-2.9.3-14-Sonoma.pkg

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -336,18 +336,18 @@ jobs:
       with:
         variant: sccache
         max-size: "1G"
-        key: ${{ runner.os }}-ccache2-${{ github.ref }}-${{ github.sha }}
+        key: ${{ runner.os }}-ccache1-${{ github.ref }}-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-ccache2-${{ github.ref }}
-          ${{ runner.os }}-ccache2-
+          ${{ runner.os }}-ccache1-${{ github.ref }}
+          ${{ runner.os }}-ccache1-
     - name: Cache build folder
       uses: actions/cache@v4
       with:
         save-always: true
-        key: ${{ runner.os }}-build2-${{ github.ref }}-${{ github.sha }}
+        key: ${{ runner.os }}-build1-${{ github.ref }}-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-build2-${{ github.ref }}
-          ${{ runner.os }}-build2-
+          ${{ runner.os }}-build1-${{ github.ref }}
+          ${{ runner.os }}-build1-
         path: |
           build-windows
           vcpkg

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -194,8 +194,6 @@ jobs:
           ${{ runner.os }}-14-macports-
     - name: Install MacPorts (if necessary)
       run: |
-        command -v port
-        echo $?
         if [ command -v port &>/dev/null ]; then
           echo "MacPorts already installed"
         else
@@ -217,8 +215,8 @@ jobs:
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
         cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64"
-        cmake --build build-cmake --config Release --target Generate2ShipOtr --parallel 10
         cmake --build build-cmake --config Release --parallel 10
+        cmake --build build-cmake --config Release --target Generate2ShipOtr --parallel 10
         (cd build-cmake && cpack)
 
         mv _packages/*.dmg 2Ship.dmg
@@ -307,8 +305,8 @@ jobs:
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
         cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release -DBUILD_REMOTE_CONTROL=1
-        cmake --build build-cmake --config Release --target Generate2ShipOtr -j3
         cmake --build build-cmake --config Release -j3
+        cmake --build build-cmake --config Release --target Generate2ShipOtr -j3
         (cd build-cmake && cpack -G External)
 
         mv README.md readme.txt
@@ -368,8 +366,8 @@ jobs:
       run: |
         set $env:PATH="$env:USERPROFILE/.cargo/bin;$env:PATH"
         cmake -S . -B build-windows -G Ninja -DCMAKE_MAKE_PROGRAM=ninja -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
-        cmake --build build-windows --config Release --target Generate2ShipOtr --parallel 10
         cmake --build build-windows --config Release --parallel 10
+        cmake --build build-windows --config Release --target Generate2ShipOtr --parallel 10
 
         (cd build-windows && cpack)
         cd ..

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -185,9 +185,9 @@ jobs:
       uses: actions/cache@v4
       with:
         path: /opt/local/
-        key: ${{ runner.os }}-macports-${{ hashFiles('.github/workflows/macports-deps.txt') }}
+        key: ${{ runner.os }}-14-macports-${{ hashFiles('.github/workflows/macports-deps.txt') }}
         restore-keys: |
-          ${{ runner.os }}-macports
+          ${{ runner.os }}-14-macports
     - name: Install MacPorts (if necessary)
       run: |
         if [ port version ]; then

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -178,6 +178,8 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-14-ccache-${{ github.ref }}
           ${{ runner.os }}-14-ccache
+    - name: Prepare MacPorts
+      run: sudo mkdir -p /opt/local
     - name: Cache MacPorts
       id: cache-macports
       uses: actions/cache@v4
@@ -188,7 +190,7 @@ jobs:
           ${{ runner.os }}-macports
     - name: Install MacPorts (if necessary)
       run: |
-        if [ -d /opt/local/ ]; then
+        if [ port version ]; then
           echo "MacPorts already installed"
         else
           wget https://github.com/macports/macports-base/releases/download/v2.9.3/MacPorts-2.9.3-14-Sonoma.pkg

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -177,7 +177,7 @@ jobs:
         key: ${{ runner.os }}-14-ccache-${{ github.ref }}-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-14-ccache-${{ github.ref }}
-          ${{ runner.os }}-14-ccache
+          ${{ runner.os }}-14-ccache-
     - name: Prepare MacPorts
       run: sudo mkdir -p /opt/local
     - name: Cache MacPorts
@@ -187,7 +187,7 @@ jobs:
         path: /opt/local/
         key: ${{ runner.os }}-14-macports-${{ hashFiles('.github/workflows/macports-deps.txt') }}
         restore-keys: |
-          ${{ runner.os }}-14-macports
+          ${{ runner.os }}-14-macports-
     - name: Install MacPorts (if necessary)
       run: |
         if [ port version ]; then
@@ -218,7 +218,6 @@ jobs:
         mv _packages/*.dmg 2Ship.dmg
         mv README.md readme.txt
     - name: Upload build
-      if: ${{ startsWith(github.ref, 'refs/heads/develop') }}
       uses: actions/upload-artifact@v4
       with:
         name: 2ship-mac
@@ -238,19 +237,19 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y $(cat .github/workflows/apt-deps.txt)
     - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2.11
+      uses: hendrikmuhs/ccache-action@v1.2.13
       with:
         key: linux-ccache-${{ github.ref }}-${{ github.sha }}
         restore-keys: |
           linux-ccache-${{ github.ref }}
-          linux-ccache
+          linux-ccache-
     - name: Cache build folders
       uses: actions/cache@v4
       with:
         key: linux-build-${{ github.ref }}-${{ github.sha }}
         restore-keys: |
           linux-build-${{ github.ref }}
-          linux-build
+          linux-build-
         path: |
           SDL2-2.28.5
           SDL2_net-2.2.0
@@ -331,14 +330,14 @@ jobs:
       with:
         submodules: true
     - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2.11
+      uses: hendrikmuhs/ccache-action@v1.2.13
       with:
         variant: sccache
         max-size: "1G"
         key: ${{ runner.os }}-ccache-${{ github.ref }}-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-ccache-${{ github.ref }}
-          ${{ runner.os }}-ccache
+          ${{ runner.os }}-ccache-
     - name: Cache build folder
       uses: actions/cache@v4
       with:
@@ -346,7 +345,7 @@ jobs:
         key: ${{ runner.os }}-build-${{ github.ref }}-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-build-${{ github.ref }}
-          ${{ runner.os }}-build
+          ${{ runner.os }}-build-
         path: |
           build-windows
           vcpkg
@@ -358,7 +357,7 @@ jobs:
     #     name: 2ship.o2r
     #     path: build-windows/mm
     - name: Build 2Ship
-      env: 
+      env:
         VCPKG_ROOT: ${{github.workspace}}/vcpkg
       run: |
         set $env:PATH="$env:USERPROFILE/.cargo/bin;$env:PATH"
@@ -372,7 +371,6 @@ jobs:
     - name: Unzip package
       run: Expand-Archive -Path _packages/2ship-windows.zip -DestinationPath 2ship-windows
     - name: Upload build
-      if: ${{ startsWith(github.ref, 'refs/heads/develop') }}
       uses: actions/upload-artifact@v4
       with:
         name: 2ship-windows

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -178,8 +178,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-14-ccache-${{ github.ref }}
           ${{ runner.os }}-14-ccache-
-    # - name: Prepare MacPorts
-    #   run: sudo mkdir -p /opt/local
+    # Needed to apply sudo for macports cache restore
     - name: Install gtar wrapper
       run: |
         sudo mv /opt/homebrew/bin/gtar /opt/homebrew/bin/gtar.orig
@@ -195,7 +194,7 @@ jobs:
           ${{ runner.os }}-14-macports-
     - name: Install MacPorts (if necessary)
       run: |
-        if [ port version ]; then
+        if [ -x "$(command -v port)" ]; then
           echo "MacPorts already installed"
         else
           wget https://github.com/macports/macports-base/releases/download/v2.9.3/MacPorts-2.9.3-14-Sonoma.pkg

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -178,8 +178,13 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-14-ccache-${{ github.ref }}
           ${{ runner.os }}-14-ccache-
-    - name: Prepare MacPorts
-      run: sudo mkdir -p /opt/local
+    # - name: Prepare MacPorts
+    #   run: sudo mkdir -p /opt/local
+    - name: Install gtar wrapper
+      run: |
+        sudo mv /opt/homebrew/bin/gtar /opt/homebrew/bin/gtar.orig
+        sudo cp .github/workflows/gtar /opt/homebrew/bin/gtar
+        sudo chmod +x /opt/homebrew/bin/gtar
     - name: Cache MacPorts
       id: cache-macports
       uses: actions/cache@v4
@@ -361,7 +366,7 @@ jobs:
         VCPKG_ROOT: ${{github.workspace}}/vcpkg
       run: |
         set $env:PATH="$env:USERPROFILE/.cargo/bin;$env:PATH"
-        cmake -S . -B build-windows -G Ninja -DCMAKE_MAKE_PROGRAM=ninja -DCMAKE_BUILD_TYPE:STRING=Release
+        cmake -S . -B build-windows -G Ninja -DCMAKE_MAKE_PROGRAM=ninja -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
         cmake --build build-windows --config Release --target Generate2ShipOtr --parallel 10
         cmake --build build-windows --config Release --parallel 10
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -338,18 +338,18 @@ jobs:
       with:
         variant: sccache
         max-size: "1G"
-        key: ${{ runner.os }}-ccache-${{ github.ref }}-${{ github.sha }}
+        key: ${{ runner.os }}-ccache2-${{ github.ref }}-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-ccache-${{ github.ref }}
-          ${{ runner.os }}-ccache-
+          ${{ runner.os }}-ccache2-${{ github.ref }}
+          ${{ runner.os }}-ccache2-
     - name: Cache build folder
       uses: actions/cache@v4
       with:
         save-always: true
-        key: ${{ runner.os }}-build-${{ github.ref }}-${{ github.sha }}
+        key: ${{ runner.os }}-build2-${{ github.ref }}-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-build-${{ github.ref }}
-          ${{ runner.os }}-build-
+          ${{ runner.os }}-build2-${{ github.ref }}
+          ${{ runner.os }}-build2-
         path: |
           build-windows
           vcpkg

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,73 +98,73 @@ jobs:
   #       source-dir: _packages
   #       destination-dir: ./
 
-  # generate-2ship-otr:
-  #   runs-on: ubuntu-22.04
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #     with:
-  #       submodules: true
-  #   - name: ccache
-  #     uses: hendrikmuhs/ccache-action@v1.2.11
-  #     with:
-  #       key: ${{ runner.os }}-otr-ccache-${{ github.ref }}-${{ github.sha }}
-  #       restore-keys: |
-  #         ${{ runner.os }}-otr-ccache-${{ github.ref }}
-  #         ${{ runner.os }}-otr-ccache
-  #   - name: Install dependencies
-  #     run: |
-  #       sudo apt-get update
-  #       sudo apt-get install -y $(cat .github/workflows/apt-deps.txt)
-  #   - name: Cache build folders
-  #     uses: actions/cache@v4
-  #     with:
-  #       key: ${{ runner.os }}-otr-build-${{ github.ref }}-${{ github.sha }}
-  #       restore-keys: |
-  #         ${{ runner.os }}-otr-build-${{ github.ref }}
-  #         ${{ runner.os }}-otr-build
-  #       path: |
-  #         build-cmake
-  #         SDL2-2.28.5
-  #         tinyxml2-10.0.0
-  #   - name: Install latest SDL
-  #     run: |
-  #       export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-  #       if [ ! -d "SDL2-2.28.5" ]; then
-  #         wget https://www.libsdl.org/release/SDL2-2.28.5.tar.gz
-  #         tar -xzf SDL2-2.28.5.tar.gz
-  #       fi
-  #       cd SDL2-2.28.5
-  #       ./configure --enable-hidapi-libusb
-  #       make -j 10
-  #       sudo make install
-  #       sudo cp -av /usr/local/lib/libSDL* /lib/x86_64-linux-gnu/
-  #   - name: Install latest tinyxml2
-  #     run: |
-  #       sudo apt-get remove libtinyxml2-dev
-  #       export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-  #       if [ ! -d "tinyxml2-10.0.0" ]; then
-  #         wget https://github.com/leethomason/tinyxml2/archive/refs/tags/10.0.0.tar.gz
-  #         tar -xzf 10.0.0.tar.gz
-  #       fi
-  #       cd tinyxml2-10.0.0
-  #       mkdir -p build
-  #       cd build
-  #       cmake ..
-  #       make
-  #       sudo make install
-  #   - name: Generate 2ship.o2r
-  #     run: |
-  #       export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-  #       cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release
-  #       cmake --build build-cmake --config Release --target Generate2ShipOtr -j3
-  #   - uses: actions/upload-artifact@v4
-  #     with:
-  #       name: 2ship.o2r
-  #       path: 2ship.o2r
-  #       retention-days: 1
+  generate-2ship-otr:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2.13
+      with:
+        key: ${{ runner.os }}-otr-ccache-${{ github.ref }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-otr-ccache-${{ github.ref }}
+          ${{ runner.os }}-otr-ccache-
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y $(cat .github/workflows/apt-deps.txt)
+    - name: Cache build folders
+      uses: actions/cache@v4
+      with:
+        key: ${{ runner.os }}-otr-build-${{ github.ref }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-otr-build-${{ github.ref }}
+          ${{ runner.os }}-otr-build-
+        path: |
+          build-cmake
+          SDL2-2.28.5
+          tinyxml2-10.0.0
+    - name: Install latest SDL
+      run: |
+        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+        if [ ! -d "SDL2-2.28.5" ]; then
+          wget https://www.libsdl.org/release/SDL2-2.28.5.tar.gz
+          tar -xzf SDL2-2.28.5.tar.gz
+        fi
+        cd SDL2-2.28.5
+        ./configure --enable-hidapi-libusb
+        make -j 10
+        sudo make install
+        sudo cp -av /usr/local/lib/libSDL* /lib/x86_64-linux-gnu/
+    - name: Install latest tinyxml2
+      run: |
+        sudo apt-get remove libtinyxml2-dev
+        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+        if [ ! -d "tinyxml2-10.0.0" ]; then
+          wget https://github.com/leethomason/tinyxml2/archive/refs/tags/10.0.0.tar.gz
+          tar -xzf 10.0.0.tar.gz
+        fi
+        cd tinyxml2-10.0.0
+        mkdir -p build
+        cd build
+        cmake ..
+        make
+        sudo make install
+    - name: Generate 2ship.o2r
+      run: |
+        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+        cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release
+        cmake --build build-cmake --config Release --target Generate2ShipOtr -j3
+    - uses: actions/upload-artifact@v4
+      with:
+        name: 2ship.o2r
+        path: 2ship.o2r
+        retention-days: 1
 
   build-macos:
-    # needs: generate-2ship-otr
+    needs: generate-2ship-otr
     runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
@@ -206,17 +206,16 @@ jobs:
         brew uninstall --ignore-dependencies libpng
         sudo port install $(cat .github/workflows/macports-deps.txt)
         brew install ninja
-    # - name: Download 2ship.o2r
-    #   uses: actions/download-artifact@v4
-    #   with:
-    #     name: 2ship.o2r
-    #     path: build-cmake/mm
+    - name: Download 2ship.o2r
+      uses: actions/download-artifact@v4
+      with:
+        name: 2ship.o2r
+        path: build-cmake/mm
     - name: Build 2Ship
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
         cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64"
         cmake --build build-cmake --config Release --parallel 10
-        cmake --build build-cmake --config Release --target Generate2ShipOtr --parallel 10
         (cd build-cmake && cpack)
 
         mv _packages/*.dmg 2Ship.dmg
@@ -230,7 +229,7 @@ jobs:
           readme.txt
 
   build-linux:
-    # needs: generate-2ship-otr
+    needs: generate-2ship-otr
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
@@ -296,17 +295,16 @@ jobs:
         make -j 10
         sudo make install
         sudo cp -av /usr/local/lib/libSDL* /lib/x86_64-linux-gnu/
-    # - name: Download 2ship.o2r
-    #   uses: actions/download-artifact@v4
-    #   with:
-    #     name: 2ship.o2r
-    #     path: build-cmake/mm
+    - name: Download 2ship.o2r
+      uses: actions/download-artifact@v4
+      with:
+        name: 2ship.o2r
+        path: build-cmake/mm
     - name: Build 2Ship
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
         cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release -DBUILD_REMOTE_CONTROL=1
         cmake --build build-cmake --config Release -j3
-        cmake --build build-cmake --config Release --target Generate2ShipOtr -j3
         (cd build-cmake && cpack -G External)
 
         mv README.md readme.txt
@@ -323,7 +321,7 @@ jobs:
           readme.txt
 
   build-windows:
-    # needs: generate-2ship-otr
+    needs: generate-2ship-otr
     runs-on: windows-latest
     steps:
     - name: Install dependencies
@@ -355,11 +353,11 @@ jobs:
           vcpkg
     - name: Configure Developer Command Prompt
       uses: ilammy/msvc-dev-cmd@v1
-    # - name: Download 2ship.o2r
-    #   uses: actions/download-artifact@v4
-    #   with:
-    #     name: 2ship.o2r
-    #     path: build-windows/mm
+    - name: Download 2ship.o2r
+      uses: actions/download-artifact@v4
+      with:
+        name: 2ship.o2r
+        path: build-windows/mm
     - name: Build 2Ship
       env:
         VCPKG_ROOT: ${{github.workspace}}/vcpkg
@@ -367,7 +365,6 @@ jobs:
         set $env:PATH="$env:USERPROFILE/.cargo/bin;$env:PATH"
         cmake -S . -B build-windows -G Ninja -DCMAKE_MAKE_PROGRAM=ninja -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
         cmake --build build-windows --config Release --parallel 10
-        cmake --build build-windows --config Release --target Generate2ShipOtr --parallel 10
 
         (cd build-windows && cpack)
         cd ..

--- a/.github/workflows/pr-artifacts.yml
+++ b/.github/workflows/pr-artifacts.yml
@@ -48,6 +48,7 @@ jobs:
 
             return allArtifacts.data.artifacts.reduce((acc, item) => {
               if (item.name === "assets") return acc;
+              it (item.name === "2ship.o2r") return acc;
               acc += `
               - [${item.name}.zip](https://nightly.link/${context.repo.owner}/${context.repo.repo}/actions/artifacts/${item.id}.zip)`;
               return acc;

--- a/CMake/DefaultCXX.cmake
+++ b/CMake/DefaultCXX.cmake
@@ -8,5 +8,10 @@ if(MSVC)
 
     set_target_properties("${PROPS_TARGET}" PROPERTIES MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
     set_config_specific_property("DEFAULT_CXX_EXCEPTION_HANDLING" "/EHsc")
-    set_config_specific_property("DEFAULT_CXX_DEBUG_INFORMATION_FORMAT" "/Zi")
+
+    if (CMAKE_C_COMPILER_LAUNCHER MATCHES "ccache|sccache")
+        set_config_specific_property("DEFAULT_CXX_DEBUG_INFORMATION_FORMAT" "/Z7")
+    else()
+        set_config_specific_property("DEFAULT_CXX_DEBUG_INFORMATION_FORMAT" "/Zi")
+    endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,7 @@ set_property(TARGET 2ship PROPERTY APPIMAGE_ICON_FILE "${CMAKE_BINARY_DIR}/2s2hI
 
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
 install(PROGRAMS "${CMAKE_BINARY_DIR}/linux/2s2h.sh" DESTINATION . COMPONENT appimage)
-install(FILES "${CMAKE_SOURCE_DIR}/2ship.o2r" DESTINATION . COMPONENT ship)
+install(FILES "${CMAKE_BINARY_DIR}/mm/2ship.o2r" DESTINATION . COMPONENT ship)
 install(TARGETS ZAPD DESTINATION ./assets/extractor COMPONENT extractor)
 install(DIRECTORY "${CMAKE_SOURCE_DIR}/mm/assets/extractor/" DESTINATION ./assets/extractor COMPONENT extractor)
 install(DIRECTORY "${CMAKE_SOURCE_DIR}/mm/assets/xml/" DESTINATION ./assets/extractor/xmls COMPONENT extractor)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,15 @@ set(PROJECT_BUILD_NAME "Rika Alfa" CACHE STRING "")
 set(PROJECT_TEAM "github.com/harbourmasters" CACHE STRING "")
 
 set_property(DIRECTORY ${CMAKE_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT 2ship)
+
 add_compile_options($<$<CXX_COMPILER_ID:MSVC>:/MP>)
 add_compile_options($<$<CXX_COMPILER_ID:MSVC>:/utf-8>)
+
+if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    if (CMAKE_C_COMPILER_LAUNCHER MATCHES "ccache|sccache")
+        set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT Embedded)
+    endif()
+endif()
 
 if (CMAKE_SYSTEM_NAME MATCHES "Windows|Linux")
     if(NOT DEFINED BUILD_CROWD_CONTROL)
@@ -52,6 +59,7 @@ elseif ("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "x64")
 	set(VCPKG_TRIPLET x64-windows-static)
 	set(VCPKG_TARGET_TRIPLET x64-windows-static)
 endif()
+
 vcpkg_bootstrap()
 vcpkg_install_packages(zlib bzip2 libzip libpng sdl2 sdl2-net glew glfw3 nlohmann-json tinyxml2 spdlog)
 endif()

--- a/mm/CMake/DefaultCXX.cmake
+++ b/mm/CMake/DefaultCXX.cmake
@@ -8,5 +8,10 @@ if(MSVC)
 
     set_target_properties("${PROPS_TARGET}" PROPERTIES MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
     set_config_specific_property("DEFAULT_CXX_EXCEPTION_HANDLING" "/EHsc")
-    set_config_specific_property("DEFAULT_CXX_DEBUG_INFORMATION_FORMAT" "/Zi")
+
+    if (CMAKE_C_COMPILER_LAUNCHER MATCHES "ccache|sccache")
+        set_config_specific_property("DEFAULT_CXX_DEBUG_INFORMATION_FORMAT" "/Z7")
+    else()
+        set_config_specific_property("DEFAULT_CXX_DEBUG_INFORMATION_FORMAT" "/Zi")
+    endif()
 endif()


### PR DESCRIPTION
* Add gtar wrapper to fix macports cache restoration issues
* Add sccache changes and make windows cmake actually use it to fix windows build cache
* Active the "gen 2ship o2r" runner and make the other runners depend on it/download the artifact
* Remove 2ship.o2r from the pr-artifacts job since those are removed after 1 day anyway

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship.o2r.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1542198116.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1542200839.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1542201816.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1542210439.zip)
<!--- section:artifacts:end -->