### PR TITLE
Fix: Add reset func for EnBats actor

### DIFF
--- a/mm/src/overlays/actors/ovl_En_Bat/z_en_bat.c
+++ b/mm/src/overlays/actors/ovl_En_Bat/z_en_bat.c
@@ -18,6 +18,7 @@ void EnBat_Init(Actor* thisx, PlayState* play);
 void EnBat_Destroy(Actor* thisx, PlayState* play);
 void EnBat_Update(Actor* thisx, PlayState* play);
 void EnBat_Draw(Actor* thisx, PlayState* play);
+void EnBat_Reset(void);
 
 s32 EnBat_IsGraveyardOnSecondDay(PlayState* play);
 void EnBat_SetupPerch(EnBat* this);
@@ -39,6 +40,7 @@ ActorInit En_Bat_InitVars = {
     /**/ EnBat_Destroy,
     /**/ EnBat_Update,
     /**/ EnBat_Draw,
+    /**/ EnBat_Reset,
 };
 
 static ColliderSphereInit sSphereInit = {
@@ -559,4 +561,9 @@ void EnBat_Draw(Actor* thisx, PlayState* play) {
         Actor_DrawDamageEffects(play, &this->actor, this->bodyPartsPos, BAD_BAT_BODYPART_MAX, this->drawDmgEffScale,
                                 this->drawDmgEffFrozenSteamScale, this->drawDmgEffAlpha, this->drawDmgEffType);
     }
+}
+
+void EnBat_Reset(void) {
+    sNumberAttacking = 0;
+    sAlreadySpawned = false;
 }


### PR DESCRIPTION
Adds a reset func for bats.

Fixes an issue where bats would no longer spawn after entering the graveyard on day 2.

Fixes #524

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1646960143.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1646960427.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1646963201.zip)
<!--- section:artifacts:end -->