### PR TITLE
Fix enum value for Woodfall restoration

### DIFF
--- a/mm/2s2h/Enhancements/Restorations/WoodfallMountainAppearance.cpp
+++ b/mm/2s2h/Enhancements/Restorations/WoodfallMountainAppearance.cpp
@@ -8,7 +8,7 @@ extern "C" {
 }
 
 typedef enum {
-    /*  2 */ BGBREAKWALL_F_2 = 3, // Poisoned Woodfall Mountain
+    /*  2 */ BGBREAKWALL_F_2 = 2, // Poisoned Woodfall Mountain
     /*  3 */ BGBREAKWALL_F_3 = 3, // Spring Woodfall Mountain
 } BgBreakwallParamEx;
 


### PR DESCRIPTION
Had a typo after a final change with the Woodfall restoration PR. This fixes the enum so that it actually works.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1926361443.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1926372468.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1926380587.zip)
<!--- section:artifacts:end -->