### PR TITLE
Custom message override PoC

### DIFF
--- a/mm/2s2h/CustomMessage/CustomMessage.cpp
+++ b/mm/2s2h/CustomMessage/CustomMessage.cpp
@@ -1,0 +1,89 @@
+
+#include "CustomMessage.h"
+#include <libultraship/bridge.h>
+#include "2s2h/Enhancements/GameInteractor/GameInteractor.h"
+#include <map>
+
+extern "C" {
+#include "z64.h"
+extern PlayState* gPlayState;
+}
+
+static s32 activeMessageModId = -1;
+static s32 activeMessageTextId = -1;
+
+#define DEFINE_MESSAGE(textId, typePos, msg) { SHIP_TEXT_##textId, typePos, msg "\xBF" },
+
+MessageTableEntry shipMessagesTable[] = {
+#include "2s2h/CustomMessage/ShipMessages.h"
+    { 0xFFFF, 0, NULL },
+};
+
+#undef DEFINE_MESSAGE
+
+// Intended to be used in conjunction with GI's OnOpenText hook
+void CustomMessage_SetActiveMessage(s32 modId, s32 textId) {
+    activeMessageModId = modId;
+    activeMessageTextId = textId;
+}
+
+void CustomMessage_Replace(std::string* msg, const std::string& placeholder, const std::string& value) {
+    size_t pos = 0;
+    while ((pos = msg->find(placeholder, pos)) != std::string::npos) {
+        msg->replace(pos, placeholder.length(), value);
+        pos += value.length();
+    }
+}
+
+// Intended to be called in place of Message_StartTextbox within the source code when overriding messages
+extern "C" void CustomMessage_StartTextbox(PlayState* play, s32 modId, s32 textId, Actor* actor) {
+    activeMessageModId = modId;
+    activeMessageTextId = textId;
+    Message_StartTextbox(play, CUSTOM_MESSAGE_ID, actor);
+}
+
+// Intended to be called in place of Message_ContinueTextbox within the source code when overriding messages
+extern "C" void CustomMessage_ContinueTextbox(PlayState* play, s32 modId, s32 textId) {
+    activeMessageModId = modId;
+    activeMessageTextId = textId;
+    Message_ContinueTextbox(play, CUSTOM_MESSAGE_ID);
+}
+
+extern "C" void CustomMessage_HandleCustomMessage() {
+    if (activeMessageTextId == -1 || activeMessageModId == -1)
+        return;
+
+    // Currently we only support the ship mod
+    if (activeMessageModId != MOD_ID_SHIP)
+        return;
+
+    MessageContext* msgCtx = &gPlayState->msgCtx;
+    Font* font = &msgCtx->font;
+
+    MessageTableEntry* msgEntry = &shipMessagesTable[activeMessageTextId];
+    char buff[1280] = { 0 };
+
+    // Copy message metadata
+    memcpy(buff, msgEntry->segment, 11);
+
+    // Convert the rest of the message to a std::string
+    std::string msg = msgEntry->segment + 11;
+    // Allow the message to be modified by the game interactor
+    GameInteractor_ExecuteOnHandleCustomMessage(activeMessageModId, activeMessageTextId, &msg);
+
+    // If messaage is too long, truncate it and add the message end character
+    if (msg.length() > 1269) {
+        msg = msg.substr(0, 1268);
+        msg += '\xBF';
+    }
+
+    // Copy modified message to the buffer
+    memcpy(buff + 11, msg.c_str(), msg.length());
+
+    // Set the message length and copy the buffer to the real message buffer
+    msgCtx->msgLength = msg.length() + 11;
+    memcpy(&font->msgBuf, buff, msgCtx->msgLength);
+
+    activeMessageModId = -1;
+    activeMessageTextId = -1;
+}

--- a/mm/2s2h/CustomMessage/CustomMessage.h
+++ b/mm/2s2h/CustomMessage/CustomMessage.h
@@ -1,0 +1,39 @@
+#ifndef CUSTOM_MESSAGE_H
+#define CUSTOM_MESSAGE_H
+
+#ifdef __cplusplus
+#include <string>
+
+extern "C" {
+#include "z64.h"
+#endif
+
+// Not really sure what the best ID is for this, but it needs to be between 0-255
+// because it's used as a u8 somewhere in the chain
+static const u16 CUSTOM_MESSAGE_ID = 0x004B;
+
+typedef enum ModId {
+    MOD_ID_VANILLA = 0,
+    MOD_ID_SHIP = 1,
+} ModId;
+
+#define DEFINE_MESSAGE(textId, typePos, msg) SHIP_TEXT_##textId,
+
+typedef enum ShipTextId {
+#include "2s2h/CustomMessage/ShipMessages.h"
+    SHIP_TEXT_MAX,
+} ShipTextId;
+
+#undef DEFINE_MESSAGE
+
+void CustomMessage_StartTextbox(PlayState* play, s32 modId, s32 textId, Actor* actor);
+void CustomMessage_ContinueTextbox(PlayState* play, s32 modId, s32 textId);
+void CustomMessage_HandleCustomMessage();
+
+#ifdef __cplusplus
+};
+void CustomMessage_SetActiveMessage(s32 modId, s32 textId);
+void CustomMessage_Replace(std::string* msg, const std::string& placeholder, const std::string& value);
+#endif
+
+#endif

--- a/mm/2s2h/CustomMessage/ShipMessages.h
+++ b/mm/2s2h/CustomMessage/ShipMessages.h
@@ -1,0 +1,7 @@
+// clang-format off
+DEFINE_MESSAGE(HELLO_WORLD, 0x00, "\x06\x00" "\xFE" "\xFF\xFF" "\xFF\xFF" "\xFF\xFF" "\xFF\xFF"
+"Hello World!\x11"
+"You have {{rupees}} rupee(s).\x11"
+"\x11"
+"                   - The Moon"
+)

--- a/mm/2s2h/DeveloperTools/EventLog.cpp
+++ b/mm/2s2h/DeveloperTools/EventLog.cpp
@@ -239,11 +239,11 @@ void RegisterEventLogHooks() {
         TrimEventLog();
     });
 
-    onOpenTextHookId = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnOpenText>([](s16 textId) {
+    onOpenTextHookId = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnOpenText>([](u16* textId) {
         eventLogEntries.insert(eventLogEntries.begin(), {
                                                             .timestamp = CurrentTime(),
                                                             .type = EVENT_LOG_ENTRY_TYPE_OPEN_TEXT,
-                                                            .meta = fmt::format("0x{:02x}", textId),
+                                                            .meta = fmt::format("0x{:02x}", *textId),
                                                         });
         TrimEventLog();
     });

--- a/mm/2s2h/Enhancements/Cheats/OverrideTextExample.cpp
+++ b/mm/2s2h/Enhancements/Cheats/OverrideTextExample.cpp
@@ -1,0 +1,26 @@
+#include <libultraship/bridge.h>
+#include "Enhancements/GameInteractor/GameInteractor.h"
+#include "2s2h/CustomMessage/CustomMessage.h"
+
+extern "C" {
+extern SaveContext gSaveContext;
+}
+
+// This is not actually used, but it's a good example of how to override text
+// until we have good examples of usage. This will be deleted eventually.
+void RegisterOverrideTextExample() {
+    // Overrides the sign in south clock town message
+    GameInteractor::Instance->RegisterGameHookForID<GameInteractor::OnOpenText>(0x1C18, [](u16* textId) {
+        CustomMessage_SetActiveMessage(MOD_ID_SHIP, SHIP_TEXT_HELLO_WORLD);
+        *textId = CUSTOM_MESSAGE_ID;
+    });
+
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnHandleCustomMessage>(
+        [](s32 modId, s32 textId, std::string* msg) {
+            if (modId != MOD_ID_SHIP || textId != SHIP_TEXT_HELLO_WORLD) {
+                return;
+            }
+
+            CustomMessage_Replace(msg, "{{rupees}}", std::to_string(gSaveContext.save.saveInfo.playerData.rupees));
+        });
+}

--- a/mm/2s2h/Enhancements/GameInteractor/GameInteractor.cpp
+++ b/mm/2s2h/Enhancements/GameInteractor/GameInteractor.cpp
@@ -208,11 +208,16 @@ void GameInteractor_ExecuteOnPassPlayerInputs(Input* input) {
     GameInteractor::Instance->ExecuteHooksForFilter<GameInteractor::OnPassPlayerInputs>(input);
 }
 
-void GameInteractor_ExecuteOnOpenText(u16 textId) {
-    SPDLOG_DEBUG("OnOpenText: textId: {}", textId);
+void GameInteractor_ExecuteOnOpenText(u16* textId) {
+    SPDLOG_DEBUG("OnOpenText: textId: {}", *textId);
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnOpenText>(textId);
-    GameInteractor::Instance->ExecuteHooksForID<GameInteractor::OnOpenText>(textId, textId);
+    GameInteractor::Instance->ExecuteHooksForID<GameInteractor::OnOpenText>(*textId, textId);
     GameInteractor::Instance->ExecuteHooksForFilter<GameInteractor::OnOpenText>(textId);
+}
+
+void GameInteractor_ExecuteOnHandleCustomMessage(s32 modId, s32 textId, std::string* msg) {
+    GameInteractor::Instance->ExecuteHooks<GameInteractor::OnHandleCustomMessage>(modId, textId, msg);
+    GameInteractor::Instance->ExecuteHooksForFilter<GameInteractor::OnHandleCustomMessage>(modId, textId, msg);
 }
 
 bool GameInteractor_ShouldItemGive(u8 item) {

--- a/mm/2s2h/Enhancements/GameInteractor/GameInteractor.h
+++ b/mm/2s2h/Enhancements/GameInteractor/GameInteractor.h
@@ -298,7 +298,8 @@ class GameInteractor {
 
     DEFINE_HOOK(OnPassPlayerInputs, (Input * input));
 
-    DEFINE_HOOK(OnOpenText, (u16 textId));
+    DEFINE_HOOK(OnOpenText, (u16 * textId));
+    DEFINE_HOOK(OnHandleCustomMessage, (s32 modId, s32 textId, std::string* msg));
 
     DEFINE_HOOK(ShouldItemGive, (u8 item, bool* should));
     DEFINE_HOOK(OnItemGive, (u8 item));
@@ -348,7 +349,7 @@ void GameInteractor_ExecuteOnCameraChangeSettingsFlags(Camera* camera);
 
 void GameInteractor_ExecuteOnPassPlayerInputs(Input* input);
 
-void GameInteractor_ExecuteOnOpenText(u16 textId);
+void GameInteractor_ExecuteOnOpenText(u16* textId);
 
 bool GameInteractor_ShouldItemGive(u8 item);
 void GameInteractor_ExecuteOnItemGive(u8 item);
@@ -363,6 +364,9 @@ uint32_t GameInteractor_Dpad(GIDpadType type, uint32_t buttonCombo);
 
 #ifdef __cplusplus
 }
+
+void GameInteractor_ExecuteOnHandleCustomMessage(s32 modId, s32 textId, std::string* msg);
+
 #endif
 
 #endif // GAME_INTERACTOR_H

--- a/mm/CMakeLists.txt
+++ b/mm/CMakeLists.txt
@@ -171,6 +171,13 @@ file(GLOB_RECURSE soh__SaveManager RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
     "2s2h/SaveManager/*.hpp"
 )
 
+file(GLOB_RECURSE soh__CustomMessage RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+    "2s2h/CustomMessage/*.c"
+    "2s2h/CustomMessage/*.cpp"
+    "2s2h/CustomMessage/*.h"
+    "2s2h/CustomMessage/*.hpp"
+)
+
 #list(REMOVE_ITEM soh__Enhancements "soh/Enhancements/gamecommand.h")
 #list(FILTER soh__Enhancements EXCLUDE REGEX "soh/Enhancements/gfx.*")
 
@@ -284,6 +291,7 @@ set(ALL_FILES
     ${soh__Enhancements}
     ${soh__BenGui}
     ${soh__SaveManager}
+    ${soh__CustomMessage}
     ${soh__Extractor}
     ${soh__Resource}
     ${src__}

--- a/mm/src/code/z_message.c
+++ b/mm/src/code/z_message.c
@@ -7,6 +7,7 @@
 #include "overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_scope.h"
 #include "BenPort.h"
 #include "2s2h/Enhancements/GameInteractor/GameInteractor.h"
+#include "2s2h/CustomMessage/CustomMessage.h"
 #include "assets/archives/schedule_dma_static/schedule_dma_static_yar.h"
 #include "assets/archives/icon_item_static/icon_item_static_yar.h"
 #include "assets/archives/icon_item_24_static/icon_item_24_static_yar.h"
@@ -3280,7 +3281,7 @@ void Message_OpenText(PlayState* play, u16 textId) {
     Player* player = GET_PLAYER(play);
     f32 var_fv0;
 
-    GameInteractor_ExecuteOnOpenText(textId);
+    GameInteractor_ExecuteOnOpenText(&textId);
 
     // BENTODO do this somewhere else
     gSaveContext.options.language = LANGUAGE_ENG;
@@ -3357,8 +3358,9 @@ void Message_OpenText(PlayState* play, u16 textId) {
     sCharTexSize = msgCtx->textCharScale * 16.0f;
     sCharTexScale = 1024.0f / msgCtx->textCharScale;
     D_801F6B08 = 1024.0f / var_fv0;
-    // BENTODO all of these
-    if (msgCtx->textIsCredits) {
+    if (textId == CUSTOM_MESSAGE_ID) {
+        CustomMessage_HandleCustomMessage();
+    } else if (msgCtx->textIsCredits) {
         Message_FindCreditsMessage(play, textId);
         MessageTableEntry* msgEntry = (MessageTableEntry*)font->messageStart;
         msgCtx->msgLength = msgEntry->msgSize;


### PR DESCRIPTION
It's not perfect, but it works.

This isn't meant to be an end all solution, but aims to be short - medium term solution for custom messages. The idea is that you register your custom message in `ShipMessages.h` using the same format messages are extracted to in https://github.com/zeldaret/mm (after you have built the project look for `message_data.h`)

One thing that is absent, and still needs to be figured out is a good framework for replacing message contents, there is obviously built in control codes for this, but we'll want both more flexibility and more user friendliness than just using control codes. (eg templating like `{{}}`)

We also need to bring in all of the message related changes from upstream so we can get all of the macros required to craft a message

<img width="1379" alt="Screenshot 2024-06-05 at 8 59 53 PM" src="https://github.com/HarbourMasters/2ship2harkinian/assets/7316699/9fc2375c-dd77-4c3a-8d67-4229f3c087fc">

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1933161506.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1933164135.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1933164922.zip)
<!--- section:artifacts:end -->