### PR TITLE
Fix: Handle reloading skybox textures

### DIFF
--- a/mm/include/z64skybox.h
+++ b/mm/include/z64skybox.h
@@ -23,7 +23,7 @@ typedef enum SkyboxId {
 
 typedef struct SkyboxContext {
     /* 0x000 */ View view;
-    /* 0x168 */ void* staticSegments[2][5];
+    /* 0x168 */ void* staticSegments[2][6]; // 2S2H [Port] Changed to hold enough pointers to OTR resources
     /* 0x178 */ void* paletteStaticSegment;
     /* 0x17C */ Gfx (*dListBuf)[150];
     /* 0x180 */ Gfx* roomDL;
@@ -40,33 +40,6 @@ typedef struct SkyboxContext {
     /* 0x222 */ Color_RGB8 prim;
     /* 0x225 */ Color_RGB8 env;
 } SkyboxContext; // size = 0x228
-
-typedef struct {
-    char** file;
-    char* palette;
-} SkyboxFiles;
-
-#if 0
-typedef struct SkyboxContext {
-    /* 0x000 */ View view;
-    /* 0x168 */ void* staticSegments[4];
-    /* 0x178 */ void* paletteStaticSegment;
-    /* 0x17C */ Gfx (*dListBuf)[150];
-    /* 0x180 */ Gfx* roomDL;
-    /* 0x184 */ Vtx* roomVtx;
-    /* 0x188 */ DmaRequest unk188;
-    /* 0x1A8 */ DmaRequest unk1A8;
-    /* 0x1C8 */ DmaRequest unk1C8;
-    /* 0x1E8 */ OSMesgQueue loadQueue;
-    /* 0x200 */ OSMesg loadMsg;
-    /* 0x204 */ s16 skyboxShouldDraw;
-    /* 0x208 */ Vec3f rot;
-    /* 0x214 */ Vec3f eye;
-    /* 0x220 */ s16 angle;
-    /* 0x222 */ Color_RGB8 prim;
-    /* 0x225 */ Color_RGB8 env;
-} SkyboxContext; // size = 0x228
-#endif
 
 typedef struct struct_801C5F44 {
     /* 0x00 */ s32 unk0;
@@ -87,5 +60,14 @@ void Skybox_SetColors(SkyboxContext* skyboxCtx, u8 primR, u8 primG, u8 primB, u8
 void Skybox_Draw(SkyboxContext* skyboxCtx, struct GraphicsContext* gfxCtx, s16 skyboxId, s16 blend, f32 x, f32 y,
                  f32 z);
 void Skybox_Update(SkyboxContext* skyboxCtx);
+
+// #region 2S2H [Port]
+typedef enum SkyboxTexturesIndex {
+    /* 0 */ SKYBOX_TEXTURES_FINE,
+    /* 1 */ SKYBOX_TEXTURES_CLOUD,
+} SkyboxTexturesIndex;
+
+extern TexturePtr sSkyboxTextures[2][6];
+// #endregion
 
 #endif

--- a/mm/src/code/z_kankyo.c
+++ b/mm/src/code/z_kankyo.c
@@ -1049,28 +1049,44 @@ void Environment_UpdateSkybox(u8 skyboxId, EnvironmentContext* envCtx, SkyboxCon
 
         if ((envCtx->skybox1Index != skybox1Index) && (envCtx->skyboxDmaState == SKYBOX_DMA_INACTIVE)) {
             envCtx->skyboxDmaState = SKYBOX_DMA_TEXTURE1_START;
-            size = sNormalSkyFiles[skybox1Index].file.vromEnd - sNormalSkyFiles[skybox1Index].file.vromStart;
-            osCreateMesgQueue(&envCtx->loadQueue, envCtx->loadMsg, ARRAY_COUNT(envCtx->loadMsg));
-            DmaMgr_SendRequestImpl(&envCtx->dmaRequest, skyboxCtx->staticSegments[0],
-                                   sNormalSkyFiles[skybox1Index].file.vromStart, size, 0, &envCtx->loadQueue,
-                                   OS_MESG_PTR(NULL));
+            // size = sNormalSkyFiles[skybox1Index].file.vromEnd - sNormalSkyFiles[skybox1Index].file.vromStart;
+            // osCreateMesgQueue(&envCtx->loadQueue, envCtx->loadMsg, ARRAY_COUNT(envCtx->loadMsg));
+            // DmaMgr_SendRequestImpl(&envCtx->dmaRequest, skyboxCtx->staticSegments[0],
+            //                        sNormalSkyFiles[skybox1Index].file.vromStart, size, 0, &envCtx->loadQueue,
+            //                        OS_MESG_PTR(NULL));
+
+            // 2S2h [Port] Bypass DMA request and assign each skybox texture directly to the static segment
+            for (size_t i = 0; i < ARRAY_COUNTU(skyboxCtx->staticSegments[0]); i++) {
+                skyboxCtx->staticSegments[0][i] = sSkyboxTextures[skybox1Index][i];
+            }
+
             envCtx->skybox1Index = skybox1Index;
         }
 
         if ((envCtx->skybox2Index != skybox2Index) && (envCtx->skyboxDmaState == SKYBOX_DMA_INACTIVE)) {
             envCtx->skyboxDmaState = SKYBOX_DMA_TEXTURE2_START;
-            size = sNormalSkyFiles[skybox2Index].file.vromEnd - sNormalSkyFiles[skybox2Index].file.vromStart;
-            osCreateMesgQueue(&envCtx->loadQueue, envCtx->loadMsg, ARRAY_COUNT(envCtx->loadMsg));
-            DmaMgr_SendRequestImpl(&envCtx->dmaRequest, skyboxCtx->staticSegments[1],
-                                   sNormalSkyFiles[skybox2Index].file.vromStart, size, 0, &envCtx->loadQueue,
-                                   OS_MESG_PTR(NULL));
+            // size = sNormalSkyFiles[skybox2Index].file.vromEnd - sNormalSkyFiles[skybox2Index].file.vromStart;
+            // osCreateMesgQueue(&envCtx->loadQueue, envCtx->loadMsg, ARRAY_COUNT(envCtx->loadMsg));
+            // DmaMgr_SendRequestImpl(&envCtx->dmaRequest, skyboxCtx->staticSegments[1],
+            //                        sNormalSkyFiles[skybox2Index].file.vromStart, size, 0, &envCtx->loadQueue,
+            //                        OS_MESG_PTR(NULL));
+
+            for (size_t i = 0; i < ARRAY_COUNTU(skyboxCtx->staticSegments[1]); i++) {
+                skyboxCtx->staticSegments[1][i] = sSkyboxTextures[skybox2Index][i];
+            }
+
             envCtx->skybox2Index = skybox2Index;
         }
 
         if ((envCtx->skyboxDmaState == SKYBOX_DMA_TEXTURE1_START) ||
             (envCtx->skyboxDmaState == SKYBOX_DMA_TEXTURE2_START)) {
-            if (osRecvMesg(&envCtx->loadQueue, NULL, 0) == 0) {
+            // if (osRecvMesg(&envCtx->loadQueue, NULL, 0) == 0) {
+            if (true) {
                 envCtx->skyboxDmaState = SKYBOX_DMA_INACTIVE;
+                // 2S2H [Port] Since the skybox static segments point to OTR strings, we need to re-create the skybox
+                // display lists to have the new textures loaded
+                func_80143148(skyboxCtx, 5);
+                // #endregion
             }
         }
 


### PR DESCRIPTION
The skybox displaylists are only created once on play init, and with us switching the static segments to point to resource strings, this meant that the displaylists were still using the original textures, instead of the new textures requested by the skybox config. Additionally, the skybox blending logic was still performing DMA requests instead of updating to use our resource strings.

This PR addresses these issues by recreating the skybox displaylists whenever the static segment pointers are updated as well.
I've also cleaned up some of this code to simply and reuse structures
This should maintain HD texture support.

Fixes #504 

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1638640266.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1638640971.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1638642733.zip)
<!--- section:artifacts:end -->