### PR TITLE
Fix some Fierce Diety interactions in Clock Town

### DIFF
--- a/mm/src/overlays/actors/ovl_En_Stop_heishi/z_en_stop_heishi.c
+++ b/mm/src/overlays/actors/ovl_En_Stop_heishi/z_en_stop_heishi.c
@@ -405,6 +405,11 @@ void func_80AE7F34(EnStopheishi* this, PlayState* play) {
         case PLAYER_FORM_GORON:
             phi_a2 = 2;
             break;
+
+        // 2SH2 [FD Enhancement] - Guard treats FD as if Human has already talked
+        case PLAYER_FORM_FIERCE_DEITY:
+            phi_a2 = 1;
+            break;
     }
 
     if (((phi_a2 == 1) || (phi_a2 == 2) || (phi_a2 == 3)) &&

--- a/mm/src/overlays/actors/ovl_En_Syateki_Man/z_en_syateki_man.c
+++ b/mm/src/overlays/actors/ovl_En_Syateki_Man/z_en_syateki_man.c
@@ -587,6 +587,9 @@ void EnSyatekiMan_Town_StartIntroTextbox(EnSyatekiMan* this, PlayState* play) {
             }
             break;
 
+        // 2SH2 [FD Enhancement]  Don't allow playing town archery with FD becuase Swamp prevents FD archery by default.
+        // Get Goron's "quite the build" text
+        case PLAYER_FORM_FIERCE_DEITY:
         case PLAYER_FORM_GORON:
             if (CURRENT_DAY != 3) {
                 if (!(this->talkFlags & TALK_FLAG_TOWN_HAS_SPOKEN_WITH_GORON)) {


### PR DESCRIPTION
This PR adds logic to:

1. The Town Shooting Gallery to prevent softlocking with Fierce Deity. I made the decision to prevent FD from playing the minigame because the Swamp Shooting Gallery already prevents him from playing. However, the minigame is playable with FD if the human logic is applied to FD. The higher player height makes the minigame easier and the bow model is messed up.
2. The gate guards to prevent them from stopping Fierce Deity from leaving town.

Related to Issue #647 

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1650741728.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1650743632.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1650752172.zip)
<!--- section:artifacts:end -->