### PR TITLE
Fix HUD editor position bugs

### DIFF
--- a/mm/2s2h/BenGui/HudEditor.cpp
+++ b/mm/2s2h/BenGui/HudEditor.cpp
@@ -59,9 +59,9 @@ extern "C" void HudEditor_ModifyRectPosValuesFromBase(s16 baseX, s16 baseY, s16*
     *rectTop = baseY + (offsetFromBaseY * CVarGetFloat(hudEditorElements[hudEditorActiveElement].scaleCvar, 1.0f));
 }
 
-extern "C" void HudEditor_ModifyRectPosValues(s16* rectLeft, s16* rectTop) {
-    s16 offsetFromBaseX = *rectLeft - hudEditorElements[hudEditorActiveElement].defaultX;
-    s16 offsetFromBaseY = *rectTop - hudEditorElements[hudEditorActiveElement].defaultY;
+void HudEditor_ModifyRectPosValuesFloat(f32* rectLeft, f32* rectTop) {
+    f32 offsetFromBaseX = *rectLeft - hudEditorElements[hudEditorActiveElement].defaultX;
+    f32 offsetFromBaseY = *rectTop - hudEditorElements[hudEditorActiveElement].defaultY;
     *rectLeft = CVarGetInteger(hudEditorElements[hudEditorActiveElement].xCvar,
                                hudEditorElements[hudEditorActiveElement].defaultX) +
                 (offsetFromBaseX * CVarGetFloat(hudEditorElements[hudEditorActiveElement].scaleCvar, 1.0f));
@@ -78,6 +78,16 @@ extern "C" void HudEditor_ModifyRectPosValues(s16* rectLeft, s16* rectTop) {
     }
 }
 
+extern "C" void HudEditor_ModifyRectPosValues(s16* rectLeft, s16* rectTop) {
+    f32 newLeft = *rectLeft;
+    f32 newTop = *rectTop;
+
+    HudEditor_ModifyRectPosValuesFloat(&newLeft, &newTop);
+
+    *rectLeft = (s16)newLeft;
+    *rectTop = (s16)newTop;
+}
+
 extern "C" void HudEditor_ModifyRectSizeValues(s16* rectWidth, s16* rectHeight) {
     *rectWidth *= CVarGetFloat(hudEditorElements[hudEditorActiveElement].scaleCvar, 1.0f);
     *rectHeight *= CVarGetFloat(hudEditorElements[hudEditorActiveElement].scaleCvar, 1.0f);
@@ -90,16 +100,13 @@ extern "C" void HudEditor_ModifyTextureStepValues(s16* dsdx, s16* dtdy) {
 
 // Modify matrix values based on the identity matrix (0,0) centered on the screen
 extern "C" void HudEditor_ModifyMatrixValues(f32* transX, f32* transY) {
-    *transX = (f32)(SCREEN_WIDTH / 2) + *transX;
-    *transY = (f32)(SCREEN_HEIGHT / 2) - *transY;
+    *transX = ((f32)SCREEN_WIDTH / 2) + *transX;
+    *transY = ((f32)SCREEN_HEIGHT / 2) - *transY;
 
-    s16 newX = *transX;
-    s16 newY = *transY;
+    HudEditor_ModifyRectPosValuesFloat(transX, transY);
 
-    HudEditor_ModifyRectPosValues(&newX, &newY);
-
-    *transX = (f32)newX - (SCREEN_WIDTH / 2);
-    *transY = (f32)(SCREEN_HEIGHT / 2) - newY;
+    *transX = *transX - ((f32)SCREEN_WIDTH / 2);
+    *transY = ((f32)SCREEN_HEIGHT / 2) - *transY;
 }
 
 extern "C" void HudEditor_ModifyKaleidoEquipAnimValues(s16* ulx, s16* uly, s16* shrinkRate) {

--- a/mm/src/code/z_parameter.c
+++ b/mm/src/code/z_parameter.c
@@ -7391,10 +7391,10 @@ void Interface_DrawTimers(PlayState* play) {
     s16 j;
     s16 i;
     // 2S2H [Cosmetic] Hud editor values for timers
-    s16 newTimerX;
-    s16 newTimerY;
-    u8 modifiedTimerHudValues;
-    s16 hudTimerElement;
+    s16 newTimerX = 0;
+    s16 newTimerY = 0;
+    u8 modifiedTimerHudValues = false;
+    s16 hudTimerElement = HUD_EDITOR_ELEMENT_NONE;
 
     OPEN_DISPS(play->state.gfxCtx);
 


### PR DESCRIPTION
The behavior for `HudEditor_ModifyMatrixValues` was down-casting the float values to ints causing truncation. This lead to the sun/moon icons on the clock HUD to "jump" in increments instead of moving smoothly.

Also fixed an issue where ints where not initialized which led to garbage values being read. This caused the HUD timers position to not obey the HUD editor values.

Fixes #506, #503 

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1557054955.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1557059147.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1557063914.zip)
<!--- section:artifacts:end -->