### PR TITLE
PowerShell clang fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ _packages/
 
 /mm/src/boot/build.c
 /mm/windows/properties.h
+/clang-format.exe

--- a/run-clang-format.ps1
+++ b/run-clang-format.ps1
@@ -1,3 +1,4 @@
+Using Namespace System.Net
 $url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.6/LLVM-14.0.6-win64.exe"
 $llvmInstallerPath = ".\LLVM-14.0.6-win64.exe"
 $clangFormatFilePath = ".\clang-format.exe"

--- a/run-clang-format.ps1
+++ b/run-clang-format.ps1
@@ -1,4 +1,4 @@
-Using Namespace System.Net
+Using Namespace System
 $url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.6/LLVM-14.0.6-win64.exe"
 $llvmInstallerPath = ".\LLVM-14.0.6-win64.exe"
 $clangFormatFilePath = ".\clang-format.exe"


### PR DESCRIPTION
Fixes script running in commandline mode by adding System.Net inclusion at the top.
Also adds clang-format.exe to gitignore.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1634302839.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1634306070.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1634308476.zip)
<!--- section:artifacts:end -->