### PR TITLE
Fix Fast Text Not Working on Instant Textboxes

### DIFF
--- a/mm/src/code/z_message.c
+++ b/mm/src/code/z_message.c
@@ -5638,11 +5638,7 @@ void Message_Update(PlayState* play) {
 
         case MSGMODE_TEXT_DISPLAYING:
             if (msgCtx->textBoxType != TEXTBOX_TYPE_4) {
-                if ((CHECK_BTN_ALL(input->press.button, BTN_B) ||
-                     // 2S2H [Enhancement] When fast text is on, we want to check if B is held instead of only if it was
-                     // just pressed
-                     (CVarGetInteger("gEnhancements.Dialogue.FastText", 0) &&
-                      CHECK_BTN_ALL(input->cur.button, BTN_B))) &&
+                if (CHECK_BTN_ALL(input->press.button, BTN_B) &&
                     !msgCtx->textUnskippable) {
                     msgCtx->textboxSkipped = true;
                     msgCtx->textDrawPos = msgCtx->decodedTextLen;
@@ -5657,6 +5653,13 @@ void Message_Update(PlayState* play) {
                         }
                         msgCtx->textDrawPos++;
                     }
+                // 2S2H [Enhancement] When fast text is on, we want to check if B is held instead of only if it was
+                // just pressed. Has an additional check that the textbox hasnt been skipped already to prevent the
+                // message from failing to continue.
+                } else if ((CVarGetInteger("gEnhancements.Dialogue.FastText", 0) &&
+                      CHECK_BTN_ALL(input->cur.button, BTN_B)) && !msgCtx->textUnskippable && !msgCtx->textboxSkipped) {
+                    msgCtx->textboxSkipped = true;
+                    msgCtx->textDrawPos = msgCtx->decodedTextLen;
                 }
             } else if (CHECK_BTN_ALL(input->press.button, BTN_A) && (msgCtx->textUnskippable == 0)) {
                 while (true) {

--- a/mm/src/code/z_message.c
+++ b/mm/src/code/z_message.c
@@ -5638,8 +5638,7 @@ void Message_Update(PlayState* play) {
 
         case MSGMODE_TEXT_DISPLAYING:
             if (msgCtx->textBoxType != TEXTBOX_TYPE_4) {
-                if (CHECK_BTN_ALL(input->press.button, BTN_B) &&
-                    !msgCtx->textUnskippable) {
+                if (CHECK_BTN_ALL(input->press.button, BTN_B) && !msgCtx->textUnskippable) {
                     msgCtx->textboxSkipped = true;
                     msgCtx->textDrawPos = msgCtx->decodedTextLen;
                 } else if (CHECK_BTN_ALL(input->press.button, BTN_A) && !msgCtx->textUnskippable) {
@@ -5653,11 +5652,12 @@ void Message_Update(PlayState* play) {
                         }
                         msgCtx->textDrawPos++;
                     }
-                // 2S2H [Enhancement] When fast text is on, we want to check if B is held instead of only if it was
-                // just pressed. Has an additional check that the textbox hasnt been skipped already to prevent the
-                // message from failing to continue.
+                    // 2S2H [Enhancement] When fast text is on, we want to check if B is held instead of only if it was
+                    // just pressed. Has an additional check that the textbox hasnt been skipped already to prevent the
+                    // message from failing to continue.
                 } else if ((CVarGetInteger("gEnhancements.Dialogue.FastText", 0) &&
-                      CHECK_BTN_ALL(input->cur.button, BTN_B)) && !msgCtx->textUnskippable && !msgCtx->textboxSkipped) {
+                            CHECK_BTN_ALL(input->cur.button, BTN_B)) &&
+                           !msgCtx->textUnskippable && !msgCtx->textboxSkipped) {
                     msgCtx->textboxSkipped = true;
                     msgCtx->textDrawPos = msgCtx->decodedTextLen;
                 }


### PR DESCRIPTION
Having the code flow path pass through here from the first frame continuously causes problems because of the `msgCtx->textDrawPos = msgCtx->decodedTextLen;` setting the text draw pos back to a lower position than it should be

Fixes #533 

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1568194538.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1568198200.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1568199690.zip)
<!--- section:artifacts:end -->