### PR TITLE
Rupee Dash Mode - v1

### DIFF
--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -426,7 +426,7 @@ void DrawEnhancementsMenu() {
 
             ImGui::EndMenu();
         }
-                
+
         if (UIWidgets::BeginMenu("Saving / Time Cycle")) {
 
             ImGui::SeparatorText("Saving");
@@ -482,21 +482,19 @@ void DrawEnhancementsMenu() {
 
         if (UIWidgets::BeginMenu("Difficulty Options")) {
             ImGui::SeparatorText("Rupee Dash Mode");
-            UIWidgets::CVarCheckbox(
-                    "Disable Sound Effect", "gEnhancements.Difficulty.RupeeSound",
-                    { .tooltip = "Disable the sound effect when Rupee Dash Modes reduce Rupees." });
+            UIWidgets::CVarCheckbox("Disable Sound Effect", "gEnhancements.Difficulty.RupeeSound",
+                                    { .tooltip = "Disable the sound effect when Rupee Dash Modes reduce Rupees." });
             ImGui::Separator();
             UIWidgets::CVarCheckbox(
-                    "Rupee Bleed", "gEnhancements.Difficulty.RupeeBleed",
-                    { .tooltip = "Rupees decrease over time, once Link reaches 0 he will take 1 Heart instead." });
+                "Rupee Bleed", "gEnhancements.Difficulty.RupeeBleed",
+                { .tooltip = "Rupees decrease over time, once Link reaches 0 he will take 1 Heart instead." });
             if (CVarGetInteger("gEnhancements.Difficulty.RupeeBleed", 0)) {
-                UIWidgets::CVarSliderInt(
-                    "Bleed Interval", "gEnhancements.Difficulty.BleedInterval", 1, 30, 5,
-                    { .color = UIWidgets::Colors::Indigo,
-                      .tooltip = "Interval (in seconds) before the next Bleed occurs." });
+                UIWidgets::CVarSliderInt("Bleed Interval", "gEnhancements.Difficulty.BleedInterval", 1, 30, 5,
+                                         { .color = UIWidgets::Colors::Indigo,
+                                           .tooltip = "Interval (in seconds) before the next Bleed occurs." });
                 ImGui::Separator();
             }
-            
+
             ImGui::EndMenu();
         }
 

--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -426,7 +426,7 @@ void DrawEnhancementsMenu() {
 
             ImGui::EndMenu();
         }
-
+                
         if (UIWidgets::BeginMenu("Saving / Time Cycle")) {
 
             ImGui::SeparatorText("Saving");
@@ -477,6 +477,26 @@ void DrawEnhancementsMenu() {
                 "Fast Text", "gEnhancements.Dialogue.FastText",
                 { .tooltip = "Speeds up text rendering, and enables holding of B progress to next message" });
 
+            ImGui::EndMenu();
+        }
+
+        if (UIWidgets::BeginMenu("Difficulty Options")) {
+            ImGui::SeparatorText("Rupee Dash Mode");
+            UIWidgets::CVarCheckbox(
+                    "Disable Sound Effect", "gEnhancements.Difficulty.RupeeSound",
+                    { .tooltip = "Disable the sound effect when Rupee Dash Modes reduce Rupees." });
+            ImGui::Separator();
+            UIWidgets::CVarCheckbox(
+                    "Rupee Bleed", "gEnhancements.Difficulty.RupeeBleed",
+                    { .tooltip = "Rupees decrease over time, once Link reaches 0 he will take 1 Heart instead." });
+            if (CVarGetInteger("gEnhancements.Difficulty.RupeeBleed", 0)) {
+                UIWidgets::CVarSliderInt(
+                    "Bleed Interval", "gEnhancements.Difficulty.BleedInterval", 1, 30, 5,
+                    { .color = UIWidgets::Colors::Indigo,
+                      .tooltip = "Interval (in seconds) before the next Bleed occurs." });
+                ImGui::Separator();
+            }
+            
             ImGui::EndMenu();
         }
 

--- a/mm/2s2h/Enhancements/DifficultyOptions/RupeeDashOptions.cpp
+++ b/mm/2s2h/Enhancements/DifficultyOptions/RupeeDashOptions.cpp
@@ -27,7 +27,11 @@ void RegisterRupeeDash() {
                     if (bleedInterval <= 0) {
                         if (gSaveContext.save.saveInfo.playerData.rupees >= 1) {
                             s8 walletSize = CUR_UPG_VALUE(UPG_WALLET) + 1;
-                            RupeeReductionEffect(walletSize);
+                            if (gSaveContext.save.saveInfo.playerData.rupees >= walletSize) {
+                                RupeeReductionEffect(walletSize);
+                            } else {
+                                RupeeReductionEffect(gSaveContext.save.saveInfo.playerData.rupees);
+                            }
                         } else {
                             gSaveContext.save.saveInfo.playerData.health -= 0x10;
                         }

--- a/mm/2s2h/Enhancements/DifficultyOptions/RupeeDashOptions.cpp
+++ b/mm/2s2h/Enhancements/DifficultyOptions/RupeeDashOptions.cpp
@@ -1,0 +1,45 @@
+#include <libultraship/bridge.h>
+#include "Enhancements/GameInteractor/GameInteractor.h"
+#include "global.h"
+
+uint32_t bleedInterval = 0;
+
+void RupeeReductionEffect(s8 amount) {
+    if (CVarGetInteger("gEnhancements.Difficulty.RupeeSound", 0)) {
+        gSaveContext.save.saveInfo.playerData.rupees -= amount;
+    } else {
+        Rupees_ChangeBy(-amount);
+    }
+}
+
+void RegisterRupeeDash() {
+    GameInteractor::Instance->RegisterGameHookForID<GameInteractor::OnActorInit>(ACTOR_PLAYER, [](Actor* outerActor) {
+        static uint32_t playerUpdateHook = 0;
+        static uint32_t playerKillHook = 0;
+        GameInteractor::Instance->UnregisterGameHookForPtr<GameInteractor::OnActorUpdate>(playerUpdateHook);
+        GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnSceneInit>(playerKillHook);
+        playerUpdateHook = 0;
+        playerKillHook = 0;
+
+        playerUpdateHook = GameInteractor::Instance->RegisterGameHookForPtr<GameInteractor::OnActorUpdate>(
+                (uintptr_t)outerActor, [](Actor* actor) {
+            if (CVarGetInteger("gEnhancements.Difficulty.RupeeBleed", 0)) {
+                    if (bleedInterval <= 0) {
+                        if (gSaveContext.save.saveInfo.playerData.rupees >= 1) {
+                            s8 walletSize = CUR_UPG_VALUE(UPG_WALLET) + 1;
+                            RupeeReductionEffect(walletSize);
+                        } else {
+                            gSaveContext.save.saveInfo.playerData.health -= 0x10;
+                        }
+                        bleedInterval = (CVarGetInteger("gEnhancements.Difficulty.BleedInterval", 0) * 20);
+                    }
+                    bleedInterval--;
+            } else {
+                playerKillHook = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSceneInit>([](s8 sceneId, s8 spawnNum) {
+                        GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnActorUpdate>(playerUpdateHook);
+                        GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnSceneInit>(playerKillHook);
+                });
+            }
+        });
+    });
+}

--- a/mm/2s2h/Enhancements/DifficultyOptions/RupeeDashOptions.cpp
+++ b/mm/2s2h/Enhancements/DifficultyOptions/RupeeDashOptions.cpp
@@ -14,8 +14,8 @@ void RupeeReductionEffect(s8 amount) {
 
 void RegisterRupeeDash() {
     GameInteractor::Instance->RegisterGameHookForID<GameInteractor::OnActorInit>(ACTOR_PLAYER, [](Actor* outerActor) {
-        static uint32_t playerUpdateHook = 0;
-        static uint32_t playerKillHook = 0;
+        static HOOK_ID playerUpdateHook = 0;
+        static HOOK_ID playerKillHook = 0;
         GameInteractor::Instance->UnregisterGameHookForPtr<GameInteractor::OnActorUpdate>(playerUpdateHook);
         GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnSceneInit>(playerKillHook);
         playerUpdateHook = 0;

--- a/mm/2s2h/Enhancements/DifficultyOptions/RupeeDashOptions.cpp
+++ b/mm/2s2h/Enhancements/DifficultyOptions/RupeeDashOptions.cpp
@@ -22,8 +22,8 @@ void RegisterRupeeDash() {
         playerKillHook = 0;
 
         playerUpdateHook = GameInteractor::Instance->RegisterGameHookForPtr<GameInteractor::OnActorUpdate>(
-                (uintptr_t)outerActor, [](Actor* actor) {
-            if (CVarGetInteger("gEnhancements.Difficulty.RupeeBleed", 0)) {
+            (uintptr_t)outerActor, [](Actor* actor) {
+                if (CVarGetInteger("gEnhancements.Difficulty.RupeeBleed", 0)) {
                     if (bleedInterval <= 0) {
                         if (gSaveContext.save.saveInfo.playerData.rupees >= 1) {
                             s8 walletSize = CUR_UPG_VALUE(UPG_WALLET) + 1;
@@ -34,12 +34,14 @@ void RegisterRupeeDash() {
                         bleedInterval = (CVarGetInteger("gEnhancements.Difficulty.BleedInterval", 0) * 20);
                     }
                     bleedInterval--;
-            } else {
-                playerKillHook = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSceneInit>([](s8 sceneId, s8 spawnNum) {
-                        GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnActorUpdate>(playerUpdateHook);
-                        GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnSceneInit>(playerKillHook);
-                });
-            }
-        });
+                } else {
+                    playerKillHook = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSceneInit>(
+                        [](s8 sceneId, s8 spawnNum) {
+                            GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnActorUpdate>(
+                                playerUpdateHook);
+                            GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnSceneInit>(playerKillHook);
+                        });
+                }
+            });
     });
 }

--- a/mm/2s2h/Enhancements/DifficultyOptions/RupeeDashOptions.h
+++ b/mm/2s2h/Enhancements/DifficultyOptions/RupeeDashOptions.h
@@ -1,0 +1,6 @@
+#ifndef RUPEE_DASH_OPTIONS_H
+#define RUPEE_DASH_OPTIONS_H
+
+void RegisterRupeeDash();
+
+#endif // RUPEE_DASH_OPTIONS_H

--- a/mm/2s2h/Enhancements/Enhancements.cpp
+++ b/mm/2s2h/Enhancements/Enhancements.cpp
@@ -20,6 +20,9 @@ void InitEnhancements() {
     RegisterSavingEnhancements();
     RegisterAutosave();
 
+    // Difficulty Options
+    RegisterRupeeDash();
+
     // Masks
     RegisterFastTransformation();
     RegisterFierceDeityAnywhere();

--- a/mm/2s2h/Enhancements/Enhancements.h
+++ b/mm/2s2h/Enhancements/Enhancements.h
@@ -10,6 +10,7 @@
 #include "Cheats/UnbreakableRazorSword.h"
 #include "Cheats/UnrestrictedItems.h"
 #include "Cycle/EndOfCycle.h"
+#include "DifficultyOptions/RupeeDashOptions.h"
 #include "Masks/FierceDeityAnywhere.h"
 #include "Masks/NoBlastMaskCooldown.h"
 #include "Masks/FastTransformation.h"


### PR DESCRIPTION
Adding this mode in (more for myself but if desired can be merged in).

Rupees deplete at a rate that varies based on your current Wallet Size:
- Starter Wallet (99 max) = -1 per tick
- Adult Wallet (200 max) = -2 per tick
- Giant Wallet (500 max) = -3 per tick

- Adds new Difficulty Options category to Menu Bar
- Adds Disable Sound Effect option (check the box to turn off the Rupee *plink* sound when bleed occurs)
- Adds Rupee Bleed (rupees diminish over time, if Link is at 0 rupees it starts taking health)
- Adds Bleed Interval to adjust difficulty

More options can be added to the RupeeDashOptions file as needed instead of creating a brand new file for each.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1559476561.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1559479903.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1559483696.zip)
<!--- section:artifacts:end -->