### PR TITLE
Fix the PRNG not being seeded when opening intro is skipped

### DIFF
--- a/mm/src/overlays/gamestates/ovl_title/z_title.c
+++ b/mm/src/overlays/gamestates/ovl_title/z_title.c
@@ -201,6 +201,9 @@ void ConsoleLogo_Main(GameState* thisx) {
 
         STOP_GAMESTATE(&this->state);
         if (CVarGetInteger("gEnhancements.Cutscenes.SkipToFileSelect", 0)) {
+            // Normally the PRNG seed is set at least once from the title opening running Play_Init
+            // We need to call it manually before file select creates RNG values for new saves
+            Rand_Seed(osGetTime());
             SET_NEXT_GAMESTATE(&this->state, FileSelect_Init, sizeof(FileSelectState));
         } else {
             SET_NEXT_GAMESTATE(&this->state, TitleSetup_Init, sizeof(TitleSetupState));


### PR DESCRIPTION
The skip to File Select enhancement was skipping past what normally would initially seed the PRNG. This would lead to the first save file created to have the same RNG values (bombers code, lottery codes, spider house mask order).

We just need to set the seed manually when the enhancement is on.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1559570941.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1559572020.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1559574083.zip)
<!--- section:artifacts:end -->