### PR TITLE
Bump LUS with color combiner fixes

### DIFF
--- a/mm/2s2h/Enhancements/GfxPatcher/AuthenticGfxPatches.cpp
+++ b/mm/2s2h/Enhancements/GfxPatcher/AuthenticGfxPatches.cpp
@@ -2,22 +2,12 @@
 
 extern "C" {
 #include <libultraship/libultra.h>
-#include "objects/object_uch/object_uch.h"
 #include "overlays/ovl_En_Syateki_Okuta/ovl_En_Syateki_Okuta.h"
 #include "overlays/ovl_Obj_Jgame_Light/ovl_Obj_Jgame_Light.h"
 
 void ResourceMgr_PatchGfxByName(const char* path, const char* patchName, int index, Gfx instruction);
 void ResourceMgr_UnpatchGfxByName(const char* path, const char* patchName);
 Gfx* ResourceMgr_LoadGfxByName(const char* path);
-}
-
-void PatchAlienEyeBeams() {
-    // A bug in the Alien's eye beam DL is incorrectly referring to TEXEL1 in the color combiner when
-    // the texture is loaded into TEXEL0, causing the CC rendering whatever was last loaded into TEXEL1.
-    // Patching the instruction to TEXEL0 restores the effect as seen on hardware.
-    ResourceMgr_PatchGfxByName(gAlienEyeBeamDL, "AlienEyeBeamFix", 4,
-                               gsDPSetCombineLERP(NOISE, 0, PRIMITIVE, 0, 0, 0, 0, ENVIRONMENT, COMBINED, 0,
-                                                  PRIMITIVE_ALPHA, PRIMITIVE, COMBINED, 0, TEXEL0, 0));
 }
 
 void PatchMiniGameCrossAndCircleSymbols() {
@@ -48,6 +38,5 @@ void PatchMiniGameCrossAndCircleSymbols() {
 
 // Applies required patches for authentic bugs to allow the game to play and render properly
 void GfxPatcher_ApplyNecessaryAuthenticPatches() {
-    PatchAlienEyeBeams();
     PatchMiniGameCrossAndCircleSymbols();
 }


### PR DESCRIPTION
Bumps LUS with some more color combiner fixes for some textures that were duplicating.

The recent color combiner fixes allow us to remove the Alien eyebeams gfx patch as it now works properly as is.

Fixes #705

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1629388949.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1629389495.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1629390824.zip)
<!--- section:artifacts:end -->