### PR TITLE
[Fix] Fixes Powder Keg Test

### DIFF
--- a/mm/2s2h/BenGui/UIWidgets.cpp
+++ b/mm/2s2h/BenGui/UIWidgets.cpp
@@ -180,6 +180,8 @@ bool Checkbox(const char* _label, bool* value, const CheckboxOptions& options) {
     if (window->SkipItems)
         return false;
 
+    ImGui::BeginDisabled(options.disabled);
+
     bool above = options.labelPosition == LabelPosition::Above;
     bool lpFar = options.labelPosition == LabelPosition::Far;
     bool right = options.alignment == ComponentAlignment::Right;
@@ -210,19 +212,15 @@ bool Checkbox(const char* _label, bool* value, const CheckboxOptions& options) {
 
     ImGui::ItemSize(total_bb, style.FramePadding.y);
     if (!ImGui::ItemAdd(total_bb, id)) {
-        IMGUI_TEST_ENGINE_ITEM_INFO(id, label,
-                                    g.LastItemData.StatusFlags | ImGuiItemStatusFlags_Checkable |
-                                        (*value ? ImGuiItemStatusFlags_Checked : 0));
+        ImGui::EndDisabled();
         return false;
     }
-
-    bool hovered, held;
-    bool pressed = ImGui::ButtonBehavior(total_bb, id, &hovered, &held);
+    bool hovered, held, pressed;
+    pressed = ImGui::ButtonBehavior(total_bb, id, &hovered, &held);
     if (pressed) {
         *value = !(*value);
         ImGui::MarkItemEdited(id);
     }
-    ImGui::BeginDisabled(options.disabled);
     PushStyleCheckbox(options.color);
     ImVec2 checkPos = pos;
     ImVec2 labelPos = pos;

--- a/mm/2s2h/Enhancements/Camera/FreeLook.cpp
+++ b/mm/2s2h/Enhancements/Camera/FreeLook.cpp
@@ -172,6 +172,7 @@ void RegisterCameraFreeLook() {
                 case CAM_FUNC_JUMP3:
                 case CAM_FUNC_BATTLE1:
                 case CAM_FUNC_UNIQUE2:
+                case CAM_FUNC_UNIQUE3:
                     if (Camera_CanFreeLook(camera)) {
                         Camera_FreeLook(camera);
                         *should = false;

--- a/mm/2s2h/Enhancements/Cheats/Infinite.cpp
+++ b/mm/2s2h/Enhancements/Cheats/Infinite.cpp
@@ -32,7 +32,11 @@ void RegisterInfiniteCheats() {
             AMMO(ITEM_DEKU_STICK) = CUR_CAPACITY(UPG_DEKU_STICKS);
             AMMO(ITEM_DEKU_NUT) = CUR_CAPACITY(UPG_DEKU_NUTS);
             AMMO(ITEM_MAGIC_BEANS) = 20;
-            AMMO(ITEM_POWDER_KEG) = 1;
+            if (INV_CONTENT(ITEM_POWDER_KEG) != ITEM_NONE) {
+                AMMO(ITEM_POWDER_KEG) = 1;
+            } else {
+                AMMO(ITEM_POWDER_KEG) = 0;
+            }
         }
     });
 }

--- a/mm/2s2h/Enhancements/Cheats/Infinite.cpp
+++ b/mm/2s2h/Enhancements/Cheats/Infinite.cpp
@@ -26,17 +26,23 @@ void RegisterInfiniteCheats() {
         }
 
         if (CVarGetInteger("gCheats.InfiniteConsumables", 0)) {
-            AMMO(ITEM_BOW) = CUR_CAPACITY(UPG_QUIVER);
-            AMMO(ITEM_BOMB) = CUR_CAPACITY(UPG_BOMB_BAG);
-            AMMO(ITEM_BOMBCHU) = CUR_CAPACITY(UPG_BOMB_BAG);
-            AMMO(ITEM_DEKU_STICK) = CUR_CAPACITY(UPG_DEKU_STICKS);
-            AMMO(ITEM_DEKU_NUT) = CUR_CAPACITY(UPG_DEKU_NUTS);
-            AMMO(ITEM_MAGIC_BEANS) = 20;
-            if (INV_CONTENT(ITEM_POWDER_KEG) != ITEM_NONE) {
-                AMMO(ITEM_POWDER_KEG) = 1;
-            } else {
-                AMMO(ITEM_POWDER_KEG) = 0;
-            }
+            uint32_t ammoItems[7] = {   ITEM_BOW,         ITEM_BOMB,          ITEM_BOMBCHU,   ITEM_DEKU_STICK,
+                                        ITEM_DEKU_NUT,    ITEM_MAGIC_BEANS,   ITEM_POWDER_KEG };
+            uint32_t upgCapacity[7] = { UPG_QUIVER,     UPG_BOMB_BAG,       UPG_BOMB_BAG,   UPG_DEKU_STICKS,
+                                        UPG_DEKU_NUTS,  ITEM_MAGIC_BEANS,   ITEM_POWDER_KEG };
+            for (int i = 0; i <= sizeof(ammoItems) / sizeof(ammoItems[0]); i++) {
+                if (INV_CONTENT(ammoItems[i]) == ammoItems[i]) {
+                    if (ammoItems[i] == ITEM_MAGIC_BEANS) {
+                        AMMO(ammoItems[i]) = 20;
+                    } else if (ammoItems[i] == ITEM_POWDER_KEG) {
+                        AMMO(ammoItems[i]) = 1;
+                    } else {
+                        AMMO(ammoItems[i]) = CUR_CAPACITY(upgCapacity[i]);
+                    }
+                } else if (ammoItems[i] == ITEM_POWDER_KEG) {
+                    AMMO(ammoItems[i]) = 0;
+                }
+            };
         }
     });
 }

--- a/mm/2s2h/Enhancements/Cheats/Infinite.cpp
+++ b/mm/2s2h/Enhancements/Cheats/Infinite.cpp
@@ -26,10 +26,10 @@ void RegisterInfiniteCheats() {
         }
 
         if (CVarGetInteger("gCheats.InfiniteConsumables", 0)) {
-            uint32_t ammoItems[7] = {   ITEM_BOW,         ITEM_BOMB,          ITEM_BOMBCHU,   ITEM_DEKU_STICK,
-                                        ITEM_DEKU_NUT,    ITEM_MAGIC_BEANS,   ITEM_POWDER_KEG };
-            uint32_t upgCapacity[7] = { UPG_QUIVER,     UPG_BOMB_BAG,       UPG_BOMB_BAG,   UPG_DEKU_STICKS,
-                                        UPG_DEKU_NUTS,  ITEM_MAGIC_BEANS,   ITEM_POWDER_KEG };
+            uint32_t ammoItems[7] = { ITEM_BOW,      ITEM_BOMB,        ITEM_BOMBCHU,   ITEM_DEKU_STICK,
+                                      ITEM_DEKU_NUT, ITEM_MAGIC_BEANS, ITEM_POWDER_KEG };
+            uint32_t upgCapacity[7] = { UPG_QUIVER,    UPG_BOMB_BAG,     UPG_BOMB_BAG,   UPG_DEKU_STICKS,
+                                        UPG_DEKU_NUTS, ITEM_MAGIC_BEANS, ITEM_POWDER_KEG };
             for (int i = 0; i <= sizeof(ammoItems) / sizeof(ammoItems[0]); i++) {
                 if (INV_CONTENT(ammoItems[i]) == ammoItems[i]) {
                     if (ammoItems[i] == ITEM_MAGIC_BEANS) {

--- a/mm/src/overlays/actors/ovl_En_Dnq/z_en_dnq.c
+++ b/mm/src/overlays/actors/ovl_En_Dnq/z_en_dnq.c
@@ -457,10 +457,12 @@ void func_80A52FB8(EnDnq* this, PlayState* play) {
 }
 
 void EnDnq_HandleCutscene(EnDnq* this, PlayState* play) {
+    //! @bug The credits cutscene accesses this array OOB with a cueId of 6, which ends up giving 0
     static s32 sCsAnimIndex[] = {
         DEKU_KING_ANIM_IDLE,          DEKU_KING_ANIM_IDLE_MORPH,
         DEKU_KING_ANIM_SURPRISE,      DEKU_KING_ANIM_JUMPED_ON_START,
         DEKU_KING_ANIM_JUMPED_ON_END, DEKU_KING_ANIM_JUMPED_ON_END_MORPH,
+        DEKU_KING_ANIM_IDLE, // 2S2H [Port] Added to prevent a crash with garbage data for cueId 6
     };
     s32 cueChannel;
     u32 cueId;

--- a/mm/src/overlays/gamestates/ovl_title/z_title.c
+++ b/mm/src/overlays/gamestates/ovl_title/z_title.c
@@ -25,10 +25,10 @@ static const ALIGN_ASSET(2) char gLUSLogoTextTex[] = dgLUSLogoTextTex;
 const char* GetGameVersionString() {
     uint32_t gameVersion = ResourceMgr_GetGameVersion(0);
     switch (gameVersion) {
-        // BENTODO: Use enums from LUS once added and add rest of version names
-        case 0x5354631C:
-        case 0xDA6983E7:
+        case MM_NTSC_US_10:
             return "MM-US 1.0";
+        case MM_NTSC_US_GC:
+            return "MM-US GC";
         default:
             return "UNKNOWN";
     }


### PR DESCRIPTION
Fixes the Powder Keg test provided by the Medigoron when Infinite Consumables is enabled.

As long as the Powder Keg is not in the players inventory, Medigoron will act normally.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1549882916.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1549887618.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1549913604.zip)
<!--- section:artifacts:end -->