### PR TITLE
Allow non-ascii characters in filepath on Windows

### DIFF
--- a/mm/src/code/main.c
+++ b/mm/src/code/main.c
@@ -1,6 +1,7 @@
 #ifdef _WIN32
 #include <Windows.h>
 #include <stdio.h>
+#include <locale.h>
 #endif
 
 #include "audiomgr.h"
@@ -66,6 +67,8 @@ void SDL_main(int argc, char** argv /* void* arg*/) {
 #ifndef _DEBUG
     ShowWindow(GetConsoleWindow(), SW_HIDE);
 #endif
+    // Allow non-ascii characters for Windows
+    setlocale(LC_ALL, ".UTF8");
 #endif // _WIN32
 
     InitOTR();


### PR DESCRIPTION
This PR fixes Issue #525 and allows 2ship to properly launch when there are non-ascii characters (such as þ) in the file path. I'm not sure if this was a Windows-only problem, but Windows is the only thing I can test. 

I'm not sure if I put the changes in the best spot (src > code > main.c), so I'm open to moving those lines somewhere else if it's more appropriate. 

Before:
![before](https://github.com/HarbourMasters/2ship2harkinian/assets/55861555/2289efd9-a693-4643-b780-11e73e43fa57)

After:
![after](https://github.com/HarbourMasters/2ship2harkinian/assets/55861555/cca6c3c3-bd17-4e42-aa91-1c90f5bc6897)


<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1684814238.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1684819633.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1684822884.zip)
<!--- section:artifacts:end -->