### PR TITLE
[Cheat] Stop time in Temples and Dungeons

### DIFF
--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -664,8 +664,9 @@ void DrawCheatsMenu() {
                                     { .tooltip = "Holding L makes you float into the air" })) {
             RegisterMoonJumpOnL();
         }
-        UIWidgets::CVarCheckbox("Stop Time in Temples", "gCheats.TempleTimeStop",
-                                { .tooltip = "Time will not advance while in Temples" });
+        UIWidgets::CVarCheckbox(
+            "Stop Time in Temples", "gCheats.TempleTimeStop",
+            { .tooltip = "Time will not advance while in Temples. Requires a scene change to update." });
 
         ImGui::EndMenu();
     }

--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -664,6 +664,8 @@ void DrawCheatsMenu() {
                                     { .tooltip = "Holding L makes you float into the air" })) {
             RegisterMoonJumpOnL();
         }
+        UIWidgets::CVarCheckbox("Stop Time in Temples", "gCheats.TempleTimeStop",
+                                { .tooltip = "Time will not advance while in Temples" });
 
         ImGui::EndMenu();
     }

--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -60,9 +60,8 @@ static const std::unordered_map<int32_t, const char*> alwaysWinDoggyraceOptions 
 
 static const std::unordered_map<int32_t, const char*> timeStopOptions = {
     { TIME_STOP_OFF, "Off" },
-    { TIME_STOP_TEMPLES, "Time stops in the 4 main temples. Requires a scene update to take effect." },
-    { TIME_STOP_TEMPLES_DUNGEONS,
-      "Time stops in the 4 main temples and the mini-dungeons. Requires a scene update to take effect." },
+    { TIME_STOP_TEMPLES, "In the 4 main temples. Requires a room change to update." },
+    { TIME_STOP_TEMPLES_DUNGEONS, "In the 4 main temples and mini-dungeons. Requires a room change to update." },
 };
 
 namespace BenGui {

--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -58,6 +58,13 @@ static const std::unordered_map<int32_t, const char*> alwaysWinDoggyraceOptions 
     { ALWAYS_WIN_DOGGY_RACE_ALWAYS, "Always" },
 };
 
+static const std::unordered_map<int32_t, const char*> timeStopOptions = {
+    { TIME_STOP_OFF, "Off" },
+    { TIME_STOP_TEMPLES, "Time stops in the 4 main temples. Requires a scene update to take effect." },
+    { TIME_STOP_TEMPLES_DUNGEONS,
+      "Time stops in the 4 main temples and the mini-dungeons. Requires a scene update to take effect." },
+};
+
 namespace BenGui {
 
 void DrawMenuBarIcon() {
@@ -664,9 +671,7 @@ void DrawCheatsMenu() {
                                     { .tooltip = "Holding L makes you float into the air" })) {
             RegisterMoonJumpOnL();
         }
-        UIWidgets::CVarCheckbox(
-            "Stop Time in Temples", "gCheats.TempleTimeStop",
-            { .tooltip = "Time will not advance while in Temples. Requires a scene change to update." });
+        UIWidgets::CVarCombobox("Stop Time in Dungeons", "gCheats.TempleTimeStop", timeStopOptions);
 
         ImGui::EndMenu();
     }

--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -60,8 +60,8 @@ static const std::unordered_map<int32_t, const char*> alwaysWinDoggyraceOptions 
 
 static const std::unordered_map<int32_t, const char*> timeStopOptions = {
     { TIME_STOP_OFF, "Off" },
-    { TIME_STOP_TEMPLES, "In the 4 main temples. Requires a room change to update." },
-    { TIME_STOP_TEMPLES_DUNGEONS, "In the 4 main temples and mini-dungeons. Requires a room change to update." },
+    { TIME_STOP_TEMPLES, "Temples" },
+    { TIME_STOP_TEMPLES_DUNGEONS, "Temples + Mini Dungeons" },
 };
 
 namespace BenGui {
@@ -670,7 +670,14 @@ void DrawCheatsMenu() {
                                     { .tooltip = "Holding L makes you float into the air" })) {
             RegisterMoonJumpOnL();
         }
-        UIWidgets::CVarCombobox("Stop Time in Dungeons", "gCheats.TempleTimeStop", timeStopOptions);
+        UIWidgets::CVarCombobox(
+            "Stop Time in Dungeons", "gCheats.TempleTimeStop", timeStopOptions,
+            { .tooltip = "Stops time from advancing in selected areas. Requires a room change to update.\n\n"
+                         "- Off: Vanilla behaviour.\n"
+                         "- Temples: Stops time in Woodfall, Snowhead, Great Bay, and Stone Tower Temples.\n"
+                         "- Temples + Mini Dungeons: In addition to the above temples, stops time in both Spider "
+                         "Houses, Pirate's Fortress, Beneath the Well, Ancient Castle of Ikana, and Secret Shrine.",
+              .defaultIndex = TIME_STOP_OFF });
 
         ImGui::EndMenu();
     }

--- a/mm/2s2h/Enhancements/Cheats/TimeStop.cpp
+++ b/mm/2s2h/Enhancements/Cheats/TimeStop.cpp
@@ -60,28 +60,5 @@ void RegisterTimeStopInTemples() {
             default:
                 break;
         }
-
-        if (CVarGetInteger("gCheats.TempleTimeStop", 0)) {
-
-            switch (gPlayState->sceneId) {
-                // Woodfall Temple + Odolwa
-                case SCENE_MITURIN:
-                case SCENE_MITURIN_BS:
-                // Snowhead Temple + Goht
-                case SCENE_HAKUGIN:
-                case SCENE_HAKUGIN_BS:
-                // Great Bay Temple + Gyorg
-                case SCENE_SEA:
-                case SCENE_SEA_BS:
-                // Stone Tower Temple (+ inverted) + Twinmold
-                case SCENE_INISIE_N:
-                case SCENE_INISIE_R:
-                case SCENE_INISIE_BS:
-                    R_TIME_SPEED = 0;
-                    break;
-                default:
-                    break;
-            }
-        }
     });
 }

--- a/mm/2s2h/Enhancements/Cheats/TimeStop.cpp
+++ b/mm/2s2h/Enhancements/Cheats/TimeStop.cpp
@@ -1,0 +1,35 @@
+#include <libultraship/libultraship.h>
+#include "BenPort.h"
+#include "Enhancements/GameInteractor/GameInteractor.h"
+
+extern "C" {
+#include <variables.h>
+#include <functions.h>
+}
+
+void RegisterTimeStopInTemples() {
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSceneInit>([](s16 sceneId, s8 spawnNum) {
+        if (CVarGetInteger("gCheats.TempleTimeStop", 0)) {
+
+            switch (gPlayState->sceneId) {
+                // Woodfall Temple + Odolwa
+                case SCENE_MITURIN:
+                case SCENE_MITURIN_BS:
+                // Snowhead Temple + Goht
+                case SCENE_HAKUGIN:
+                case SCENE_HAKUGIN_BS:
+                // Great Bay Temple + Gyorg
+                case SCENE_SEA:
+                case SCENE_SEA_BS:
+                // Stone Tower Temple (+ inverted) + Twinmold
+                case SCENE_INISIE_N:
+                case SCENE_INISIE_R:
+                case SCENE_INISIE_BS:
+                    R_TIME_SPEED = 0;
+                    break;
+                default:
+                    break;
+            }
+        }
+    });
+}

--- a/mm/2s2h/Enhancements/Cheats/TimeStop.cpp
+++ b/mm/2s2h/Enhancements/Cheats/TimeStop.cpp
@@ -9,56 +9,57 @@ extern "C" {
 }
 
 void RegisterTimeStopInTemples() {
-    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSceneInit>([](s16 sceneId, s8 spawnNum) {
-        uint8_t selectedOption = CVarGetInteger("gCheats.TempleTimeStop", 0);
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnRoomInitAfterSceneCommands>(
+        [](s16 sceneId, s8 roomNum) {
+            uint8_t selectedOption = CVarGetInteger("gCheats.TempleTimeStop", 0);
 
-        switch (selectedOption) {
-            case TIME_STOP_TEMPLES_DUNGEONS:
-                switch (gPlayState->sceneId) {
-                    // Swamp + Ocean Spider House
-                    case SCENE_KINSTA1:
-                    case SCENE_KINDAN2:
-                    // Pirates' Fortress
-                    case SCENE_KAIZOKU:
-                    case SCENE_PIRATE:
-                    case SCENE_TORIDE:
-                    // Beneath the Well
-                    case SCENE_REDEAD:
-                    // Ancient Castle of Ikana + Igos's Lair
-                    case SCENE_CASTLE:
-                    case SCENE_IKNINSIDE:
-                    // Secret Shrine
-                    case SCENE_RANDOM:
-                        R_TIME_SPEED = 0;
-                        break;
-                    default:
-                        break;
-                }
-            case TIME_STOP_TEMPLES:
-                switch (gPlayState->sceneId) {
-                    // Woodfall Temple + Odolwa
-                    case SCENE_MITURIN:
-                    case SCENE_MITURIN_BS:
-                    // Snowhead Temple + Goht
-                    case SCENE_HAKUGIN:
-                    case SCENE_HAKUGIN_BS:
-                    // Great Bay Temple + Gyorg
-                    case SCENE_SEA:
-                    case SCENE_SEA_BS:
-                    // Stone Tower Temple (+ inverted) + Twinmold
-                    case SCENE_INISIE_N:
-                    case SCENE_INISIE_R:
-                    case SCENE_INISIE_BS:
-                        R_TIME_SPEED = 0;
-                        break;
-                    default:
-                        break;
-                }
-                break;
-            case TIME_STOP_OFF:
-                break;
-            default:
-                break;
-        }
-    });
+            switch (selectedOption) {
+                case TIME_STOP_TEMPLES_DUNGEONS:
+                    switch (gPlayState->sceneId) {
+                        // Swamp + Ocean Spider House
+                        case SCENE_KINSTA1:
+                        case SCENE_KINDAN2:
+                        // Pirates' Fortress
+                        case SCENE_KAIZOKU:
+                        case SCENE_PIRATE:
+                        case SCENE_TORIDE:
+                        // Beneath the Well
+                        case SCENE_REDEAD:
+                        // Ancient Castle of Ikana + Igos's Lair
+                        case SCENE_CASTLE:
+                        case SCENE_IKNINSIDE:
+                        // Secret Shrine
+                        case SCENE_RANDOM:
+                            R_TIME_SPEED = 0;
+                            break;
+                        default:
+                            break;
+                    }
+                case TIME_STOP_TEMPLES:
+                    switch (gPlayState->sceneId) {
+                        // Woodfall Temple + Odolwa
+                        case SCENE_MITURIN:
+                        case SCENE_MITURIN_BS:
+                        // Snowhead Temple + Goht
+                        case SCENE_HAKUGIN:
+                        case SCENE_HAKUGIN_BS:
+                        // Great Bay Temple + Gyorg
+                        case SCENE_SEA:
+                        case SCENE_SEA_BS:
+                        // Stone Tower Temple (+ inverted) + Twinmold
+                        case SCENE_INISIE_N:
+                        case SCENE_INISIE_R:
+                        case SCENE_INISIE_BS:
+                            R_TIME_SPEED = 0;
+                            break;
+                        default:
+                            break;
+                    }
+                    break;
+                case TIME_STOP_OFF:
+                    break;
+                default:
+                    break;
+            }
+        });
 }

--- a/mm/2s2h/Enhancements/Cheats/TimeStop.cpp
+++ b/mm/2s2h/Enhancements/Cheats/TimeStop.cpp
@@ -10,7 +10,7 @@ extern "C" {
 
 void RegisterTimeStopInTemples() {
     GameInteractor::Instance->RegisterGameHook<GameInteractor::AfterRoomSceneCommands>([](s16 sceneId, s8 roomNum) {
-        uint8_t selectedOption = CVarGetInteger("gCheats.TempleTimeStop", 0);
+        uint8_t selectedOption = CVarGetInteger("gCheats.TempleTimeStop", TIME_STOP_OFF);
 
         switch (selectedOption) {
             case TIME_STOP_TEMPLES_DUNGEONS:

--- a/mm/2s2h/Enhancements/Cheats/TimeStop.cpp
+++ b/mm/2s2h/Enhancements/Cheats/TimeStop.cpp
@@ -34,6 +34,7 @@ void RegisterTimeStopInTemples() {
                     default:
                         break;
                 }
+                // fallthrough
             case TIME_STOP_TEMPLES:
                 switch (gPlayState->sceneId) {
                     // Woodfall Temple + Odolwa

--- a/mm/2s2h/Enhancements/Cheats/TimeStop.cpp
+++ b/mm/2s2h/Enhancements/Cheats/TimeStop.cpp
@@ -1,6 +1,7 @@
 #include <libultraship/libultraship.h>
 #include "BenPort.h"
 #include "Enhancements/GameInteractor/GameInteractor.h"
+#include "Enhancements/Enhancements.h"
 
 extern "C" {
 #include <variables.h>
@@ -9,6 +10,57 @@ extern "C" {
 
 void RegisterTimeStopInTemples() {
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSceneInit>([](s16 sceneId, s8 spawnNum) {
+        uint8_t selectedOption = CVarGetInteger("gCheats.TempleTimeStop", 0);
+
+        switch (selectedOption) {
+            case TIME_STOP_TEMPLES_DUNGEONS:
+                switch (gPlayState->sceneId) {
+                    // Swamp Spider House
+                    case SCENE_KINSTA1:
+                    // Ocean Spider House
+                    case SCENE_KINDAN2:
+                    // Pirates' Fortress
+                    case SCENE_KAIZOKU:
+                    // Beneath the Well
+                    case SCENE_REDEAD:
+                    // Ancient Castle of Ikana
+                    case SCENE_CASTLE:
+                    // Igos du Ikana's Lair
+                    case SCENE_IKNINSIDE:
+                    // Secret Shrine
+                    case SCENE_RANDOM:
+                        R_TIME_SPEED = 0;
+                        break;
+                    default:
+                        break;
+                }
+            case TIME_STOP_TEMPLES:
+                switch (gPlayState->sceneId) {
+                    // Woodfall Temple + Odolwa
+                    case SCENE_MITURIN:
+                    case SCENE_MITURIN_BS:
+                    // Snowhead Temple + Goht
+                    case SCENE_HAKUGIN:
+                    case SCENE_HAKUGIN_BS:
+                    // Great Bay Temple + Gyorg
+                    case SCENE_SEA:
+                    case SCENE_SEA_BS:
+                    // Stone Tower Temple (+ inverted) + Twinmold
+                    case SCENE_INISIE_N:
+                    case SCENE_INISIE_R:
+                    case SCENE_INISIE_BS:
+                        R_TIME_SPEED = 0;
+                        break;
+                    default:
+                        break;
+                }
+                break;
+            case TIME_STOP_OFF:
+                break;
+            default:
+                break;
+        }
+
         if (CVarGetInteger("gCheats.TempleTimeStop", 0)) {
 
             switch (gPlayState->sceneId) {

--- a/mm/2s2h/Enhancements/Cheats/TimeStop.cpp
+++ b/mm/2s2h/Enhancements/Cheats/TimeStop.cpp
@@ -9,57 +9,56 @@ extern "C" {
 }
 
 void RegisterTimeStopInTemples() {
-    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnRoomInitAfterSceneCommands>(
-        [](s16 sceneId, s8 roomNum) {
-            uint8_t selectedOption = CVarGetInteger("gCheats.TempleTimeStop", 0);
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::AfterRoomSceneCommands>([](s16 sceneId, s8 roomNum) {
+        uint8_t selectedOption = CVarGetInteger("gCheats.TempleTimeStop", 0);
 
-            switch (selectedOption) {
-                case TIME_STOP_TEMPLES_DUNGEONS:
-                    switch (gPlayState->sceneId) {
-                        // Swamp + Ocean Spider House
-                        case SCENE_KINSTA1:
-                        case SCENE_KINDAN2:
-                        // Pirates' Fortress
-                        case SCENE_KAIZOKU:
-                        case SCENE_PIRATE:
-                        case SCENE_TORIDE:
-                        // Beneath the Well
-                        case SCENE_REDEAD:
-                        // Ancient Castle of Ikana + Igos's Lair
-                        case SCENE_CASTLE:
-                        case SCENE_IKNINSIDE:
-                        // Secret Shrine
-                        case SCENE_RANDOM:
-                            R_TIME_SPEED = 0;
-                            break;
-                        default:
-                            break;
-                    }
-                case TIME_STOP_TEMPLES:
-                    switch (gPlayState->sceneId) {
-                        // Woodfall Temple + Odolwa
-                        case SCENE_MITURIN:
-                        case SCENE_MITURIN_BS:
-                        // Snowhead Temple + Goht
-                        case SCENE_HAKUGIN:
-                        case SCENE_HAKUGIN_BS:
-                        // Great Bay Temple + Gyorg
-                        case SCENE_SEA:
-                        case SCENE_SEA_BS:
-                        // Stone Tower Temple (+ inverted) + Twinmold
-                        case SCENE_INISIE_N:
-                        case SCENE_INISIE_R:
-                        case SCENE_INISIE_BS:
-                            R_TIME_SPEED = 0;
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                case TIME_STOP_OFF:
-                    break;
-                default:
-                    break;
-            }
-        });
+        switch (selectedOption) {
+            case TIME_STOP_TEMPLES_DUNGEONS:
+                switch (gPlayState->sceneId) {
+                    // Swamp + Ocean Spider House
+                    case SCENE_KINSTA1:
+                    case SCENE_KINDAN2:
+                    // Pirates' Fortress
+                    case SCENE_KAIZOKU:
+                    case SCENE_PIRATE:
+                    case SCENE_TORIDE:
+                    // Beneath the Well
+                    case SCENE_REDEAD:
+                    // Ancient Castle of Ikana + Igos's Lair
+                    case SCENE_CASTLE:
+                    case SCENE_IKNINSIDE:
+                    // Secret Shrine
+                    case SCENE_RANDOM:
+                        R_TIME_SPEED = 0;
+                        break;
+                    default:
+                        break;
+                }
+            case TIME_STOP_TEMPLES:
+                switch (gPlayState->sceneId) {
+                    // Woodfall Temple + Odolwa
+                    case SCENE_MITURIN:
+                    case SCENE_MITURIN_BS:
+                    // Snowhead Temple + Goht
+                    case SCENE_HAKUGIN:
+                    case SCENE_HAKUGIN_BS:
+                    // Great Bay Temple + Gyorg
+                    case SCENE_SEA:
+                    case SCENE_SEA_BS:
+                    // Stone Tower Temple (+ inverted) + Twinmold
+                    case SCENE_INISIE_N:
+                    case SCENE_INISIE_R:
+                    case SCENE_INISIE_BS:
+                        R_TIME_SPEED = 0;
+                        break;
+                    default:
+                        break;
+                }
+                break;
+            case TIME_STOP_OFF:
+                break;
+            default:
+                break;
+        }
+    });
 }

--- a/mm/2s2h/Enhancements/Cheats/TimeStop.cpp
+++ b/mm/2s2h/Enhancements/Cheats/TimeStop.cpp
@@ -15,17 +15,17 @@ void RegisterTimeStopInTemples() {
         switch (selectedOption) {
             case TIME_STOP_TEMPLES_DUNGEONS:
                 switch (gPlayState->sceneId) {
-                    // Swamp Spider House
+                    // Swamp + Ocean Spider House
                     case SCENE_KINSTA1:
-                    // Ocean Spider House
                     case SCENE_KINDAN2:
                     // Pirates' Fortress
                     case SCENE_KAIZOKU:
+                    case SCENE_PIRATE:
+                    case SCENE_TORIDE:
                     // Beneath the Well
                     case SCENE_REDEAD:
-                    // Ancient Castle of Ikana
+                    // Ancient Castle of Ikana + Igos's Lair
                     case SCENE_CASTLE:
-                    // Igos du Ikana's Lair
                     case SCENE_IKNINSIDE:
                     // Secret Shrine
                     case SCENE_RANDOM:

--- a/mm/2s2h/Enhancements/Cheats/TimeStop.h
+++ b/mm/2s2h/Enhancements/Cheats/TimeStop.h
@@ -1,0 +1,6 @@
+#ifndef CHEATS_TIME_STOPS_H
+#define CHEATS_TIME_STOPS_H
+
+void RegisterTimeStopInTemples();
+
+#endif // CHEATS_TIME_STOPS_H

--- a/mm/2s2h/Enhancements/Enhancements.cpp
+++ b/mm/2s2h/Enhancements/Enhancements.cpp
@@ -12,6 +12,7 @@ void InitEnhancements() {
     RegisterMoonJumpOnL();
     RegisterUnbreakableRazorSword();
     RegisterUnrestrictedItems();
+    RegisterTimeStopInTemples();
 
     // Clock
     RegisterTextBasedClock();

--- a/mm/2s2h/Enhancements/Enhancements.h
+++ b/mm/2s2h/Enhancements/Enhancements.h
@@ -11,6 +11,7 @@
 #include "Cheats/Cheats.h"
 #include "Cheats/UnbreakableRazorSword.h"
 #include "Cheats/UnrestrictedItems.h"
+#include "Cheats/TimeStop.h"
 #include "Cycle/EndOfCycle.h"
 #include "Equipment/SkipMagicArrowEquip.h"
 #include "Masks/BlastMaskKeg.h"

--- a/mm/2s2h/Enhancements/Enhancements.h
+++ b/mm/2s2h/Enhancements/Enhancements.h
@@ -37,6 +37,12 @@ enum AlwaysWinDoggyRaceOptions {
     ALWAYS_WIN_DOGGY_RACE_ALWAYS,
 };
 
+enum TimeStopOptions {
+    TIME_STOP_OFF,
+    TIME_STOP_TEMPLES,
+    TIME_STOP_TEMPLES_DUNGEONS,
+};
+
 enum ClockTypeOptions {
     CLOCK_TYPE_ORIGINAL,
     CLOCK_TYPE_TEXT_BASED,

--- a/mm/2s2h/Enhancements/GameInteractor/GameInteractor.cpp
+++ b/mm/2s2h/Enhancements/GameInteractor/GameInteractor.cpp
@@ -53,6 +53,14 @@ void GameInteractor_ExecuteOnRoomInit(s16 sceneId, s8 roomNum) {
     GameInteractor::Instance->ExecuteHooksForFilter<GameInteractor::OnRoomInit>(sceneId, roomNum);
 }
 
+void GameInteractor_ExecuteOnRoomInitAfterSceneCommands(s16 sceneId, s8 roomNum) {
+    SPDLOG_DEBUG("OnRoomInitAfterSceneCommands: sceneId: {}, roomNum: {}", sceneId, roomNum);
+    GameInteractor::Instance->ExecuteHooks<GameInteractor::OnRoomInitAfterSceneCommands>(sceneId, roomNum);
+    GameInteractor::Instance->ExecuteHooksForID<GameInteractor::OnRoomInitAfterSceneCommands>(sceneId, sceneId,
+                                                                                              roomNum);
+    GameInteractor::Instance->ExecuteHooksForFilter<GameInteractor::OnRoomInitAfterSceneCommands>(sceneId, roomNum);
+}
+
 void GameInteractor_ExecuteOnPlayDestroy() {
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnPlayDestroy>();
 }

--- a/mm/2s2h/Enhancements/GameInteractor/GameInteractor.cpp
+++ b/mm/2s2h/Enhancements/GameInteractor/GameInteractor.cpp
@@ -53,12 +53,11 @@ void GameInteractor_ExecuteOnRoomInit(s16 sceneId, s8 roomNum) {
     GameInteractor::Instance->ExecuteHooksForFilter<GameInteractor::OnRoomInit>(sceneId, roomNum);
 }
 
-void GameInteractor_ExecuteOnRoomInitAfterSceneCommands(s16 sceneId, s8 roomNum) {
-    SPDLOG_DEBUG("OnRoomInitAfterSceneCommands: sceneId: {}, roomNum: {}", sceneId, roomNum);
-    GameInteractor::Instance->ExecuteHooks<GameInteractor::OnRoomInitAfterSceneCommands>(sceneId, roomNum);
-    GameInteractor::Instance->ExecuteHooksForID<GameInteractor::OnRoomInitAfterSceneCommands>(sceneId, sceneId,
-                                                                                              roomNum);
-    GameInteractor::Instance->ExecuteHooksForFilter<GameInteractor::OnRoomInitAfterSceneCommands>(sceneId, roomNum);
+void GameInteractor_ExecuteAfterRoomSceneCommands(s16 sceneId, s8 roomNum) {
+    SPDLOG_DEBUG("AfterRoomSceneCommands: sceneId: {}, roomNum: {}", sceneId, roomNum);
+    GameInteractor::Instance->ExecuteHooks<GameInteractor::AfterRoomSceneCommands>(sceneId, roomNum);
+    GameInteractor::Instance->ExecuteHooksForID<GameInteractor::AfterRoomSceneCommands>(sceneId, sceneId, roomNum);
+    GameInteractor::Instance->ExecuteHooksForFilter<GameInteractor::AfterRoomSceneCommands>(sceneId, roomNum);
 }
 
 void GameInteractor_ExecuteOnPlayDestroy() {

--- a/mm/2s2h/Enhancements/GameInteractor/GameInteractor.h
+++ b/mm/2s2h/Enhancements/GameInteractor/GameInteractor.h
@@ -265,7 +265,7 @@ class GameInteractor {
 
     DEFINE_HOOK(OnSceneInit, (s8 sceneId, s8 spawnNum));
     DEFINE_HOOK(OnRoomInit, (s8 sceneId, s8 roomNum));
-    DEFINE_HOOK(OnRoomInitAfterSceneCommands, (s8 sceneId, s8 roomNum));
+    DEFINE_HOOK(AfterRoomSceneCommands, (s8 sceneId, s8 roomNum));
     DEFINE_HOOK(OnPlayDestroy, ());
 
     DEFINE_HOOK(ShouldActorInit, (Actor * actor, bool* should));
@@ -309,7 +309,7 @@ void GameInteractor_ExecuteBeforeMoonCrashSaveReset();
 
 void GameInteractor_ExecuteOnSceneInit(s16 sceneId, s8 spawnNum);
 void GameInteractor_ExecuteOnRoomInit(s16 sceneId, s8 roomNum);
-void GameInteractor_ExecuteOnRoomInitAfterSceneCommands(s16 sceneId, s8 roomNum);
+void GameInteractor_ExecuteAfterRoomSceneCommands(s16 sceneId, s8 roomNum);
 void GameInteractor_ExecuteOnPlayDestroy();
 
 bool GameInteractor_ShouldActorInit(Actor* actor);

--- a/mm/2s2h/Enhancements/GameInteractor/GameInteractor.h
+++ b/mm/2s2h/Enhancements/GameInteractor/GameInteractor.h
@@ -265,6 +265,7 @@ class GameInteractor {
 
     DEFINE_HOOK(OnSceneInit, (s8 sceneId, s8 spawnNum));
     DEFINE_HOOK(OnRoomInit, (s8 sceneId, s8 roomNum));
+    DEFINE_HOOK(OnRoomInitAfterSceneCommands, (s8 sceneId, s8 roomNum));
     DEFINE_HOOK(OnPlayDestroy, ());
 
     DEFINE_HOOK(ShouldActorInit, (Actor * actor, bool* should));
@@ -308,6 +309,7 @@ void GameInteractor_ExecuteBeforeMoonCrashSaveReset();
 
 void GameInteractor_ExecuteOnSceneInit(s16 sceneId, s8 spawnNum);
 void GameInteractor_ExecuteOnRoomInit(s16 sceneId, s8 roomNum);
+void GameInteractor_ExecuteOnRoomInitAfterSceneCommands(s16 sceneId, s8 roomNum);
 void GameInteractor_ExecuteOnPlayDestroy();
 
 bool GameInteractor_ShouldActorInit(Actor* actor);

--- a/mm/2s2h/z_play_2SH.cpp
+++ b/mm/2s2h/z_play_2SH.cpp
@@ -74,7 +74,7 @@ extern "C" s32 OTRfunc_800973FC(PlayState* play, RoomContext* roomCtx) {
                 Environment_StopStormNatureAmbience(play);
             }
             // Insert hook
-            GameInteractor_ExecuteOnRoomInitAfterSceneCommands(play->sceneId, roomCtx->curRoom.num);
+            GameInteractor_ExecuteAfterRoomSceneCommands(play->sceneId, roomCtx->curRoom.num);
             return 1;
         }
 

--- a/mm/2s2h/z_play_2SH.cpp
+++ b/mm/2s2h/z_play_2SH.cpp
@@ -3,6 +3,8 @@
 #include "2s2h/resource/type/Scene.h"
 #include <utils/StringHelper.h>
 #include <Vertex.h>
+#include "2s2h/Enhancements/GameInteractor/GameInteractor.h"
+
 extern "C" {
 #include "global.h"
 extern uintptr_t gSegments[NUM_SEGMENTS];
@@ -71,6 +73,8 @@ extern "C" s32 OTRfunc_800973FC(PlayState* play, RoomContext* roomCtx) {
             if (Environment_GetStormState(play) == STORM_STATE_OFF) {
                 Environment_StopStormNatureAmbience(play);
             }
+            // Insert hook
+            GameInteractor_ExecuteOnRoomInitAfterSceneCommands(play->sceneId, roomCtx->curRoom.num);
             return 1;
         }
 


### PR DESCRIPTION
This PR will add a cheat that will stop time while in temples. Toggling the cheat will require a room change to take effect. 
The clock will also be hidden while in the temple.

EDIT: Cheat has 3 settings: 
-  Off
- Temples (Woodfall Temple, Snowhead Temple, Great Bay Temple, and Stone Tower Temple)
- Temples and Dungeons (includes the four temples, both spider houses, Pirates' Fortress, Beneath the Well, Ikana Castle, and Secret Shrine)

KNOWN ISSUES:

- [x] Doesn't work in Igos's throne room, despite working in the entryway.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1748423500.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1748427181.zip)
<!--- section:artifacts:end -->