### PR TITLE
Adds Dungeon Items to the Save Editor

### DIFF
--- a/mm/2s2h/DeveloperTools/SaveEditor.cpp
+++ b/mm/2s2h/DeveloperTools/SaveEditor.cpp
@@ -967,11 +967,11 @@ void SetDungeonItems(uint32_t dungeonItem, uint32_t dungeonId) {
     }
 }
 
+const char* dungeonNames[4] = { "Woodfall Temple", "Snowhead Temple", "Great Bay Temple", "Stone Tower Temple" };
+uint32_t smallKeyCounts[4] = { 1, 3, 1, 4 };
+const char* fairyIcons[] = { gDungeonStrayFairyWoodfallIconTex, gDungeonStrayFairySnowheadIconTex,
+                             gDungeonStrayFairyGreatBayIconTex, gDungeonStrayFairyStoneTowerIconTex };
 void DrawDungeonItemTab() {
-    const char* dungeonNames[4] = { "Woodfall Temple", "Snowhead Temple", "Great Bay Temple", "Stone Tower Temple" };
-    uint32_t smallKeyCounts[4] = { 1, 3, 1, 4 };
-    const char* fairyIcons[] = { gDungeonStrayFairyWoodfallIconTex, gDungeonStrayFairySnowheadIconTex,
-                                 gDungeonStrayFairyGreatBayIconTex, gDungeonStrayFairyStoneTowerIconTex };
     ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.0f, 1.0f, 1.0f, 0.0f));
     ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 3.0f);
     ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(8.0f, 8.0f));
@@ -1832,6 +1832,15 @@ void SaveEditorWindow::DrawElement() {
     ImGui::End();
 }
 
+const char* textureLoad[8] = { gDungeonStrayFairyWoodfallIconTex,
+                               gDungeonStrayFairySnowheadIconTex,
+                               gDungeonStrayFairyGreatBayIconTex,
+                               gDungeonStrayFairyStoneTowerIconTex,
+                               gQuestIconDungeonMapTex,
+                               gQuestIconCompassTex,
+                               gQuestIconSmallKeyTex,
+                               gQuestIconBossKeyTex };
+
 void SaveEditorWindow::InitElement() {
     initSafeItemsForInventorySlot();
 
@@ -1839,14 +1848,6 @@ void SaveEditorWindow::InitElement() {
         const char* path = static_cast<const char*>(entry);
         Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadGuiTexture(path, path, ImVec4(1, 1, 1, 1));
     }
-    const char* textureLoad[8] = { gDungeonStrayFairyWoodfallIconTex,
-                                   gDungeonStrayFairySnowheadIconTex,
-                                   gDungeonStrayFairyGreatBayIconTex,
-                                   gDungeonStrayFairyStoneTowerIconTex,
-                                   gQuestIconDungeonMapTex,
-                                   gQuestIconCompassTex,
-                                   gQuestIconSmallKeyTex,
-                                   gQuestIconBossKeyTex };
     for (int i = 0; i <= 7; i++) {
         Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadGuiTexture(textureLoad[i], textureLoad[i],
                                                                             ImVec4(1, 1, 1, 1));

--- a/mm/2s2h/DeveloperTools/SaveEditor.cpp
+++ b/mm/2s2h/DeveloperTools/SaveEditor.cpp
@@ -971,12 +971,12 @@ void DrawDungeonItemTab() {
     const char* dungeonNames[4] = { "Woodfall Temple", "Snowhead Temple", "Great Bay Temple", "Stone Tower Temple" };
     uint32_t smallKeyCounts[4] = { 1, 3, 1, 4 };
     const char* fairyIcons[] = { gDungeonStrayFairyWoodfallIconTex, gDungeonStrayFairySnowheadIconTex,
-                                gDungeonStrayFairyGreatBayIconTex, gDungeonStrayFairyStoneTowerIconTex };
+                                 gDungeonStrayFairyGreatBayIconTex, gDungeonStrayFairyStoneTowerIconTex };
     ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.0f, 1.0f, 1.0f, 0.0f));
     ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 3.0f);
     ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(8.0f, 8.0f));
     ImGui::BeginChild("dungeonTab", ImVec2(0, 0), true);
-    
+
     for (int i = DUNGEON_INDEX_WOODFALL_TEMPLE; i <= DUNGEON_INDEX_STONE_TOWER_TEMPLE; i++) {
         std::string stray_id = "Stray" + std::to_string(i);
         std::string map_id = "Map" + std::to_string(i);
@@ -985,48 +985,54 @@ void DrawDungeonItemTab() {
         std::string bKey_id = "Boss Key" + std::to_string(i);
         int dungeonId = i;
         ImGui::BeginChild(std::to_string(i).c_str(),
-                        ImVec2(INV_GRID_WIDTH * 6 + INV_GRID_PADDING * 2, INV_GRID_HEIGHT * 1.5 + INV_GRID_PADDING),
-                        ImGuiChildFlags_Border);
+                          ImVec2(INV_GRID_WIDTH * 6 + INV_GRID_PADDING * 2, INV_GRID_HEIGHT * 1.5 + INV_GRID_PADDING),
+                          ImGuiChildFlags_Border);
         ImGui::Text(dungeonNames[i]);
-        if (ImGui::ImageButton(stray_id.c_str(),
-                        Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName(fairyIcons[dungeonId]),
+        if (ImGui::ImageButton(
+                stray_id.c_str(),
+                Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName(fairyIcons[dungeonId]),
                 ImVec2(INV_GRID_ICON_SIZE, INV_GRID_ICON_SIZE), ImVec2(0, 0), ImVec2(1, 1), ImVec4(0, 0, 0, 0),
                 ImVec4(1, 1, 1, gSaveContext.save.saveInfo.inventory.strayFairies[dungeonId] ? 1.0f : 0.4f))) {
             ImGui::OpenPopup("strayFairies");
         }
         ImGui::SameLine();
-        if (ImGui::ImageButton(map_id.c_str(),
-                        Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName(gQuestIconDungeonMapTex),
-                        ImVec2(INV_GRID_ICON_SIZE, INV_GRID_ICON_SIZE), ImVec2(0, 0), ImVec2(1, 1), ImVec4(0, 0, 0, 0),
-                        ImVec4(1, 1, 1, CHECK_DUNGEON_ITEM(DUNGEON_MAP, i) ? 1.0f : 0.4f))) {
+        if (ImGui::ImageButton(
+                map_id.c_str(),
+                Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName(gQuestIconDungeonMapTex),
+                ImVec2(INV_GRID_ICON_SIZE, INV_GRID_ICON_SIZE), ImVec2(0, 0), ImVec2(1, 1), ImVec4(0, 0, 0, 0),
+                ImVec4(1, 1, 1, CHECK_DUNGEON_ITEM(DUNGEON_MAP, i) ? 1.0f : 0.4f))) {
             SetDungeonItems(DUNGEON_MAP, i);
         }
         ImGui::SameLine();
-        if (ImGui::ImageButton(comp_id.c_str(),
-                        Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName(gQuestIconCompassTex),
-                        ImVec2(INV_GRID_ICON_SIZE, INV_GRID_ICON_SIZE), ImVec2(0, 0), ImVec2(1, 1), ImVec4(0, 0, 0, 0),
-                        ImVec4(1, 1, 1, CHECK_DUNGEON_ITEM(DUNGEON_COMPASS, i) ? 1.0f : 0.4f))) {
+        if (ImGui::ImageButton(
+                comp_id.c_str(),
+                Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName(gQuestIconCompassTex),
+                ImVec2(INV_GRID_ICON_SIZE, INV_GRID_ICON_SIZE), ImVec2(0, 0), ImVec2(1, 1), ImVec4(0, 0, 0, 0),
+                ImVec4(1, 1, 1, CHECK_DUNGEON_ITEM(DUNGEON_COMPASS, i) ? 1.0f : 0.4f))) {
             SetDungeonItems(DUNGEON_COMPASS, i);
         }
         ImGui::SameLine();
-        if (ImGui::ImageButton(sKey_id.c_str(),
-                        Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName(gQuestIconSmallKeyTex),
-                        ImVec2(INV_GRID_ICON_SIZE, INV_GRID_ICON_SIZE), ImVec2(0, 0), ImVec2(1, 1), ImVec4(0, 0, 0, 0),
-                        ImVec4(1, 1, 1, DUNGEON_KEY_COUNT(i) + 1 ? 1.0f : 0.4f))) {
+        if (ImGui::ImageButton(
+                sKey_id.c_str(),
+                Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName(gQuestIconSmallKeyTex),
+                ImVec2(INV_GRID_ICON_SIZE, INV_GRID_ICON_SIZE), ImVec2(0, 0), ImVec2(1, 1), ImVec4(0, 0, 0, 0),
+                ImVec4(1, 1, 1, DUNGEON_KEY_COUNT(i) + 1 ? 1.0f : 0.4f))) {
             ImGui::OpenPopup("smallKeys");
         }
         ImGui::SameLine();
-        if (ImGui::ImageButton(bKey_id.c_str(),
+        if (ImGui::ImageButton(
+                bKey_id.c_str(),
                 Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName(gQuestIconBossKeyTex),
-                        ImVec2(INV_GRID_ICON_SIZE, INV_GRID_ICON_SIZE), ImVec2(0, 0), ImVec2(1, 1), ImVec4(0, 0, 0, 0),
-                        ImVec4(1, 1, 1, CHECK_DUNGEON_ITEM(DUNGEON_BOSS_KEY, i) ? 1.0f : 0.4f))) {
+                ImVec2(INV_GRID_ICON_SIZE, INV_GRID_ICON_SIZE), ImVec2(0, 0), ImVec2(1, 1), ImVec4(0, 0, 0, 0),
+                ImVec4(1, 1, 1, CHECK_DUNGEON_ITEM(DUNGEON_BOSS_KEY, i) ? 1.0f : 0.4f))) {
             SetDungeonItems(DUNGEON_BOSS_KEY, i);
         }
         if (ImGui::BeginPopup("strayFairies")) {
             s32 minStray = 0;
             s32 maxStray = 15;
             int currentStrays = gSaveContext.save.saveInfo.inventory.strayFairies[dungeonId];
-            if (ImGui::SliderScalar("##strayCount", ImGuiDataType_S32, &currentStrays, &minStray, &maxStray, "Strays: %d")) {
+            if (ImGui::SliderScalar("##strayCount", ImGuiDataType_S32, &currentStrays, &minStray, &maxStray,
+                                    "Strays: %d")) {
                 gSaveContext.save.saveInfo.inventory.strayFairies[dungeonId] = currentStrays;
             }
             ImGui::EndPopup();
@@ -1035,7 +1041,8 @@ void DrawDungeonItemTab() {
             s32 minKey = -1;
             s32 maxKey = smallKeyCounts[dungeonId];
             int currentKeys = gSaveContext.save.saveInfo.inventory.dungeonKeys[dungeonId];
-            if (ImGui::SliderScalar("##sKeyCount", ImGuiDataType_S32, &currentKeys, &minKey, &maxKey, "Small Keys: %d")) {
+            if (ImGui::SliderScalar("##sKeyCount", ImGuiDataType_S32, &currentKeys, &minKey, &maxKey,
+                                    "Small Keys: %d")) {
                 gSaveContext.save.saveInfo.inventory.dungeonKeys[dungeonId] = currentKeys;
             }
             ImGui::EndPopup();
@@ -1832,11 +1839,16 @@ void SaveEditorWindow::InitElement() {
         const char* path = static_cast<const char*>(entry);
         Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadGuiTexture(path, path, ImVec4(1, 1, 1, 1));
     }
-    const char* textureLoad[8] = {  gDungeonStrayFairyWoodfallIconTex,    gDungeonStrayFairySnowheadIconTex,
-                                    gDungeonStrayFairyGreatBayIconTex,    gDungeonStrayFairyStoneTowerIconTex,
-                                    gQuestIconDungeonMapTex,              gQuestIconCompassTex, 
-                                    gQuestIconSmallKeyTex,                gQuestIconBossKeyTex };
-    for (int i = 0 ; i <= 7; i++) {
-        Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadGuiTexture(textureLoad[i], textureLoad[i], ImVec4(1, 1, 1, 1));
+    const char* textureLoad[8] = { gDungeonStrayFairyWoodfallIconTex,
+                                   gDungeonStrayFairySnowheadIconTex,
+                                   gDungeonStrayFairyGreatBayIconTex,
+                                   gDungeonStrayFairyStoneTowerIconTex,
+                                   gQuestIconDungeonMapTex,
+                                   gQuestIconCompassTex,
+                                   gQuestIconSmallKeyTex,
+                                   gQuestIconBossKeyTex };
+    for (int i = 0; i <= 7; i++) {
+        Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadGuiTexture(textureLoad[i], textureLoad[i],
+                                                                            ImVec4(1, 1, 1, 1));
     }
 }

--- a/mm/2s2h/DeveloperTools/SaveEditor.cpp
+++ b/mm/2s2h/DeveloperTools/SaveEditor.cpp
@@ -2,6 +2,9 @@
 #include "2s2h/BenGui/UIWidgets.hpp"
 #include "2s2h/Enhancements/GameInteractor/GameInteractor.h"
 
+#include "interface/icon_item_dungeon_static/icon_item_dungeon_static.h"
+#include "archives/icon_item_24_static/icon_item_24_static_yar.h"
+
 extern "C" {
 #include <z64.h>
 #include <z64save.h>
@@ -279,6 +282,15 @@ void DrawGeneralTab() {
         gSaveContext.save.saveInfo.playerData.magicLevel = 0;
         gSaveContext.save.saveInfo.playerData.isMagicAcquired = false;
         gSaveContext.save.saveInfo.playerData.isDoubleMagicAcquired = false;
+    }
+    ImGui::SameLine();
+    bool spinAttack = CHECK_WEEKEVENTREG(WEEKEVENTREG_OBTAINED_GREAT_SPIN_ATTACK);
+    if (UIWidgets::Checkbox("Spin Lv2", &spinAttack, { .color = UIWidgets::Colors::DarkGreen })) {
+        if (spinAttack) {
+            SET_WEEKEVENTREG(WEEKEVENTREG_OBTAINED_GREAT_SPIN_ATTACK);
+        } else {
+            CLEAR_WEEKEVENTREG(WEEKEVENTREG_OBTAINED_GREAT_SPIN_ATTACK);
+        }
     }
     UIWidgets::PushStyleSlider(UIWidgets::Colors::DarkGreen);
     if (ImGui::SliderScalar("##magicLevelSlider", ImGuiDataType_S8, &gSaveContext.save.saveInfo.playerData.magicLevel,
@@ -942,6 +954,94 @@ void DrawQuestStatusTab() {
     UIWidgets::PopStyleCombobox();
     ImGui::EndChild();
 
+    ImGui::EndChild();
+    ImGui::PopStyleVar(2);
+    ImGui::PopStyleColor(1);
+}
+
+void SetDungeonItems(uint32_t dungeonItem, uint32_t dungeonId) {
+    if (CHECK_DUNGEON_ITEM(dungeonItem, dungeonId)) {
+        REMOVE_DUNGEON_ITEM(dungeonItem, dungeonId);
+    } else {
+        SET_DUNGEON_ITEM(dungeonItem, dungeonId);
+    }
+}
+
+void DrawDungeonItemTab() {
+    const char* dungeonNames[4] = { "Woodfall Temple", "Snowhead Temple", "Great Bay Temple", "Stone Tower Temple" };
+    uint32_t smallKeyCounts[4] = { 1, 3, 1, 4 };
+    const char* fairyIcons[] = { gDungeonStrayFairyWoodfallIconTex, gDungeonStrayFairySnowheadIconTex,
+                                gDungeonStrayFairyGreatBayIconTex, gDungeonStrayFairyStoneTowerIconTex };
+    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.0f, 1.0f, 1.0f, 0.0f));
+    ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 3.0f);
+    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(8.0f, 8.0f));
+    ImGui::BeginChild("dungeonTab", ImVec2(0, 0), true);
+    
+    for (int i = DUNGEON_INDEX_WOODFALL_TEMPLE; i <= DUNGEON_INDEX_STONE_TOWER_TEMPLE; i++) {
+        std::string stray_id = "Stray" + std::to_string(i);
+        std::string map_id = "Map" + std::to_string(i);
+        std::string comp_id = "Compass" + std::to_string(i);
+        std::string sKey_id = "Small Key" + std::to_string(i);
+        std::string bKey_id = "Boss Key" + std::to_string(i);
+        int dungeonId = i;
+        ImGui::BeginChild(std::to_string(i).c_str(),
+                        ImVec2(INV_GRID_WIDTH * 6 + INV_GRID_PADDING * 2, INV_GRID_HEIGHT * 1.5 + INV_GRID_PADDING),
+                        ImGuiChildFlags_Border);
+        ImGui::Text(dungeonNames[i]);
+        if (ImGui::ImageButton(stray_id.c_str(),
+                        Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName(fairyIcons[dungeonId]),
+                ImVec2(INV_GRID_ICON_SIZE, INV_GRID_ICON_SIZE), ImVec2(0, 0), ImVec2(1, 1), ImVec4(0, 0, 0, 0),
+                ImVec4(1, 1, 1, gSaveContext.save.saveInfo.inventory.strayFairies[dungeonId] ? 1.0f : 0.4f))) {
+            ImGui::OpenPopup("strayFairies");
+        }
+        ImGui::SameLine();
+        if (ImGui::ImageButton(map_id.c_str(),
+                        Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName(gQuestIconDungeonMapTex),
+                        ImVec2(INV_GRID_ICON_SIZE, INV_GRID_ICON_SIZE), ImVec2(0, 0), ImVec2(1, 1), ImVec4(0, 0, 0, 0),
+                        ImVec4(1, 1, 1, CHECK_DUNGEON_ITEM(DUNGEON_MAP, i) ? 1.0f : 0.4f))) {
+            SetDungeonItems(DUNGEON_MAP, i);
+        }
+        ImGui::SameLine();
+        if (ImGui::ImageButton(comp_id.c_str(),
+                        Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName(gQuestIconCompassTex),
+                        ImVec2(INV_GRID_ICON_SIZE, INV_GRID_ICON_SIZE), ImVec2(0, 0), ImVec2(1, 1), ImVec4(0, 0, 0, 0),
+                        ImVec4(1, 1, 1, CHECK_DUNGEON_ITEM(DUNGEON_COMPASS, i) ? 1.0f : 0.4f))) {
+            SetDungeonItems(DUNGEON_COMPASS, i);
+        }
+        ImGui::SameLine();
+        if (ImGui::ImageButton(sKey_id.c_str(),
+                        Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName(gQuestIconSmallKeyTex),
+                        ImVec2(INV_GRID_ICON_SIZE, INV_GRID_ICON_SIZE), ImVec2(0, 0), ImVec2(1, 1), ImVec4(0, 0, 0, 0),
+                        ImVec4(1, 1, 1, DUNGEON_KEY_COUNT(i) + 1 ? 1.0f : 0.4f))) {
+            ImGui::OpenPopup("smallKeys");
+        }
+        ImGui::SameLine();
+        if (ImGui::ImageButton(bKey_id.c_str(),
+                Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName(gQuestIconBossKeyTex),
+                        ImVec2(INV_GRID_ICON_SIZE, INV_GRID_ICON_SIZE), ImVec2(0, 0), ImVec2(1, 1), ImVec4(0, 0, 0, 0),
+                        ImVec4(1, 1, 1, CHECK_DUNGEON_ITEM(DUNGEON_BOSS_KEY, i) ? 1.0f : 0.4f))) {
+            SetDungeonItems(DUNGEON_BOSS_KEY, i);
+        }
+        if (ImGui::BeginPopup("strayFairies")) {
+            s32 minStray = 0;
+            s32 maxStray = 15;
+            int currentStrays = gSaveContext.save.saveInfo.inventory.strayFairies[dungeonId];
+            if (ImGui::SliderScalar("##strayCount", ImGuiDataType_S32, &currentStrays, &minStray, &maxStray, "Strays: %d")) {
+                gSaveContext.save.saveInfo.inventory.strayFairies[dungeonId] = currentStrays;
+            }
+            ImGui::EndPopup();
+        }
+        if (ImGui::BeginPopup("smallKeys")) {
+            s32 minKey = -1;
+            s32 maxKey = smallKeyCounts[dungeonId];
+            int currentKeys = gSaveContext.save.saveInfo.inventory.dungeonKeys[dungeonId];
+            if (ImGui::SliderScalar("##sKeyCount", ImGuiDataType_S32, &currentKeys, &minKey, &maxKey, "Small Keys: %d")) {
+                gSaveContext.save.saveInfo.inventory.dungeonKeys[dungeonId] = currentKeys;
+            }
+            ImGui::EndPopup();
+        }
+        ImGui::EndChild();
+    }
     ImGui::EndChild();
     ImGui::PopStyleVar(2);
     ImGui::PopStyleColor(1);
@@ -1694,6 +1794,11 @@ void SaveEditorWindow::DrawElement() {
             ImGui::EndTabItem();
         }
 
+        if (ImGui::BeginTabItem("Dungeon Items")) {
+            DrawDungeonItemTab();
+            ImGui::EndTabItem();
+        }
+
         if (ImGui::BeginTabItem("Reg Editor")) {
             DrawRegEditorTab();
             ImGui::EndTabItem();
@@ -1726,5 +1831,12 @@ void SaveEditorWindow::InitElement() {
     for (TexturePtr entry : gItemIcons) {
         const char* path = static_cast<const char*>(entry);
         Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadGuiTexture(path, path, ImVec4(1, 1, 1, 1));
+    }
+    const char* textureLoad[8] = {  gDungeonStrayFairyWoodfallIconTex,    gDungeonStrayFairySnowheadIconTex,
+                                    gDungeonStrayFairyGreatBayIconTex,    gDungeonStrayFairyStoneTowerIconTex,
+                                    gQuestIconDungeonMapTex,              gQuestIconCompassTex, 
+                                    gQuestIconSmallKeyTex,                gQuestIconBossKeyTex };
+    for (int i = 0 ; i <= 7; i++) {
+        Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadGuiTexture(textureLoad[i], textureLoad[i], ImVec4(1, 1, 1, 1));
     }
 }

--- a/mm/include/z64save.h
+++ b/mm/include/z64save.h
@@ -526,6 +526,7 @@ typedef enum {
 #define CHECK_DUNGEON_ITEM(item, dungeonIndex) (gSaveContext.save.saveInfo.inventory.dungeonItems[(void)0, dungeonIndex] & gBitFlags[item])
 #define CHECK_DUNGEON_ITEM_ALT(item, dungeonIndex) (gSaveContext.save.saveInfo.inventory.dungeonItems[dungeonIndex] & gBitFlags[item])
 #define SET_DUNGEON_ITEM(item, dungeonIndex) (gSaveContext.save.saveInfo.inventory.dungeonItems[(void)0, dungeonIndex] |= (u8)gBitFlags[item])
+// 2S2H [Enhancements] We added this for save editor
 #define REMOVE_DUNGEON_ITEM(item, dungeonIndex) (gSaveContext.save.saveInfo.inventory.dungeonItems[(void)0, dungeonIndex] &= ~(u8)gBitFlags[item])
 #define DUNGEON_KEY_COUNT(dungeonIndex) (gSaveContext.save.saveInfo.inventory.dungeonKeys[(void)0, dungeonIndex])
 #define GET_DUNGEON_FLOOR_VISITED(sceneId, floor) (gSaveContext.save.saveInfo.permanentSceneFlags[(sceneId)].unk_14 & gBitFlags[floor])

--- a/mm/include/z64save.h
+++ b/mm/include/z64save.h
@@ -526,6 +526,7 @@ typedef enum {
 #define CHECK_DUNGEON_ITEM(item, dungeonIndex) (gSaveContext.save.saveInfo.inventory.dungeonItems[(void)0, dungeonIndex] & gBitFlags[item])
 #define CHECK_DUNGEON_ITEM_ALT(item, dungeonIndex) (gSaveContext.save.saveInfo.inventory.dungeonItems[dungeonIndex] & gBitFlags[item])
 #define SET_DUNGEON_ITEM(item, dungeonIndex) (gSaveContext.save.saveInfo.inventory.dungeonItems[(void)0, dungeonIndex] |= (u8)gBitFlags[item])
+#define REMOVE_DUNGEON_ITEM(item, dungeonIndex) (gSaveContext.save.saveInfo.inventory.dungeonItems[(void)0, dungeonIndex] &= ~(u8)gBitFlags[item])
 #define DUNGEON_KEY_COUNT(dungeonIndex) (gSaveContext.save.saveInfo.inventory.dungeonKeys[(void)0, dungeonIndex])
 #define GET_DUNGEON_FLOOR_VISITED(sceneId, floor) (gSaveContext.save.saveInfo.permanentSceneFlags[(sceneId)].unk_14 & gBitFlags[floor])
 #define SET_DUNGEON_FLOOR_VISITED(sceneId, floor) (gSaveContext.save.saveInfo.permanentSceneFlags[(sceneId)].unk_14 |= gBitFlags[floor])


### PR DESCRIPTION
This adds a Dungeons Items tab to the Save Editor enabling the following features per Dungeon:

- Adding/Removing Stray Fairies
- Adding/Removing Dungeon Maps
- Adding/Removing Dungeon Compasses
- Adding/Removing Dungeon Small Keys (This pulls the max value for each dungeon into the Slider)
- Adding/Removing Dungeon Boss Keys

This also adds the following outside of the Dungeon Items tab:

- REMOVE_DUNGEON_ITEM, this is added to z64save.h as the macro did not exist.
- Spin Lv2 Checkbox to the General tab in Save Editor, this unlocks the Level 2 Spin Slash the Woodfall Great Fairy awards.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1549348710.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1549349429.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1549357776.zip)
<!--- section:artifacts:end -->