### PR TITLE
Fixes for cycle reset, fairy bottle, auto save, and save editor equips

### DIFF
--- a/mm/2s2h/DeveloperTools/SaveEditor.cpp
+++ b/mm/2s2h/DeveloperTools/SaveEditor.cpp
@@ -573,38 +573,38 @@ void DrawEquipItemMenu(InventorySlot slot) {
 
     if (ImGui::BeginMenu("Equip")) {
         if (ImGui::MenuItem("C-Left")) {
-            gSaveContext.save.saveInfo.equips.buttonItems[CUR_FORM][EQUIP_SLOT_C_LEFT] = currentItemId;
-            gSaveContext.save.saveInfo.equips.cButtonSlots[CUR_FORM][EQUIP_SLOT_C_LEFT] = slot;
+            SET_CUR_FORM_BTN_ITEM(EQUIP_SLOT_C_LEFT, currentItemId);
+            SET_CUR_FORM_BTN_SLOT(EQUIP_SLOT_C_LEFT, slot);
             Interface_LoadItemIconImpl(gPlayState, EQUIP_SLOT_C_LEFT);
         }
         if (ImGui::MenuItem("C-Down")) {
-            gSaveContext.save.saveInfo.equips.buttonItems[CUR_FORM][EQUIP_SLOT_C_DOWN] = currentItemId;
-            gSaveContext.save.saveInfo.equips.cButtonSlots[CUR_FORM][EQUIP_SLOT_C_DOWN] = slot;
+            SET_CUR_FORM_BTN_ITEM(EQUIP_SLOT_C_DOWN, currentItemId);
+            SET_CUR_FORM_BTN_SLOT(EQUIP_SLOT_C_DOWN, slot);
             Interface_LoadItemIconImpl(gPlayState, EQUIP_SLOT_C_DOWN);
         }
         if (ImGui::MenuItem("C-Right")) {
-            gSaveContext.save.saveInfo.equips.buttonItems[CUR_FORM][EQUIP_SLOT_C_RIGHT] = currentItemId;
-            gSaveContext.save.saveInfo.equips.cButtonSlots[CUR_FORM][EQUIP_SLOT_C_RIGHT] = slot;
+            SET_CUR_FORM_BTN_ITEM(EQUIP_SLOT_C_RIGHT, currentItemId);
+            SET_CUR_FORM_BTN_SLOT(EQUIP_SLOT_C_RIGHT, slot);
             Interface_LoadItemIconImpl(gPlayState, EQUIP_SLOT_C_RIGHT);
         }
         if (ImGui::MenuItem("D-Right")) {
-            gSaveContext.save.shipSaveInfo.dpadEquips.dpadItems[CUR_FORM][EQUIP_SLOT_D_RIGHT] = currentItemId;
-            gSaveContext.save.shipSaveInfo.dpadEquips.dpadSlots[CUR_FORM][EQUIP_SLOT_D_RIGHT] = slot;
+            DPAD_SET_CUR_FORM_BTN_ITEM(EQUIP_SLOT_D_RIGHT, currentItemId);
+            DPAD_SET_CUR_FORM_BTN_SLOT(EQUIP_SLOT_D_RIGHT, slot);
             Interface_Dpad_LoadItemIconImpl(gPlayState, EQUIP_SLOT_D_RIGHT);
         }
         if (ImGui::MenuItem("D-Left")) {
-            gSaveContext.save.shipSaveInfo.dpadEquips.dpadItems[CUR_FORM][EQUIP_SLOT_D_LEFT] = currentItemId;
-            gSaveContext.save.shipSaveInfo.dpadEquips.dpadSlots[CUR_FORM][EQUIP_SLOT_D_LEFT] = slot;
+            DPAD_SET_CUR_FORM_BTN_ITEM(EQUIP_SLOT_D_LEFT, currentItemId);
+            DPAD_SET_CUR_FORM_BTN_SLOT(EQUIP_SLOT_D_LEFT, slot);
             Interface_Dpad_LoadItemIconImpl(gPlayState, EQUIP_SLOT_D_LEFT);
         }
         if (ImGui::MenuItem("D-Down")) {
-            gSaveContext.save.shipSaveInfo.dpadEquips.dpadItems[CUR_FORM][EQUIP_SLOT_D_DOWN] = currentItemId;
-            gSaveContext.save.shipSaveInfo.dpadEquips.dpadSlots[CUR_FORM][EQUIP_SLOT_D_DOWN] = slot;
+            DPAD_SET_CUR_FORM_BTN_ITEM(EQUIP_SLOT_D_DOWN, currentItemId);
+            DPAD_SET_CUR_FORM_BTN_SLOT(EQUIP_SLOT_D_DOWN, slot);
             Interface_Dpad_LoadItemIconImpl(gPlayState, EQUIP_SLOT_D_DOWN);
         }
         if (ImGui::MenuItem("D-Up")) {
-            gSaveContext.save.shipSaveInfo.dpadEquips.dpadItems[CUR_FORM][EQUIP_SLOT_D_UP] = currentItemId;
-            gSaveContext.save.shipSaveInfo.dpadEquips.dpadSlots[CUR_FORM][EQUIP_SLOT_D_UP] = slot;
+            DPAD_SET_CUR_FORM_BTN_ITEM(EQUIP_SLOT_D_UP, currentItemId);
+            DPAD_SET_CUR_FORM_BTN_SLOT(EQUIP_SLOT_D_UP, slot);
             Interface_Dpad_LoadItemIconImpl(gPlayState, EQUIP_SLOT_D_UP);
         }
         ImGui::EndMenu();
@@ -677,9 +677,13 @@ void DrawSlot(InventorySlot slot) {
     ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.0f, 1.0f, 1.0f, 0.0f));
     ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(1.0f, 1.0f, 1.0f, 0.2f));
     ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(1.0f, 1.0f, 1.0f, 0.1f));
-    if (gSaveContext.save.saveInfo.equips.cButtonSlots[CUR_FORM][EQUIP_SLOT_C_LEFT] == slot ||
-        gSaveContext.save.saveInfo.equips.cButtonSlots[CUR_FORM][EQUIP_SLOT_C_DOWN] == slot ||
-        gSaveContext.save.saveInfo.equips.cButtonSlots[CUR_FORM][EQUIP_SLOT_C_RIGHT] == slot) {
+    if (GET_CUR_FORM_BTN_SLOT(EQUIP_SLOT_C_LEFT) == slot || GET_CUR_FORM_BTN_SLOT(EQUIP_SLOT_C_DOWN) == slot ||
+        GET_CUR_FORM_BTN_SLOT(EQUIP_SLOT_C_RIGHT) == slot ||
+        (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0) &&
+         (DPAD_GET_CUR_FORM_BTN_SLOT(EQUIP_SLOT_D_RIGHT) == slot ||
+          DPAD_GET_CUR_FORM_BTN_SLOT(EQUIP_SLOT_D_LEFT) == slot ||
+          DPAD_GET_CUR_FORM_BTN_SLOT(EQUIP_SLOT_D_DOWN) == slot ||
+          DPAD_GET_CUR_FORM_BTN_SLOT(EQUIP_SLOT_D_UP) == slot))) {
         ImGui::PushStyleColor(ImGuiCol_Border, UIWidgets::Colors::White);
     } else {
         ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(1.0f, 1.0f, 1.0f, 0.0f));

--- a/mm/2s2h/Enhancements/Masks/FastTransformation.cpp
+++ b/mm/2s2h/Enhancements/Masks/FastTransformation.cpp
@@ -40,6 +40,11 @@ void RegisterFastTransformation() {
             TransitionFade_SetColor(&gPlayState->unk_18E48, 0x000000);
             R_TRANS_FADE_FLASH_ALPHA_STEP = -1;
             Player_PlaySfx(GET_PLAYER(gPlayState), NA_SE_SY_TRANSFORM_MASK_FLASH);
+
+            // Clear previous mask to prevent crashing with masks being drawn while we switch transformations
+            if (player->transformation == PLAYER_FORM_HUMAN) {
+                player->prevMask = PLAYER_MASK_NONE;
+            }
         }
     });
 }

--- a/mm/2s2h/Enhancements/Saving/SavingEnhancements.cpp
+++ b/mm/2s2h/Enhancements/Saving/SavingEnhancements.cpp
@@ -74,6 +74,13 @@ extern "C" bool SavingEnhancements_CanSave() {
         return false;
     }
 
+    // Not in minigames that set temporary flags
+    if (CHECK_WEEKEVENTREG(WEEKEVENTREG_08_01) || CHECK_WEEKEVENTREG(WEEKEVENTREG_82_08) ||
+        CHECK_WEEKEVENTREG(WEEKEVENTREG_90_20) || CHECK_WEEKEVENTREG(WEEKEVENTREG_KICKOUT_WAIT) ||
+        CHECK_EVENTINF(EVENTINF_34) || CHECK_EVENTINF(EVENTINF_41)) {
+        return false;
+    }
+
     return true;
 }
 

--- a/mm/src/code/z_parameter.c
+++ b/mm/src/code/z_parameter.c
@@ -4325,7 +4325,7 @@ s32 Inventory_ConsumeFairy(PlayState* play) {
             }
             // #region 2S2H [Dpad]
             if (CVarGetInteger("gEnhancements.Dpad.DpadEquips", 0)) {
-                for (u8 dpadBtn = EQUIP_SLOT_C_LEFT; dpadBtn <= EQUIP_SLOT_C_RIGHT; dpadBtn++) {
+                for (u8 dpadBtn = EQUIP_SLOT_D_RIGHT; dpadBtn <= EQUIP_SLOT_D_UP; dpadBtn++) {
                     if (DPAD_GET_CUR_FORM_BTN_ITEM(dpadBtn) == ITEM_FAIRY) {
                         DPAD_SET_CUR_FORM_BTN_ITEM(dpadBtn, ITEM_BOTTLE);
                         Interface_Dpad_LoadItemIconImpl(play, dpadBtn);

--- a/mm/src/overlays/gamestates/ovl_select/z_select.c
+++ b/mm/src/overlays/gamestates/ovl_select/z_select.c
@@ -37,9 +37,16 @@ void MapSelect_LoadGame(MapSelectState* this, u32 entrance, s32 spawn) {
         // #endregion
     }
 
-    // #region 2S2H [Debug] Clear some potential lingering flags
+    // #region 2S2H [Debug] Clear some potential lingering flags and values
+    CLEAR_WEEKEVENTREG(WEEKEVENTREG_08_01);
+    CLEAR_WEEKEVENTREG(WEEKEVENTREG_KICKOUT_WAIT);
+    CLEAR_WEEKEVENTREG(WEEKEVENTREG_82_08);
+    CLEAR_WEEKEVENTREG(WEEKEVENTREG_90_20);
     CLEAR_EVENTINF(EVENTINF_17);
+    CLEAR_EVENTINF(EVENTINF_34);
+    CLEAR_EVENTINF(EVENTINF_41);
     CLEAR_EVENTINF(EVENTINF_TRIGGER_DAYTELOP);
+    gSaveContext.save.equippedMask = PLAYER_MASK_NONE;
     // #endregion
 
     gSaveContext.buttonStatus[EQUIP_SLOT_B] = BTN_ENABLED;


### PR DESCRIPTION
Various fixes:
* "Do not reset Razor Sword" was assigning razor sword to the current form B button instead of the human form, causing razor sword to go onto zora/goron/deku and messing up their B button actions
  * Fixed to now only set the human form, and also to check if the Razor sword is a stolen item or being forged at the smithy
* "Do not reset Bottle Contents" wasn't considered for DPad equipped bottles
* Fairy revive was skipping clearing out DPad right bottles due to incorrect enums in for-loop
* Save editor was displaying/setting item equips to the current form, when actually C equips/DPad equips are only used with the human form
  * Fixed by using macros that set the right values
* Prevent auto save during some minigames that set temporary flags
* Clear more flags on debug warp
* Fix crash when equipping great fairy mask and transformation mask too quickly with the fast transform enhancement

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1687049427.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1687057201.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1687069027.zip)
<!--- section:artifacts:end -->