### PR TITLE
Add restoration for woodfall mountain cleared state

### DIFF
--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -652,6 +652,14 @@ void DrawEnhancementsMenu() {
             UIWidgets::CVarCheckbox("Tatl ISG", "gEnhancements.Restorations.TatlISG",
                                     { .tooltip = "Restores Navi ISG from OOT, but now with Tatl." });
 
+            if (UIWidgets::CVarCheckbox(
+                    "Woodfall Mountain Appearance", "gEnhancements.Restorations.WoodfallMountainAppearance",
+                    { .tooltip = "Restores the appearance of Woodfall mountain to not look poisoned "
+                                 "when viewed from Termina Field after clearing Woodfall Temple\n\n"
+                                 "Requires a scene reload to take effect" })) {
+                RegisterWoodfallMountainAppearance();
+            }
+
             ImGui::EndMenu();
         }
 

--- a/mm/2s2h/Enhancements/Enhancements.cpp
+++ b/mm/2s2h/Enhancements/Enhancements.cpp
@@ -59,6 +59,7 @@ void InitEnhancements() {
     RegisterSideRoll();
     RegisterTatlISG();
     RegisterVariableFlipHop();
+    RegisterWoodfallMountainAppearance();
 
     // Cutscenes
     RegisterCutscenes();

--- a/mm/2s2h/Enhancements/Enhancements.h
+++ b/mm/2s2h/Enhancements/Enhancements.h
@@ -24,6 +24,7 @@
 #include "Cutscenes/Cutscenes.h"
 #include "Restorations/FlipHopVariable.h"
 #include "Restorations/PowerCrouchStab.h"
+#include "Restorations/Restorations.h"
 #include "Restorations/SideRoll.h"
 #include "Restorations/TatlISG.h"
 #include "Graphics/3DItemDrops.h"

--- a/mm/2s2h/Enhancements/Restorations/Restorations.h
+++ b/mm/2s2h/Enhancements/Restorations/Restorations.h
@@ -1,0 +1,6 @@
+#ifndef ENHANCEMENTS_RESTORATIONS_H
+#define ENHANCEMENTS_RESTORATIONS_H
+
+void RegisterWoodfallMountainAppearance();
+
+#endif // ENHANCEMENTS_RESTORATIONS_H

--- a/mm/2s2h/Enhancements/Restorations/WoodfallMountainAppearance.cpp
+++ b/mm/2s2h/Enhancements/Restorations/WoodfallMountainAppearance.cpp
@@ -7,6 +7,11 @@ extern "C" {
 #include "overlays/actors/ovl_Bg_Breakwall/z_bg_breakwall.h"
 }
 
+typedef enum {
+    /*  2 */ BGBREAKWALL_F_2 = 3, // Poisoned Woodfall Mountain
+    /*  3 */ BGBREAKWALL_F_3 = 3, // Spring Woodfall Mountain
+} BgBreakwallParamEx;
+
 void RegisterWoodfallMountainAppearance() {
     static HOOK_ID breakwallInitID = 0;
     GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::OnActorInit>(breakwallInitID);
@@ -18,8 +23,9 @@ void RegisterWoodfallMountainAppearance() {
 
     breakwallInitID = GameInteractor::Instance->RegisterGameHookForID<GameInteractor::OnActorInit>(
         ACTOR_BG_BREAKWALL, [](Actor* actor) {
-            if (BGBREAKWALL_GET_F(actor) == 2 && CHECK_WEEKEVENTREG(WEEKEVENTREG_CLEARED_WOODFALL_TEMPLE)) {
-                actor->params = (actor->params & 0xFFF0) | 3;
+            if (BGBREAKWALL_GET_F(actor) == BGBREAKWALL_F_2 &&
+                CHECK_WEEKEVENTREG(WEEKEVENTREG_CLEARED_WOODFALL_TEMPLE)) {
+                actor->params = (actor->params & 0xFFF0) | BGBREAKWALL_F_3;
             }
         });
 }

--- a/mm/2s2h/Enhancements/Restorations/WoodfallMountainAppearance.cpp
+++ b/mm/2s2h/Enhancements/Restorations/WoodfallMountainAppearance.cpp
@@ -1,0 +1,25 @@
+
+#include <libultraship/bridge.h>
+#include "2s2h/Enhancements/GameInteractor/GameInteractor.h"
+
+extern "C" {
+#include "z64save.h"
+#include "overlays/actors/ovl_Bg_Breakwall/z_bg_breakwall.h"
+}
+
+void RegisterWoodfallMountainAppearance() {
+    static HOOK_ID breakwallInitID = 0;
+    GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::OnActorInit>(breakwallInitID);
+    breakwallInitID = 0;
+
+    if (!CVarGetInteger("gEnhancements.Restorations.WoodfallMountainAppearance", 0)) {
+        return;
+    }
+
+    breakwallInitID = GameInteractor::Instance->RegisterGameHookForID<GameInteractor::OnActorInit>(
+        ACTOR_BG_BREAKWALL, [](Actor* actor) {
+            if (BGBREAKWALL_GET_F(actor) == 2 && CHECK_WEEKEVENTREG(WEEKEVENTREG_CLEARED_WOODFALL_TEMPLE)) {
+                actor->params = (actor->params & 0xFFF0) | 3;
+            }
+        });
+}


### PR DESCRIPTION
There is an unused model for the Woodfall Mountain without poison when seen from Terminal Field. Nothing in N64 MM shows this model, but in 3DS MM it was fixed to display properly.

This PR adds a restoration toggle so that the Mountain model will react to the current cycle Woodfall clear flag and display properly.

![image](https://github.com/user-attachments/assets/77c0239c-d2c2-402d-bd09-3e0769827910)


<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1903091571.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1903099191.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1903102029.zip)
<!--- section:artifacts:end -->