### PR TITLE
Document Scene Assets

### DIFF
--- a/mm/assets/xml/GC_US/scenes/KAKUSIANA/KAKUSIANA.xml
+++ b/mm/assets/xml/GC_US/scenes/KAKUSIANA/KAKUSIANA.xml
@@ -1,9 +1,63 @@
 <Root>
     <File Name="KAKUSIANA" Segment="2" Game="MM">
         <Scene Name="KAKUSIANA" Offset="0x0"/>
+
+        <Path Name="KAKUSIANAPathwayList_0003A4" OutName="KAKUSIANAPathwayList_0003A4" NumPaths="9" Offset="0x3A4">
+        <Path Name="KAKUSIANAPathwayList_0003DC" OutName="KAKUSIANAPathwayList_0003DC" NumPaths="7" Offset="0x3DC">
+        <!-- <TextureAnimationParams Name="KAKUSIANATexAnim_000970TexScrollParams_000940" OutName="KAKUSIANATexAnim_000970TexScrollParams_000940" Offset="0x940"> -->
+        <!-- <TextureAnimationParams Name="KAKUSIANATexAnim_000970TexScrollParams_000948" OutName="KAKUSIANATexAnim_000970TexScrollParams_000948" Offset="0x948"> -->
+        <!-- <TextureAnimationParams Name="KAKUSIANATexAnim_000970TexScrollParams_000950" OutName="KAKUSIANATexAnim_000970TexScrollParams_000950" Offset="0x950"> -->
+        <!-- <TextureAnimationParams Name="KAKUSIANATexAnim_000970TexScrollParams_000958" OutName="KAKUSIANATexAnim_000970TexScrollParams_000958" Offset="0x958"> -->
+        <!-- <TextureAnimationParams Name="KAKUSIANATexAnim_000970TexScrollParams_000960" OutName="KAKUSIANATexAnim_000970TexScrollParams_000960" Offset="0x960"> -->
+        <!-- <TextureAnimationParams Name="KAKUSIANATexAnim_000970TexScrollParams_000968" OutName="KAKUSIANATexAnim_000970TexScrollParams_000968" Offset="0x968"> -->
+        <TextureAnimation Name="KAKUSIANATexAnim_000970" OutName="KAKUSIANATexAnim_000970" Offset="0x970">
+        <Collision Name="KAKUSIANACollisionHeader_00AC9C" OutName="KAKUSIANACollisionHeader_00AC9C" Offset="0xAC9C">
+        <Texture Name="KAKUSIANATex_00ACD0" OutName="KAKUSIANATex_00ACD0" Format="i4" Width="64" Height="64" Offset="0xACD0">
+        <Texture Name="KAKUSIANATex_00B4D0" OutName="KAKUSIANATex_00B4D0" Format="ia16" Width="32" Height="16" Offset="0xB4D0">
+        <Texture Name="KAKUSIANATex_00B8D0" OutName="KAKUSIANATex_00B8D0" Format="rgba16" Width="32" Height="32" Offset="0xB8D0">
+        <Texture Name="KAKUSIANATex_00C0D0" OutName="KAKUSIANATex_00C0D0" Format="rgba16" Width="32" Height="32" Offset="0xC0D0">
+        <Texture Name="KAKUSIANATex_00C8D0" OutName="KAKUSIANATex_00C8D0" Format="rgba16" Width="32" Height="32" Offset="0xC8D0">
+        <Texture Name="KAKUSIANATex_00D0D0" OutName="KAKUSIANATex_00D0D0" Format="rgba16" Width="32" Height="32" Offset="0xD0D0">
+        <Texture Name="KAKUSIANATex_00D8D0" OutName="KAKUSIANATex_00D8D0" Format="rgba16" Width="32" Height="32" Offset="0xD8D0">
+        <Texture Name="KAKUSIANATex_00E0D0" OutName="KAKUSIANATex_00E0D0" Format="rgba16" Width="32" Height="32" Offset="0xE0D0">
+        <Texture Name="KAKUSIANATex_00E8D0" OutName="KAKUSIANATex_00E8D0" Format="rgba16" Width="32" Height="32" Offset="0xE8D0">
+        <Texture Name="KAKUSIANATex_00F0D0" OutName="KAKUSIANATex_00F0D0" Format="ia8" Width="32" Height="32" Offset="0xF0D0">
+        <Texture Name="KAKUSIANATex_00F4D0" OutName="KAKUSIANATex_00F4D0" Format="rgba16" Width="32" Height="32" Offset="0xF4D0">
     </File>
     <File Name="KAKUSIANA_room_00" Segment="3" Game="MM">
         <Room Name="KAKUSIANA_room_00" Offset="0x0"/>
+        <!-- <ActorList Name="KAKUSIANA_room_00ActorEntry_000048" OutName="KAKUSIANA_room_00ActorEntry_000048" Offset="0x48"> -->
+        <Array Name="KAKUSIANA_room_00Vtx_0001B0" OutName="KAKUSIANA_room_00Vtx_0001B0" Count="87" Offset="0x1B0">
+            <Vtx/>
+        </Array>
+        <DList Name="KAKUSIANA_room_00DL_000720" OutName="KAKUSIANA_room_00DL_000720" Offset="0x720">
+        <Array Name="KAKUSIANA_room_00Vtx_0008B0" OutName="KAKUSIANA_room_00Vtx_0008B0" Count="78" Offset="0x8B0">
+            <Vtx/>
+        </Array>
+        <DList Name="KAKUSIANA_room_00DL_000D90" OutName="KAKUSIANA_room_00DL_000D90" Offset="0xD90">
+        <Array Name="KAKUSIANA_room_00Vtx_000F90" OutName="KAKUSIANA_room_00Vtx_000F90" Count="51" Offset="0xF90">
+            <Vtx/>
+        </Array>
+        <DList Name="KAKUSIANA_room_00DL_0012C0" OutName="KAKUSIANA_room_00DL_0012C0" Offset="0x12C0">
+        <Array Name="KAKUSIANA_room_00Vtx_0013F8" OutName="KAKUSIANA_room_00Vtx_0013F8" Count="116" Offset="0x13F8">
+            <Vtx/>
+        </Array>
+        <DList Name="KAKUSIANA_room_00DL_001B38" OutName="KAKUSIANA_room_00DL_001B38" Offset="0x1B38">
+        <Array Name="KAKUSIANA_room_00Vtx_001D10" OutName="KAKUSIANA_room_00Vtx_001D10" Count="12" Offset="0x1D10">
+            <Vtx/>
+        </Array>
+        <DList Name="KAKUSIANA_room_00DL_001DD0" OutName="KAKUSIANA_room_00DL_001DD0" Offset="0x1DD0">
+        <Texture Name="KAKUSIANA_room_00Tex_001EA0" OutName="KAKUSIANA_room_00Tex_001EA0" Format="rgba16" Width="64" Height="32" Offset="0x1EA0">
+        <Texture Name="KAKUSIANA_room_00Tex_002EA0" OutName="KAKUSIANA_room_00Tex_002EA0" Format="rgba16" Width="32" Height="32" Offset="0x2EA0">
+        <DList Name="KAKUSIANA_room_00DL_0036A0" OutName="KAKUSIANA_room_00DL_0036A0" Offset="0x36A0">
+        <Array Name="KAKUSIANA_room_00Vtx_0036A8" OutName="KAKUSIANA_room_00Vtx_0036A8" Count="12" Offset="0x36A8">
+            <Vtx/>
+        </Array>
+        <DList Name="KAKUSIANA_room_00DL_003768" OutName="KAKUSIANA_room_00DL_003768" Offset="0x3768">
+        <Array Name="KAKUSIANA_room_00Vtx_003840" OutName="KAKUSIANA_room_00Vtx_003840" Count="20" Offset="0x3840">
+            <Vtx/>
+        </Array>
+        <DList Name="KAKUSIANA_room_00DL_003980" OutName="KAKUSIANA_room_00DL_003980" Offset="0x3980">
     </File>
     <File Name="KAKUSIANA_room_01" Segment="3" Game="MM">
         <Room Name="KAKUSIANA_room_01" Offset="0x0"/>

--- a/mm/assets/xml/N64_US/scenes/KAKUSIANA/KAKUSIANA.xml
+++ b/mm/assets/xml/N64_US/scenes/KAKUSIANA/KAKUSIANA.xml
@@ -1,9 +1,63 @@
 <Root>
     <File Name="KAKUSIANA" Segment="2" Game="MM">
         <Scene Name="KAKUSIANA" Offset="0x0"/>
+
+        <Path Name="KAKUSIANAPathwayList_0003A4" OutName="KAKUSIANAPathwayList_0003A4" NumPaths="9" Offset="0x3A4">
+        <Path Name="KAKUSIANAPathwayList_0003DC" OutName="KAKUSIANAPathwayList_0003DC" NumPaths="7" Offset="0x3DC">
+        <!-- <TextureAnimationParams Name="KAKUSIANATexAnim_000970TexScrollParams_000940" OutName="KAKUSIANATexAnim_000970TexScrollParams_000940" Offset="0x940"> -->
+        <!-- <TextureAnimationParams Name="KAKUSIANATexAnim_000970TexScrollParams_000948" OutName="KAKUSIANATexAnim_000970TexScrollParams_000948" Offset="0x948"> -->
+        <!-- <TextureAnimationParams Name="KAKUSIANATexAnim_000970TexScrollParams_000950" OutName="KAKUSIANATexAnim_000970TexScrollParams_000950" Offset="0x950"> -->
+        <!-- <TextureAnimationParams Name="KAKUSIANATexAnim_000970TexScrollParams_000958" OutName="KAKUSIANATexAnim_000970TexScrollParams_000958" Offset="0x958"> -->
+        <!-- <TextureAnimationParams Name="KAKUSIANATexAnim_000970TexScrollParams_000960" OutName="KAKUSIANATexAnim_000970TexScrollParams_000960" Offset="0x960"> -->
+        <!-- <TextureAnimationParams Name="KAKUSIANATexAnim_000970TexScrollParams_000968" OutName="KAKUSIANATexAnim_000970TexScrollParams_000968" Offset="0x968"> -->
+        <TextureAnimation Name="KAKUSIANATexAnim_000970" OutName="KAKUSIANATexAnim_000970" Offset="0x970">
+        <Collision Name="KAKUSIANACollisionHeader_00AC9C" OutName="KAKUSIANACollisionHeader_00AC9C" Offset="0xAC9C">
+        <Texture Name="KAKUSIANATex_00ACD0" OutName="KAKUSIANATex_00ACD0" Format="i4" Width="64" Height="64" Offset="0xACD0">
+        <Texture Name="KAKUSIANATex_00B4D0" OutName="KAKUSIANATex_00B4D0" Format="ia16" Width="32" Height="16" Offset="0xB4D0">
+        <Texture Name="KAKUSIANATex_00B8D0" OutName="KAKUSIANATex_00B8D0" Format="rgba16" Width="32" Height="32" Offset="0xB8D0">
+        <Texture Name="KAKUSIANATex_00C0D0" OutName="KAKUSIANATex_00C0D0" Format="rgba16" Width="32" Height="32" Offset="0xC0D0">
+        <Texture Name="KAKUSIANATex_00C8D0" OutName="KAKUSIANATex_00C8D0" Format="rgba16" Width="32" Height="32" Offset="0xC8D0">
+        <Texture Name="KAKUSIANATex_00D0D0" OutName="KAKUSIANATex_00D0D0" Format="rgba16" Width="32" Height="32" Offset="0xD0D0">
+        <Texture Name="KAKUSIANATex_00D8D0" OutName="KAKUSIANATex_00D8D0" Format="rgba16" Width="32" Height="32" Offset="0xD8D0">
+        <Texture Name="KAKUSIANATex_00E0D0" OutName="KAKUSIANATex_00E0D0" Format="rgba16" Width="32" Height="32" Offset="0xE0D0">
+        <Texture Name="KAKUSIANATex_00E8D0" OutName="KAKUSIANATex_00E8D0" Format="rgba16" Width="32" Height="32" Offset="0xE8D0">
+        <Texture Name="KAKUSIANATex_00F0D0" OutName="KAKUSIANATex_00F0D0" Format="ia8" Width="32" Height="32" Offset="0xF0D0">
+        <Texture Name="KAKUSIANATex_00F4D0" OutName="KAKUSIANATex_00F4D0" Format="rgba16" Width="32" Height="32" Offset="0xF4D0">
     </File>
     <File Name="KAKUSIANA_room_00" Segment="3" Game="MM">
         <Room Name="KAKUSIANA_room_00" Offset="0x0"/>
+        <!-- <ActorList Name="KAKUSIANA_room_00ActorEntry_000048" OutName="KAKUSIANA_room_00ActorEntry_000048" Offset="0x48"> -->
+        <Array Name="KAKUSIANA_room_00Vtx_0001B0" OutName="KAKUSIANA_room_00Vtx_0001B0" Count="87" Offset="0x1B0">
+            <Vtx/>
+        </Array>
+        <DList Name="KAKUSIANA_room_00DL_000720" OutName="KAKUSIANA_room_00DL_000720" Offset="0x720">
+        <Array Name="KAKUSIANA_room_00Vtx_0008B0" OutName="KAKUSIANA_room_00Vtx_0008B0" Count="78" Offset="0x8B0">
+            <Vtx/>
+        </Array>
+        <DList Name="KAKUSIANA_room_00DL_000D90" OutName="KAKUSIANA_room_00DL_000D90" Offset="0xD90">
+        <Array Name="KAKUSIANA_room_00Vtx_000F90" OutName="KAKUSIANA_room_00Vtx_000F90" Count="51" Offset="0xF90">
+            <Vtx/>
+        </Array>
+        <DList Name="KAKUSIANA_room_00DL_0012C0" OutName="KAKUSIANA_room_00DL_0012C0" Offset="0x12C0">
+        <Array Name="KAKUSIANA_room_00Vtx_0013F8" OutName="KAKUSIANA_room_00Vtx_0013F8" Count="116" Offset="0x13F8">
+            <Vtx/>
+        </Array>
+        <DList Name="KAKUSIANA_room_00DL_001B38" OutName="KAKUSIANA_room_00DL_001B38" Offset="0x1B38">
+        <Array Name="KAKUSIANA_room_00Vtx_001D10" OutName="KAKUSIANA_room_00Vtx_001D10" Count="12" Offset="0x1D10">
+            <Vtx/>
+        </Array>
+        <DList Name="KAKUSIANA_room_00DL_001DD0" OutName="KAKUSIANA_room_00DL_001DD0" Offset="0x1DD0">
+        <Texture Name="KAKUSIANA_room_00Tex_001EA0" OutName="KAKUSIANA_room_00Tex_001EA0" Format="rgba16" Width="64" Height="32" Offset="0x1EA0">
+        <Texture Name="KAKUSIANA_room_00Tex_002EA0" OutName="KAKUSIANA_room_00Tex_002EA0" Format="rgba16" Width="32" Height="32" Offset="0x2EA0">
+        <DList Name="KAKUSIANA_room_00DL_0036A0" OutName="KAKUSIANA_room_00DL_0036A0" Offset="0x36A0">
+        <Array Name="KAKUSIANA_room_00Vtx_0036A8" OutName="KAKUSIANA_room_00Vtx_0036A8" Count="12" Offset="0x36A8">
+            <Vtx/>
+        </Array>
+        <DList Name="KAKUSIANA_room_00DL_003768" OutName="KAKUSIANA_room_00DL_003768" Offset="0x3768">
+        <Array Name="KAKUSIANA_room_00Vtx_003840" OutName="KAKUSIANA_room_00Vtx_003840" Count="20" Offset="0x3840">
+            <Vtx/>
+        </Array>
+        <DList Name="KAKUSIANA_room_00DL_003980" OutName="KAKUSIANA_room_00DL_003980" Offset="0x3980">
     </File>
     <File Name="KAKUSIANA_room_01" Segment="3" Game="MM">
         <Room Name="KAKUSIANA_room_01" Offset="0x0"/>


### PR DESCRIPTION
This is a large bit of maintenance stuff that needs to be done for supporting otr/o2r mods between different game versions.
Making this a draft so anyone can feel free to contribute since this can end up being quite large.

The most important ones to get done early (and may be split into separate PR and fast-tracked) is SPOT00 and Z2_IKANA_room_00 since those are the only two that differ between N64 US and GC US.

I'm leaving certain things which ZAPDTR doesn't support direct extraction for (as far as I can tell) commented out for now. Later we should try and make sure every file which becomes a record entry in the otr/o2r can have its own individual extraction.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1544143627.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1544144009.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1544269132.zip)
<!--- section:artifacts:end -->