### PR TITLE
Add Free Look Camera Reset

### DIFF
--- a/mm/2s2h/Enhancements/Camera/FreeLook.cpp
+++ b/mm/2s2h/Enhancements/Camera/FreeLook.cpp
@@ -141,6 +141,11 @@ bool Camera_CanFreeLook(Camera* camera) {
     if (!sCanFreeLook && (fabsf(camX) >= 15.0f || fabsf(camY) >= 15.0f)) {
         sCanFreeLook = true;
     }
+    // Pressing Z will "Reset" Camera
+    if (CHECK_BTN_ALL(sCamPlayState->state.input[0].press.button, BTN_Z)) {
+        sCanFreeLook = false;
+    }
+
     return sCanFreeLook;
 }
 


### PR DESCRIPTION
Pressing Z will reset the camera back to its normal function, taking you out of the free look state

Addresses #649 

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1568708417.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1568715800.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1568726439.zip)
<!--- section:artifacts:end -->