### PR TITLE
[Enhancement] Skip the scarecrow song

### DIFF
--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -755,6 +755,8 @@ void DrawEnhancementsMenu() {
                                     { .tooltip = "Enables using the Dpad for Ocarina playback." });
             UIWidgets::CVarCheckbox("Prevent Dropped Ocarina Inputs", "gEnhancements.Playback.NoDropOcarinaInput",
                                     { .tooltip = "Prevent dropping inputs when playing the ocarina quickly" });
+            UIWidgets::CVarCheckbox("Skip Scarecrow Song", "gEnhancements.Playback.SkipScarecrowSong",
+                                    { .tooltip = "Pierre appears when the Ocarina is pulled out." });
             UIWidgets::CVarCheckbox("Pause Owl Warp", "gEnhancements.Songs.PauseOwlWarp",
                                     { .tooltip = "Allows the player to use the pause menu map to owl warp instead of "
                                                  "having to play the Song of Soaring." });

--- a/mm/2s2h/BenGui/SearchableMenuItems.h
+++ b/mm/2s2h/BenGui/SearchableMenuItems.h
@@ -1249,6 +1249,8 @@ void AddEnhancements() {
                 { 1, 7, 7 } },
               { "Prevent Dropped Ocarina Inputs", "gEnhancements.Playback.NoDropOcarinaInput",
                 "Prevent dropping inputs when playing the ocarina quickly.", WIDGET_CVAR_CHECKBOX },
+              { "Skip Scarecrow Song", "gEnhancements.Playback.SkipScarecrowSong",
+                "Pierre appears when the Ocarina is pulled out.", WIDGET_CVAR_CHECKBOX },
               { "Faster Song Playback",
                 "gEnhancements.Songs.FasterSongPlayback",
                 "Speeds up the playback of songs.",

--- a/mm/2s2h/Enhancements/Enhancements.cpp
+++ b/mm/2s2h/Enhancements/Enhancements.cpp
@@ -61,6 +61,7 @@ void InitEnhancements() {
     RegisterFasterSongPlayback();
     RegisterPauseOwlWarp();
     RegisterZoraEggCount();
+    RegisterSkipScarecrowSong();
 
     // Restorations
     RegisterPowerCrouchStab();

--- a/mm/2s2h/Enhancements/Songs/SkipScarecrowSong.cpp
+++ b/mm/2s2h/Enhancements/Songs/SkipScarecrowSong.cpp
@@ -1,0 +1,29 @@
+#include <libultraship/bridge.h>
+#include "2s2h/GameInteractor/GameInteractor.h"
+
+extern "C" {
+#include "z64.h"
+#include "functions.h"
+#include "src/overlays/actors/ovl_En_Kakasi/z_en_kakasi.h"
+extern PlayState* gPlayState;
+}
+
+void RegisterSkipScarecrowSong() {
+    REGISTER_VB_SHOULD(VB_NEED_SCARECROW_SONG, {
+        if (CVarGetInteger("gEnhancements.Playback.SkipScarecrowSong", 0)) {
+            EnKakasi* enKakasi = (EnKakasi*)opt;
+            /*
+             * This is somewhat similar to the condition that the scarecrow normally checks, except it checks if the
+             * instrument is being played at all instead of having played the Scarecrow's Song in particular, and it
+             * bypasses the check that Link has taught Pierre a song this cycle.
+             */
+            if ((enKakasi->picto.actor.xzDistToPlayer < enKakasi->songSummonDist) &&
+                ((BREG(1) != 0) || (gPlayState->msgCtx.ocarinaMode == OCARINA_MODE_ACTIVE))) {
+                *should = true;
+                // Properly get out of the ocarina playing state
+                AudioOcarina_SetInstrument(OCARINA_INSTRUMENT_OFF);
+                Message_CloseTextbox(gPlayState);
+            }
+        }
+    });
+}

--- a/mm/2s2h/Enhancements/Songs/SkipScarecrowSong.cpp
+++ b/mm/2s2h/Enhancements/Songs/SkipScarecrowSong.cpp
@@ -11,7 +11,7 @@ extern PlayState* gPlayState;
 void RegisterSkipScarecrowSong() {
     REGISTER_VB_SHOULD(VB_NEED_SCARECROW_SONG, {
         if (CVarGetInteger("gEnhancements.Playback.SkipScarecrowSong", 0)) {
-            EnKakasi* enKakasi = (EnKakasi*)opt;
+            EnKakasi* enKakasi = va_arg(args, EnKakasi*);
             /*
              * This is somewhat similar to the condition that the scarecrow normally checks, except it checks if the
              * instrument is being played at all instead of having played the Scarecrow's Song in particular, and it

--- a/mm/2s2h/Enhancements/Songs/Songs.h
+++ b/mm/2s2h/Enhancements/Songs/Songs.h
@@ -5,6 +5,7 @@ void RegisterEnableSunsSong();
 void RegisterFasterSongPlayback();
 void RegisterZoraEggCount();
 void RegisterPauseOwlWarp();
+void RegisterSkipScarecrowSong();
 
 #ifdef __cplusplus
 extern "C" {

--- a/mm/2s2h/GameInteractor/GameInteractor.h
+++ b/mm/2s2h/GameInteractor/GameInteractor.h
@@ -68,6 +68,7 @@ typedef enum {
     VB_FD_ALWAYS_WIELD_SWORD,
     VB_SHOULD_PUTAWAY,
     VB_ELEGY_CHECK_SCENE,
+    VB_NEED_SCARECROW_SONG,
 } GIVanillaBehavior;
 
 typedef enum {

--- a/mm/src/overlays/actors/ovl_En_Kakasi/z_en_kakasi.c
+++ b/mm/src/overlays/actors/ovl_En_Kakasi/z_en_kakasi.c
@@ -7,6 +7,7 @@
 #include "prevent_bss_reordering.h"
 #include "z_en_kakasi.h"
 #include "objects/object_ka/object_ka.h"
+#include "2s2h/GameInteractor/GameInteractor.h"
 
 #define FLAGS (ACTOR_FLAG_TARGETABLE | ACTOR_FLAG_FRIENDLY | ACTOR_FLAG_10 | ACTOR_FLAG_2000000)
 
@@ -1053,8 +1054,11 @@ void EnKakasi_SetupIdleUnderground(EnKakasi* this) {
 }
 
 void EnKakasi_IdleUnderground(EnKakasi* this, PlayState* play) {
-    if (CHECK_WEEKEVENTREG(WEEKEVENTREG_79_08) && (this->picto.actor.xzDistToPlayer < this->songSummonDist) &&
-        ((BREG(1) != 0) || (play->msgCtx.ocarinaMode == OCARINA_MODE_PLAYED_SCARECROW_SPAWN))) {
+    if (GameInteractor_Should(VB_NEED_SCARECROW_SONG,
+                              CHECK_WEEKEVENTREG(WEEKEVENTREG_79_08) &&
+                                  (this->picto.actor.xzDistToPlayer < this->songSummonDist) &&
+                                  ((BREG(1) != 0) || (play->msgCtx.ocarinaMode == OCARINA_MODE_PLAYED_SCARECROW_SPAWN)),
+                              this)) {
         this->picto.actor.flags &= ~ACTOR_FLAG_CANT_LOCK_ON;
         play->msgCtx.ocarinaMode = OCARINA_MODE_END;
         this->actionFunc = EnKakasi_SetupRiseOutOfGround;


### PR DESCRIPTION
Much like the setting in SoH, this allows Link to summon Pierre just by pulling out his instrument near a spawn point. This incidentally means that the 3-day cycle reset won't impact Link's ability to call Pierre.

https://github.com/HarbourMasters/2ship2harkinian/assets/7004497/f2458033-0be9-4afd-81a6-d0b41412af07

If and when entrance randomizer becomes a thing, this will have to be taken into consideration, as the song is typically gated by being able to reach Pierre in Clock Town.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2041046363.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2041059830.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2041113072.zip)
<!--- section:artifacts:end -->