### PR TITLE
Fix for segfault when moon jump is activated on the day change

### DIFF
--- a/mm/2s2h/Enhancements/Cheats/MoonJump.cpp
+++ b/mm/2s2h/Enhancements/Cheats/MoonJump.cpp
@@ -19,7 +19,7 @@ void RegisterMoonJumpOnL() {
 
                 Player* player = GET_PLAYER(gPlayState);
 
-                if (CHECK_BTN_ANY(gPlayState->state.input[0].cur.button, BTN_L)) {
+                if (player != nullptr && CHECK_BTN_ANY(gPlayState->state.input[0].cur.button, BTN_L)) {
                     player->actor.velocity.y = 6.34375f;
                 }
             });


### PR DESCRIPTION
Fix for issue #692
Adds a null pointer check to the moonjump code to prevent crashing when the game changes days.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1604166861.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1604168334.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1604170163.zip)
<!--- section:artifacts:end -->