### PR TITLE
[Enhancement] Friendly dogs

### DIFF
--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -574,6 +574,13 @@ void DrawEnhancementsMenu() {
             ImGui::EndMenu();
         }
 
+        if (UIWidgets::BeginMenu("Misc")) {
+            UIWidgets::CVarCheckbox("Friendly Dogs", "gEnhancements.Misc.FriendlyDogs", 
+                                    {.tooltip = "Dogs will always be friendly no matter what form Link is in."});
+
+            ImGui::EndMenu();
+        }
+
         if (mHudEditorWindow) {
             UIWidgets::WindowButton("Hud Editor", "gWindows.HudEditor", mHudEditorWindow,
                                     { .tooltip = "Enables the Hud Editor window, allowing you to edit your hud" });

--- a/mm/src/overlays/actors/ovl_En_Dg/z_en_dg.c
+++ b/mm/src/overlays/actors/ovl_En_Dg/z_en_dg.c
@@ -933,6 +933,10 @@ void EnDg_SitNextToPlayer(EnDg* this, PlayState* play) {
     if (!(this->dogFlags & DOG_FLAG_FOLLOWING_BREMEN_MASK)) {
         EnDg_PlaySfxWhine(this);
     }
+    
+    if (CVarGetInteger("gEnhancements.Misc.FriendlyDogs", 0)) {
+        EnDg_TryPickUp(this, play);
+    }
 }
 
 void EnDg_JumpAttack(EnDg* this, PlayState* play) {
@@ -1018,7 +1022,12 @@ void EnDg_SetupBremenMaskApproachPlayer(EnDg* this, PlayState* play) {
 void EnDg_Fall(EnDg* this, PlayState* play) {
     if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
         EnDg_ChangeAnim(&this->skelAnime, sAnimationInfo, DOG_ANIM_RUN);
-        this->actionFunc = EnDg_IdleMove;
+
+        if ((CVarGetInteger("gEnhancements.Misc.FriendlyDogs", 0))) {
+            this->actionFunc = EnDg_ApproachPlayer;
+        } else {
+            this->actionFunc = EnDg_IdleMove;
+        }
     }
 
     Actor_MoveWithGravity(&this->actor);
@@ -1326,7 +1335,12 @@ void EnDg_Thrown(EnDg* this, PlayState* play) {
     if (DECR(this->sitAfterThrowTimer) == 0) {
         this->grabState = DOG_GRAB_STATE_NONE;
         EnDg_SetupIdleMove(this, play);
-        this->actionFunc = EnDg_IdleMove;
+        if ((CVarGetInteger("gEnhancements.Misc.FriendlyDogs", 0))) {
+            this->actionFunc = EnDg_ApproachPlayer;
+        } else {
+            this->actionFunc = EnDg_IdleMove;
+        }
+        
     }
 
     Actor_MoveWithGravity(&this->actor);


### PR DESCRIPTION
Adds an enhancement option that makes dogs react positively to all of link's forms just as they do for Zora Link normally. Also works for Fierce Deity Link when using the Fierce Deity anywhere enhancement. No issues with Bremen Mask. You just need to get some distance from the dog or change forms to update its behaviour when toggling the enhancement on or off.
Makes idling as Deku Link in South Clock Town while configuring stuff a little easier, but this will probably be obsolete if and when that dog follower mod from SoH gets ported.

Not sure how you guys wanna handle where i've put the enhancement checkbox if you use this. A "Misc" category would probably just end up as a dumping ground for menu bloat down the line but nothing else that was there already really fit so I just went with something generic pending feedback.