### PR TITLE
Eliminate Graphics Menu Lag

### DIFF
--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -64,11 +64,9 @@ void UpdateWindowBackendObjects() {
     Ship::WindowBackend runningWindowBackend = Ship::Context::GetInstance()->GetWindow()->GetWindowBackend();
     Ship::WindowBackend configWindowBackend;
     int32_t configWindowBackendId = Ship::Context::GetInstance()->GetConfig()->GetInt("Window.Backend.Id", -1);
-    if (configWindowBackendId != -1 &&
-        configWindowBackendId < static_cast<int>(Ship::WindowBackend::BACKEND_COUNT)) {
+    if (configWindowBackendId != -1 && configWindowBackendId < static_cast<int>(Ship::WindowBackend::BACKEND_COUNT)) {
         configWindowBackend = static_cast<Ship::WindowBackend>(configWindowBackendId);
-    }
-    else {
+    } else {
         configWindowBackend = runningWindowBackend;
     }
 

--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -56,6 +56,27 @@ static const std::unordered_map<int32_t, const char*> alwaysWinDoggyraceOptions 
 };
 
 namespace BenGui {
+std::shared_ptr<std::vector<Ship::WindowBackend>> availableWindowBackends;
+std::unordered_map<Ship::WindowBackend, const char*> availableWindowBackendsMap;
+Ship::WindowBackend configWindowBackend;
+
+void UpdateWindowBackendObjects() {
+    Ship::WindowBackend runningWindowBackend = Ship::Context::GetInstance()->GetWindow()->GetWindowBackend();
+    Ship::WindowBackend configWindowBackend;
+    int32_t configWindowBackendId = Ship::Context::GetInstance()->GetConfig()->GetInt("Window.Backend.Id", -1);
+    if (configWindowBackendId != -1 &&
+        configWindowBackendId < static_cast<int>(Ship::WindowBackend::BACKEND_COUNT)) {
+        configWindowBackend = static_cast<Ship::WindowBackend>(configWindowBackendId);
+    }
+    else {
+        configWindowBackend = runningWindowBackend;
+    }
+
+    availableWindowBackends = Ship::Context::GetInstance()->GetWindow()->GetAvailableWindowBackends();
+    for (auto& backend : *availableWindowBackends) {
+        availableWindowBackendsMap[backend] = windowBackendsMap[backend];
+    }
+}
 
 void DrawMenuBarIcon() {
     static bool gameIconLoaded = false;
@@ -244,32 +265,17 @@ void DrawSettingsMenu() {
             // UIWidgets::PaddedSeparator(true, true, 3.0f, 3.0f);
             //  #endregion */
 
-            Ship::WindowBackend runningWindowBackend = Ship::Context::GetInstance()->GetWindow()->GetWindowBackend();
-            Ship::WindowBackend configWindowBackend;
-            int32_t configWindowBackendId = Ship::Context::GetInstance()->GetConfig()->GetInt("Window.Backend.Id", -1);
-            if (configWindowBackendId != -1 &&
-                configWindowBackendId < static_cast<int>(Ship::WindowBackend::BACKEND_COUNT)) {
-                configWindowBackend = static_cast<Ship::WindowBackend>(configWindowBackendId);
-            } else {
-                configWindowBackend = runningWindowBackend;
-            }
-
-            auto availableWindowBackends = Ship::Context::GetInstance()->GetWindow()->GetAvailableWindowBackends();
-            std::unordered_map<Ship::WindowBackend, const char*> availableWindowBackendsMap;
-            for (auto& backend : *availableWindowBackends) {
-                availableWindowBackendsMap[backend] = windowBackendsMap[backend];
-            }
-
             if (UIWidgets::Combobox(
                     "Renderer API (Needs reload)", &configWindowBackend, availableWindowBackendsMap,
                     { .tooltip = "Sets the renderer API used by the game. Requires a relaunch to take effect.",
-                      .disabled = Ship::Context::GetInstance()->GetWindow()->GetAvailableWindowBackends()->size() <= 1,
+                      .disabled = availableWindowBackends->size() <= 1,
                       .disabledTooltip = "Only one renderer API is available on this platform." })) {
                 Ship::Context::GetInstance()->GetConfig()->SetInt("Window.Backend.Id",
                                                                   static_cast<int32_t>(configWindowBackend));
                 Ship::Context::GetInstance()->GetConfig()->SetString("Window.Backend.Name",
                                                                      windowBackendsMap.at(configWindowBackend));
                 Ship::Context::GetInstance()->GetConfig()->Save();
+                UpdateWindowBackendObjects();
             }
 
             if (Ship::Context::GetInstance()->GetWindow()->CanDisableVerticalSync()) {
@@ -736,6 +742,10 @@ void DrawDeveloperToolsMenu() {
         }
         ImGui::EndMenu();
     }
+}
+
+void BenMenuBar::InitElement() {
+    UpdateWindowBackendObjects();
 }
 
 void BenMenuBar::DrawElement() {

--- a/mm/2s2h/BenGui/BenMenuBar.h
+++ b/mm/2s2h/BenGui/BenMenuBar.h
@@ -15,7 +15,7 @@ class BenMenuBar : public Ship::GuiMenuBar {
 
   protected:
     void DrawElement() override;
-    void InitElement() override{};
+    void InitElement() override;
     void UpdateElement() override{};
 };
 } // namespace BenGui


### PR DESCRIPTION
Primarily caused by CVarGetInt for config backend, none of the surrounding data needed to be populated every frame, so I moved all of it to a function that gets called on Init and when the backend combobox is changed which completely eliminated the lag, even on super high FPS.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1661295919.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1661312091.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1661318756.zip)
<!--- section:artifacts:end -->