### PR TITLE
Tweak: Improve Save Editor time options

### DIFF
--- a/mm/src/code/z_play.c
+++ b/mm/src/code/z_play.c
@@ -2184,9 +2184,6 @@ void Play_FillScreen(GameState* thisx, s16 fillScreenOn, u8 red, u8 green, u8 bl
 
 void Play_Init(GameState* thisx) {
     PlayState* this = (PlayState*)thisx;
-    // #region 2S2H [General] Making gPlayState available
-    gPlayState = this;
-    // #endregion
     GraphicsContext* gfxCtx = this->state.gfxCtx;
     s32 pad;
     uintptr_t zAlloc;
@@ -2219,6 +2216,11 @@ void Play_Init(GameState* thisx) {
         SET_NEXT_GAMESTATE(&this->state, TitleSetup_Init, sizeof(TitleSetupState));
         return;
     }
+
+    // #region 2S2H [General] Making gPlayState available
+    // Setting after the early returns, so that Play_Destroy is registered to unset the ptr later
+    gPlayState = this;
+    // #endregion
 
     if ((gSaveContext.nextCutsceneIndex == 0xFFEF) || (gSaveContext.nextCutsceneIndex == 0xFFF0)) {
         scene = ((void)0, gSaveContext.save.entrance) >> 9;

--- a/mm/src/overlays/gamestates/ovl_daytelop/z_daytelop.c
+++ b/mm/src/overlays/gamestates/ovl_daytelop/z_daytelop.c
@@ -135,6 +135,12 @@ TexturePtr sHoursLeftTextures[] = {
 void DayTelop_Draw(DayTelopState* this) {
     GraphicsContext* gfxCtx = this->state.gfxCtx;
 
+    // 2S2H [Port] Exit early for day 0 or less to avoid an OOB read on the texture arrays.
+    // This is only possible when using the save editor while the "Dawn of" screen is up.
+    if (CURRENT_DAY <= 0) {
+        return;
+    }
+
     OPEN_DISPS(gfxCtx);
 
     Gfx_SetupDL39_Opa(this->state.gfxCtx);


### PR DESCRIPTION
This PR significantly improves time editing from the save editor. Before it was very easy to accidentally moon crash when changing time. The `EnTest4` actor manages the three-day events and keeps track of the previous time, which is why the events would trigger after changing the time.

Updates in this PR:
* Changing days now preserves the current time, updates the skybox and env lighting, clears the rainy weather from day 2.
* Can now select day 0 and day 4 from the slider. (Could extend this to 9, if we wanted, but that's also achievable by ctrl-clicking and entering in the number)
* Changing time no longer triggers the three-day events. Can now freely adjust the time without concern of the day changing or moon crashing.
* Audio sequences will re-trigger on time change, if needed.
* Fixed an edge case where `gPlayState` could have a dangling ptr and cause crashes with hooks.

Fixes #573

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1673016414.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1673017397.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1673018966.zip)
<!--- section:artifacts:end -->