### PR TITLE
[Enhancement] Fix Fierce Deity interactions with Bombers

### DIFF
--- a/mm/src/overlays/actors/ovl_En_Bombers/z_en_bombers.c
+++ b/mm/src/overlays/actors/ovl_En_Bombers/z_en_bombers.c
@@ -257,7 +257,11 @@ void func_80C039A8(EnBombers* this, PlayState* play) {
                 this->actor.textId = 0x744;
             }
             break;
-
+        // #region 2S2H - Enhancements. Fierce Deity gets same dialog as Human without notebook
+        case PLAYER_FORM_FIERCE_DEITY:
+            this->actor.textId = 0x73D;
+            break;
+        // #endregion
         default:
             break;
     }

--- a/mm/src/overlays/actors/ovl_En_Bombers2/z_en_bombers2.c
+++ b/mm/src/overlays/actors/ovl_En_Bombers2/z_en_bombers2.c
@@ -165,6 +165,9 @@ void func_80C04BA0(EnBombers2* this, PlayState* play) {
     player = GET_PLAYER(play);
 
     switch (player->transformation) {
+        // #region 2S2H - Enhancements. Fierce Deity gets same dialog as Goron and Zora
+        case PLAYER_FORM_FIERCE_DEITY:
+        // #endregion
         case PLAYER_FORM_GORON:
         case PLAYER_FORM_ZORA:
             this->textIdIndex = 1;
@@ -233,6 +236,9 @@ void func_80C04D8C(EnBombers2* this, PlayState* play) {
             this->unk_28E = -0xFA0;
             break;
 
+        // #region 2S2H - Enhancements. Fierce Deity.
+        case PLAYER_FORM_FIERCE_DEITY:
+        // #endregion
         case PLAYER_FORM_GORON:
         case PLAYER_FORM_ZORA:
             this->unk_28E = -0x1770;

--- a/mm/src/overlays/actors/ovl_En_Bomjima/z_en_bomjima.c
+++ b/mm/src/overlays/actors/ovl_En_Bomjima/z_en_bomjima.c
@@ -84,19 +84,19 @@ static ColliderCylinderInit sCylinderInit = {
     { 10, 30, 0, { 0, 0, 0 } },
 };
 
-u16 D_80C00A44[] = { 0x719, 0x71A, 0x71B, 0x708 }; //text IDs before popping balloon
+u16 D_80C00A44[] = { 0x719, 0x71A, 0x71B, 0x708 }; // text IDs before popping balloon
 
-u16 D_80C00A4C[] = { 0x739, 0x73A, 0x73B, 0x000 }; //text IDs after popping balloon
+u16 D_80C00A4C[] = { 0x739, 0x73A, 0x73B, 0x000 }; // text IDs after popping balloon
 
 u16 D_80C00A54[] = {
     0x739, 0x73A, 0x73B, 0x714, 0x709, 0x70A, 0x70B, 0x70C, 0x70D, 0x70E, 0x70F, 0x712, 0x713,
-}; //text IDs for Deku after popping balloon
+}; // text IDs for Deku after popping balloon
 
 u16 D_80C00A70[] = {
     0x739, 0x73A, 0x73B, 0x759, 0x753, 0x754, 0x755, 0x756, 0x70D, 0x757, 0x758, 0x712, 0x713,
-}; //text IDs for Human after popping balloon
+}; // text IDs for Human after popping balloon
 
-u16 D_80C00A8C[] = { 0x736, 0x737, 0x738, 0x74E }; //text IDs after hide and seek
+u16 D_80C00A8C[] = { 0x736, 0x737, 0x738, 0x74E }; // text IDs after hide and seek
 
 typedef enum {
     /*   -1 */ ENBOMJIMA_ANIM_NONE = -1,

--- a/mm/src/overlays/actors/ovl_En_Bomjima/z_en_bomjima.c
+++ b/mm/src/overlays/actors/ovl_En_Bomjima/z_en_bomjima.c
@@ -84,19 +84,19 @@ static ColliderCylinderInit sCylinderInit = {
     { 10, 30, 0, { 0, 0, 0 } },
 };
 
-u16 D_80C00A44[] = { 0x719, 0x71A, 0x71B, 0x708 };
+u16 D_80C00A44[] = { 0x719, 0x71A, 0x71B, 0x708 }; //text IDs before popping balloon
 
-u16 D_80C00A4C[] = { 0x739, 0x73A, 0x73B, 0x000 };
+u16 D_80C00A4C[] = { 0x739, 0x73A, 0x73B, 0x000 }; //text IDs after popping balloon
 
 u16 D_80C00A54[] = {
     0x739, 0x73A, 0x73B, 0x714, 0x709, 0x70A, 0x70B, 0x70C, 0x70D, 0x70E, 0x70F, 0x712, 0x713,
-};
+}; //text IDs for Deku after popping balloon
 
 u16 D_80C00A70[] = {
     0x739, 0x73A, 0x73B, 0x759, 0x753, 0x754, 0x755, 0x756, 0x70D, 0x757, 0x758, 0x712, 0x713,
-};
+}; //text IDs for Human after popping balloon
 
-u16 D_80C00A8C[] = { 0x736, 0x737, 0x738, 0x74E };
+u16 D_80C00A8C[] = { 0x736, 0x737, 0x738, 0x74E }; //text IDs after hide and seek
 
 typedef enum {
     /*   -1 */ ENBOMJIMA_ANIM_NONE = -1,
@@ -225,9 +225,11 @@ void func_80BFE32C(EnBomjima* this, PlayState* play, s32 arg2) {
     if (player->transformation == PLAYER_FORM_GORON) {
         this->unk_2C8 = 1;
     }
-    if (player->transformation == PLAYER_FORM_ZORA) {
+    // #region 2S2H - Enhancements. Fierce Deity gets same dialog as Zora
+    if (player->transformation == PLAYER_FORM_ZORA || player->transformation == PLAYER_FORM_FIERCE_DEITY) {
         this->unk_2C8 = 2;
     }
+    // #endregion
 
     switch (this->unk_2CA) {
         case 0:

--- a/mm/src/overlays/actors/ovl_En_Bomjima/z_en_bomjima.h
+++ b/mm/src/overlays/actors/ovl_En_Bomjima/z_en_bomjima.h
@@ -37,7 +37,7 @@ typedef struct EnBomjima {
     /* 0x2C2 */ s16 unk_2C2;
     /* 0x2C4 */ s16 cutsceneTimer;
     /* 0x2C6 */ s16 unk_2C6;
-    /* 0x2C8 */ s16 unk_2C8;
+    /* 0x2C8 */ s16 unk_2C8; //index into arrays of textIDs
     /* 0x2CA */ s16 unk_2CA;
     /* 0x2CC */ f32 animEndFrame;
     /* 0x2D0 */ f32 unk_2D0;


### PR DESCRIPTION
This PR adds logic to a few switch/if statements for 3 bomber actors so Fierce Deity doesn't softlock while talking to the bombers. I understand that touching code in the /src folder isn't ideal, but I felt that these changes aren't very invasive and shouldn't alter vanilla behavior. 

Partially fixes Issue #647 

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1585070989.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1585073113.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1585091593.zip)
<!--- section:artifacts:end -->