### PR TITLE
Adds sanity checks for bottle duping over items and prevents the issue causing Big Goron to not give the player the Keg License.

### DIFF
--- a/mm/2s2h/Enhancements/Cheats/Infinite.cpp
+++ b/mm/2s2h/Enhancements/Cheats/Infinite.cpp
@@ -50,7 +50,7 @@ void RegisterInfiniteCheats() {
             if (INV_CONTENT(ITEM_MAGIC_BEANS) == ITEM_MAGIC_BEANS) {
                 AMMO(ITEM_MAGIC_BEANS) = 20;
             }
-            
+
             if (INV_CONTENT(ITEM_POWDER_KEG) == ITEM_POWDER_KEG) {
                 AMMO(ITEM_POWDER_KEG) = 1;
             }

--- a/mm/2s2h/Enhancements/Cheats/Infinite.cpp
+++ b/mm/2s2h/Enhancements/Cheats/Infinite.cpp
@@ -26,13 +26,27 @@ void RegisterInfiniteCheats() {
         }
 
         if (CVarGetInteger("gCheats.InfiniteConsumables", 0)) {
-            AMMO(ITEM_BOW) = CUR_CAPACITY(UPG_QUIVER);
-            AMMO(ITEM_BOMB) = CUR_CAPACITY(UPG_BOMB_BAG);
-            AMMO(ITEM_BOMBCHU) = CUR_CAPACITY(UPG_BOMB_BAG);
-            AMMO(ITEM_DEKU_STICK) = CUR_CAPACITY(UPG_DEKU_STICKS);
-            AMMO(ITEM_DEKU_NUT) = CUR_CAPACITY(UPG_DEKU_NUTS);
-            AMMO(ITEM_MAGIC_BEANS) = 20;
-            AMMO(ITEM_POWDER_KEG) = 1;
+            
+            if (INV_CONTENT(ITEM_BOW) == ITEM_BOW) //Sanity check for bottle duping.
+                AMMO(ITEM_BOW) = CUR_CAPACITY(UPG_QUIVER);
+
+            if (INV_CONTENT(ITEM_BOMB) == ITEM_BOMB)
+                AMMO(ITEM_BOMB) = CUR_CAPACITY(UPG_BOMB_BAG);
+
+            if (INV_CONTENT(ITEM_BOMBCHU) == ITEM_BOMBCHU)
+                AMMO(ITEM_BOMBCHU) = CUR_CAPACITY(UPG_BOMB_BAG);
+
+            if (INV_CONTENT(ITEM_DEKU_STICK) == ITEM_DEKU_STICK)
+                AMMO(ITEM_DEKU_STICK) = CUR_CAPACITY(UPG_DEKU_STICKS);
+
+            if (INV_CONTENT(ITEM_DEKU_NUT) == ITEM_DEKU_NUT)
+                AMMO(ITEM_DEKU_NUT) = CUR_CAPACITY(UPG_DEKU_NUTS);
+
+            if (INV_CONTENT(ITEM_MAGIC_BEANS) == ITEM_MAGIC_BEANS)
+                AMMO(ITEM_MAGIC_BEANS) = 20;
+            
+            if (INV_CONTENT(ITEM_POWDER_KEG) == ITEM_POWDER_KEG) //This both checks for sanity on duping and avoids the Keg License issue. 
+                AMMO(ITEM_POWDER_KEG) = 1;
         }
     });
 }

--- a/mm/2s2h/Enhancements/Cheats/Infinite.cpp
+++ b/mm/2s2h/Enhancements/Cheats/Infinite.cpp
@@ -26,7 +26,6 @@ void RegisterInfiniteCheats() {
         }
 
         if (CVarGetInteger("gCheats.InfiniteConsumables", 0)) {
-            
             if (INV_CONTENT(ITEM_BOW) == ITEM_BOW) {
                 AMMO(ITEM_BOW) = CUR_CAPACITY(UPG_QUIVER);
             }

--- a/mm/2s2h/Enhancements/Cheats/Infinite.cpp
+++ b/mm/2s2h/Enhancements/Cheats/Infinite.cpp
@@ -27,26 +27,33 @@ void RegisterInfiniteCheats() {
 
         if (CVarGetInteger("gCheats.InfiniteConsumables", 0)) {
             
-            if (INV_CONTENT(ITEM_BOW) == ITEM_BOW) //Sanity check for bottle duping.
+            if (INV_CONTENT(ITEM_BOW) == ITEM_BOW) {
                 AMMO(ITEM_BOW) = CUR_CAPACITY(UPG_QUIVER);
+            }
 
-            if (INV_CONTENT(ITEM_BOMB) == ITEM_BOMB)
+            if (INV_CONTENT(ITEM_BOMB) == ITEM_BOMB) {
                 AMMO(ITEM_BOMB) = CUR_CAPACITY(UPG_BOMB_BAG);
+            }
 
-            if (INV_CONTENT(ITEM_BOMBCHU) == ITEM_BOMBCHU)
+            if (INV_CONTENT(ITEM_BOMBCHU) == ITEM_BOMBCHU) {
                 AMMO(ITEM_BOMBCHU) = CUR_CAPACITY(UPG_BOMB_BAG);
+            }
 
-            if (INV_CONTENT(ITEM_DEKU_STICK) == ITEM_DEKU_STICK)
+            if (INV_CONTENT(ITEM_DEKU_STICK) == ITEM_DEKU_STICK) {
                 AMMO(ITEM_DEKU_STICK) = CUR_CAPACITY(UPG_DEKU_STICKS);
+            }
 
-            if (INV_CONTENT(ITEM_DEKU_NUT) == ITEM_DEKU_NUT)
+            if (INV_CONTENT(ITEM_DEKU_NUT) == ITEM_DEKU_NUT) {
                 AMMO(ITEM_DEKU_NUT) = CUR_CAPACITY(UPG_DEKU_NUTS);
+            }
 
-            if (INV_CONTENT(ITEM_MAGIC_BEANS) == ITEM_MAGIC_BEANS)
+            if (INV_CONTENT(ITEM_MAGIC_BEANS) == ITEM_MAGIC_BEANS) {
                 AMMO(ITEM_MAGIC_BEANS) = 20;
+            }
             
-            if (INV_CONTENT(ITEM_POWDER_KEG) == ITEM_POWDER_KEG) //This both checks for sanity on duping and avoids the Keg License issue. 
+            if (INV_CONTENT(ITEM_POWDER_KEG) == ITEM_POWDER_KEG) {
                 AMMO(ITEM_POWDER_KEG) = 1;
+            }
         }
     });
 }


### PR DESCRIPTION
Adds sanity checks for bottle duping and prevents the issue causing Big Goron to not give the player the Keg License.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1550157905.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1550166933.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1550224278.zip)
<!--- section:artifacts:end -->