### PR TITLE
Tweaks to warp point

### DIFF
--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -12,7 +12,6 @@
 #include "2s2h/Enhancements/Graphics/PlayAsKafei.h"
 #include "2s2h/Enhancements/Modes/TimeMovesWhenYouMove.h"
 #include "2s2h/DeveloperTools/DeveloperTools.h"
-#include "2s2h/DeveloperTools/WarpPoint.h"
 #include "2s2h/Enhancements/Cheats/Cheats.h"
 #include "2s2h/Enhancements/Player/Player.h"
 #include "HudEditor.h"

--- a/mm/2s2h/DeveloperTools/DeveloperTools.cpp
+++ b/mm/2s2h/DeveloperTools/DeveloperTools.cpp
@@ -155,4 +155,5 @@ void InitDeveloperTools() {
     RegisterPreventActorUpdateHooks();
     RegisterPreventActorDrawHooks();
     RegisterPreventActorInitHooks();
+    RegisterWarpPoint();
 }

--- a/mm/2s2h/DeveloperTools/DeveloperTools.h
+++ b/mm/2s2h/DeveloperTools/DeveloperTools.h
@@ -11,6 +11,8 @@ void RegisterDebugSaveCreate();
 void RegisterPreventActorUpdateHooks();
 void RegisterPreventActorDrawHooks();
 void RegisterPreventActorInitHooks();
+void RegisterWarpPoint();
+void RenderWarpPointSection();
 void InitDeveloperTools();
 
 #endif // DEVELOPER_TOOLS_H

--- a/mm/2s2h/DeveloperTools/WarpPoint.cpp
+++ b/mm/2s2h/DeveloperTools/WarpPoint.cpp
@@ -1,15 +1,16 @@
-#include "WarpPoint.h"
-
 #include <libultraship/libultraship.h>
 #include "2s2h/BenGui/UIWidgets.hpp"
 #include "window/gui/IconsFontAwesome4.h"
+#include "2s2h/Enhancements/GameInteractor/GameInteractor.h"
 
 extern "C" {
 #include "z64.h"
 #include "macros.h"
 #include "functions.h"
+#include "overlays/gamestates/ovl_select/z_select.h"
 extern PlayState* gPlayState;
 extern SaveContext gSaveContext;
+extern GameState* gGameState;
 }
 
 #define CV "gDeveloperTools.WarpPoint."
@@ -26,6 +27,56 @@ std::unordered_map<s16, const char*> warpPointSceneList = {
 
 #undef DEFINE_SCENE
 #undef DEFINE_SCENE_UNSET
+
+void Warp() {
+    Vec3f pos = { CVarGetFloat(CV "X", 0.0f), CVarGetFloat(CV "Y", 0.0f), CVarGetFloat(CV "Z", 0.0f) };
+    s32 entrance = CVarGetInteger(CV "Entrance", ENTRANCE(SOUTH_CLOCK_TOWN, 0));
+
+    if (gPlayState == NULL) {
+        // If gPlayState is NULL, it means the the user opted into BootToWarpPoint and the game is starting up. This is
+        // a hidden cvar for developers, while it is extremely useful for quick testing and debugging, I am not 100%
+        // confident in it's stability and ability to initialize the game properly in all cases. So for now, I'm going
+        // to leave it as a hidden cvar. This is incompatible with the SkipToFileSelect enhancement. To enable it open
+        // the Console and type: `set gDeveloperTools.WarpPoint.BootToWarpPoint 1`
+        gSaveContext.gameMode = GAMEMODE_NORMAL;
+        Sram_InitNewSave();
+        gSaveContext.sceneLayer = 0;
+        gSaveContext.save.time = CLOCK_TIME(8, 0);
+        gSaveContext.save.day = 1;
+        gSaveContext.save.cutsceneIndex = 0;
+        gSaveContext.save.playerForm = PLAYER_FORM_HUMAN;
+        gSaveContext.save.linkAge = 0;
+        gSaveContext.fileNum = 0xFF;
+        MapSelect_LoadGame((MapSelectState*)gGameState, CVarGetInteger(CV "Entrance", 0), 0);
+    } else {
+        // The else case, and the rest of this function is primarly relevant code copied from Play_SetRespawnData and
+        // func_80169EFC, minus the parts that copy scene flags to scene we are warping to (this is obviously
+        // undesireable)
+        gPlayState->nextEntrance = Entrance_Create(entrance >> 9, 0, entrance & 0xF);
+        gPlayState->transitionTrigger = TRANS_TRIGGER_START;
+        gPlayState->transitionType = TRANS_TYPE_INSTANT;
+    }
+    gSaveContext.respawn[RESPAWN_MODE_DOWN].entrance = Entrance_Create(entrance >> 9, 0, entrance & 0xF);
+    gSaveContext.respawn[RESPAWN_MODE_DOWN].roomIndex = CVarGetInteger(CV "Room", 0);
+    gSaveContext.respawn[RESPAWN_MODE_DOWN].pos = pos;
+    gSaveContext.respawn[RESPAWN_MODE_DOWN].yaw = CVarGetFloat(CV "Rotation", 0.0f);
+    gSaveContext.respawn[RESPAWN_MODE_DOWN].playerParams = PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D);
+    gSaveContext.nextTransitionType = TRANS_TYPE_FADE_BLACK_FAST;
+    gSaveContext.respawnFlag = -8;
+}
+
+void RegisterWarpPoint() {
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnConsoleLogoUpdate>([]() {
+        if (!CVarGetInteger("gEnhancements.Cutscenes.SkipToFileSelect", 0) && CVarGetInteger(CV "BootToWarpPoint", 0) &&
+            CVarGetInteger(CV "Saved", 0)) {
+            // Normally called on console logo screen
+            gSaveContext.seqId = (u8)NA_BGM_DISABLED;
+            gSaveContext.ambienceId = AMBIENCE_ID_DISABLED;
+            gSaveContext.gameMode = GAMEMODE_TITLE_SCREEN;
+            Warp();
+        }
+    });
+}
 
 void RenderWarpPointSection() {
     if (gPlayState == NULL)
@@ -60,14 +111,7 @@ void RenderWarpPointSection() {
         }
         ImGui::SameLine();
         if (UIWidgets::Button("Warp", { .size = UIWidgets::Sizes::Inline })) {
-            Vec3f pos = { CVarGetFloat(CV "X", 0.0f), CVarGetFloat(CV "Y", 0.0f), CVarGetFloat(CV "Z", 0.0f) };
-
-            Play_SetRespawnData(&gPlayState->state, RESPAWN_MODE_DOWN,
-                                CVarGetInteger(CV "Entrance", ENTRANCE(SOUTH_CLOCK_TOWN, 0)),
-                                CVarGetInteger(CV "Room", 0), PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D), &pos,
-                                CVarGetFloat(CV "Rotation", 0.0f));
-            func_80169EFC(&gPlayState->state);
-            gSaveContext.respawnFlag = -8;
+            Warp();
         }
     }
 }

--- a/mm/2s2h/DeveloperTools/WarpPoint.h
+++ b/mm/2s2h/DeveloperTools/WarpPoint.h
@@ -1,6 +1,0 @@
-#ifndef DEVELOPER_TOOLS_WARP_POINT_H
-#define DEVELOPER_TOOLS_WARP_POINT_H
-
-void RenderWarpPointSection();
-
-#endif // DEVELOPER_TOOLS_WARP_POINT_H

--- a/mm/2s2h/Enhancements/Cutscenes/Cutscenes.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/Cutscenes.cpp
@@ -12,4 +12,5 @@ void RegisterCutscenes() {
     RegisterHideTitleCards();
     RegisterSkipEntranceCutscenes();
     RegisterSkipIntroSequence();
+    RegisterSkipToFileSelect();
 }

--- a/mm/2s2h/Enhancements/Cutscenes/Cutscenes.h
+++ b/mm/2s2h/Enhancements/Cutscenes/Cutscenes.h
@@ -14,5 +14,6 @@ void RegisterSkipClockTowerOpen();
 void RegisterHideTitleCards();
 void RegisterSkipEntranceCutscenes();
 void RegisterSkipIntroSequence();
+void RegisterSkipToFileSelect();
 
 #endif // CUTSCENES_H

--- a/mm/2s2h/Enhancements/Cutscenes/SkipToFileSelect.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/SkipToFileSelect.cpp
@@ -5,6 +5,7 @@ extern "C" {
 #include "z64.h"
 #include "z64game.h"
 #include "overlays/gamestates/ovl_file_choose/z_file_select.h"
+#include "overlays/gamestates/ovl_title/z_title.h"
 extern SaveContext gSaveContext;
 extern GameState* gGameState;
 }
@@ -12,15 +13,21 @@ extern GameState* gGameState;
 void RegisterSkipToFileSelect() {
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnConsoleLogoUpdate>([]() {
         if (CVarGetInteger("gEnhancements.Cutscenes.SkipToFileSelect", 0)) {
-            // Normally the PRNG seed is set at least once from the title opening running Play_Init
-            // We need to call it manually before file select creates RNG values for new saves
-            Rand_Seed(osGetTime());
-            // Normally called on console logo screen
-            gSaveContext.seqId = (u8)NA_BGM_DISABLED;
-            gSaveContext.ambienceId = AMBIENCE_ID_DISABLED;
-            gSaveContext.gameMode = GAMEMODE_TITLE_SCREEN;
-            STOP_GAMESTATE(gGameState);
-            SET_NEXT_GAMESTATE(gGameState, FileSelect_Init, sizeof(FileSelectState));
+            ConsoleLogoState* consoleLogoState = (ConsoleLogoState*)gGameState;
+
+            // Wait for the console logo to fade out
+            if (consoleLogoState->exit) {
+                // Normally the PRNG seed is set at least once from the title opening running Play_Init
+                // We need to call it manually before file select creates RNG values for new saves
+                Rand_Seed(osGetTime());
+                // Normally called on console logo screen
+                gSaveContext.seqId = (u8)NA_BGM_DISABLED;
+                gSaveContext.ambienceId = AMBIENCE_ID_DISABLED;
+                gSaveContext.gameMode = GAMEMODE_TITLE_SCREEN;
+
+                STOP_GAMESTATE(gGameState);
+                SET_NEXT_GAMESTATE(gGameState, FileSelect_Init, sizeof(FileSelectState));
+            }
         }
     });
 }

--- a/mm/2s2h/Enhancements/Cutscenes/SkipToFileSelect.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/SkipToFileSelect.cpp
@@ -1,0 +1,26 @@
+#include <libultraship/bridge.h>
+#include "Enhancements/GameInteractor/GameInteractor.h"
+
+extern "C" {
+#include "z64.h"
+#include "z64game.h"
+#include "overlays/gamestates/ovl_file_choose/z_file_select.h"
+extern SaveContext gSaveContext;
+extern GameState* gGameState;
+}
+
+void RegisterSkipToFileSelect() {
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnConsoleLogoUpdate>([]() {
+        if (CVarGetInteger("gEnhancements.Cutscenes.SkipToFileSelect", 0)) {
+            // Normally the PRNG seed is set at least once from the title opening running Play_Init
+            // We need to call it manually before file select creates RNG values for new saves
+            Rand_Seed(osGetTime());
+            // Normally called on console logo screen
+            gSaveContext.seqId = (u8)NA_BGM_DISABLED;
+            gSaveContext.ambienceId = AMBIENCE_ID_DISABLED;
+            gSaveContext.gameMode = GAMEMODE_TITLE_SCREEN;
+            STOP_GAMESTATE(gGameState);
+            SET_NEXT_GAMESTATE(gGameState, FileSelect_Init, sizeof(FileSelectState));
+        }
+    });
+}

--- a/mm/2s2h/Enhancements/GameInteractor/GameInteractor.cpp
+++ b/mm/2s2h/Enhancements/GameInteractor/GameInteractor.cpp
@@ -19,6 +19,10 @@ void GameInteractor_ExecuteOnGameStateUpdate() {
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnGameStateUpdate>();
 }
 
+void GameInteractor_ExecuteOnConsoleLogoUpdate() {
+    GameInteractor::Instance->ExecuteHooks<GameInteractor::OnConsoleLogoUpdate>();
+}
+
 void GameInteractor_ExecuteOnKaleidoUpdate(PauseContext* pauseCtx) {
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnKaleidoUpdate>(pauseCtx);
 }

--- a/mm/2s2h/Enhancements/GameInteractor/GameInteractor.h
+++ b/mm/2s2h/Enhancements/GameInteractor/GameInteractor.h
@@ -257,6 +257,7 @@ class GameInteractor {
     DEFINE_HOOK(OnGameStateMainFinish, ());
     DEFINE_HOOK(OnGameStateDrawFinish, ());
     DEFINE_HOOK(OnGameStateUpdate, ());
+    DEFINE_HOOK(OnConsoleLogoUpdate, ());
     DEFINE_HOOK(OnKaleidoUpdate, (PauseContext * pauseCtx));
     DEFINE_HOOK(OnSaveInit, (s16 fileNum));
     DEFINE_HOOK(BeforeEndOfCycleSave, ());
@@ -300,6 +301,7 @@ extern "C" {
 void GameInteractor_ExecuteOnGameStateMainFinish();
 void GameInteractor_ExecuteOnGameStateDrawFinish();
 void GameInteractor_ExecuteOnGameStateUpdate();
+void GameInteractor_ExecuteOnConsoleLogoUpdate();
 void GameInteractor_ExecuteOnKaleidoUpdate(PauseContext* pauseCtx);
 void GameInteractor_ExecuteOnSaveInit(s16 fileNum);
 void GameInteractor_ExecuteBeforeEndOfCycleSave();

--- a/mm/include/variables.h
+++ b/mm/include/variables.h
@@ -1765,6 +1765,7 @@ extern u16 D_0F000000[];
 
 // #region 2S2H [General]
 extern PlayState* gPlayState;
+extern GameState* gGameState;
 // #endregion
 
 #ifdef __cplusplus

--- a/mm/src/code/game.c
+++ b/mm/src/code/game.c
@@ -26,6 +26,10 @@ VisZbuf sGameVisZbuf;
 VisMono sGameVisMono;
 ViMode sGameViMode;
 
+// #region 2S2H [General] Making gGameState available
+GameState* gGameState;
+// #endregion
+
 void GameState_UpdateFramerateDivisors(s32 divisor) {
     gFramerateDivisor = divisor;
     gFramerateDivisorF = divisor;
@@ -205,6 +209,7 @@ void GameState_Realloc(GameState* gameState, size_t size) {
 }
 
 void GameState_Init(GameState* gameState, GameStateFunc init, GraphicsContext* gfxCtx) {
+    gGameState = gameState;
     gameState->gfxCtx = gfxCtx;
     gameState->frames = 0;
     gameState->main = NULL;
@@ -256,6 +261,7 @@ void GameState_Destroy(GameState* gameState) {
     ViMode_Destroy(&sGameViMode);
     THA_Destroy(&gameState->tha);
     GameAlloc_Cleanup(&gameState->alloc);
+    gGameState = NULL;
 }
 
 GameStateFunc GameState_GetInit(GameState* gameState) {

--- a/mm/src/overlays/gamestates/ovl_title/z_title.c
+++ b/mm/src/overlays/gamestates/ovl_title/z_title.c
@@ -11,9 +11,9 @@
 #include "overlays/gamestates/ovl_opening/z_opening.h"
 #include "misc/nintendo_rogo_static/nintendo_rogo_static.h"
 
-#include "overlays/gamestates/ovl_file_choose/z_file_select.h"
 #include "build.h"
 #include "BenPort.h"
+#include "2s2h/Enhancements/GameInteractor/GameInteractor.h"
 #include <stdlib.h>
 
 #define dgShipLogoDL "__OTR__misc/nintendo_rogo_static/gShipLogoDL"
@@ -200,15 +200,10 @@ void ConsoleLogo_Main(GameState* thisx) {
         gSaveContext.gameMode = GAMEMODE_TITLE_SCREEN;
 
         STOP_GAMESTATE(&this->state);
-        if (CVarGetInteger("gEnhancements.Cutscenes.SkipToFileSelect", 0)) {
-            // Normally the PRNG seed is set at least once from the title opening running Play_Init
-            // We need to call it manually before file select creates RNG values for new saves
-            Rand_Seed(osGetTime());
-            SET_NEXT_GAMESTATE(&this->state, FileSelect_Init, sizeof(FileSelectState));
-        } else {
-            SET_NEXT_GAMESTATE(&this->state, TitleSetup_Init, sizeof(TitleSetupState));
-        }
+        SET_NEXT_GAMESTATE(&this->state, TitleSetup_Init, sizeof(TitleSetupState));
     }
+
+    GameInteractor_ExecuteOnConsoleLogoUpdate();
 
     CLOSE_DISPS(this->state.gfxCtx);
 }


### PR DESCRIPTION
Summary: 
- Fix issue where some flags from current scene would be applied to target scene when warping
- Increased speed of warp
- Introduce hidden cvar for dev use only to boot into the warp point (very very very nice)
  - This is hidden because I'm not 100% confident it sets everything up correctly. Works in my testing
  - This is incompatible with SkipToFileSelect
- Hookify SkipToFileSelect

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1569390697.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1569390815.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1569393679.zip)
<!--- section:artifacts:end -->