### PR TITLE
ci(linux): install libzip without crypto, bump sdl from 2.28.5 -> 2.30.3

### DIFF
--- a/.github/workflows/apt-deps.txt
+++ b/.github/workflows/apt-deps.txt
@@ -1,1 +1,1 @@
-libusb-dev libusb-1.0-0-dev libsdl2-dev libsdl2-net-dev libpng-dev libglew-dev libzip-dev zipcmp zipmerge ziptool nlohmann-json3-dev libtinyxml2-dev libspdlog-dev ninja-build
+libusb-dev libusb-1.0-0-dev libsdl2-dev libsdl2-net-dev libpng-dev libglew-dev nlohmann-json3-dev libtinyxml2-dev libspdlog-dev ninja-build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -152,7 +152,6 @@ jobs:
         cmake ..
         make
         sudo make install
-        sudo cp -av /usr/local/lib/libzip* /lib/x86_64-linux-gnu/
     - name: Generate 2ship.o2r
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
@@ -297,6 +296,7 @@ jobs:
         cmake .. -DENABLE_COMMONCRYPTO=OFF -DENABLE_GNUTLS=OFF -DENABLE_MBEDTLS=OFF -DENABLE_OPENSSL=OFF
         make
         sudo make install
+        sudo cp -av /usr/local/lib/libzip* /lib/x86_64-linux-gnu/
     - name: Download 2ship.o2r
       uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,7 +114,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y $(cat .github/workflows/apt-deps.txt)
+        sudo apt-get install -y $(cat .github/workflows/apt-deps.txt) libzip-dev zipcmp zipmerge ziptool
     - name: Cache build folders
       uses: actions/cache@v4
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -152,6 +152,7 @@ jobs:
         cmake ..
         make
         sudo make install
+        sudo cp -av /usr/local/lib/libzip* /lib/x86_64-linux-gnu/
     - name: Generate 2ship.o2r
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -254,17 +254,17 @@ jobs:
           linux-build-${{ github.ref }}
           linux-build-
         path: |
-          SDL2-2.28.5
-          SDL2_net-2.2.0
+          SDL2-2.30.3
           tinyxml2-10.0.0
+          libzip-1.10.1
     - name: Install latest SDL
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-        if [ ! -d "SDL2-2.28.5" ]; then
-          wget https://www.libsdl.org/release/SDL2-2.28.5.tar.gz
-          tar -xzf SDL2-2.28.5.tar.gz
+        if [ ! -d "SDL2-2.30.3" ]; then
+          wget https://www.libsdl.org/release/SDL2-2.30.3.tar.gz
+          tar -xzf SDL2-2.30.3.tar.gz
         fi
-        cd SDL2-2.28.5
+        cd SDL2-2.30.3
         ./configure --enable-hidapi-libusb
         make -j 10
         sudo make install
@@ -283,18 +283,19 @@ jobs:
         cmake ..
         make
         sudo make install
-    - name: Install latest SDL_net
+    - name: Install libzip without crypto
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-        if [ ! -d "SDL2_net-2.2.0" ]; then
-          wget https://www.libsdl.org/projects/SDL_net/release/SDL2_net-2.2.0.tar.gz
-          tar -xzf SDL2_net-2.2.0.tar.gz
+        if [ ! -d "libzip-1.10.1" ]; then
+          wget https://github.com/nih-at/libzip/releases/download/v1.10.1/libzip-1.10.1.tar.gz
+          tar -xzf libzip-1.10.1.tar.gz
         fi
-        cd SDL2_net-2.2.0
-        ./configure
-        make -j 10
+        cd libzip-1.10.1
+        mkdir -p build
+        cd build
+        cmake .. -DENABLE_COMMONCRYPTO=OFF -DENABLE_GNUTLS=OFF -DENABLE_MBEDTLS=OFF -DENABLE_OPENSSL=OFF
+        make
         sudo make install
-        sudo cp -av /usr/local/lib/libSDL* /lib/x86_64-linux-gnu/
     - name: Download 2ship.o2r
       uses: actions/download-artifact@v4
       with:

--- a/CMake/Packaging.cmake
+++ b/CMake/Packaging.cmake
@@ -79,7 +79,6 @@ execute_process(
     --executable=$<TARGET_FILE:2ship>
     $<$<BOOL:$<TARGET_PROPERTY:2ship,APPIMAGE_DESKTOP_FILE>>:--desktop-file=$<TARGET_PROPERTY:2ship,APPIMAGE_DESKTOP_FILE>>
     $<$<BOOL:$<TARGET_PROPERTY:2ship,APPIMAGE_ICON_FILE>>:--icon-file=$<TARGET_PROPERTY:2ship,APPIMAGE_ICON_FILE>>
-    --exclude-library "*libcrypto*"
     --output=appimage
     # --verbosity=2
 )


### PR DESCRIPTION
null

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1546269247.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1546270532.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1546276998.zip)
<!--- section:artifacts:end -->