### PR TITLE
Fix: Prevent Dawn Of screen crashing with 4th day glitch

### DIFF
--- a/mm/src/overlays/gamestates/ovl_daytelop/z_daytelop.c
+++ b/mm/src/overlays/gamestates/ovl_daytelop/z_daytelop.c
@@ -12,6 +12,7 @@
 #include "interface/icon_item_gameover_static/icon_item_gameover_static.h"
 
 #include "BenPort.h"
+#include "assets/2s2h_assets.h"
 
 // unused
 UNK_TYPE D_808158E0[] = {
@@ -126,6 +127,9 @@ TexturePtr sHoursLeftTextures[] = {
     gDaytelop72HoursNESTex,
     gDaytelop48HoursNESTex,
     gDaytelop24HoursNESTex,
+
+    // 2S2H [Port] Added empty texture to support "Dawn of" with the 4th day glitch and prevent crashing
+    gEmptyTexture,
 };
 
 void DayTelop_Draw(DayTelopState* this) {


### PR DESCRIPTION
The "Dawn Of" screen would crash with the 4th day glitch due to an OOB read for the textures with the hours remaining text. Adding another entry at the end of this array with our empty texture fix prevents the crash and replicates console behavior of nothing rendering there.

This happens because the `CURRENT_DAY` macro mods the day value with `5` and then in the Dawn Of screen, the macro value is subtracted by `1`. So a value of `3` is used to index all the texture arrays. The Dawn Of arrays already have a 4th entry for the "New Day" textures.

Because the 4th day glitch always repeats the 4th day and doesn't increment the day value means we don't have to worry about an index of `4` going into these arrays.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1637980949.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1637983884.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1638089016.zip)
<!--- section:artifacts:end -->