### PR TITLE
Add various tweaks and a warning to debug mode toggle

### DIFF
--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -615,8 +615,32 @@ const char* logLevels[] = {
 
 void DrawDeveloperToolsMenu() {
     if (UIWidgets::BeginMenu("Developer Tools", UIWidgets::Colors::Yellow)) {
-        UIWidgets::CVarCheckbox("Debug Mode", "gDeveloperTools.DebugEnabled",
-                                { .tooltip = "Enables Debug Mode, allowing you to select maps with L + R + Z." });
+        if (UIWidgets::CVarCheckbox("Debug Mode", "gDeveloperTools.DebugEnabled",
+                                    { .tooltip = "Enables Debug Mode, revealing some developer options and allows you "
+                                                 "to enter Map Select with L + R + Z" })) {
+            // If disabling debug mode, disable all debug features
+            if (!CVarGetInteger("gDeveloperTools.DebugEnabled", 0)) {
+                CVarClear("gDeveloperTools.DebugSaveFileMode");
+                CVarClear("gDeveloperTools.PreventActorUpdate");
+                CVarClear("gDeveloperTools.PreventActorDraw");
+                CVarClear("gDeveloperTools.PreventActorInit");
+                CVarClear("gDeveloperTools.DisableObjectDependency");
+                if (gPlayState != NULL) {
+                    gPlayState->frameAdvCtx.enabled = false;
+                }
+                RegisterDebugSaveCreate();
+                RegisterPreventActorUpdateHooks();
+                RegisterPreventActorDrawHooks();
+                RegisterPreventActorInitHooks();
+            }
+        }
+        if (ImGui::IsItemHovered()) {
+            ImGui::BeginTooltip();
+            ImGui::TextColored(ImVec4(1.0f, 1.0f, 0.0f, 1.0f),
+                               "Warning: Some of these features can break your game,\nor cause unexpected behavior, "
+                               "please ensure you disable them\nbefore reporting any bugs.");
+            ImGui::EndTooltip();
+        }
 
         if (CVarGetInteger("gDeveloperTools.DebugEnabled", 0)) {
             UIWidgets::CVarCheckbox(
@@ -629,45 +653,48 @@ void DrawDeveloperToolsMenu() {
                           "Change the behavior of creating saves while debug mode is enabled:\n\n"
                           "- Empty Save: The default 3 heart save file in first cycle\n"
                           "- Vanilla Debug Save: Uses the title screen save info (8 hearts, all items and masks)\n"
-                          "- 100\% Save: All items, equipment, mask, quast status and bombers notebook complete" })) {
+                          "- 100\% Save: All items, equipment, mask, quast status and bombers notebook complete",
+                      .defaultIndex = DEBUG_SAVE_INFO_NONE })) {
                 RegisterDebugSaveCreate();
             }
-        }
 
-        if (UIWidgets::CVarCheckbox("Prevent Actor Update", "gDeveloperTools.PreventActorUpdate")) {
-            RegisterPreventActorUpdateHooks();
-        }
-        if (UIWidgets::CVarCheckbox("Prevent Actor Draw", "gDeveloperTools.PreventActorDraw")) {
-            RegisterPreventActorDrawHooks();
-        }
-        if (UIWidgets::CVarCheckbox("Prevent Actor Init", "gDeveloperTools.PreventActorInit")) {
-            RegisterPreventActorInitHooks();
-        }
-        if (UIWidgets::CVarCombobox("Log Level", "gDeveloperTools.LogLevel", logLevels,
-                                    {
-                                        .tooltip = "The log level determines which messages are printed to the "
-                                                   "console. This does not affect the log file output",
-                                        .defaultIndex = 1,
-                                    })) {
-            Ship::Context::GetInstance()->GetLogger()->set_level(
-                (spdlog::level::level_enum)CVarGetInteger("gDeveloperTools.LogLevel", 1));
-        }
+            if (UIWidgets::CVarCheckbox("Prevent Actor Update", "gDeveloperTools.PreventActorUpdate")) {
+                RegisterPreventActorUpdateHooks();
+            }
+            if (UIWidgets::CVarCheckbox("Prevent Actor Draw", "gDeveloperTools.PreventActorDraw")) {
+                RegisterPreventActorDrawHooks();
+            }
+            if (UIWidgets::CVarCheckbox("Prevent Actor Init", "gDeveloperTools.PreventActorInit")) {
+                RegisterPreventActorInitHooks();
+            }
+            UIWidgets::CVarCheckbox("Disable Object Dependency", "gDeveloperTools.DisableObjectDependency");
 
-        if (gPlayState != NULL) {
-            ImGui::Separator();
-            UIWidgets::Checkbox(
-                "Frame Advance", (bool*)&gPlayState->frameAdvCtx.enabled,
-                { .tooltip = "This allows you to advance through the game one frame at a time on command. "
-                             "To advance a frame, hold Z and tap R on the second controller. Holding Z "
-                             "and R will advance a frame every half second. You can also use the buttons below." });
-            if (gPlayState->frameAdvCtx.enabled) {
-                if (UIWidgets::Button("Advance 1", { .size = UIWidgets::Sizes::Inline })) {
-                    CVarSetInteger("gDeveloperTools.FrameAdvanceTick", 1);
-                }
-                ImGui::SameLine();
-                UIWidgets::Button("Advance (Hold)", { .size = UIWidgets::Sizes::Inline });
-                if (ImGui::IsItemActive()) {
-                    CVarSetInteger("gDeveloperTools.FrameAdvanceTick", 1);
+            if (UIWidgets::CVarCombobox("Log Level", "gDeveloperTools.LogLevel", logLevels,
+                                        {
+                                            .tooltip = "The log level determines which messages are printed to the "
+                                                       "console. This does not affect the log file output",
+                                            .defaultIndex = 1,
+                                        })) {
+                Ship::Context::GetInstance()->GetLogger()->set_level(
+                    (spdlog::level::level_enum)CVarGetInteger("gDeveloperTools.LogLevel", 1));
+            }
+
+            if (gPlayState != NULL) {
+                ImGui::Separator();
+                UIWidgets::Checkbox(
+                    "Frame Advance", (bool*)&gPlayState->frameAdvCtx.enabled,
+                    { .tooltip = "This allows you to advance through the game one frame at a time on command. "
+                                 "To advance a frame, hold Z and tap R on the second controller. Holding Z "
+                                 "and R will advance a frame every half second. You can also use the buttons below." });
+                if (gPlayState->frameAdvCtx.enabled) {
+                    if (UIWidgets::Button("Advance 1", { .size = UIWidgets::Sizes::Inline })) {
+                        CVarSetInteger("gDeveloperTools.FrameAdvanceTick", 1);
+                    }
+                    ImGui::SameLine();
+                    UIWidgets::Button("Advance (Hold)", { .size = UIWidgets::Sizes::Inline });
+                    if (ImGui::IsItemActive()) {
+                        CVarSetInteger("gDeveloperTools.FrameAdvanceTick", 1);
+                    }
                 }
             }
         }

--- a/mm/2s2h/DeveloperTools/ActorViewer.cpp
+++ b/mm/2s2h/DeveloperTools/ActorViewer.cpp
@@ -277,8 +277,15 @@ void ActorViewerWindow::DrawElement() {
             ImGui::InputScalar("rZ", ImGuiDataType_S16, &newActor.rot.z);
             ImGui::EndGroup();
 
-            UIWidgets::CVarCheckbox("Remove Obj Dep?", "gObjDep",
-                                    { .tooltip = "Allows actors to spawn where/when they normally wouldn't." });
+            UIWidgets::CVarCheckbox("Disable Object Dependency", "gDeveloperTools.DisableObjectDependency");
+            if (ImGui::IsItemHovered()) {
+                ImGui::BeginTooltip();
+                ImGui::TextColored(
+                    ImVec4(1.0f, 1.0f, 0.0f, 1.0f),
+                    "Warning: This will cause some actors to spawn in places they normally wouldn't,\nplease ensure "
+                    "this is disabled before reporting any actor related issues");
+                ImGui::EndTooltip();
+            }
 
             if (UIWidgets::Button("Fetch from Link")) {
                 Player* player = GET_PLAYER(gPlayState);

--- a/mm/2s2h/DeveloperTools/WarpPoint.cpp
+++ b/mm/2s2h/DeveloperTools/WarpPoint.cpp
@@ -67,6 +67,7 @@ void RenderWarpPointSection() {
                                 CVarGetInteger(CV "Room", 0), PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D), &pos,
                                 CVarGetFloat(CV "Rotation", 0.0f));
             func_80169EFC(&gPlayState->state);
+            gSaveContext.respawnFlag = -8;
         }
     }
 }

--- a/mm/src/code/z_scene.c
+++ b/mm/src/code/z_scene.c
@@ -110,7 +110,7 @@ s32 Object_GetSlot(ObjectContext* objectCtx, s16 objectId) {
         }
     }
 
-    return CVarGetInteger("gObjDep", 0) ? 0 : -1;
+    return CVarGetInteger("gDeveloperTools.DisableObjectDependency", 0) ? 0 : -1;
 }
 
 s32 Object_IsLoaded(ObjectContext* objectCtx, s32 slot) {


### PR DESCRIPTION
- Hide various debug options behind debug toggle
- Put a warning on debug toggle
- When disabling debug, unset/reset debug options
- Fix player taking damage when using debug warp

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1560433660.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1560434500.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1560437030.zip)
<!--- section:artifacts:end -->