### PR TITLE
Fix some actor shadow textures not updating

### DIFF
--- a/mm/src/code/z_sub_s.c
+++ b/mm/src/code/z_sub_s.c
@@ -1009,6 +1009,8 @@ void SubS_DrawShadowTex(Actor* actor, GameState* gameState, u8* tex) {
 
     OPEN_DISPS(gfxCtx);
 
+    gSPInvalidateTexCache(POLY_OPA_DISP++, tex);
+
     Gfx_SetupDL25_Opa(gfxCtx);
     gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 0, 0, 0, 100);
     gDPSetEnvColor(POLY_OPA_DISP++, 0, 0, 0, 0);

--- a/mm/src/overlays/actors/ovl_Boss_01/z_boss_01.c
+++ b/mm/src/overlays/actors/ovl_Boss_01/z_boss_01.c
@@ -3106,6 +3106,8 @@ void Boss01_DrawShadowTex(u8* tex, Boss01* this, PlayState* play) {
 
     OPEN_DISPS(gfxCtx);
 
+    gSPInvalidateTexCache(POLY_OPA_DISP++, tex);
+
     Gfx_SetupDL25_Opa(play->state.gfxCtx);
 
     alpha = (400.0f - this->actor.world.pos.y) * (1.0f / 400.0f);

--- a/mm/src/overlays/actors/ovl_Boss_07/z_boss_07.c
+++ b/mm/src/overlays/actors/ovl_Boss_07/z_boss_07.c
@@ -2935,6 +2935,8 @@ void Boss07_Wrath_DrawShadowTex(u8* shadowTex, Boss07* this, PlayState* play) {
 
     OPEN_DISPS(gfxCtx);
 
+    gSPInvalidateTexCache(POLY_OPA_DISP++, shadowTex);
+
     Gfx_SetupDL25_Opa(play->state.gfxCtx);
     phi_f0 = (400.0f - this->actor.world.pos.y) * 0.0025f;
     phi_f0 = CLAMP_MIN(phi_f0, 0.0f);

--- a/mm/src/overlays/actors/ovl_Boss_Hakugin/z_boss_hakugin.c
+++ b/mm/src/overlays/actors/ovl_Boss_Hakugin/z_boss_hakugin.c
@@ -3066,6 +3066,8 @@ void BossHakugin_DrawShadowTex(u8* tex, BossHakugin* this, PlayState* play) {
 
     OPEN_DISPS(gfxCtx);
 
+    gSPInvalidateTexCache(POLY_OPA_DISP++, tex);
+
     Gfx_SetupDL25_Opa(play->state.gfxCtx);
 
     alpha = (400.0f - this->actor.world.pos.y) * (1.0f / 400.0f);

--- a/mm/src/overlays/actors/ovl_En_Kanban/z_en_kanban.c
+++ b/mm/src/overlays/actors/ovl_En_Kanban/z_en_kanban.c
@@ -1043,6 +1043,7 @@ void EnKanban_Draw(Actor* thisx, PlayState* play) {
             }
         }
 
+        gSPInvalidateTexCache(POLY_XLU_DISP++, shadowTex);
         gSPSegment(POLY_XLU_DISP++, 0x08, Lib_SegmentedToVirtual(shadowTex));
         gSPDisplayList(POLY_XLU_DISP++, gEnKanban_D_80957DE0);
     }

--- a/mm/src/overlays/actors/ovl_En_Sda/z_en_sda.c
+++ b/mm/src/overlays/actors/ovl_En_Sda/z_en_sda.c
@@ -324,6 +324,8 @@ void func_80947668(u8* shadowTexture, Player* player, PlayState* play) {
 
     OPEN_DISPS(gfxCtx);
 
+    gSPInvalidateTexCache(POLY_XLU_DISP++, shadowTexture);
+
     Gfx_SetupDL44_Xlu(play->state.gfxCtx);
 
     gDPSetPrimColor(POLY_XLU_DISP++, 0x00, 0x00, 0, 0, 0, (BREG(52) + 50));


### PR DESCRIPTION
Shadow textures like from bosses, signs, and dragonfly's were not updating properly. Sometimes they would flicker from one state to another based on camera angle. This is because although `GRAPH_ALLOC` returns a fresh memory structure every frame for the shadow textures, the likely hood that they would end up with the same or previously used pointer address was higher. Our Fast3D renderer texture cache would see the pointer and use the last cached value.

This adds texture invalidation for these special shadow textures, allowing them to update correctly.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1834401978.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1834408137.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1834415692.zip)
<!--- section:artifacts:end -->