### PR TITLE
Fix taking transformation mask off setting unexpected flags

### DIFF
--- a/mm/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/mm/src/overlays/actors/ovl_player_actor/z_player.c
@@ -18258,10 +18258,11 @@ void func_80855218(PlayState* play, Player* this, struct_8085D910** arg2) {
 }
 
 u16 D_8085D908[] = {
-    WEEKEVENTREG_30_80, // PLAYER_FORM_FIERCE_DEITY
-    WEEKEVENTREG_30_20, // PLAYER_FORM_GORON
-    WEEKEVENTREG_30_40, // PLAYER_FORM_ZORA
-    WEEKEVENTREG_30_10, // PLAYER_FORM_DEKU
+    WEEKEVENTREG_30_80,               // PLAYER_FORM_FIERCE_DEITY
+    WEEKEVENTREG_30_20,               // PLAYER_FORM_GORON
+    WEEKEVENTREG_30_40,               // PLAYER_FORM_ZORA
+    WEEKEVENTREG_30_10,               // PLAYER_FORM_DEKU
+    PACK_WEEKEVENTREG_FLAG(16, 0x0A), // 2S2H [Port] Added to match OOB value read on console for human form
 };
 struct_8085D910 D_8085D910[] = {
     { 0x10, 0xA, 0x3B, 0x3F },
@@ -18297,6 +18298,11 @@ void Player_Action_86(Player* this, PlayState* play) {
             this->actor.draw = NULL;
             this->av1.actionVar1 = 0;
             Play_DisableMotionBlurPriority();
+            //! @bug When taking off a transformation mask, PLAYER_FORM_HUMAN will index OOB leading
+            // to the next value causing WEEKEVENT_REG 16 being set with 0x0A which sets two flags at once
+            // WEEKEVENTREG_16_02 and WEEKEVENTREG_16_08
+            // WEEKEVENTREG_16_02 corresponds to showing a text ID from the Gorman Brothers on the 3rd day
+            // if the player has saved the farm, so this bug would prevent that text from displaying
             SET_WEEKEVENTREG(D_8085D908[GET_PLAYER_FORM]);
         }
     } else if ((this->av1.actionVar1++ > ((this->transformation == PLAYER_FORM_HUMAN) ? 0x53 : 0x37)) ||


### PR DESCRIPTION
The game sets some flags when putting on a transformation mask. These flags are what allow the player to press a button to "skip" the cutscene after the first time. An array tracks the flag for each player form.

The problem is this logic also executes for taking a mask _off_ which leads to `PLAYER_FORM_HUMAN` being passed into the same array. This ends up as a OOB read, causing garbage data to be passed into `SET_WEEKEVENTREG` meaning random flag(s) are potentially set. It's been observed on LInux that this sets a few flags pertaining to learning Goron Lullaby.

Checking on console reveals that the OOB value that gets used on console is `0x100A` which translates to two flags being set: `WEEKEVENTREG_16_02` and `WEEKEVENTREG_16_08`
The later of the two appears to be unused. The first however is used by the Gorman Brothers to present or skip a specific text ID that would show on the third day if the player completed the alien quest.
The text is the "I head some garos attacked the milk wagon".

I've opted to add a value to the array that matches console, so these flags will be set when taking a mask off, restoring original behavior with the OOB read.

Alternatively, we could fix the bug by checking for the human form and just not call `SET_WEEKEVENTREG` at all if that is more preferred.

Fixes #490 

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1553793249.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1553795755.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1553802221.zip)
<!--- section:artifacts:end -->