### PR TITLE
Fix Dpad Ocarina L Btn & GI Dpad Stuff

### DIFF
--- a/mm/2s2h/Enhancements/GameInteractor/GameInteractor.cpp
+++ b/mm/2s2h/Enhancements/GameInteractor/GameInteractor.cpp
@@ -230,3 +230,22 @@ int GameInteractor_InvertControl(GIInvertType type) {
 
     return result;
 }
+
+uint32_t GameInteractor_Dpad(GIDpadType type, uint32_t buttonCombo) {
+    uint32_t result = 0;
+
+    switch (type) {
+        case GI_DPAD_OCARINA:
+            if (CVarGetInteger("gEnhancements.Playback.DpadOcarina", 0)) {
+                result = buttonCombo;
+            }
+            break;
+        case GI_DPAD_EQUIP:
+            if (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0)) {
+                result = buttonCombo;
+            }
+            break;
+    }
+
+    return result;
+}

--- a/mm/2s2h/Enhancements/GameInteractor/GameInteractor.h
+++ b/mm/2s2h/Enhancements/GameInteractor/GameInteractor.h
@@ -58,6 +58,11 @@ typedef enum {
     GI_INVERT_CAMERA_RIGHT_STICK_Y,
 } GIInvertType;
 
+typedef enum {
+    GI_DPAD_OCARINA,
+    GI_DPAD_EQUIP,
+} GIDpadType;
+
 #ifdef __cplusplus
 
 #include <vector>
@@ -327,6 +332,7 @@ bool GameInteractor_Should(GIVanillaBehavior flag, bool result, void* optionalAr
         flag, [](GIVanillaBehavior _, bool* should, void* opt) body)
 
 int GameInteractor_InvertControl(GIInvertType type);
+uint32_t GameInteractor_Dpad(GIDpadType type, uint32_t buttonCombo);
 
 #ifdef __cplusplus
 }

--- a/mm/include/z64save.h
+++ b/mm/include/z64save.h
@@ -559,11 +559,12 @@ typedef enum {
     (void)0
 
 // #region 2S2H [DPad]
+#define BTN_DPAD (BTN_DRIGHT | BTN_DLEFT | BTN_DDOWN | BTN_DUP)
 #define DPAD_TO_HELD_ITEM(btn) (btn + EQUIP_SLOT_MAX) 
 #define HELD_ITEM_TO_DPAD(heldBtn) (heldBtn - EQUIP_SLOT_MAX)
 #define IS_HELD_DPAD(heldBtn) ((heldBtn >= DPAD_TO_HELD_ITEM(EQUIP_SLOT_D_RIGHT)) && (heldBtn <= DPAD_TO_HELD_ITEM(EQUIP_SLOT_D_UP)))
 
-#define BTN_DPAD_EQUIP (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0) ? (BTN_DRIGHT | BTN_DLEFT | BTN_DDOWN | BTN_DUP) : 0)
+#define BTN_DPAD_EQUIP (GameInteractor_Dpad(GI_DPAD_EQUIP, BTN_DPAD))
 #define CHECK_BTN_DPAD(input) (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0) && \
                               (CHECK_BTN_ALL(input, BTN_DRIGHT) || \
                                CHECK_BTN_ALL(input, BTN_DLEFT)  || \

--- a/mm/src/audio/code_8019AF00.c
+++ b/mm/src/audio/code_8019AF00.c
@@ -2521,7 +2521,8 @@ void AudioOcarina_CheckSongsWithoutMusicStaff(void) {
     u8 k;
 
     if (CHECK_BTN_ANY(sOcarinaInputButtonCur, BTN_L) &&
-        CHECK_BTN_ANY(sOcarinaInputButtonCur, BTN_A | BTN_CRIGHT | BTN_CLEFT | BTN_CDOWN | BTN_CUP)) {
+        CHECK_BTN_ANY(sOcarinaInputButtonCur, BTN_A | BTN_CRIGHT | BTN_CLEFT | BTN_CDOWN | BTN_CUP |
+                                                  GameInteractor_Dpad(GI_DPAD_OCARINA, BTN_DPAD))) {
         AudioOcarina_StartDefault(sOcarinaFlags);
         return;
     }
@@ -2596,17 +2597,17 @@ void AudioOcarina_PlayControllerInput(u8 isOcarinaSfxSuppressedWhenCancelled) {
     // Ensures the button pressed to start the ocarina does not also play an ocarina note
     if ((sOcarinaInputButtonStart == 0) ||
         ((sOcarinaInputButtonStart &
-          (BTN_A | BTN_CRIGHT | BTN_CLEFT | BTN_CDOWN | BTN_CUP | BTN_DRIGHT | BTN_DLEFT | BTN_DDOWN | BTN_DUP)) !=
+          (BTN_A | BTN_CRIGHT | BTN_CLEFT | BTN_CDOWN | BTN_CUP | GameInteractor_Dpad(GI_DPAD_OCARINA, BTN_DPAD))) !=
          (sOcarinaInputButtonCur &
-          (BTN_A | BTN_CRIGHT | BTN_CLEFT | BTN_CDOWN | BTN_CUP | BTN_DRIGHT | BTN_DLEFT | BTN_DDOWN | BTN_DUP)))) {
+          (BTN_A | BTN_CRIGHT | BTN_CLEFT | BTN_CDOWN | BTN_CUP | GameInteractor_Dpad(GI_DPAD_OCARINA, BTN_DPAD))))) {
         sOcarinaInputButtonStart = 0;
         if (1) {}
         sCurOcarinaPitch = OCARINA_PITCH_NONE;
         sCurOcarinaButtonIndex = OCARINA_BTN_INVALID;
-        ocarinaBtnsHeld = (sOcarinaInputButtonCur & (BTN_A | BTN_CRIGHT | BTN_CLEFT | BTN_CDOWN | BTN_CUP | BTN_DRIGHT |
-                                                     BTN_DLEFT | BTN_DDOWN | BTN_DUP)) &
+        ocarinaBtnsHeld = (sOcarinaInputButtonCur & (BTN_A | BTN_CRIGHT | BTN_CLEFT | BTN_CDOWN | BTN_CUP |
+                                                     GameInteractor_Dpad(GI_DPAD_OCARINA, BTN_DPAD))) &
                           (sOcarinaInputButtonPrev & (BTN_A | BTN_CRIGHT | BTN_CLEFT | BTN_CDOWN | BTN_CUP |
-                                                      BTN_DRIGHT | BTN_DLEFT | BTN_DDOWN | BTN_DUP));
+                                                      GameInteractor_Dpad(GI_DPAD_OCARINA, BTN_DPAD)));
 
         if (!(sOcarinaInputButtonPress & ocarinaBtnsHeld) && (sOcarinaInputButtonCur != 0)) {
             sOcarinaInputButtonPress = sOcarinaInputButtonCur;
@@ -2621,19 +2622,22 @@ void AudioOcarina_PlayControllerInput(u8 isOcarinaSfxSuppressedWhenCancelled) {
             sCurOcarinaPitch = OCARINA_PITCH_D4;
             sCurOcarinaButtonIndex = OCARINA_BTN_A;
 
-        } else if (CHECK_BTN_ANY(sOcarinaInputButtonPress, BTN_CDOWN | (dpadCvarActive ? BTN_DDOWN : 0))) {
+        } else if (CHECK_BTN_ANY(sOcarinaInputButtonPress,
+                                 BTN_CDOWN | GameInteractor_Dpad(GI_DPAD_OCARINA, BTN_DDOWN))) {
             sCurOcarinaPitch = OCARINA_PITCH_F4;
             sCurOcarinaButtonIndex = OCARINA_BTN_C_DOWN;
 
-        } else if (CHECK_BTN_ANY(sOcarinaInputButtonPress, BTN_CRIGHT | (dpadCvarActive ? BTN_DRIGHT : 0))) {
+        } else if (CHECK_BTN_ANY(sOcarinaInputButtonPress,
+                                 BTN_CRIGHT | GameInteractor_Dpad(GI_DPAD_OCARINA, BTN_DRIGHT))) {
             sCurOcarinaPitch = OCARINA_PITCH_A4;
             sCurOcarinaButtonIndex = OCARINA_BTN_C_RIGHT;
 
-        } else if (CHECK_BTN_ANY(sOcarinaInputButtonPress, BTN_CLEFT | (dpadCvarActive ? BTN_DLEFT : 0))) {
+        } else if (CHECK_BTN_ANY(sOcarinaInputButtonPress,
+                                 BTN_CLEFT | GameInteractor_Dpad(GI_DPAD_OCARINA, BTN_DLEFT))) {
             sCurOcarinaPitch = OCARINA_PITCH_B4;
             sCurOcarinaButtonIndex = OCARINA_BTN_C_LEFT;
 
-        } else if (CHECK_BTN_ANY(sOcarinaInputButtonPress, BTN_CUP | (dpadCvarActive ? BTN_DUP : 0))) {
+        } else if (CHECK_BTN_ANY(sOcarinaInputButtonPress, BTN_CUP | GameInteractor_Dpad(GI_DPAD_OCARINA, BTN_DUP))) {
             sCurOcarinaPitch = OCARINA_PITCH_D5;
             sCurOcarinaButtonIndex = OCARINA_BTN_C_UP;
         }

--- a/mm/src/overlays/actors/ovl_Arms_Hook/z_arms_hook.c
+++ b/mm/src/overlays/actors/ovl_Arms_Hook/z_arms_hook.c
@@ -7,6 +7,7 @@
 #include "z_arms_hook.h"
 #include "objects/gameplay_keep/gameplay_keep.h"
 #include "objects/object_link_child/object_link_child.h"
+#include "2s2h/Enhancements/GameInteractor/GameInteractor.h"
 
 #define FLAGS (ACTOR_FLAG_10 | ACTOR_FLAG_20)
 

--- a/mm/src/overlays/actors/ovl_Boss_02/z_boss_02.c
+++ b/mm/src/overlays/actors/ovl_Boss_02/z_boss_02.c
@@ -12,6 +12,7 @@
 #include "overlays/actors/ovl_Item_B_Heart/z_item_b_heart.h"
 #include "objects/gameplay_keep/gameplay_keep.h"
 #include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
+#include "2s2h/Enhancements/GameInteractor/GameInteractor.h"
 
 #define FLAGS (ACTOR_FLAG_TARGETABLE | ACTOR_FLAG_UNFRIENDLY | ACTOR_FLAG_10 | ACTOR_FLAG_20)
 

--- a/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_mask.c
+++ b/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_mask.c
@@ -8,6 +8,7 @@
 #include "interface/parameter_static/parameter_static.h"
 
 #include "BenGui/HudEditor.h"
+#include "2s2h/Enhancements/GameInteractor/GameInteractor.h"
 
 s16 sMaskEquipState = EQUIP_STATE_MAGIC_ARROW_GROW_ORB;
 


### PR DESCRIPTION
Tried Following the Pattern from #441 Here

This should fix #544 

Few thoughts on my part:

- Can we cache the Cvar Result for each frame and reset them?
- Can this work as a hook which sets a bool only changing it when the cvar changes?
- Are Cvars expensive enough that the points above would make sense?

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1543736588.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1543747405.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1543870590.zip)
<!--- section:artifacts:end -->