### PR TITLE
Fix 3ds clock fill texture position

### DIFF
--- a/mm/2s2h/Enhancements/Graphics/3DSClock.cpp
+++ b/mm/2s2h/Enhancements/Graphics/3DSClock.cpp
@@ -112,7 +112,8 @@ void Register3DSClock() {
                     HudEditor_SetActiveElement(HUD_EDITOR_ELEMENT_CLOCK);
                     OVERLAY_DISP =
                         Gfx_DrawTexRectIA8(OVERLAY_DISP, (TexturePtr)gThreeDayClock3DSFillTex, CLOCK_SECTION_WIDTH, 12,
-                                           posX - CLOCK_SECTION_WIDTH, posY, CLOCK_SECTION_WIDTH, 12, 1 << 10, 1 << 10);
+                                           posX - CLOCK_SECTION_HALFWIDTH - CLOCK_SECTION_WIDTH, posY,
+                                           CLOCK_SECTION_WIDTH, 12, 1 << 10, 1 << 10);
 
                     fillalpha = 64;
                     if (gSaveContext.save.day == 2) {


### PR DESCRIPTION
Fixes the positioning of the day 1 fill texture (blue) on the 3DS clock

Before / After
![image](https://github.com/user-attachments/assets/4fff8755-c73c-459c-9997-96cb33a9375f)


<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1950680558.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1950684484.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/1950697972.zip)
<!--- section:artifacts:end -->