### PR TITLE
Tweak FreeLook camera reset logic

### DIFF
--- a/mm/2s2h/Enhancements/Camera/FreeLook.cpp
+++ b/mm/2s2h/Enhancements/Camera/FreeLook.cpp
@@ -21,24 +21,26 @@ extern s32 sCameraInterfaceFlags;
 static bool sCanFreeLook = false;
 
 void UpdateFreeLookState(Camera* camera) {
-    if (CAM_MODE_TARGET <= camera->mode && camera->mode <= CAM_MODE_BATTLE) {
-        sCanFreeLook = false;
-    }
-
-    if (CAM_MODE_FIRSTPERSON <= camera->mode && camera->mode <= CAM_MODE_CLIMBZ) {
-        sCanFreeLook = false;
-    }
-
-    if (camera->mode == CAM_MODE_HANGZ) {
-        sCanFreeLook = false;
-    }
-
-    if (CAM_MODE_BOOMERANG <= camera->mode && camera->mode <= CAM_MODE_ZORAFINZ) {
-        sCanFreeLook = false;
-    }
-
-    if (gPlayState != nullptr && Player_InCsMode(gPlayState)) {
-        sCanFreeLook = false;
+    switch (camera->mode) {
+        case CAM_MODE_BOWARROWZ:
+        case CAM_MODE_FIRSTPERSON:
+        case CAM_MODE_FOLLOWBOOMERANG:
+        case CAM_MODE_ZORAFIN:
+        case CAM_MODE_FOLLOWTARGET:
+        case CAM_MODE_TARGET:
+        case CAM_MODE_TALK:
+        case CAM_MODE_SLINGSHOT:
+        case CAM_MODE_BOWARROW:
+        case CAM_MODE_BATTLE:
+        case CAM_MODE_DEKUHIDE:
+        case CAM_MODE_CLIMBZ:
+        case CAM_MODE_HOOKSHOT:
+        case CAM_MODE_HANGZ:
+        case CAM_MODE_DEKUFLYZ:
+        case CAM_MODE_BOOMERANG:
+        case CAM_MODE_CHARGEZ:
+        case CAM_MODE_ZORAFINZ:
+            sCanFreeLook = false;
     }
 }
 
@@ -143,6 +145,10 @@ bool Camera_CanFreeLook(Camera* camera) {
     }
     // Pressing Z will "Reset" Camera
     if (CHECK_BTN_ALL(sCamPlayState->state.input[0].press.button, BTN_Z)) {
+        sCanFreeLook = false;
+    }
+    // Reset camera during cutscenes
+    if (gPlayState != nullptr && Player_InCsMode(gPlayState)) {
         sCanFreeLook = false;
     }
 


### PR DESCRIPTION
The FreeLook camera was resetting when performing simple actions like attacking with a sword. The camera mode check had some confusing and overlapping range checks, so I've switched to using a switch with explicit cases for the camera modes we want to clear (essentially any Z targeting, aiming, firstperson, and boomerang modes).

I also moved the cutscene check to `CanFreeLook` so that we check on all frames for cutscene mode, instead of just when the camera mode changes. This addresses the strange camera position issue when moving the camera through a transition while riding Epona.

Fixes #508

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1638945765.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1638946535.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1638949168.zip)
<!--- section:artifacts:end -->