### PR TITLE
Fix: Clean up flags when using debug warp

### DIFF
--- a/mm/src/overlays/gamestates/ovl_select/z_select.c
+++ b/mm/src/overlays/gamestates/ovl_select/z_select.c
@@ -21,7 +21,7 @@ void MapSelect_LoadGame(MapSelectState* this, u32 entrance, s32 spawn) {
     if (gSaveContext.fileNum == 0xFF) {
         Sram_InitDebugSave();
 
-        // #region 2S2h [Debug] Clear all flags when using debug file slot.
+        // #region 2S2H [Debug] Clear all flags when using debug file slot.
         // This is mostly copied from Sram_OpenSave.
         for (size_t i = 0; i < ARRAY_COUNT(gSaveContext.eventInf); i++) {
             gSaveContext.eventInf[i] = 0;
@@ -40,7 +40,7 @@ void MapSelect_LoadGame(MapSelectState* this, u32 entrance, s32 spawn) {
     // #region 2S2H [Debug] Clear some potential lingering flags
     CLEAR_EVENTINF(EVENTINF_17);
     CLEAR_EVENTINF(EVENTINF_TRIGGER_DAYTELOP);
-    // #region
+    // #endregion
 
     gSaveContext.buttonStatus[EQUIP_SLOT_B] = BTN_ENABLED;
     gSaveContext.buttonStatus[EQUIP_SLOT_C_LEFT] = BTN_ENABLED;

--- a/mm/src/overlays/gamestates/ovl_select/z_select.c
+++ b/mm/src/overlays/gamestates/ovl_select/z_select.c
@@ -20,13 +20,33 @@ void MapSelect_LoadConsoleLogo(MapSelectState* this) {
 void MapSelect_LoadGame(MapSelectState* this, u32 entrance, s32 spawn) {
     if (gSaveContext.fileNum == 0xFF) {
         Sram_InitDebugSave();
+
+        // #region 2S2h [Debug] Clear all flags when using debug file slot.
+        // This is mostly copied from Sram_OpenSave.
+        for (size_t i = 0; i < ARRAY_COUNT(gSaveContext.eventInf); i++) {
+            gSaveContext.eventInf[i] = 0;
+        }
+
+        for (size_t i = 0; i < ARRAY_COUNT(gSaveContext.cycleSceneFlags); i++) {
+            gSaveContext.cycleSceneFlags[i].chest = gSaveContext.save.saveInfo.permanentSceneFlags[i].chest;
+            gSaveContext.cycleSceneFlags[i].switch0 = gSaveContext.save.saveInfo.permanentSceneFlags[i].switch0;
+            gSaveContext.cycleSceneFlags[i].switch1 = gSaveContext.save.saveInfo.permanentSceneFlags[i].switch1;
+            gSaveContext.cycleSceneFlags[i].clearedRoom = gSaveContext.save.saveInfo.permanentSceneFlags[i].clearedRoom;
+            gSaveContext.cycleSceneFlags[i].collectible = gSaveContext.save.saveInfo.permanentSceneFlags[i].collectible;
+        }
+        // #endregion
     }
+
+    // #region 2S2H [Debug] Clear some potential lingering flags
+    CLEAR_EVENTINF(EVENTINF_17);
+    CLEAR_EVENTINF(EVENTINF_TRIGGER_DAYTELOP);
+    // #region
 
     gSaveContext.buttonStatus[EQUIP_SLOT_B] = BTN_ENABLED;
     gSaveContext.buttonStatus[EQUIP_SLOT_C_LEFT] = BTN_ENABLED;
     gSaveContext.buttonStatus[EQUIP_SLOT_C_DOWN] = BTN_ENABLED;
     gSaveContext.buttonStatus[EQUIP_SLOT_C_RIGHT] = BTN_ENABLED;
-    // #region 2S2H
+    // #region 2S2H [Dpad]
     gSaveContext.shipSaveContext.dpad.status[EQUIP_SLOT_D_RIGHT] = BTN_ENABLED;
     gSaveContext.shipSaveContext.dpad.status[EQUIP_SLOT_D_LEFT] = BTN_ENABLED;
     gSaveContext.shipSaveContext.dpad.status[EQUIP_SLOT_D_DOWN] = BTN_ENABLED;


### PR DESCRIPTION
This adds some flag cleanups when using the debug warp.

* For all saves, we clear two flags relating to the day transition. This should resolve issues around not being able to pause after activating debug warp during a day/night transition.
* For debug saves we want debug warp to completely reset the save. The `Sram_InitDebugSave` would memset `gSaveContext.save.saveInfo` which has all the persistent flags, but there are few other flags higher up on the save context that wouldn't clear out. So I copied over some of the logic from `Sram_OpenSave` to help prevent things from sticking around.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1650070261.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1650077147.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1650078933.zip)
<!--- section:artifacts:end -->