### PR TITLE
Fix crash with graphics menu index out of bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you're having any trouble after reading through this `README`, feel free ask 
 ### 1. Verify your ROM dump
 You can verify you have dumped a supported copy of the game by using the compatibility checker at https://2ship.equipment/. If you'd prefer to manually validate your ROM dump, you can cross-reference its `sha1` hash with the hashes [here](docs/supportedHashes.json).
 
-### 2. Download The Ship of Harkinian from [Releases](https://github.com/HarbourMasters/2Ship2Harkinian/releases)
+### 2. Download 2 Ship 2 Harkinian from [Releases](https://github.com/HarbourMasters/2Ship2Harkinian/releases)
 
 ### 3. Launch the Game!
 #### Windows
@@ -25,7 +25,7 @@ You can verify you have dumped a supported copy of the game by using the compati
 
 #### Linux
 * Place your supported copy of the game in the same folder as the appimage.
-* Execute `2ship.appimage`.  You may have to `chmod +x` the appimage via terminal.
+* Execute `2ship.appimage`. You may have to `chmod +x` the appimage via terminal.
 
 #### macOS
 * Run `2ship.app`.

--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -62,7 +62,6 @@ Ship::WindowBackend configWindowBackend;
 
 void UpdateWindowBackendObjects() {
     Ship::WindowBackend runningWindowBackend = Ship::Context::GetInstance()->GetWindow()->GetWindowBackend();
-    Ship::WindowBackend configWindowBackend;
     int32_t configWindowBackendId = Ship::Context::GetInstance()->GetConfig()->GetInt("Window.Backend.Id", -1);
     if (configWindowBackendId != -1 && configWindowBackendId < static_cast<int>(Ship::WindowBackend::BACKEND_COUNT)) {
         configWindowBackend = static_cast<Ship::WindowBackend>(configWindowBackendId);


### PR DESCRIPTION
Fix crash introduced by #733
There was a local scope variable with the same name as the class member variable which meant that the variable used in the graphics menu combobox was default 0 (which is DX11). This value would appear to work fine for Windows, but it would crash on Mac and Linux as the DX11 backend doesn't exist there.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1680399285.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1680402689.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1680405539.zip)
<!--- section:artifacts:end -->