### PR TITLE
[Enhancement] Preseve time speed during cycle reset

### DIFF
--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -462,6 +462,8 @@ void DrawEnhancementsMenu() {
                 { .tooltip = "Playing the Song Of Time will not reset the Sword back to Kokiri Sword." });
             UIWidgets::CVarCheckbox("Do not reset Rupees", "gEnhancements.Cycle.DoNotResetRupees",
                                     { .tooltip = "Playing the Song Of Time will not reset the your rupees." });
+            UIWidgets::CVarCheckbox("Do not reset Time Speed", "gEnhancements.Cycle.DoNotResetTimeSpeed",
+                                    { .tooltip = "Playing the Song Of Time will not reset the current time speed set by Inverted Song of Time." });
 
             ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(255, 255, 0, 255));
             ImGui::SeparatorText("Unstable");

--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -462,8 +462,10 @@ void DrawEnhancementsMenu() {
                 { .tooltip = "Playing the Song Of Time will not reset the Sword back to Kokiri Sword." });
             UIWidgets::CVarCheckbox("Do not reset Rupees", "gEnhancements.Cycle.DoNotResetRupees",
                                     { .tooltip = "Playing the Song Of Time will not reset the your rupees." });
-            UIWidgets::CVarCheckbox("Do not reset Time Speed", "gEnhancements.Cycle.DoNotResetTimeSpeed",
-                                    { .tooltip = "Playing the Song Of Time will not reset the current time speed set by Inverted Song of Time." });
+            UIWidgets::CVarCheckbox(
+                "Do not reset Time Speed", "gEnhancements.Cycle.DoNotResetTimeSpeed",
+                { .tooltip =
+                      "Playing the Song Of Time will not reset the current time speed set by Inverted Song of Time." });
 
             ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(255, 255, 0, 255));
             ImGui::SeparatorText("Unstable");

--- a/mm/2s2h/Enhancements/Cycle/EndOfCycle.cpp
+++ b/mm/2s2h/Enhancements/Cycle/EndOfCycle.cpp
@@ -7,7 +7,7 @@ extern "C" {
 }
 
 SaveInfo saveInfoCopy;
-s32 timeSpeedOffsetCopy;
+s32 timeSpeedOffsetCopy = 3;
 
 void RegisterEndOfCycleSaveHooks() {
     GameInteractor::Instance->RegisterGameHook<GameInteractor::BeforeEndOfCycleSave>([]() {

--- a/mm/2s2h/Enhancements/Cycle/EndOfCycle.cpp
+++ b/mm/2s2h/Enhancements/Cycle/EndOfCycle.cpp
@@ -7,10 +7,12 @@ extern "C" {
 }
 
 SaveInfo saveInfoCopy;
+s32 timeSpeedOffsetCopy;
 
 void RegisterEndOfCycleSaveHooks() {
     GameInteractor::Instance->RegisterGameHook<GameInteractor::BeforeEndOfCycleSave>(
-        []() { memcpy(&saveInfoCopy, &gSaveContext.save.saveInfo, sizeof(SaveInfo)); });
+        []() { memcpy(&saveInfoCopy, &gSaveContext.save.saveInfo, sizeof(SaveInfo));
+               memcpy(&timeSpeedOffsetCopy, &gSaveContext.save.timeSpeedOffset, sizeof(s32)); });
 
     GameInteractor::Instance->RegisterGameHook<GameInteractor::AfterEndOfCycleSave>([]() {
         if (CVarGetInteger("gEnhancements.Cycle.DoNotResetRupees", 0)) {
@@ -76,6 +78,10 @@ void RegisterEndOfCycleSaveHooks() {
 
             SET_EQUIP_VALUE(EQUIP_TYPE_SWORD, EQUIP_VALUE_SWORD_RAZOR);
             CUR_FORM_EQUIP(EQUIP_SLOT_B) = ITEM_SWORD_RAZOR;
+        }
+
+        if (CVarGetInteger("gEnhancements.Cycle.DoNotResetTimeSpeed", 0)) {
+            gSaveContext.save.timeSpeedOffset = timeSpeedOffsetCopy;
         }
     });
 }

--- a/mm/2s2h/Enhancements/Cycle/EndOfCycle.cpp
+++ b/mm/2s2h/Enhancements/Cycle/EndOfCycle.cpp
@@ -12,7 +12,7 @@ s32 timeSpeedOffsetCopy;
 void RegisterEndOfCycleSaveHooks() {
     GameInteractor::Instance->RegisterGameHook<GameInteractor::BeforeEndOfCycleSave>([]() {
         memcpy(&saveInfoCopy, &gSaveContext.save.saveInfo, sizeof(SaveInfo));
-        memcpy(&timeSpeedOffsetCopy, &gSaveContext.save.timeSpeedOffset, sizeof(s32));
+        timeSpeedOffsetCopy = gSaveContext.save.timeSpeedOffset;
     });
 
     GameInteractor::Instance->RegisterGameHook<GameInteractor::AfterEndOfCycleSave>([]() {

--- a/mm/2s2h/Enhancements/Cycle/EndOfCycle.cpp
+++ b/mm/2s2h/Enhancements/Cycle/EndOfCycle.cpp
@@ -7,7 +7,7 @@ extern "C" {
 }
 
 SaveInfo saveInfoCopy;
-s32 timeSpeedOffsetCopy = 3;
+s32 timeSpeedOffsetCopy = 0;
 
 void RegisterEndOfCycleSaveHooks() {
     GameInteractor::Instance->RegisterGameHook<GameInteractor::BeforeEndOfCycleSave>([]() {

--- a/mm/2s2h/Enhancements/Cycle/EndOfCycle.cpp
+++ b/mm/2s2h/Enhancements/Cycle/EndOfCycle.cpp
@@ -10,9 +10,10 @@ SaveInfo saveInfoCopy;
 s32 timeSpeedOffsetCopy;
 
 void RegisterEndOfCycleSaveHooks() {
-    GameInteractor::Instance->RegisterGameHook<GameInteractor::BeforeEndOfCycleSave>(
-        []() { memcpy(&saveInfoCopy, &gSaveContext.save.saveInfo, sizeof(SaveInfo));
-               memcpy(&timeSpeedOffsetCopy, &gSaveContext.save.timeSpeedOffset, sizeof(s32)); });
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::BeforeEndOfCycleSave>([]() {
+        memcpy(&saveInfoCopy, &gSaveContext.save.saveInfo, sizeof(SaveInfo));
+        memcpy(&timeSpeedOffsetCopy, &gSaveContext.save.timeSpeedOffset, sizeof(s32));
+    });
 
     GameInteractor::Instance->RegisterGameHook<GameInteractor::AfterEndOfCycleSave>([]() {
         if (CVarGetInteger("gEnhancements.Cycle.DoNotResetRupees", 0)) {


### PR DESCRIPTION
This PR adds an enhancement that will preserve the current time speed through a cycle reset. So you won't need to play the Inverted Song of Time after each reset if you prefer having a slower time speed. 


<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1680404202.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1680406934.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1680416535.zip)
<!--- section:artifacts:end -->