### PR TITLE
Fix rumble lasting too long

### DIFF
--- a/mm/src/code/z_rumble.c
+++ b/mm/src/code/z_rumble.c
@@ -12,9 +12,18 @@
 
 RumbleManager gRumbleMgr;
 
+#define RUMBLE_FRAMES_PER_UPDATE (R_UPDATE_RATE > 0 ? R_UPDATE_RATE : 1)
+
 void Rumble_Update(void* arg0) {
-    RumbleManager_Update(&gRumbleMgr);
-    PadMgr_RumbleSet(gRumbleMgr.rumbleEnabled);
+    // BENTODO: Workaround for rumble being too long.
+    // On hardware, PadMgr_ThreadEntry would run once per VI (60hertz),
+    // however we do not have OS Threads implemented, and instead opted to execute the PadMgr alongside
+    // the Graph thread. This means it will run less often when the game is in 20fps or 30fps mode.
+    // Here we call the rumble manager extra times to simulate updates happening at 60hertz.
+    for (int i = 0; i < RUMBLE_FRAMES_PER_UPDATE; i++) {
+        RumbleManager_Update(&gRumbleMgr);
+        PadMgr_RumbleSet(gRumbleMgr.rumbleEnabled);
+    }
 }
 
 // Used by some bosses (and fishing)


### PR DESCRIPTION
This fix for rumble duration is modeled after the one in SoH https://github.com/HarbourMasters/Shipwright/pull/2419 with a slight improvement to account for when the game is in 30fps or 60fps update rates.

Notably, this has the draw back of quick/weak rumble requests getting skipped by being less than 3 VI (charged sword attack rumble).

As mentioned on the SoH side, a proper solution for OS Threads would be more ideal, but this at least gets 2Ship experience in line with SoH.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1676311109.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1676313331.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1676313388.zip)
<!--- section:artifacts:end -->