### PR TITLE
[Enhancement] Get Both Letter to Mama rewards in one cycle

### DIFF
--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -465,6 +465,10 @@ void DrawEnhancementsMenu() {
                 { .tooltip = "Playing the Song Of Time will not reset the Sword back to Kokiri Sword." });
             UIWidgets::CVarCheckbox("Do not reset Rupees", "gEnhancements.Cycle.DoNotResetRupees",
                                     { .tooltip = "Playing the Song Of Time will not reset the your rupees." });
+            UIWidgets::CVarCheckbox(
+                "Both Letter to Mama Rewards", "gEnhancements.Cycle.BothLetterToMamaRewards",
+                { .tooltip =
+                      "Giving the Letter to Mama to either Madame Aroma or the Postman will yield both rewards." });
 
             ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(255, 255, 0, 255));
             ImGui::SeparatorText("Unstable");

--- a/mm/2s2h/Enhancements/Cycle/BothLetterToMamaRewards.cpp
+++ b/mm/2s2h/Enhancements/Cycle/BothLetterToMamaRewards.cpp
@@ -1,0 +1,47 @@
+#include <libultraship/bridge.h>
+#include "Enhancements/GameInteractor/GameInteractor.h"
+
+extern "C" {
+#include "functions.h"
+#include "z64message.h"
+#include "variables.h"
+extern PlayState* gPlayState;
+}
+
+void RegisterBothLetterToMamaRewards() {
+
+    GameInteractor::Instance->RegisterGameHookForID<GameInteractor::OnActorUpdate>(ACTOR_EN_AL, [](Actor* actor) {
+        if (CVarGetInteger("gEnhancements.Cycle.BothLetterToMamaRewards", 0)) {
+            /*
+             * Player has given letter to Madame Aroma this cycle but does not have the Postman's Hat. This mirrors
+             * how the Postman himself directly checks the inventory for the Postman's Hat, although there does
+             * exist the Bomber's Notebook flag marking the Postman's quest as complete
+             * (WEEKEVENTREG_BOMBERS_NOTEBOOK_EVENT_RECEIVED_POSTMANS_HAT). Also wait until msgMode is free,
+             * otherwise this can softlock when executed during the dialog that sets Madame Aroma's flags.
+             */
+            if ((CHECK_WEEKEVENTREG(WEEKEVENTREG_57_04) && INV_CONTENT(ITEM_MASK_POSTMAN) != ITEM_MASK_POSTMAN) &&
+                gPlayState->msgCtx.msgMode == MSGMODE_NONE) {
+                Actor_OfferGetItemFar(actor, gPlayState, GI_MASK_POSTMAN);
+                Message_BombersNotebookQueueEvent(gPlayState, BOMBERS_NOTEBOOK_EVENT_RECEIVED_POSTMANS_HAT);
+                Message_BombersNotebookQueueEvent(gPlayState, BOMBERS_NOTEBOOK_EVENT_MET_POSTMAN);
+            }
+        }
+    });
+
+    GameInteractor::Instance->RegisterGameHookForID<GameInteractor::OnActorUpdate>(ACTOR_EN_PM, [](Actor* actor) {
+        if (CVarGetInteger("gEnhancements.Cycle.BothLetterToMamaRewards", 0)) {
+            /*
+             * Postman is fleeing, but the player has not obtained Madame Aroma's reward. Also wait until msgMode
+             * is free, otherwise this can softlock when executed during the dialog that sets the Postman's flags.
+             */
+            if (CHECK_WEEKEVENTREG(WEEKEVENTREG_90_01) && !CHECK_WEEKEVENTREG(WEEKEVENTREG_57_08) &&
+                gPlayState->msgCtx.msgMode == MSGMODE_NONE) {
+                SET_WEEKEVENTREG(WEEKEVENTREG_57_04); // Cycle flag that marks Madame Aroma's reward as obtained
+                SET_WEEKEVENTREG(WEEKEVENTREG_57_08); // Persistent flag that marks Madame Aroma's reward as obtained
+                Actor_OfferGetItemFar(actor, gPlayState, GI_CHATEAU_BOTTLE);
+                Message_BombersNotebookQueueEvent(gPlayState, BOMBERS_NOTEBOOK_EVENT_DELIVERED_PRIORITY_MAIL);
+                Message_BombersNotebookQueueEvent(gPlayState, BOMBERS_NOTEBOOK_EVENT_MET_MADAME_AROMA);
+            }
+        }
+    });
+}

--- a/mm/2s2h/Enhancements/Cycle/BothLetterToMamaRewards.h
+++ b/mm/2s2h/Enhancements/Cycle/BothLetterToMamaRewards.h
@@ -1,0 +1,6 @@
+#ifndef BOTH_LETTER_TO_MAMA_REWARDS_H
+#define BOTH_LETTER_TO_MAMA_REWARDS_H
+
+void RegisterBothLetterToMamaRewards();
+
+#endif // BOTH_LETTER_TO_MAMA_REWARDS_H

--- a/mm/2s2h/Enhancements/Enhancements.cpp
+++ b/mm/2s2h/Enhancements/Enhancements.cpp
@@ -20,6 +20,7 @@ void InitEnhancements() {
     RegisterEndOfCycleSaveHooks();
     RegisterSavingEnhancements();
     RegisterAutosave();
+    RegisterBothLetterToMamaRewards();
 
     // Dialogue
     RegisterFastBankSelection();

--- a/mm/2s2h/Enhancements/Enhancements.h
+++ b/mm/2s2h/Enhancements/Enhancements.h
@@ -12,6 +12,7 @@
 #include "Cheats/UnbreakableRazorSword.h"
 #include "Cheats/UnrestrictedItems.h"
 #include "Cycle/EndOfCycle.h"
+#include "Cycle/BothLetterToMamaRewards.h"
 #include "Equipment/SkipMagicArrowEquip.h"
 #include "Masks/BlastMaskKeg.h"
 #include "Masks/FierceDeityAnywhere.h"


### PR DESCRIPTION
This removes the need to go through the Anju and Kafei sidequest twice to get both of the mutually exclusive rewards from delivering the Letter to Mama. Now the player can either get the Postman's Hat when hand delivering the letter to Madame Aroma or get the Chateau Romani from the Postman after he delivers the letter.

https://github.com/HarbourMasters/2ship2harkinian/assets/7004497/4163b202-450a-4255-ba93-35d57f6a5ac7

https://github.com/HarbourMasters/2ship2harkinian/assets/7004497/93015751-3211-4381-8e08-314373277898



I filed this under Time Cycle, since it doesn't strictly allow the player to circumvent any requirements needed to get either item, with one edge case exception. Getting the Chateau Romani requires Romani's Mask only if it's after 10 P.M., while the Postman can be interacted with at any time on the night of the final day. Madame Aroma is, however, normally reachable without the mask if done so before 10 P.M.

This will require another look when randomizer considerations are on the table. I made each actor mirror the other's conditions when deciding whether to give their rewards. This made me realize that the Postman himself doesn't check any persistent flags when deciding on whether to give his hat to the player; he checks the player's inventory directly for the hat. A persistent flag does exist in the Bomber's Notebook (`WEEKEVENTREG_BOMBERS_NOTEBOOK_EVENT_RECEIVED_POSTMANS_HAT`), but the Postman does not check that when deciding on whether to give the Postman's Hat.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1660570197.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1660572013.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1660580999.zip)
<!--- section:artifacts:end -->