### PR TITLE
Fix crash with Deku King during credits

### DIFF
--- a/mm/src/overlays/actors/ovl_En_Dnq/z_en_dnq.c
+++ b/mm/src/overlays/actors/ovl_En_Dnq/z_en_dnq.c
@@ -457,10 +457,12 @@ void func_80A52FB8(EnDnq* this, PlayState* play) {
 }
 
 void EnDnq_HandleCutscene(EnDnq* this, PlayState* play) {
+    //! @bug The credits cutscene accesses this array OOB with a cueId of 6, which ends up giving 0
     static s32 sCsAnimIndex[] = {
         DEKU_KING_ANIM_IDLE,          DEKU_KING_ANIM_IDLE_MORPH,
         DEKU_KING_ANIM_SURPRISE,      DEKU_KING_ANIM_JUMPED_ON_START,
         DEKU_KING_ANIM_JUMPED_ON_END, DEKU_KING_ANIM_JUMPED_ON_END_MORPH,
+        DEKU_KING_ANIM_IDLE, // 2S2H [Port] Added to prevent a crash with garbage data for cueId 6
     };
     s32 cueChannel;
     u32 cueId;


### PR DESCRIPTION
The cutscene data for the credits with King Deku sets a cueId of 6, but there is not a matching value in `sCsAnimIndex` for that cueId which would lead to a garbage value being read and potentially crashing on animation change.

Checking on console confirms that the OOB value it reads is `0` corresponding to `DEKU_KING_ANIM_IDLE`. Adding this value prevents the crash for us.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1548925531.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1548927619.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1548937820.zip)
<!--- section:artifacts:end -->