### PR TITLE
Extract pause maps and minimaps, support alt assets, fix pause map icons

### DIFF
--- a/mm/2s2h/z_scene_2SH.cpp
+++ b/mm/2s2h/z_scene_2SH.cpp
@@ -258,6 +258,7 @@ void Scene_CommandTransiActorList(PlayState* play, SOH::ISceneCommand* cmd) {
 
     play->transitionActors.count = list->numTransitionActors;
     play->transitionActors.list = (TransitionActorEntry*)list->GetRawPointer();
+    MapDisp_InitTransitionActorData(play, play->transitionActors.count, play->transitionActors.list);
 }
 
 void Scene_CommandEnvLightSettings(PlayState* play, SOH::ISceneCommand* cmd) {

--- a/mm/assets/archives/map_grand_static/map_grand_static.h
+++ b/mm/assets/archives/map_grand_static/map_grand_static.h
@@ -3,297 +3,297 @@
 
 #include "align_asset_macro.h"
 
-#define dmap_grand_static_Blob_000000 "__OTR__map_grand_static/map_grand_static_Blob_000000"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_000000[] = dmap_grand_static_Blob_000000;
+#define dgMapGrandStatic100Tex "__OTR__map_grand_static/gMapGrandStatic100Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic100Tex[] = dgMapGrandStatic100Tex;
 
-#define dmap_grand_static_Blob_000FF0 "__OTR__map_grand_static/map_grand_static_Blob_000FF0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_000FF0[] = dmap_grand_static_Blob_000FF0;
+#define dgMapGrandStatic101Tex "__OTR__map_grand_static/gMapGrandStatic101Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic101Tex[] = dgMapGrandStatic101Tex;
 
-#define dmap_grand_static_Blob_001FE0 "__OTR__map_grand_static/map_grand_static_Blob_001FE0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_001FE0[] = dmap_grand_static_Blob_001FE0;
+#define dgMapGrandStatic102Tex "__OTR__map_grand_static/gMapGrandStatic102Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic102Tex[] = dgMapGrandStatic102Tex;
 
-#define dmap_grand_static_Blob_002FD0 "__OTR__map_grand_static/map_grand_static_Blob_002FD0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_002FD0[] = dmap_grand_static_Blob_002FD0;
+#define dgMapGrandStatic103Tex "__OTR__map_grand_static/gMapGrandStatic103Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic103Tex[] = dgMapGrandStatic103Tex;
 
-#define dmap_grand_static_Blob_003FC0 "__OTR__map_grand_static/map_grand_static_Blob_003FC0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_003FC0[] = dmap_grand_static_Blob_003FC0;
+#define dgMapGrandStatic104Tex "__OTR__map_grand_static/gMapGrandStatic104Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic104Tex[] = dgMapGrandStatic104Tex;
 
-#define dmap_grand_static_Blob_004FB0 "__OTR__map_grand_static/map_grand_static_Blob_004FB0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_004FB0[] = dmap_grand_static_Blob_004FB0;
+#define dgMapGrandStatic105Tex "__OTR__map_grand_static/gMapGrandStatic105Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic105Tex[] = dgMapGrandStatic105Tex;
 
-#define dmap_grand_static_Blob_005AF0 "__OTR__map_grand_static/map_grand_static_Blob_005AF0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_005AF0[] = dmap_grand_static_Blob_005AF0;
+#define dgMapGrandStatic106Tex "__OTR__map_grand_static/gMapGrandStatic106Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic106Tex[] = dgMapGrandStatic106Tex;
 
-#define dmap_grand_static_Blob_006AE0 "__OTR__map_grand_static/map_grand_static_Blob_006AE0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_006AE0[] = dmap_grand_static_Blob_006AE0;
+#define dgMapGrandStatic107Tex "__OTR__map_grand_static/gMapGrandStatic107Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic107Tex[] = dgMapGrandStatic107Tex;
 
-#define dmap_grand_static_Blob_007AD0 "__OTR__map_grand_static/map_grand_static_Blob_007AD0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_007AD0[] = dmap_grand_static_Blob_007AD0;
+#define dgMapGrandStatic108Tex "__OTR__map_grand_static/gMapGrandStatic108Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic108Tex[] = dgMapGrandStatic108Tex;
 
-#define dmap_grand_static_Blob_008AC0 "__OTR__map_grand_static/map_grand_static_Blob_008AC0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_008AC0[] = dmap_grand_static_Blob_008AC0;
+#define dgMapGrandStatic109Tex "__OTR__map_grand_static/gMapGrandStatic109Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic109Tex[] = dgMapGrandStatic109Tex;
 
-#define dmap_grand_static_Blob_009AB0 "__OTR__map_grand_static/map_grand_static_Blob_009AB0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_009AB0[] = dmap_grand_static_Blob_009AB0;
+#define dgMapGrandStatic10ATex "__OTR__map_grand_static/gMapGrandStatic10ATex"
+static const ALIGN_ASSET(2) char gMapGrandStatic10ATex[] = dgMapGrandStatic10ATex;
 
-#define dmap_grand_static_Blob_009ED0 "__OTR__map_grand_static/map_grand_static_Blob_009ED0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_009ED0[] = dmap_grand_static_Blob_009ED0;
+#define dgMapGrandStatic10BTex "__OTR__map_grand_static/gMapGrandStatic10BTex"
+static const ALIGN_ASSET(2) char gMapGrandStatic10BTex[] = dgMapGrandStatic10BTex;
 
-#define dmap_grand_static_Blob_00AEC0 "__OTR__map_grand_static/map_grand_static_Blob_00AEC0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_00AEC0[] = dmap_grand_static_Blob_00AEC0;
+#define dgMapGrandStatic10CTex "__OTR__map_grand_static/gMapGrandStatic10CTex"
+static const ALIGN_ASSET(2) char gMapGrandStatic10CTex[] = dgMapGrandStatic10CTex;
 
-#define dmap_grand_static_Blob_00B310 "__OTR__map_grand_static/map_grand_static_Blob_00B310"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_00B310[] = dmap_grand_static_Blob_00B310;
+#define dgMapGrandStatic10DTex "__OTR__map_grand_static/gMapGrandStatic10DTex"
+static const ALIGN_ASSET(2) char gMapGrandStatic10DTex[] = dgMapGrandStatic10DTex;
 
-#define dmap_grand_static_Blob_00BAB0 "__OTR__map_grand_static/map_grand_static_Blob_00BAB0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_00BAB0[] = dmap_grand_static_Blob_00BAB0;
+#define dgMapGrandStatic10ETex "__OTR__map_grand_static/gMapGrandStatic10ETex"
+static const ALIGN_ASSET(2) char gMapGrandStatic10ETex[] = dgMapGrandStatic10ETex;
 
-#define dmap_grand_static_Blob_00CAA0 "__OTR__map_grand_static/map_grand_static_Blob_00CAA0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_00CAA0[] = dmap_grand_static_Blob_00CAA0;
+#define dgMapGrandStatic10FTex "__OTR__map_grand_static/gMapGrandStatic10FTex"
+static const ALIGN_ASSET(2) char gMapGrandStatic10FTex[] = dgMapGrandStatic10FTex;
 
-#define dmap_grand_static_Blob_00DA90 "__OTR__map_grand_static/map_grand_static_Blob_00DA90"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_00DA90[] = dmap_grand_static_Blob_00DA90;
+#define dgMapGrandStatic110Tex "__OTR__map_grand_static/gMapGrandStatic110Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic110Tex[] = dgMapGrandStatic110Tex;
 
-#define dmap_grand_static_Blob_00EA80 "__OTR__map_grand_static/map_grand_static_Blob_00EA80"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_00EA80[] = dmap_grand_static_Blob_00EA80;
+#define dgMapGrandStatic111Tex "__OTR__map_grand_static/gMapGrandStatic111Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic111Tex[] = dgMapGrandStatic111Tex;
 
-#define dmap_grand_static_Blob_00F200 "__OTR__map_grand_static/map_grand_static_Blob_00F200"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_00F200[] = dmap_grand_static_Blob_00F200;
+#define dgMapGrandStatic112Tex "__OTR__map_grand_static/gMapGrandStatic112Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic112Tex[] = dgMapGrandStatic112Tex;
 
-#define dmap_grand_static_Blob_00FA00 "__OTR__map_grand_static/map_grand_static_Blob_00FA00"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_00FA00[] = dmap_grand_static_Blob_00FA00;
+#define dgMapGrandStatic113Tex "__OTR__map_grand_static/gMapGrandStatic113Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic113Tex[] = dgMapGrandStatic113Tex;
 
-#define dmap_grand_static_Blob_010250 "__OTR__map_grand_static/map_grand_static_Blob_010250"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_010250[] = dmap_grand_static_Blob_010250;
+#define dgMapGrandStatic114Tex "__OTR__map_grand_static/gMapGrandStatic114Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic114Tex[] = dgMapGrandStatic114Tex;
 
-#define dmap_grand_static_Blob_010760 "__OTR__map_grand_static/map_grand_static_Blob_010760"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_010760[] = dmap_grand_static_Blob_010760;
+#define dgMapGrandStatic115Tex "__OTR__map_grand_static/gMapGrandStatic115Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic115Tex[] = dgMapGrandStatic115Tex;
 
-#define dmap_grand_static_Blob_010E70 "__OTR__map_grand_static/map_grand_static_Blob_010E70"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_010E70[] = dmap_grand_static_Blob_010E70;
+#define dgMapGrandStatic116Tex "__OTR__map_grand_static/gMapGrandStatic116Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic116Tex[] = dgMapGrandStatic116Tex;
 
-#define dmap_grand_static_Blob_011950 "__OTR__map_grand_static/map_grand_static_Blob_011950"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_011950[] = dmap_grand_static_Blob_011950;
+#define dgMapGrandStatic117Tex "__OTR__map_grand_static/gMapGrandStatic117Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic117Tex[] = dgMapGrandStatic117Tex;
 
-#define dmap_grand_static_Blob_011FB0 "__OTR__map_grand_static/map_grand_static_Blob_011FB0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_011FB0[] = dmap_grand_static_Blob_011FB0;
+#define dgMapGrandStatic118Tex "__OTR__map_grand_static/gMapGrandStatic118Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic118Tex[] = dgMapGrandStatic118Tex;
 
-#define dmap_grand_static_Blob_012C10 "__OTR__map_grand_static/map_grand_static_Blob_012C10"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_012C10[] = dmap_grand_static_Blob_012C10;
+#define dgMapGrandStatic119Tex "__OTR__map_grand_static/gMapGrandStatic119Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic119Tex[] = dgMapGrandStatic119Tex;
 
-#define dmap_grand_static_Blob_013A20 "__OTR__map_grand_static/map_grand_static_Blob_013A20"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_013A20[] = dmap_grand_static_Blob_013A20;
+#define dgMapGrandStatic11ATex "__OTR__map_grand_static/gMapGrandStatic11ATex"
+static const ALIGN_ASSET(2) char gMapGrandStatic11ATex[] = dgMapGrandStatic11ATex;
 
-#define dmap_grand_static_Blob_013E00 "__OTR__map_grand_static/map_grand_static_Blob_013E00"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_013E00[] = dmap_grand_static_Blob_013E00;
+#define dgMapGrandStatic11BTex "__OTR__map_grand_static/gMapGrandStatic11BTex"
+static const ALIGN_ASSET(2) char gMapGrandStatic11BTex[] = dgMapGrandStatic11BTex;
 
-#define dmap_grand_static_Blob_0143A0 "__OTR__map_grand_static/map_grand_static_Blob_0143A0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_0143A0[] = dmap_grand_static_Blob_0143A0;
+#define dgMapGrandStatic11CTex "__OTR__map_grand_static/gMapGrandStatic11CTex"
+static const ALIGN_ASSET(2) char gMapGrandStatic11CTex[] = dgMapGrandStatic11CTex;
 
-#define dmap_grand_static_Blob_014BC0 "__OTR__map_grand_static/map_grand_static_Blob_014BC0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_014BC0[] = dmap_grand_static_Blob_014BC0;
+#define dgMapGrandStatic11DTex "__OTR__map_grand_static/gMapGrandStatic11DTex"
+static const ALIGN_ASSET(2) char gMapGrandStatic11DTex[] = dgMapGrandStatic11DTex;
 
-#define dmap_grand_static_Blob_015000 "__OTR__map_grand_static/map_grand_static_Blob_015000"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_015000[] = dmap_grand_static_Blob_015000;
+#define dgMapGrandStatic11ETex "__OTR__map_grand_static/gMapGrandStatic11ETex"
+static const ALIGN_ASSET(2) char gMapGrandStatic11ETex[] = dgMapGrandStatic11ETex;
 
-#define dmap_grand_static_Blob_015590 "__OTR__map_grand_static/map_grand_static_Blob_015590"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_015590[] = dmap_grand_static_Blob_015590;
+#define dgMapGrandStatic11FTex "__OTR__map_grand_static/gMapGrandStatic11FTex"
+static const ALIGN_ASSET(2) char gMapGrandStatic11FTex[] = dgMapGrandStatic11FTex;
 
-#define dmap_grand_static_Blob_015B30 "__OTR__map_grand_static/map_grand_static_Blob_015B30"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_015B30[] = dmap_grand_static_Blob_015B30;
+#define dgMapGrandStatic120Tex "__OTR__map_grand_static/gMapGrandStatic120Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic120Tex[] = dgMapGrandStatic120Tex;
 
-#define dmap_grand_static_Blob_0162D0 "__OTR__map_grand_static/map_grand_static_Blob_0162D0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_0162D0[] = dmap_grand_static_Blob_0162D0;
+#define dgMapGrandStatic121Tex "__OTR__map_grand_static/gMapGrandStatic121Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic121Tex[] = dgMapGrandStatic121Tex;
 
-#define dmap_grand_static_Blob_016A70 "__OTR__map_grand_static/map_grand_static_Blob_016A70"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_016A70[] = dmap_grand_static_Blob_016A70;
+#define dgMapGrandStatic122Tex "__OTR__map_grand_static/gMapGrandStatic122Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic122Tex[] = dgMapGrandStatic122Tex;
 
-#define dmap_grand_static_Blob_017860 "__OTR__map_grand_static/map_grand_static_Blob_017860"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_017860[] = dmap_grand_static_Blob_017860;
+#define dgMapGrandStatic123Tex "__OTR__map_grand_static/gMapGrandStatic123Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic123Tex[] = dgMapGrandStatic123Tex;
 
-#define dmap_grand_static_Blob_0180B0 "__OTR__map_grand_static/map_grand_static_Blob_0180B0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_0180B0[] = dmap_grand_static_Blob_0180B0;
+#define dgMapGrandStatic124Tex "__OTR__map_grand_static/gMapGrandStatic124Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic124Tex[] = dgMapGrandStatic124Tex;
 
-#define dmap_grand_static_Blob_018A70 "__OTR__map_grand_static/map_grand_static_Blob_018A70"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_018A70[] = dmap_grand_static_Blob_018A70;
+#define dgMapGrandStatic125Tex "__OTR__map_grand_static/gMapGrandStatic125Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic125Tex[] = dgMapGrandStatic125Tex;
 
-#define dmap_grand_static_Blob_0192F0 "__OTR__map_grand_static/map_grand_static_Blob_0192F0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_0192F0[] = dmap_grand_static_Blob_0192F0;
+#define dgMapGrandStatic126Tex "__OTR__map_grand_static/gMapGrandStatic126Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic126Tex[] = dgMapGrandStatic126Tex;
 
-#define dmap_grand_static_Blob_019950 "__OTR__map_grand_static/map_grand_static_Blob_019950"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_019950[] = dmap_grand_static_Blob_019950;
+#define dgMapGrandStatic127Tex "__OTR__map_grand_static/gMapGrandStatic127Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic127Tex[] = dgMapGrandStatic127Tex;
 
-#define dmap_grand_static_Blob_019CB0 "__OTR__map_grand_static/map_grand_static_Blob_019CB0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_019CB0[] = dmap_grand_static_Blob_019CB0;
+#define dgMapGrandStatic128Tex "__OTR__map_grand_static/gMapGrandStatic128Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic128Tex[] = dgMapGrandStatic128Tex;
 
-#define dmap_grand_static_Blob_019F10 "__OTR__map_grand_static/map_grand_static_Blob_019F10"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_019F10[] = dmap_grand_static_Blob_019F10;
+#define dgMapGrandStatic129Tex "__OTR__map_grand_static/gMapGrandStatic129Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic129Tex[] = dgMapGrandStatic129Tex;
 
-#define dmap_grand_static_Blob_01A870 "__OTR__map_grand_static/map_grand_static_Blob_01A870"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_01A870[] = dmap_grand_static_Blob_01A870;
+#define dgMapGrandStatic12ATex "__OTR__map_grand_static/gMapGrandStatic12ATex"
+static const ALIGN_ASSET(2) char gMapGrandStatic12ATex[] = dgMapGrandStatic12ATex;
 
-#define dmap_grand_static_Blob_01ABC0 "__OTR__map_grand_static/map_grand_static_Blob_01ABC0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_01ABC0[] = dmap_grand_static_Blob_01ABC0;
+#define dgMapGrandStatic12BTex "__OTR__map_grand_static/gMapGrandStatic12BTex"
+static const ALIGN_ASSET(2) char gMapGrandStatic12BTex[] = dgMapGrandStatic12BTex;
 
-#define dmap_grand_static_Blob_01B570 "__OTR__map_grand_static/map_grand_static_Blob_01B570"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_01B570[] = dmap_grand_static_Blob_01B570;
+#define dgMapGrandStatic12CTex "__OTR__map_grand_static/gMapGrandStatic12CTex"
+static const ALIGN_ASSET(2) char gMapGrandStatic12CTex[] = dgMapGrandStatic12CTex;
 
-#define dmap_grand_static_Blob_01BEF0 "__OTR__map_grand_static/map_grand_static_Blob_01BEF0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_01BEF0[] = dmap_grand_static_Blob_01BEF0;
+#define dgMapGrandStatic12DTex "__OTR__map_grand_static/gMapGrandStatic12DTex"
+static const ALIGN_ASSET(2) char gMapGrandStatic12DTex[] = dgMapGrandStatic12DTex;
 
-#define dmap_grand_static_Blob_01CEE0 "__OTR__map_grand_static/map_grand_static_Blob_01CEE0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_01CEE0[] = dmap_grand_static_Blob_01CEE0;
+#define dgMapGrandStatic12ETex "__OTR__map_grand_static/gMapGrandStatic12ETex"
+static const ALIGN_ASSET(2) char gMapGrandStatic12ETex[] = dgMapGrandStatic12ETex;
 
-#define dmap_grand_static_Blob_01DA00 "__OTR__map_grand_static/map_grand_static_Blob_01DA00"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_01DA00[] = dmap_grand_static_Blob_01DA00;
+#define dgMapGrandStatic12FTex "__OTR__map_grand_static/gMapGrandStatic12FTex"
+static const ALIGN_ASSET(2) char gMapGrandStatic12FTex[] = dgMapGrandStatic12FTex;
 
-#define dmap_grand_static_Blob_01E7A0 "__OTR__map_grand_static/map_grand_static_Blob_01E7A0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_01E7A0[] = dmap_grand_static_Blob_01E7A0;
+#define dgMapGrandStatic130Tex "__OTR__map_grand_static/gMapGrandStatic130Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic130Tex[] = dgMapGrandStatic130Tex;
 
-#define dmap_grand_static_Blob_01EFC0 "__OTR__map_grand_static/map_grand_static_Blob_01EFC0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_01EFC0[] = dmap_grand_static_Blob_01EFC0;
+#define dgMapGrandStatic131Tex "__OTR__map_grand_static/gMapGrandStatic131Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic131Tex[] = dgMapGrandStatic131Tex;
 
-#define dmap_grand_static_Blob_01F3A0 "__OTR__map_grand_static/map_grand_static_Blob_01F3A0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_01F3A0[] = dmap_grand_static_Blob_01F3A0;
+#define dgMapGrandStatic132Tex "__OTR__map_grand_static/gMapGrandStatic132Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic132Tex[] = dgMapGrandStatic132Tex;
 
-#define dmap_grand_static_Blob_01FD20 "__OTR__map_grand_static/map_grand_static_Blob_01FD20"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_01FD20[] = dmap_grand_static_Blob_01FD20;
+#define dgMapGrandStatic133Tex "__OTR__map_grand_static/gMapGrandStatic133Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic133Tex[] = dgMapGrandStatic133Tex;
 
-#define dmap_grand_static_Blob_020680 "__OTR__map_grand_static/map_grand_static_Blob_020680"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_020680[] = dmap_grand_static_Blob_020680;
+#define dgMapGrandStatic134Tex "__OTR__map_grand_static/gMapGrandStatic134Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic134Tex[] = dgMapGrandStatic134Tex;
 
-#define dmap_grand_static_Blob_020DE0 "__OTR__map_grand_static/map_grand_static_Blob_020DE0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_020DE0[] = dmap_grand_static_Blob_020DE0;
+#define dgMapGrandStatic135Tex "__OTR__map_grand_static/gMapGrandStatic135Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic135Tex[] = dgMapGrandStatic135Tex;
 
-#define dmap_grand_static_Blob_021740 "__OTR__map_grand_static/map_grand_static_Blob_021740"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_021740[] = dmap_grand_static_Blob_021740;
+#define dgMapGrandStatic136Tex "__OTR__map_grand_static/gMapGrandStatic136Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic136Tex[] = dgMapGrandStatic136Tex;
 
-#define dmap_grand_static_Blob_021910 "__OTR__map_grand_static/map_grand_static_Blob_021910"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_021910[] = dmap_grand_static_Blob_021910;
+#define dgMapGrandStatic137Tex "__OTR__map_grand_static/gMapGrandStatic137Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic137Tex[] = dgMapGrandStatic137Tex;
 
-#define dmap_grand_static_Blob_021F40 "__OTR__map_grand_static/map_grand_static_Blob_021F40"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_021F40[] = dmap_grand_static_Blob_021F40;
+#define dgMapGrandStatic138Tex "__OTR__map_grand_static/gMapGrandStatic138Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic138Tex[] = dgMapGrandStatic138Tex;
 
-#define dmap_grand_static_Blob_0225C0 "__OTR__map_grand_static/map_grand_static_Blob_0225C0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_0225C0[] = dmap_grand_static_Blob_0225C0;
+#define dgMapGrandStatic139Tex "__OTR__map_grand_static/gMapGrandStatic139Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic139Tex[] = dgMapGrandStatic139Tex;
 
-#define dmap_grand_static_Blob_022D90 "__OTR__map_grand_static/map_grand_static_Blob_022D90"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_022D90[] = dmap_grand_static_Blob_022D90;
+#define dgMapGrandStatic13ATex "__OTR__map_grand_static/gMapGrandStatic13ATex"
+static const ALIGN_ASSET(2) char gMapGrandStatic13ATex[] = dgMapGrandStatic13ATex;
 
-#define dmap_grand_static_Blob_023600 "__OTR__map_grand_static/map_grand_static_Blob_023600"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_023600[] = dmap_grand_static_Blob_023600;
+#define dgMapGrandStatic13BTex "__OTR__map_grand_static/gMapGrandStatic13BTex"
+static const ALIGN_ASSET(2) char gMapGrandStatic13BTex[] = dgMapGrandStatic13BTex;
 
-#define dmap_grand_static_Blob_024460 "__OTR__map_grand_static/map_grand_static_Blob_024460"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_024460[] = dmap_grand_static_Blob_024460;
+#define dgMapGrandStatic13CTex "__OTR__map_grand_static/gMapGrandStatic13CTex"
+static const ALIGN_ASSET(2) char gMapGrandStatic13CTex[] = dgMapGrandStatic13CTex;
 
-#define dmap_grand_static_Blob_024B70 "__OTR__map_grand_static/map_grand_static_Blob_024B70"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_024B70[] = dmap_grand_static_Blob_024B70;
+#define dgMapGrandStatic13DTex "__OTR__map_grand_static/gMapGrandStatic13DTex"
+static const ALIGN_ASSET(2) char gMapGrandStatic13DTex[] = dgMapGrandStatic13DTex;
 
-#define dmap_grand_static_Blob_025190 "__OTR__map_grand_static/map_grand_static_Blob_025190"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_025190[] = dmap_grand_static_Blob_025190;
+#define dgMapGrandStatic13ETex "__OTR__map_grand_static/gMapGrandStatic13ETex"
+static const ALIGN_ASSET(2) char gMapGrandStatic13ETex[] = dgMapGrandStatic13ETex;
 
-#define dmap_grand_static_Blob_0257B0 "__OTR__map_grand_static/map_grand_static_Blob_0257B0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_0257B0[] = dmap_grand_static_Blob_0257B0;
+#define dgMapGrandStatic13FTex "__OTR__map_grand_static/gMapGrandStatic13FTex"
+static const ALIGN_ASSET(2) char gMapGrandStatic13FTex[] = dgMapGrandStatic13FTex;
 
-#define dmap_grand_static_Blob_025E30 "__OTR__map_grand_static/map_grand_static_Blob_025E30"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_025E30[] = dmap_grand_static_Blob_025E30;
+#define dgMapGrandStatic140Tex "__OTR__map_grand_static/gMapGrandStatic140Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic140Tex[] = dgMapGrandStatic140Tex;
 
-#define dmap_grand_static_Blob_026450 "__OTR__map_grand_static/map_grand_static_Blob_026450"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_026450[] = dmap_grand_static_Blob_026450;
+#define dgMapGrandStatic141Tex "__OTR__map_grand_static/gMapGrandStatic141Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic141Tex[] = dgMapGrandStatic141Tex;
 
-#define dmap_grand_static_Blob_026660 "__OTR__map_grand_static/map_grand_static_Blob_026660"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_026660[] = dmap_grand_static_Blob_026660;
+#define dgMapGrandStatic142Tex "__OTR__map_grand_static/gMapGrandStatic142Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic142Tex[] = dgMapGrandStatic142Tex;
 
-#define dmap_grand_static_Blob_026B10 "__OTR__map_grand_static/map_grand_static_Blob_026B10"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_026B10[] = dmap_grand_static_Blob_026B10;
+#define dgMapGrandStatic143Tex "__OTR__map_grand_static/gMapGrandStatic143Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic143Tex[] = dgMapGrandStatic143Tex;
 
-#define dmap_grand_static_Blob_027190 "__OTR__map_grand_static/map_grand_static_Blob_027190"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_027190[] = dmap_grand_static_Blob_027190;
+#define dgMapGrandStatic144Tex "__OTR__map_grand_static/gMapGrandStatic144Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic144Tex[] = dgMapGrandStatic144Tex;
 
-#define dmap_grand_static_Blob_0274E0 "__OTR__map_grand_static/map_grand_static_Blob_0274E0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_0274E0[] = dmap_grand_static_Blob_0274E0;
+#define dgMapGrandStatic145Tex "__OTR__map_grand_static/gMapGrandStatic145Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic145Tex[] = dgMapGrandStatic145Tex;
 
-#define dmap_grand_static_Blob_027B40 "__OTR__map_grand_static/map_grand_static_Blob_027B40"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_027B40[] = dmap_grand_static_Blob_027B40;
+#define dgMapGrandStatic146Tex "__OTR__map_grand_static/gMapGrandStatic146Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic146Tex[] = dgMapGrandStatic146Tex;
 
-#define dmap_grand_static_Blob_027E90 "__OTR__map_grand_static/map_grand_static_Blob_027E90"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_027E90[] = dmap_grand_static_Blob_027E90;
+#define dgMapGrandStatic147Tex "__OTR__map_grand_static/gMapGrandStatic147Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic147Tex[] = dgMapGrandStatic147Tex;
 
-#define dmap_grand_static_Blob_028390 "__OTR__map_grand_static/map_grand_static_Blob_028390"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_028390[] = dmap_grand_static_Blob_028390;
+#define dgMapGrandStatic148Tex "__OTR__map_grand_static/gMapGrandStatic148Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic148Tex[] = dgMapGrandStatic148Tex;
 
-#define dmap_grand_static_Blob_028A30 "__OTR__map_grand_static/map_grand_static_Blob_028A30"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_028A30[] = dmap_grand_static_Blob_028A30;
+#define dgMapGrandStatic149Tex "__OTR__map_grand_static/gMapGrandStatic149Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic149Tex[] = dgMapGrandStatic149Tex;
 
-#define dmap_grand_static_Blob_029010 "__OTR__map_grand_static/map_grand_static_Blob_029010"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_029010[] = dmap_grand_static_Blob_029010;
+#define dgMapGrandStatic14ATex "__OTR__map_grand_static/gMapGrandStatic14ATex"
+static const ALIGN_ASSET(2) char gMapGrandStatic14ATex[] = dgMapGrandStatic14ATex;
 
-#define dmap_grand_static_Blob_029690 "__OTR__map_grand_static/map_grand_static_Blob_029690"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_029690[] = dmap_grand_static_Blob_029690;
+#define dgMapGrandStatic14BTex "__OTR__map_grand_static/gMapGrandStatic14BTex"
+static const ALIGN_ASSET(2) char gMapGrandStatic14BTex[] = dgMapGrandStatic14BTex;
 
-#define dmap_grand_static_Blob_029B10 "__OTR__map_grand_static/map_grand_static_Blob_029B10"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_029B10[] = dmap_grand_static_Blob_029B10;
+#define dgMapGrandStatic14CTex "__OTR__map_grand_static/gMapGrandStatic14CTex"
+static const ALIGN_ASSET(2) char gMapGrandStatic14CTex[] = dgMapGrandStatic14CTex;
 
-#define dmap_grand_static_Blob_02A5F0 "__OTR__map_grand_static/map_grand_static_Blob_02A5F0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_02A5F0[] = dmap_grand_static_Blob_02A5F0;
+#define dgMapGrandStatic14DTex "__OTR__map_grand_static/gMapGrandStatic14DTex"
+static const ALIGN_ASSET(2) char gMapGrandStatic14DTex[] = dgMapGrandStatic14DTex;
 
-#define dmap_grand_static_Blob_02A8C0 "__OTR__map_grand_static/map_grand_static_Blob_02A8C0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_02A8C0[] = dmap_grand_static_Blob_02A8C0;
+#define dgMapGrandStatic14ETex "__OTR__map_grand_static/gMapGrandStatic14ETex"
+static const ALIGN_ASSET(2) char gMapGrandStatic14ETex[] = dgMapGrandStatic14ETex;
 
-#define dmap_grand_static_Blob_02B450 "__OTR__map_grand_static/map_grand_static_Blob_02B450"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_02B450[] = dmap_grand_static_Blob_02B450;
+#define dgMapGrandStatic14FTex "__OTR__map_grand_static/gMapGrandStatic14FTex"
+static const ALIGN_ASSET(2) char gMapGrandStatic14FTex[] = dgMapGrandStatic14FTex;
 
-#define dmap_grand_static_Blob_02C1F0 "__OTR__map_grand_static/map_grand_static_Blob_02C1F0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_02C1F0[] = dmap_grand_static_Blob_02C1F0;
+#define dgMapGrandStatic150Tex "__OTR__map_grand_static/gMapGrandStatic150Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic150Tex[] = dgMapGrandStatic150Tex;
 
-#define dmap_grand_static_Blob_02CAB0 "__OTR__map_grand_static/map_grand_static_Blob_02CAB0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_02CAB0[] = dmap_grand_static_Blob_02CAB0;
+#define dgMapGrandStatic151Tex "__OTR__map_grand_static/gMapGrandStatic151Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic151Tex[] = dgMapGrandStatic151Tex;
 
-#define dmap_grand_static_Blob_02D4E0 "__OTR__map_grand_static/map_grand_static_Blob_02D4E0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_02D4E0[] = dmap_grand_static_Blob_02D4E0;
+#define dgMapGrandStatic152Tex "__OTR__map_grand_static/gMapGrandStatic152Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic152Tex[] = dgMapGrandStatic152Tex;
 
-#define dmap_grand_static_Blob_02D610 "__OTR__map_grand_static/map_grand_static_Blob_02D610"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_02D610[] = dmap_grand_static_Blob_02D610;
+#define dgMapGrandStatic153Tex "__OTR__map_grand_static/gMapGrandStatic153Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic153Tex[] = dgMapGrandStatic153Tex;
 
-#define dmap_grand_static_Blob_02E240 "__OTR__map_grand_static/map_grand_static_Blob_02E240"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_02E240[] = dmap_grand_static_Blob_02E240;
+#define dgMapGrandStatic154Tex "__OTR__map_grand_static/gMapGrandStatic154Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic154Tex[] = dgMapGrandStatic154Tex;
 
-#define dmap_grand_static_Blob_02EAE0 "__OTR__map_grand_static/map_grand_static_Blob_02EAE0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_02EAE0[] = dmap_grand_static_Blob_02EAE0;
+#define dgMapGrandStatic155Tex "__OTR__map_grand_static/gMapGrandStatic155Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic155Tex[] = dgMapGrandStatic155Tex;
 
-#define dmap_grand_static_Blob_02FA30 "__OTR__map_grand_static/map_grand_static_Blob_02FA30"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_02FA30[] = dmap_grand_static_Blob_02FA30;
+#define dgMapGrandStatic156Tex "__OTR__map_grand_static/gMapGrandStatic156Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic156Tex[] = dgMapGrandStatic156Tex;
 
-#define dmap_grand_static_Blob_0303E0 "__OTR__map_grand_static/map_grand_static_Blob_0303E0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_0303E0[] = dmap_grand_static_Blob_0303E0;
+#define dgMapGrandStatic157Tex "__OTR__map_grand_static/gMapGrandStatic157Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic157Tex[] = dgMapGrandStatic157Tex;
 
-#define dmap_grand_static_Blob_030B90 "__OTR__map_grand_static/map_grand_static_Blob_030B90"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_030B90[] = dmap_grand_static_Blob_030B90;
+#define dgMapGrandStatic158Tex "__OTR__map_grand_static/gMapGrandStatic158Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic158Tex[] = dgMapGrandStatic158Tex;
 
-#define dmap_grand_static_Blob_0314F0 "__OTR__map_grand_static/map_grand_static_Blob_0314F0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_0314F0[] = dmap_grand_static_Blob_0314F0;
+#define dgMapGrandStatic159Tex "__OTR__map_grand_static/gMapGrandStatic159Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic159Tex[] = dgMapGrandStatic159Tex;
 
-#define dmap_grand_static_Blob_031C30 "__OTR__map_grand_static/map_grand_static_Blob_031C30"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_031C30[] = dmap_grand_static_Blob_031C30;
+#define dgMapGrandStatic15ATex "__OTR__map_grand_static/gMapGrandStatic15ATex"
+static const ALIGN_ASSET(2) char gMapGrandStatic15ATex[] = dgMapGrandStatic15ATex;
 
-#define dmap_grand_static_Blob_032630 "__OTR__map_grand_static/map_grand_static_Blob_032630"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_032630[] = dmap_grand_static_Blob_032630;
+#define dgMapGrandStatic15BTex "__OTR__map_grand_static/gMapGrandStatic15BTex"
+static const ALIGN_ASSET(2) char gMapGrandStatic15BTex[] = dgMapGrandStatic15BTex;
 
-#define dmap_grand_static_Blob_032C70 "__OTR__map_grand_static/map_grand_static_Blob_032C70"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_032C70[] = dmap_grand_static_Blob_032C70;
+#define dgMapGrandStatic15CTex "__OTR__map_grand_static/gMapGrandStatic15CTex"
+static const ALIGN_ASSET(2) char gMapGrandStatic15CTex[] = dgMapGrandStatic15CTex;
 
-#define dmap_grand_static_Blob_0336A0 "__OTR__map_grand_static/map_grand_static_Blob_0336A0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_0336A0[] = dmap_grand_static_Blob_0336A0;
+#define dgMapGrandStatic15DTex "__OTR__map_grand_static/gMapGrandStatic15DTex"
+static const ALIGN_ASSET(2) char gMapGrandStatic15DTex[] = dgMapGrandStatic15DTex;
 
-#define dmap_grand_static_Blob_033A70 "__OTR__map_grand_static/map_grand_static_Blob_033A70"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_033A70[] = dmap_grand_static_Blob_033A70;
+#define dgMapGrandStatic15ETex "__OTR__map_grand_static/gMapGrandStatic15ETex"
+static const ALIGN_ASSET(2) char gMapGrandStatic15ETex[] = dgMapGrandStatic15ETex;
 
-#define dmap_grand_static_Blob_034770 "__OTR__map_grand_static/map_grand_static_Blob_034770"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_034770[] = dmap_grand_static_Blob_034770;
+#define dgMapGrandStatic15FTex "__OTR__map_grand_static/gMapGrandStatic15FTex"
+static const ALIGN_ASSET(2) char gMapGrandStatic15FTex[] = dgMapGrandStatic15FTex;
 
-#define dmap_grand_static_Blob_034BB0 "__OTR__map_grand_static/map_grand_static_Blob_034BB0"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_034BB0[] = dmap_grand_static_Blob_034BB0;
+#define dgMapGrandStatic160Tex "__OTR__map_grand_static/gMapGrandStatic160Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic160Tex[] = dgMapGrandStatic160Tex;
 
-#define dmap_grand_static_Blob_034F50 "__OTR__map_grand_static/map_grand_static_Blob_034F50"
-static const ALIGN_ASSET(2) char map_grand_static_Blob_034F50[] = dmap_grand_static_Blob_034F50;
+#define dgMapGrandStatic161Tex "__OTR__map_grand_static/gMapGrandStatic161Tex"
+static const ALIGN_ASSET(2) char gMapGrandStatic161Tex[] = dgMapGrandStatic161Tex;
 #endif // ARCHIVES_MAP_GRAND_STATIC_H

--- a/mm/assets/archives/map_i_static/map_i_static.h
+++ b/mm/assets/archives/map_i_static/map_i_static.h
@@ -3,177 +3,177 @@
 
 #include "align_asset_macro.h"
 
-#define dmap_i_static_Blob_000000 "__OTR__map_i_static/map_i_static_Blob_000000"
-static const ALIGN_ASSET(2) char map_i_static_Blob_000000[] = dmap_i_static_Blob_000000;
+#define dgMapIStatic00Tex "__OTR__map_i_static/gMapIStatic00Tex"
+static const ALIGN_ASSET(2) char gMapIStatic00Tex[] = dgMapIStatic00Tex;
 
-#define dmap_i_static_Blob_000FF0 "__OTR__map_i_static/map_i_static_Blob_000FF0"
-static const ALIGN_ASSET(2) char map_i_static_Blob_000FF0[] = dmap_i_static_Blob_000FF0;
+#define dgMapIStatic01Tex "__OTR__map_i_static/gMapIStatic01Tex"
+static const ALIGN_ASSET(2) char gMapIStatic01Tex[] = dgMapIStatic01Tex;
 
-#define dmap_i_static_Blob_001FE0 "__OTR__map_i_static/map_i_static_Blob_001FE0"
-static const ALIGN_ASSET(2) char map_i_static_Blob_001FE0[] = dmap_i_static_Blob_001FE0;
+#define dgMapIStatic02Tex "__OTR__map_i_static/gMapIStatic02Tex"
+static const ALIGN_ASSET(2) char gMapIStatic02Tex[] = dgMapIStatic02Tex;
 
-#define dmap_i_static_Blob_002FD0 "__OTR__map_i_static/map_i_static_Blob_002FD0"
-static const ALIGN_ASSET(2) char map_i_static_Blob_002FD0[] = dmap_i_static_Blob_002FD0;
+#define dgMapIStatic03Tex "__OTR__map_i_static/gMapIStatic03Tex"
+static const ALIGN_ASSET(2) char gMapIStatic03Tex[] = dgMapIStatic03Tex;
 
-#define dmap_i_static_Blob_003FC0 "__OTR__map_i_static/map_i_static_Blob_003FC0"
-static const ALIGN_ASSET(2) char map_i_static_Blob_003FC0[] = dmap_i_static_Blob_003FC0;
+#define dgMapIStatic04Tex "__OTR__map_i_static/gMapIStatic04Tex"
+static const ALIGN_ASSET(2) char gMapIStatic04Tex[] = dgMapIStatic04Tex;
 
-#define dmap_i_static_Blob_004FB0 "__OTR__map_i_static/map_i_static_Blob_004FB0"
-static const ALIGN_ASSET(2) char map_i_static_Blob_004FB0[] = dmap_i_static_Blob_004FB0;
+#define dgMapIStatic05Tex "__OTR__map_i_static/gMapIStatic05Tex"
+static const ALIGN_ASSET(2) char gMapIStatic05Tex[] = dgMapIStatic05Tex;
 
-#define dmap_i_static_Blob_005180 "__OTR__map_i_static/map_i_static_Blob_005180"
-static const ALIGN_ASSET(2) char map_i_static_Blob_005180[] = dmap_i_static_Blob_005180;
+#define dgMapIStatic06Tex "__OTR__map_i_static/gMapIStatic06Tex"
+static const ALIGN_ASSET(2) char gMapIStatic06Tex[] = dgMapIStatic06Tex;
 
-#define dmap_i_static_Blob_005330 "__OTR__map_i_static/map_i_static_Blob_005330"
-static const ALIGN_ASSET(2) char map_i_static_Blob_005330[] = dmap_i_static_Blob_005330;
+#define dgMapIStatic07Tex "__OTR__map_i_static/gMapIStatic07Tex"
+static const ALIGN_ASSET(2) char gMapIStatic07Tex[] = dgMapIStatic07Tex;
 
-#define dmap_i_static_Blob_005510 "__OTR__map_i_static/map_i_static_Blob_005510"
-static const ALIGN_ASSET(2) char map_i_static_Blob_005510[] = dmap_i_static_Blob_005510;
+#define dgMapIStatic08Tex "__OTR__map_i_static/gMapIStatic08Tex"
+static const ALIGN_ASSET(2) char gMapIStatic08Tex[] = dgMapIStatic08Tex;
 
-#define dmap_i_static_Blob_005610 "__OTR__map_i_static/map_i_static_Blob_005610"
-static const ALIGN_ASSET(2) char map_i_static_Blob_005610[] = dmap_i_static_Blob_005610;
+#define dgMapIStatic09Tex "__OTR__map_i_static/gMapIStatic09Tex"
+static const ALIGN_ASSET(2) char gMapIStatic09Tex[] = dgMapIStatic09Tex;
 
-#define dmap_i_static_Blob_005670 "__OTR__map_i_static/map_i_static_Blob_005670"
-static const ALIGN_ASSET(2) char map_i_static_Blob_005670[] = dmap_i_static_Blob_005670;
+#define dgMapIStatic0ATex "__OTR__map_i_static/gMapIStatic0ATex"
+static const ALIGN_ASSET(2) char gMapIStatic0ATex[] = dgMapIStatic0ATex;
 
-#define dmap_i_static_Blob_005820 "__OTR__map_i_static/map_i_static_Blob_005820"
-static const ALIGN_ASSET(2) char map_i_static_Blob_005820[] = dmap_i_static_Blob_005820;
+#define dgMapIStatic0BTex "__OTR__map_i_static/gMapIStatic0BTex"
+static const ALIGN_ASSET(2) char gMapIStatic0BTex[] = dgMapIStatic0BTex;
 
-#define dmap_i_static_Blob_005890 "__OTR__map_i_static/map_i_static_Blob_005890"
-static const ALIGN_ASSET(2) char map_i_static_Blob_005890[] = dmap_i_static_Blob_005890;
+#define dgMapIStatic0CTex "__OTR__map_i_static/gMapIStatic0CTex"
+static const ALIGN_ASSET(2) char gMapIStatic0CTex[] = dgMapIStatic0CTex;
 
-#define dmap_i_static_Blob_0059C0 "__OTR__map_i_static/map_i_static_Blob_0059C0"
-static const ALIGN_ASSET(2) char map_i_static_Blob_0059C0[] = dmap_i_static_Blob_0059C0;
+#define dgMapIStatic0DTex "__OTR__map_i_static/gMapIStatic0DTex"
+static const ALIGN_ASSET(2) char gMapIStatic0DTex[] = dgMapIStatic0DTex;
 
-#define dmap_i_static_Blob_005B60 "__OTR__map_i_static/map_i_static_Blob_005B60"
-static const ALIGN_ASSET(2) char map_i_static_Blob_005B60[] = dmap_i_static_Blob_005B60;
+#define dgMapIStatic0ETex "__OTR__map_i_static/gMapIStatic0ETex"
+static const ALIGN_ASSET(2) char gMapIStatic0ETex[] = dgMapIStatic0ETex;
 
-#define dmap_i_static_Blob_005C60 "__OTR__map_i_static/map_i_static_Blob_005C60"
-static const ALIGN_ASSET(2) char map_i_static_Blob_005C60[] = dmap_i_static_Blob_005C60;
+#define dgMapIStatic0FTex "__OTR__map_i_static/gMapIStatic0FTex"
+static const ALIGN_ASSET(2) char gMapIStatic0FTex[] = dgMapIStatic0FTex;
 
-#define dmap_i_static_Blob_005E10 "__OTR__map_i_static/map_i_static_Blob_005E10"
-static const ALIGN_ASSET(2) char map_i_static_Blob_005E10[] = dmap_i_static_Blob_005E10;
+#define dgMapIStatic10Tex "__OTR__map_i_static/gMapIStatic10Tex"
+static const ALIGN_ASSET(2) char gMapIStatic10Tex[] = dgMapIStatic10Tex;
 
-#define dmap_i_static_Blob_005F30 "__OTR__map_i_static/map_i_static_Blob_005F30"
-static const ALIGN_ASSET(2) char map_i_static_Blob_005F30[] = dmap_i_static_Blob_005F30;
+#define dgMapIStatic11Tex "__OTR__map_i_static/gMapIStatic11Tex"
+static const ALIGN_ASSET(2) char gMapIStatic11Tex[] = dgMapIStatic11Tex;
 
-#define dmap_i_static_Blob_006050 "__OTR__map_i_static/map_i_static_Blob_006050"
-static const ALIGN_ASSET(2) char map_i_static_Blob_006050[] = dmap_i_static_Blob_006050;
+#define dgMapIStatic12Tex "__OTR__map_i_static/gMapIStatic12Tex"
+static const ALIGN_ASSET(2) char gMapIStatic12Tex[] = dgMapIStatic12Tex;
 
-#define dmap_i_static_Blob_0062B0 "__OTR__map_i_static/map_i_static_Blob_0062B0"
-static const ALIGN_ASSET(2) char map_i_static_Blob_0062B0[] = dmap_i_static_Blob_0062B0;
+#define dgMapIStatic13Tex "__OTR__map_i_static/gMapIStatic13Tex"
+static const ALIGN_ASSET(2) char gMapIStatic13Tex[] = dgMapIStatic13Tex;
 
-#define dmap_i_static_Blob_006400 "__OTR__map_i_static/map_i_static_Blob_006400"
-static const ALIGN_ASSET(2) char map_i_static_Blob_006400[] = dmap_i_static_Blob_006400;
+#define dgMapIStatic14Tex "__OTR__map_i_static/gMapIStatic14Tex"
+static const ALIGN_ASSET(2) char gMapIStatic14Tex[] = dgMapIStatic14Tex;
 
-#define dmap_i_static_Blob_006620 "__OTR__map_i_static/map_i_static_Blob_006620"
-static const ALIGN_ASSET(2) char map_i_static_Blob_006620[] = dmap_i_static_Blob_006620;
+#define dgMapIStatic15Tex "__OTR__map_i_static/gMapIStatic15Tex"
+static const ALIGN_ASSET(2) char gMapIStatic15Tex[] = dgMapIStatic15Tex;
 
-#define dmap_i_static_Blob_006920 "__OTR__map_i_static/map_i_static_Blob_006920"
-static const ALIGN_ASSET(2) char map_i_static_Blob_006920[] = dmap_i_static_Blob_006920;
+#define dgMapIStatic16Tex "__OTR__map_i_static/gMapIStatic16Tex"
+static const ALIGN_ASSET(2) char gMapIStatic16Tex[] = dgMapIStatic16Tex;
 
-#define dmap_i_static_Blob_006A30 "__OTR__map_i_static/map_i_static_Blob_006A30"
-static const ALIGN_ASSET(2) char map_i_static_Blob_006A30[] = dmap_i_static_Blob_006A30;
+#define dgMapIStatic17Tex "__OTR__map_i_static/gMapIStatic17Tex"
+static const ALIGN_ASSET(2) char gMapIStatic17Tex[] = dgMapIStatic17Tex;
 
-#define dmap_i_static_Blob_006B40 "__OTR__map_i_static/map_i_static_Blob_006B40"
-static const ALIGN_ASSET(2) char map_i_static_Blob_006B40[] = dmap_i_static_Blob_006B40;
+#define dgMapIStatic18Tex "__OTR__map_i_static/gMapIStatic18Tex"
+static const ALIGN_ASSET(2) char gMapIStatic18Tex[] = dgMapIStatic18Tex;
 
-#define dmap_i_static_Blob_006C90 "__OTR__map_i_static/map_i_static_Blob_006C90"
-static const ALIGN_ASSET(2) char map_i_static_Blob_006C90[] = dmap_i_static_Blob_006C90;
+#define dgMapIStatic19Tex "__OTR__map_i_static/gMapIStatic19Tex"
+static const ALIGN_ASSET(2) char gMapIStatic19Tex[] = dgMapIStatic19Tex;
 
-#define dmap_i_static_Blob_006DB0 "__OTR__map_i_static/map_i_static_Blob_006DB0"
-static const ALIGN_ASSET(2) char map_i_static_Blob_006DB0[] = dmap_i_static_Blob_006DB0;
+#define dgMapIStatic1ATex "__OTR__map_i_static/gMapIStatic1ATex"
+static const ALIGN_ASSET(2) char gMapIStatic1ATex[] = dgMapIStatic1ATex;
 
-#define dmap_i_static_Blob_006E70 "__OTR__map_i_static/map_i_static_Blob_006E70"
-static const ALIGN_ASSET(2) char map_i_static_Blob_006E70[] = dmap_i_static_Blob_006E70;
+#define dgMapIStatic1BTex "__OTR__map_i_static/gMapIStatic1BTex"
+static const ALIGN_ASSET(2) char gMapIStatic1BTex[] = dgMapIStatic1BTex;
 
-#define dmap_i_static_Blob_006F40 "__OTR__map_i_static/map_i_static_Blob_006F40"
-static const ALIGN_ASSET(2) char map_i_static_Blob_006F40[] = dmap_i_static_Blob_006F40;
+#define dgMapIStatic1CTex "__OTR__map_i_static/gMapIStatic1CTex"
+static const ALIGN_ASSET(2) char gMapIStatic1CTex[] = dgMapIStatic1CTex;
 
-#define dmap_i_static_Blob_007170 "__OTR__map_i_static/map_i_static_Blob_007170"
-static const ALIGN_ASSET(2) char map_i_static_Blob_007170[] = dmap_i_static_Blob_007170;
+#define dgMapIStatic1DTex "__OTR__map_i_static/gMapIStatic1DTex"
+static const ALIGN_ASSET(2) char gMapIStatic1DTex[] = dgMapIStatic1DTex;
 
-#define dmap_i_static_Blob_007210 "__OTR__map_i_static/map_i_static_Blob_007210"
-static const ALIGN_ASSET(2) char map_i_static_Blob_007210[] = dmap_i_static_Blob_007210;
+#define dgMapIStatic1ETex "__OTR__map_i_static/gMapIStatic1ETex"
+static const ALIGN_ASSET(2) char gMapIStatic1ETex[] = dgMapIStatic1ETex;
 
-#define dmap_i_static_Blob_0073D0 "__OTR__map_i_static/map_i_static_Blob_0073D0"
-static const ALIGN_ASSET(2) char map_i_static_Blob_0073D0[] = dmap_i_static_Blob_0073D0;
+#define dgMapIStatic1FTex "__OTR__map_i_static/gMapIStatic1FTex"
+static const ALIGN_ASSET(2) char gMapIStatic1FTex[] = dgMapIStatic1FTex;
 
-#define dmap_i_static_Blob_0074D0 "__OTR__map_i_static/map_i_static_Blob_0074D0"
-static const ALIGN_ASSET(2) char map_i_static_Blob_0074D0[] = dmap_i_static_Blob_0074D0;
+#define dgMapIStatic20Tex "__OTR__map_i_static/gMapIStatic20Tex"
+static const ALIGN_ASSET(2) char gMapIStatic20Tex[] = dgMapIStatic20Tex;
 
-#define dmap_i_static_Blob_007650 "__OTR__map_i_static/map_i_static_Blob_007650"
-static const ALIGN_ASSET(2) char map_i_static_Blob_007650[] = dmap_i_static_Blob_007650;
+#define dgMapIStatic21Tex "__OTR__map_i_static/gMapIStatic21Tex"
+static const ALIGN_ASSET(2) char gMapIStatic21Tex[] = dgMapIStatic21Tex;
 
-#define dmap_i_static_Blob_0077A0 "__OTR__map_i_static/map_i_static_Blob_0077A0"
-static const ALIGN_ASSET(2) char map_i_static_Blob_0077A0[] = dmap_i_static_Blob_0077A0;
+#define dgMapIStatic22Tex "__OTR__map_i_static/gMapIStatic22Tex"
+static const ALIGN_ASSET(2) char gMapIStatic22Tex[] = dgMapIStatic22Tex;
 
-#define dmap_i_static_Blob_007850 "__OTR__map_i_static/map_i_static_Blob_007850"
-static const ALIGN_ASSET(2) char map_i_static_Blob_007850[] = dmap_i_static_Blob_007850;
+#define dgMapIStatic23Tex "__OTR__map_i_static/gMapIStatic23Tex"
+static const ALIGN_ASSET(2) char gMapIStatic23Tex[] = dgMapIStatic23Tex;
 
-#define dmap_i_static_Blob_0078A0 "__OTR__map_i_static/map_i_static_Blob_0078A0"
-static const ALIGN_ASSET(2) char map_i_static_Blob_0078A0[] = dmap_i_static_Blob_0078A0;
+#define dgMapIStatic24Tex "__OTR__map_i_static/gMapIStatic24Tex"
+static const ALIGN_ASSET(2) char gMapIStatic24Tex[] = dgMapIStatic24Tex;
 
-#define dmap_i_static_Blob_0078E0 "__OTR__map_i_static/map_i_static_Blob_0078E0"
-static const ALIGN_ASSET(2) char map_i_static_Blob_0078E0[] = dmap_i_static_Blob_0078E0;
+#define dgMapIStatic25Tex "__OTR__map_i_static/gMapIStatic25Tex"
+static const ALIGN_ASSET(2) char gMapIStatic25Tex[] = dgMapIStatic25Tex;
 
-#define dmap_i_static_Blob_007A50 "__OTR__map_i_static/map_i_static_Blob_007A50"
-static const ALIGN_ASSET(2) char map_i_static_Blob_007A50[] = dmap_i_static_Blob_007A50;
+#define dgMapIStatic26Tex "__OTR__map_i_static/gMapIStatic26Tex"
+static const ALIGN_ASSET(2) char gMapIStatic26Tex[] = dgMapIStatic26Tex;
 
-#define dmap_i_static_Blob_007AD0 "__OTR__map_i_static/map_i_static_Blob_007AD0"
-static const ALIGN_ASSET(2) char map_i_static_Blob_007AD0[] = dmap_i_static_Blob_007AD0;
+#define dgMapIStatic27Tex "__OTR__map_i_static/gMapIStatic27Tex"
+static const ALIGN_ASSET(2) char gMapIStatic27Tex[] = dgMapIStatic27Tex;
 
-#define dmap_i_static_Blob_007B60 "__OTR__map_i_static/map_i_static_Blob_007B60"
-static const ALIGN_ASSET(2) char map_i_static_Blob_007B60[] = dmap_i_static_Blob_007B60;
+#define dgMapIStatic28Tex "__OTR__map_i_static/gMapIStatic28Tex"
+static const ALIGN_ASSET(2) char gMapIStatic28Tex[] = dgMapIStatic28Tex;
 
-#define dmap_i_static_Blob_007C20 "__OTR__map_i_static/map_i_static_Blob_007C20"
-static const ALIGN_ASSET(2) char map_i_static_Blob_007C20[] = dmap_i_static_Blob_007C20;
+#define dgMapIStatic29Tex "__OTR__map_i_static/gMapIStatic29Tex"
+static const ALIGN_ASSET(2) char gMapIStatic29Tex[] = dgMapIStatic29Tex;
 
-#define dmap_i_static_Blob_007CA0 "__OTR__map_i_static/map_i_static_Blob_007CA0"
-static const ALIGN_ASSET(2) char map_i_static_Blob_007CA0[] = dmap_i_static_Blob_007CA0;
+#define dgMapIStatic2ATex "__OTR__map_i_static/gMapIStatic2ATex"
+static const ALIGN_ASSET(2) char gMapIStatic2ATex[] = dgMapIStatic2ATex;
 
-#define dmap_i_static_Blob_007D90 "__OTR__map_i_static/map_i_static_Blob_007D90"
-static const ALIGN_ASSET(2) char map_i_static_Blob_007D90[] = dmap_i_static_Blob_007D90;
+#define dgMapIStatic2BTex "__OTR__map_i_static/gMapIStatic2BTex"
+static const ALIGN_ASSET(2) char gMapIStatic2BTex[] = dgMapIStatic2BTex;
 
-#define dmap_i_static_Blob_007EA0 "__OTR__map_i_static/map_i_static_Blob_007EA0"
-static const ALIGN_ASSET(2) char map_i_static_Blob_007EA0[] = dmap_i_static_Blob_007EA0;
+#define dgMapIStatic2CTex "__OTR__map_i_static/gMapIStatic2CTex"
+static const ALIGN_ASSET(2) char gMapIStatic2CTex[] = dgMapIStatic2CTex;
 
-#define dmap_i_static_Blob_007FA0 "__OTR__map_i_static/map_i_static_Blob_007FA0"
-static const ALIGN_ASSET(2) char map_i_static_Blob_007FA0[] = dmap_i_static_Blob_007FA0;
+#define dgMapIStatic2DTex "__OTR__map_i_static/gMapIStatic2DTex"
+static const ALIGN_ASSET(2) char gMapIStatic2DTex[] = dgMapIStatic2DTex;
 
-#define dmap_i_static_Blob_007FF0 "__OTR__map_i_static/map_i_static_Blob_007FF0"
-static const ALIGN_ASSET(2) char map_i_static_Blob_007FF0[] = dmap_i_static_Blob_007FF0;
+#define dgMapIStatic2ETex "__OTR__map_i_static/gMapIStatic2ETex"
+static const ALIGN_ASSET(2) char gMapIStatic2ETex[] = dgMapIStatic2ETex;
 
-#define dmap_i_static_Blob_008080 "__OTR__map_i_static/map_i_static_Blob_008080"
-static const ALIGN_ASSET(2) char map_i_static_Blob_008080[] = dmap_i_static_Blob_008080;
+#define dgMapIStatic2FTex "__OTR__map_i_static/gMapIStatic2FTex"
+static const ALIGN_ASSET(2) char gMapIStatic2FTex[] = dgMapIStatic2FTex;
 
-#define dmap_i_static_Blob_008190 "__OTR__map_i_static/map_i_static_Blob_008190"
-static const ALIGN_ASSET(2) char map_i_static_Blob_008190[] = dmap_i_static_Blob_008190;
+#define dgMapIStatic30Tex "__OTR__map_i_static/gMapIStatic30Tex"
+static const ALIGN_ASSET(2) char gMapIStatic30Tex[] = dgMapIStatic30Tex;
 
-#define dmap_i_static_Blob_0081F0 "__OTR__map_i_static/map_i_static_Blob_0081F0"
-static const ALIGN_ASSET(2) char map_i_static_Blob_0081F0[] = dmap_i_static_Blob_0081F0;
+#define dgMapIStatic31Tex "__OTR__map_i_static/gMapIStatic31Tex"
+static const ALIGN_ASSET(2) char gMapIStatic31Tex[] = dgMapIStatic31Tex;
 
-#define dmap_i_static_Blob_008300 "__OTR__map_i_static/map_i_static_Blob_008300"
-static const ALIGN_ASSET(2) char map_i_static_Blob_008300[] = dmap_i_static_Blob_008300;
+#define dgMapIStatic32Tex "__OTR__map_i_static/gMapIStatic32Tex"
+static const ALIGN_ASSET(2) char gMapIStatic32Tex[] = dgMapIStatic32Tex;
 
-#define dmap_i_static_Blob_008360 "__OTR__map_i_static/map_i_static_Blob_008360"
-static const ALIGN_ASSET(2) char map_i_static_Blob_008360[] = dmap_i_static_Blob_008360;
+#define dgMapIStatic33Tex "__OTR__map_i_static/gMapIStatic33Tex"
+static const ALIGN_ASSET(2) char gMapIStatic33Tex[] = dgMapIStatic33Tex;
 
-#define dmap_i_static_Blob_0083F0 "__OTR__map_i_static/map_i_static_Blob_0083F0"
-static const ALIGN_ASSET(2) char map_i_static_Blob_0083F0[] = dmap_i_static_Blob_0083F0;
+#define dgMapIStatic34Tex "__OTR__map_i_static/gMapIStatic34Tex"
+static const ALIGN_ASSET(2) char gMapIStatic34Tex[] = dgMapIStatic34Tex;
 
-#define dmap_i_static_Blob_008500 "__OTR__map_i_static/map_i_static_Blob_008500"
-static const ALIGN_ASSET(2) char map_i_static_Blob_008500[] = dmap_i_static_Blob_008500;
+#define dgMapIStatic35Tex "__OTR__map_i_static/gMapIStatic35Tex"
+static const ALIGN_ASSET(2) char gMapIStatic35Tex[] = dgMapIStatic35Tex;
 
-#define dmap_i_static_Blob_0085F0 "__OTR__map_i_static/map_i_static_Blob_0085F0"
-static const ALIGN_ASSET(2) char map_i_static_Blob_0085F0[] = dmap_i_static_Blob_0085F0;
+#define dgMapIStatic36Tex "__OTR__map_i_static/gMapIStatic36Tex"
+static const ALIGN_ASSET(2) char gMapIStatic36Tex[] = dgMapIStatic36Tex;
 
-#define dmap_i_static_Blob_008680 "__OTR__map_i_static/map_i_static_Blob_008680"
-static const ALIGN_ASSET(2) char map_i_static_Blob_008680[] = dmap_i_static_Blob_008680;
+#define dgMapIStatic37Tex "__OTR__map_i_static/gMapIStatic37Tex"
+static const ALIGN_ASSET(2) char gMapIStatic37Tex[] = dgMapIStatic37Tex;
 
-#define dmap_i_static_Blob_008700 "__OTR__map_i_static/map_i_static_Blob_008700"
-static const ALIGN_ASSET(2) char map_i_static_Blob_008700[] = dmap_i_static_Blob_008700;
+#define dgMapIStatic38Tex "__OTR__map_i_static/gMapIStatic38Tex"
+static const ALIGN_ASSET(2) char gMapIStatic38Tex[] = dgMapIStatic38Tex;
 
-#define dmap_i_static_Blob_0087F0 "__OTR__map_i_static/map_i_static_Blob_0087F0"
-static const ALIGN_ASSET(2) char map_i_static_Blob_0087F0[] = dmap_i_static_Blob_0087F0;
+#define dgMapIStatic39Tex "__OTR__map_i_static/gMapIStatic39Tex"
+static const ALIGN_ASSET(2) char gMapIStatic39Tex[] = dgMapIStatic39Tex;
 #endif // ARCHIVES_MAP_I_STATIC_H

--- a/mm/assets/xml/GC_US/archives/map_grand_static.xml
+++ b/mm/assets/xml/GC_US/archives/map_grand_static.xml
@@ -1,102 +1,102 @@
 <Root>
     <File Name="map_grand_static">
-        <Blob Name="map_grand_static_Blob_000000" Size="0x0FF0" Offset="0x0" />
-        <Blob Name="map_grand_static_Blob_000FF0" Size="0x0FF0" Offset="0xFF0" />
-        <Blob Name="map_grand_static_Blob_001FE0" Size="0x0FF0" Offset="0x1FE0" />
-        <Blob Name="map_grand_static_Blob_002FD0" Size="0x0FF0" Offset="0x2FD0" />
-        <Blob Name="map_grand_static_Blob_003FC0" Size="0x0FF0" Offset="0x3FC0" />
-        <Blob Name="map_grand_static_Blob_004FB0" Size="0x0B40" Offset="0x4FB0" />
-        <Blob Name="map_grand_static_Blob_005AF0" Size="0x0FF0" Offset="0x5AF0" />
-        <Blob Name="map_grand_static_Blob_006AE0" Size="0x0FF0" Offset="0x6AE0" />
-        <Blob Name="map_grand_static_Blob_007AD0" Size="0x0FF0" Offset="0x7AD0" />
-        <Blob Name="map_grand_static_Blob_008AC0" Size="0x0FF0" Offset="0x8AC0" />
-        <Blob Name="map_grand_static_Blob_009AB0" Size="0x0420" Offset="0x9AB0" />
-        <Blob Name="map_grand_static_Blob_009ED0" Size="0x0FF0" Offset="0x9ED0" />
-        <Blob Name="map_grand_static_Blob_00AEC0" Size="0x0450" Offset="0xAEC0" />
-        <Blob Name="map_grand_static_Blob_00B310" Size="0x07A0" Offset="0xB310" />
-        <Blob Name="map_grand_static_Blob_00BAB0" Size="0x0FF0" Offset="0xBAB0" />
-        <Blob Name="map_grand_static_Blob_00CAA0" Size="0x0FF0" Offset="0xCAA0" />
-        <Blob Name="map_grand_static_Blob_00DA90" Size="0x0FF0" Offset="0xDA90" />
-        <Blob Name="map_grand_static_Blob_00EA80" Size="0x0780" Offset="0xEA80" />
-        <Blob Name="map_grand_static_Blob_00F200" Size="0x0800" Offset="0xF200" />
-        <Blob Name="map_grand_static_Blob_00FA00" Size="0x0850" Offset="0xFA00" />
-        <Blob Name="map_grand_static_Blob_010250" Size="0x0510" Offset="0x10250" />
-        <Blob Name="map_grand_static_Blob_010760" Size="0x0710" Offset="0x10760" />
-        <Blob Name="map_grand_static_Blob_010E70" Size="0x0AE0" Offset="0x10E70" />
-        <Blob Name="map_grand_static_Blob_011950" Size="0x0660" Offset="0x11950" />
-        <Blob Name="map_grand_static_Blob_011FB0" Size="0x0C60" Offset="0x11FB0" />
-        <Blob Name="map_grand_static_Blob_012C10" Size="0x0E10" Offset="0x12C10" />
-        <Blob Name="map_grand_static_Blob_013A20" Size="0x03E0" Offset="0x13A20" />
-        <Blob Name="map_grand_static_Blob_013E00" Size="0x05A0" Offset="0x13E00" />
-        <Blob Name="map_grand_static_Blob_0143A0" Size="0x0820" Offset="0x143A0" />
-        <Blob Name="map_grand_static_Blob_014BC0" Size="0x0440" Offset="0x14BC0" />
-        <Blob Name="map_grand_static_Blob_015000" Size="0x0590" Offset="0x15000" />
-        <Blob Name="map_grand_static_Blob_015590" Size="0x05A0" Offset="0x15590" />
-        <Blob Name="map_grand_static_Blob_015B30" Size="0x07A0" Offset="0x15B30" />
-        <Blob Name="map_grand_static_Blob_0162D0" Size="0x07A0" Offset="0x162D0" />
-        <Blob Name="map_grand_static_Blob_016A70" Size="0x0DF0" Offset="0x16A70" />
-        <Blob Name="map_grand_static_Blob_017860" Size="0x0850" Offset="0x17860" />
-        <Blob Name="map_grand_static_Blob_0180B0" Size="0x09C0" Offset="0x180B0" />
-        <Blob Name="map_grand_static_Blob_018A70" Size="0x0880" Offset="0x18A70" />
-        <Blob Name="map_grand_static_Blob_0192F0" Size="0x0660" Offset="0x192F0" />
-        <Blob Name="map_grand_static_Blob_019950" Size="0x0360" Offset="0x19950" />
-        <Blob Name="map_grand_static_Blob_019CB0" Size="0x0260" Offset="0x19CB0" />
-        <Blob Name="map_grand_static_Blob_019F10" Size="0x0960" Offset="0x19F10" />
-        <Blob Name="map_grand_static_Blob_01A870" Size="0x0350" Offset="0x1A870" />
-        <Blob Name="map_grand_static_Blob_01ABC0" Size="0x09B0" Offset="0x1ABC0" />
-        <Blob Name="map_grand_static_Blob_01B570" Size="0x0980" Offset="0x1B570" />
-        <Blob Name="map_grand_static_Blob_01BEF0" Size="0x0FF0" Offset="0x1BEF0" />
-        <Blob Name="map_grand_static_Blob_01CEE0" Size="0x0B20" Offset="0x1CEE0" />
-        <Blob Name="map_grand_static_Blob_01DA00" Size="0x0DA0" Offset="0x1DA00" />
-        <Blob Name="map_grand_static_Blob_01E7A0" Size="0x0820" Offset="0x1E7A0" />
-        <Blob Name="map_grand_static_Blob_01EFC0" Size="0x03E0" Offset="0x1EFC0" />
-        <Blob Name="map_grand_static_Blob_01F3A0" Size="0x0980" Offset="0x1F3A0" />
-        <Blob Name="map_grand_static_Blob_01FD20" Size="0x0960" Offset="0x1FD20" />
-        <Blob Name="map_grand_static_Blob_020680" Size="0x0760" Offset="0x20680" />
-        <Blob Name="map_grand_static_Blob_020DE0" Size="0x0960" Offset="0x20DE0" />
-        <Blob Name="map_grand_static_Blob_021740" Size="0x01D0" Offset="0x21740" />
-        <Blob Name="map_grand_static_Blob_021910" Size="0x0630" Offset="0x21910" />
-        <Blob Name="map_grand_static_Blob_021F40" Size="0x0680" Offset="0x21F40" />
-        <Blob Name="map_grand_static_Blob_0225C0" Size="0x07D0" Offset="0x225C0" />
-        <Blob Name="map_grand_static_Blob_022D90" Size="0x0870" Offset="0x22D90" />
-        <Blob Name="map_grand_static_Blob_023600" Size="0x0E60" Offset="0x23600" />
-        <Blob Name="map_grand_static_Blob_024460" Size="0x0710" Offset="0x24460" />
-        <Blob Name="map_grand_static_Blob_024B70" Size="0x0620" Offset="0x24B70" />
-        <Blob Name="map_grand_static_Blob_025190" Size="0x0620" Offset="0x25190" />
-        <Blob Name="map_grand_static_Blob_0257B0" Size="0x0680" Offset="0x257B0" />
-        <Blob Name="map_grand_static_Blob_025E30" Size="0x0620" Offset="0x25E30" />
-        <Blob Name="map_grand_static_Blob_026450" Size="0x0210" Offset="0x26450" />
-        <Blob Name="map_grand_static_Blob_026660" Size="0x04B0" Offset="0x26660" />
-        <Blob Name="map_grand_static_Blob_026B10" Size="0x0680" Offset="0x26B10" />
-        <Blob Name="map_grand_static_Blob_027190" Size="0x0350" Offset="0x27190" />
-        <Blob Name="map_grand_static_Blob_0274E0" Size="0x0660" Offset="0x274E0" />
-        <Blob Name="map_grand_static_Blob_027B40" Size="0x0350" Offset="0x27B40" />
-        <Blob Name="map_grand_static_Blob_027E90" Size="0x0500" Offset="0x27E90" />
-        <Blob Name="map_grand_static_Blob_028390" Size="0x06A0" Offset="0x28390" />
-        <Blob Name="map_grand_static_Blob_028A30" Size="0x05E0" Offset="0x28A30" />
-        <Blob Name="map_grand_static_Blob_029010" Size="0x0680" Offset="0x29010" />
-        <Blob Name="map_grand_static_Blob_029690" Size="0x0480" Offset="0x29690" />
-        <Blob Name="map_grand_static_Blob_029B10" Size="0x0AE0" Offset="0x29B10" />
-        <Blob Name="map_grand_static_Blob_02A5F0" Size="0x02D0" Offset="0x2A5F0" />
-        <Blob Name="map_grand_static_Blob_02A8C0" Size="0x0B90" Offset="0x2A8C0" />
-        <Blob Name="map_grand_static_Blob_02B450" Size="0x0DA0" Offset="0x2B450" />
-        <Blob Name="map_grand_static_Blob_02C1F0" Size="0x08C0" Offset="0x2C1F0" />
-        <Blob Name="map_grand_static_Blob_02CAB0" Size="0x0A30" Offset="0x2CAB0" />
-        <Blob Name="map_grand_static_Blob_02D4E0" Size="0x0130" Offset="0x2D4E0" />
-        <Blob Name="map_grand_static_Blob_02D610" Size="0x0C30" Offset="0x2D610" />
-        <Blob Name="map_grand_static_Blob_02E240" Size="0x08A0" Offset="0x2E240" />
-        <Blob Name="map_grand_static_Blob_02EAE0" Size="0x0F50" Offset="0x2EAE0" />
-        <Blob Name="map_grand_static_Blob_02FA30" Size="0x09B0" Offset="0x2FA30" />
-        <Blob Name="map_grand_static_Blob_0303E0" Size="0x07B0" Offset="0x303E0" />
-        <Blob Name="map_grand_static_Blob_030B90" Size="0x0960" Offset="0x30B90" />
-        <Blob Name="map_grand_static_Blob_0314F0" Size="0x0740" Offset="0x314F0" />
-        <Blob Name="map_grand_static_Blob_031C30" Size="0x0A00" Offset="0x31C30" />
-        <Blob Name="map_grand_static_Blob_032630" Size="0x0640" Offset="0x32630" />
-        <Blob Name="map_grand_static_Blob_032C70" Size="0x0A30" Offset="0x32C70" />
-        <Blob Name="map_grand_static_Blob_0336A0" Size="0x03D0" Offset="0x336A0" />
-        <Blob Name="map_grand_static_Blob_033A70" Size="0x0D00" Offset="0x33A70" />
-        <Blob Name="map_grand_static_Blob_034770" Size="0x0440" Offset="0x34770" />
-        <Blob Name="map_grand_static_Blob_034BB0" Size="0x03A0" Offset="0x34BB0" />
-        <Blob Name="map_grand_static_Blob_034F50" Size="0x0960" Offset="0x34F50" />
+        <Texture Name="gMapGrandStatic100Tex" OutName="map_100" Format="i4" Width="96" Height="85" Offset="0x0" />
+        <Texture Name="gMapGrandStatic101Tex" OutName="map_101" Format="i4" Width="96" Height="85" Offset="0xFF0" />
+        <Texture Name="gMapGrandStatic102Tex" OutName="map_102" Format="i4" Width="96" Height="85" Offset="0x1FE0" />
+        <Texture Name="gMapGrandStatic103Tex" OutName="map_103" Format="i4" Width="96" Height="85" Offset="0x2FD0" />
+        <Texture Name="gMapGrandStatic104Tex" OutName="map_104" Format="i4" Width="96" Height="85" Offset="0x3FC0" />
+        <Texture Name="gMapGrandStatic105Tex" OutName="map_105" Format="i4" Width="80" Height="72" Offset="0x4FB0" />
+        <Texture Name="gMapGrandStatic106Tex" OutName="map_106" Format="i4" Width="96" Height="85" Offset="0x5AF0" />
+        <Texture Name="gMapGrandStatic107Tex" OutName="map_107" Format="i4" Width="96" Height="85" Offset="0x6AE0" />
+        <Texture Name="gMapGrandStatic108Tex" OutName="map_108" Format="i4" Width="96" Height="85" Offset="0x7AD0" />
+        <Texture Name="gMapGrandStatic109Tex" OutName="map_109" Format="i4" Width="96" Height="85" Offset="0x8AC0" />
+        <Texture Name="gMapGrandStatic10ATex" OutName="map_10A" Format="i4" Width="48" Height="44" Offset="0x9AB0" />
+        <Texture Name="gMapGrandStatic10BTex" OutName="map_10B" Format="i4" Width="96" Height="85" Offset="0x9ED0" />
+        <Texture Name="gMapGrandStatic10CTex" OutName="map_10C" Format="i4" Width="48" Height="46" Offset="0xAEC0" />
+        <Texture Name="gMapGrandStatic10DTex" OutName="map_10D" Format="i4" Width="64" Height="61" Offset="0xB310" />
+        <Texture Name="gMapGrandStatic10ETex" OutName="map_10E" Format="i4" Width="96" Height="85" Offset="0xBAB0" />
+        <Texture Name="gMapGrandStatic10FTex" OutName="map_10F" Format="i4" Width="96" Height="85" Offset="0xCAA0" />
+        <Texture Name="gMapGrandStatic110Tex" OutName="map_110" Format="i4" Width="96" Height="85" Offset="0xDA90" />
+        <Texture Name="gMapGrandStatic111Tex" OutName="map_111" Format="i4" Width="48" Height="80" Offset="0xEA80" />
+        <Texture Name="gMapGrandStatic112Tex" OutName="map_112" Format="i4" Width="32" Height="128" Offset="0xF200" />
+        <Texture Name="gMapGrandStatic113Tex" OutName="map_113" Format="i4" Width="80" Height="53" Offset="0xFA00" />
+        <Texture Name="gMapGrandStatic114Tex" OutName="map_114" Format="i4" Width="32" Height="81" Offset="0x10250" />
+        <Texture Name="gMapGrandStatic115Tex" OutName="map_115" Format="i4" Width="80" Height="45" Offset="0x10760" />
+        <Texture Name="gMapGrandStatic116Tex" OutName="map_116" Format="i4" Width="64" Height="87" Offset="0x10E70" />
+        <Texture Name="gMapGrandStatic117Tex" OutName="map_117" Format="i4" Width="64" Height="51" Offset="0x11950" />
+        <Texture Name="gMapGrandStatic118Tex" OutName="map_118" Format="i4" Width="80" Height="79" Offset="0x11FB0" />
+        <Texture Name="gMapGrandStatic119Tex" OutName="map_119" Format="i4" Width="96" Height="75" Offset="0x12C10" />
+        <Texture Name="gMapGrandStatic11ATex" OutName="map_11A" Format="i4" Width="48" Height="41" Offset="0x13A20" />
+        <Texture Name="gMapGrandStatic11BTex" OutName="map_11B" Format="i4" Width="64" Height="45" Offset="0x13E00" />
+        <Texture Name="gMapGrandStatic11CTex" OutName="map_11C" Format="i4" Width="80" Height="52" Offset="0x143A0" />
+        <Texture Name="gMapGrandStatic11DTex" OutName="map_11D" Format="i4" Width="48" Height="45" Offset="0x14BC0" />
+        <Texture Name="gMapGrandStatic11ETex" OutName="map_11E" Format="i4" Width="48" Height="59" Offset="0x15000" />
+        <Texture Name="gMapGrandStatic11FTex" OutName="map_11F" Format="i4" Width="48" Height="60" Offset="0x15590" />
+        <Texture Name="gMapGrandStatic120Tex" OutName="map_120" Format="i4" Width="48" Height="81" Offset="0x15B30" />
+        <Texture Name="gMapGrandStatic121Tex" OutName="map_121" Format="i4" Width="48" Height="81" Offset="0x162D0" />
+        <Texture Name="gMapGrandStatic122Tex" OutName="map_122" Format="i4" Width="80" Height="89" Offset="0x16A70" />
+        <Texture Name="gMapGrandStatic123Tex" OutName="map_123" Format="i4" Width="80" Height="53" Offset="0x17860" />
+        <Texture Name="gMapGrandStatic124Tex" OutName="map_124" Format="i4" Width="64" Height="78" Offset="0x180B0" />
+        <Texture Name="gMapGrandStatic125Tex" OutName="map_125" Format="i4" Width="64" Height="68" Offset="0x18A70" />
+        <Texture Name="gMapGrandStatic126Tex" OutName="map_126" Format="i4" Width="48" Height="68" Offset="0x192F0" />
+        <Texture Name="gMapGrandStatic127Tex" OutName="map_127" Format="i4" Width="48" Height="36" Offset="0x19950" />
+        <Texture Name="gMapGrandStatic128Tex" OutName="map_128" Format="i4" Width="48" Height="25" Offset="0x19CB0" />
+        <Texture Name="gMapGrandStatic129Tex" OutName="map_129" Format="i4" Width="64" Height="75" Offset="0x19F10" />
+        <Texture Name="gMapGrandStatic12ATex" OutName="map_12A" Format="i4" Width="32" Height="53" Offset="0x1A870" />
+        <Texture Name="gMapGrandStatic12BTex" OutName="map_12B" Format="i4" Width="80" Height="62" Offset="0x1ABC0" />
+        <Texture Name="gMapGrandStatic12CTex" OutName="map_12C" Format="i4" Width="64" Height="76" Offset="0x1B570" />
+        <Texture Name="gMapGrandStatic12DTex" OutName="map_12D" Format="i4" Width="96" Height="85" Offset="0x1BEF0" />
+        <Texture Name="gMapGrandStatic12ETex" OutName="map_12E" Format="i4" Width="80" Height="71" Offset="0x1CEE0" />
+        <Texture Name="gMapGrandStatic12FTex" OutName="map_12F" Format="i4" Width="80" Height="87" Offset="0x1DA00" />
+        <Texture Name="gMapGrandStatic130Tex" OutName="map_130" Format="i4" Width="64" Height="65" Offset="0x1E7A0" />
+        <Texture Name="gMapGrandStatic131Tex" OutName="map_131" Format="i4" Width="48" Height="41" Offset="0x1EFC0" />
+        <Texture Name="gMapGrandStatic132Tex" OutName="map_132" Format="i4" Width="64" Height="76" Offset="0x1F3A0" />
+        <Texture Name="gMapGrandStatic133Tex" OutName="map_133" Format="i4" Width="80" Height="60" Offset="0x1FD20" />
+        <Texture Name="gMapGrandStatic134Tex" OutName="map_134" Format="i4" Width="80" Height="47" Offset="0x20680" />
+        <Texture Name="gMapGrandStatic135Tex" OutName="map_135" Format="i4" Width="80" Height="60" Offset="0x20DE0" />
+        <Texture Name="gMapGrandStatic136Tex" OutName="map_136" Format="i4" Width="48" Height="19" Offset="0x21740" />
+        <Texture Name="gMapGrandStatic137Tex" OutName="map_137" Format="i4" Width="32" Height="99" Offset="0x21910" />
+        <Texture Name="gMapGrandStatic138Tex" OutName="map_138" Format="i4" Width="48" Height="69" Offset="0x21F40" />
+        <Texture Name="gMapGrandStatic139Tex" OutName="map_139" Format="i4" Width="48" Height="83" Offset="0x225C0" />
+        <Texture Name="gMapGrandStatic13ATex" OutName="map_13A" Format="i4" Width="80" Height="54" Offset="0x22D90" />
+        <Texture Name="gMapGrandStatic13BTex" OutName="map_13B" Format="i4" Width="80" Height="92" Offset="0x23600" />
+        <Texture Name="gMapGrandStatic13CTex" OutName="map_13C" Format="i4" Width="48" Height="75" Offset="0x24460" />
+        <Texture Name="gMapGrandStatic13DTex" OutName="map_13D" Format="i4" Width="64" Height="49" Offset="0x24B70" />
+        <Texture Name="gMapGrandStatic13ETex" OutName="map_13E" Format="i4" Width="64" Height="49" Offset="0x25190" />
+        <Texture Name="gMapGrandStatic13FTex" OutName="map_13F" Format="i4" Width="64" Height="52" Offset="0x257B0" />
+        <Texture Name="gMapGrandStatic140Tex" OutName="map_140" Format="i4" Width="64" Height="49" Offset="0x25E30" />
+        <Texture Name="gMapGrandStatic141Tex" OutName="map_141" Format="i4" Width="32" Height="33" Offset="0x26450" />
+        <Texture Name="gMapGrandStatic142Tex" OutName="map_142" Format="i4" Width="48" Height="50" Offset="0x26660" />
+        <Texture Name="gMapGrandStatic143Tex" OutName="map_143" Format="i4" Width="64" Height="52" Offset="0x26B10" />
+        <Texture Name="gMapGrandStatic144Tex" OutName="map_144" Format="i4" Width="48" Height="35" Offset="0x27190" />
+        <Texture Name="gMapGrandStatic145Tex" OutName="map_145" Format="i4" Width="64" Height="51" Offset="0x274E0" />
+        <Texture Name="gMapGrandStatic146Tex" OutName="map_146" Format="i4" Width="48" Height="35" Offset="0x27B40" />
+        <Texture Name="gMapGrandStatic147Tex" OutName="map_147" Format="i4" Width="48" Height="53" Offset="0x27E90" />
+        <Texture Name="gMapGrandStatic148Tex" OutName="map_148" Format="i4" Width="64" Height="53" Offset="0x28390" />
+        <Texture Name="gMapGrandStatic149Tex" OutName="map_149" Format="i4" Width="64" Height="47" Offset="0x28A30" />
+        <Texture Name="gMapGrandStatic14ATex" OutName="map_14A" Format="i4" Width="64" Height="52" Offset="0x29010" />
+        <Texture Name="gMapGrandStatic14BTex" OutName="map_14B" Format="i4" Width="48" Height="48" Offset="0x29690" />
+        <Texture Name="gMapGrandStatic14CTex" OutName="map_14C" Format="i4" Width="64" Height="87" Offset="0x29B10" />
+        <Texture Name="gMapGrandStatic14DTex" OutName="map_14D" Format="i4" Width="48" Height="30" Offset="0x2A5F0" />
+        <Texture Name="gMapGrandStatic14ETex" OutName="map_14E" Format="i4" Width="80" Height="74" Offset="0x2A8C0" />
+        <Texture Name="gMapGrandStatic14FTex" OutName="map_14F" Format="i4" Width="80" Height="87" Offset="0x2B450" />
+        <Texture Name="gMapGrandStatic150Tex" OutName="map_150" Format="i4" Width="80" Height="56" Offset="0x2C1F0" />
+        <Texture Name="gMapGrandStatic151Tex" OutName="map_151" Format="i4" Width="80" Height="65" Offset="0x2CAB0" />
+        <Texture Name="gMapGrandStatic152Tex" OutName="map_152" Format="i4" Width="16" Height="38" Offset="0x2D4E0" />
+        <Texture Name="gMapGrandStatic153Tex" OutName="map_153" Format="i4" Width="80" Height="78" Offset="0x2D610" />
+        <Texture Name="gMapGrandStatic154Tex" OutName="map_154" Format="i4" Width="80" Height="55" Offset="0x2E240" />
+        <Texture Name="gMapGrandStatic155Tex" OutName="map_155" Format="i4" Width="80" Height="98" Offset="0x2EAE0" />
+        <Texture Name="gMapGrandStatic156Tex" OutName="map_156" Format="i4" Width="80" Height="62" Offset="0x2FA30" />
+        <Texture Name="gMapGrandStatic157Tex" OutName="map_157" Format="i4" Width="32" Height="123" Offset="0x303E0" />
+        <Texture Name="gMapGrandStatic158Tex" OutName="map_158" Format="i4" Width="80" Height="60" Offset="0x30B90" />
+        <Texture Name="gMapGrandStatic159Tex" OutName="map_159" Format="i4" Width="48" Height="77" Offset="0x314F0" />
+        <Texture Name="gMapGrandStatic15ATex" OutName="map_15A" Format="i4" Width="80" Height="64" Offset="0x31C30" />
+        <Texture Name="gMapGrandStatic15BTex" OutName="map_15B" Format="i4" Width="64" Height="50" Offset="0x32630" />
+        <Texture Name="gMapGrandStatic15CTex" OutName="map_15C" Format="i4" Width="80" Height="65" Offset="0x32C70" />
+        <Texture Name="gMapGrandStatic15DTex" OutName="map_15D" Format="i4" Width="32" Height="61" Offset="0x336A0" />
+        <Texture Name="gMapGrandStatic15ETex" OutName="map_15E" Format="i4" Width="80" Height="83" Offset="0x33A70" />
+        <Texture Name="gMapGrandStatic15FTex" OutName="map_15F" Format="i4" Width="80" Height="27" Offset="0x34770" />
+        <Texture Name="gMapGrandStatic160Tex" OutName="map_160" Format="i4" Width="80" Height="23" Offset="0x34BB0" />
+        <Texture Name="gMapGrandStatic161Tex" OutName="map_161" Format="i4" Width="80" Height="60" Offset="0x34F50" />
     </File>
 </Root>

--- a/mm/assets/xml/GC_US/archives/map_i_static.xml
+++ b/mm/assets/xml/GC_US/archives/map_i_static.xml
@@ -1,62 +1,62 @@
 <Root>
     <File Name="map_i_static">
-        <Blob Name="map_i_static_Blob_000000" Size="0x0FF0" Offset="0x0" />
-        <Blob Name="map_i_static_Blob_000FF0" Size="0x0FF0" Offset="0xFF0" />
-        <Blob Name="map_i_static_Blob_001FE0" Size="0x0FF0" Offset="0x1FE0" />
-        <Blob Name="map_i_static_Blob_002FD0" Size="0x0FF0" Offset="0x2FD0" />
-        <Blob Name="map_i_static_Blob_003FC0" Size="0x0FF0" Offset="0x3FC0" />
-        <Blob Name="map_i_static_Blob_004FB0" Size="0x01D0" Offset="0x4FB0" />
-        <Blob Name="map_i_static_Blob_005180" Size="0x01B0" Offset="0x5180" />
-        <Blob Name="map_i_static_Blob_005330" Size="0x01E0" Offset="0x5330" />
-        <Blob Name="map_i_static_Blob_005510" Size="0x0100" Offset="0x5510" />
-        <Blob Name="map_i_static_Blob_005610" Size="0x0060" Offset="0x5610" />
-        <Blob Name="map_i_static_Blob_005670" Size="0x01B0" Offset="0x5670" />
-        <Blob Name="map_i_static_Blob_005820" Size="0x0070" Offset="0x5820" />
-        <Blob Name="map_i_static_Blob_005890" Size="0x0130" Offset="0x5890" />
-        <Blob Name="map_i_static_Blob_0059C0" Size="0x01A0" Offset="0x59C0" />
-        <Blob Name="map_i_static_Blob_005B60" Size="0x0100" Offset="0x5B60" />
-        <Blob Name="map_i_static_Blob_005C60" Size="0x01B0" Offset="0x5C60" />
-        <Blob Name="map_i_static_Blob_005E10" Size="0x0120" Offset="0x5E10" />
-        <Blob Name="map_i_static_Blob_005F30" Size="0x0120" Offset="0x5F30" />
-        <Blob Name="map_i_static_Blob_006050" Size="0x0260" Offset="0x6050" />
-        <Blob Name="map_i_static_Blob_0062B0" Size="0x0150" Offset="0x62B0" />
-        <Blob Name="map_i_static_Blob_006400" Size="0x0220" Offset="0x6400" />
-        <Blob Name="map_i_static_Blob_006620" Size="0x0300" Offset="0x6620" />
-        <Blob Name="map_i_static_Blob_006920" Size="0x0110" Offset="0x6920" />
-        <Blob Name="map_i_static_Blob_006A30" Size="0x0110" Offset="0x6A30" />
-        <Blob Name="map_i_static_Blob_006B40" Size="0x0150" Offset="0x6B40" />
-        <Blob Name="map_i_static_Blob_006C90" Size="0x0120" Offset="0x6C90" />
-        <Blob Name="map_i_static_Blob_006DB0" Size="0x00C0" Offset="0x6DB0" />
-        <Blob Name="map_i_static_Blob_006E70" Size="0x00D0" Offset="0x6E70" />
-        <Blob Name="map_i_static_Blob_006F40" Size="0x0230" Offset="0x6F40" />
-        <Blob Name="map_i_static_Blob_007170" Size="0x00A0" Offset="0x7170" />
-        <Blob Name="map_i_static_Blob_007210" Size="0x01C0" Offset="0x7210" />
-        <Blob Name="map_i_static_Blob_0073D0" Size="0x0100" Offset="0x73D0" />
-        <Blob Name="map_i_static_Blob_0074D0" Size="0x0180" Offset="0x74D0" />
-        <Blob Name="map_i_static_Blob_007650" Size="0x0150" Offset="0x7650" />
-        <Blob Name="map_i_static_Blob_0077A0" Size="0x00B0" Offset="0x77A0" />
-        <Blob Name="map_i_static_Blob_007850" Size="0x0050" Offset="0x7850" />
-        <Blob Name="map_i_static_Blob_0078A0" Size="0x0040" Offset="0x78A0" />
-        <Blob Name="map_i_static_Blob_0078E0" Size="0x0170" Offset="0x78E0" />
-        <Blob Name="map_i_static_Blob_007A50" Size="0x0080" Offset="0x7A50" />
-        <Blob Name="map_i_static_Blob_007AD0" Size="0x0090" Offset="0x7AD0" />
-        <Blob Name="map_i_static_Blob_007B60" Size="0x00C0" Offset="0x7B60" />
-        <Blob Name="map_i_static_Blob_007C20" Size="0x0080" Offset="0x7C20" />
-        <Blob Name="map_i_static_Blob_007CA0" Size="0x00F0" Offset="0x7CA0" />
-        <Blob Name="map_i_static_Blob_007D90" Size="0x0110" Offset="0x7D90" />
-        <Blob Name="map_i_static_Blob_007EA0" Size="0x0100" Offset="0x7EA0" />
-        <Blob Name="map_i_static_Blob_007FA0" Size="0x0050" Offset="0x7FA0" />
-        <Blob Name="map_i_static_Blob_007FF0" Size="0x0090" Offset="0x7FF0" />
-        <Blob Name="map_i_static_Blob_008080" Size="0x0110" Offset="0x8080" />
-        <Blob Name="map_i_static_Blob_008190" Size="0x0060" Offset="0x8190" />
-        <Blob Name="map_i_static_Blob_0081F0" Size="0x0110" Offset="0x81F0" />
-        <Blob Name="map_i_static_Blob_008300" Size="0x0060" Offset="0x8300" />
-        <Blob Name="map_i_static_Blob_008360" Size="0x0090" Offset="0x8360" />
-        <Blob Name="map_i_static_Blob_0083F0" Size="0x0110" Offset="0x83F0" />
-        <Blob Name="map_i_static_Blob_008500" Size="0x00F0" Offset="0x8500" />
-        <Blob Name="map_i_static_Blob_0085F0" Size="0x0090" Offset="0x85F0" />
-        <Blob Name="map_i_static_Blob_008680" Size="0x0080" Offset="0x8680" />
-        <Blob Name="map_i_static_Blob_008700" Size="0x00F0" Offset="0x8700" />
-        <Blob Name="map_i_static_Blob_0087F0" Size="0x0050" Offset="0x87F0" />
+        <Texture Name="gMapIStatic00Tex" OutName="map_00" Format="i4" Width="96" Height="85" Offset="0x0" />
+        <Texture Name="gMapIStatic01Tex" OutName="map_01" Format="i4" Width="96" Height="85" Offset="0xFF0" />
+        <Texture Name="gMapIStatic02Tex" OutName="map_02" Format="i4" Width="96" Height="85" Offset="0x1FE0" />
+        <Texture Name="gMapIStatic03Tex" OutName="map_03" Format="i4" Width="96" Height="85" Offset="0x2FD0" />
+        <Texture Name="gMapIStatic04Tex" OutName="map_04" Format="i4" Width="96" Height="85" Offset="0x3FC0" />
+        <Texture Name="gMapIStatic05Tex" OutName="map_05" Format="i4" Width="32" Height="29" Offset="0x4FB0" />
+        <Texture Name="gMapIStatic06Tex" OutName="map_06" Format="i4" Width="32" Height="27" Offset="0x5180" />
+        <Texture Name="gMapIStatic07Tex" OutName="map_07" Format="i4" Width="32" Height="30" Offset="0x5330" />
+        <Texture Name="gMapIStatic08Tex" OutName="map_08" Format="i4" Width="16" Height="32" Offset="0x5510" />
+        <Texture Name="gMapIStatic09Tex" OutName="map_09" Format="i4" Width="16" Height="12" Offset="0x5610" />
+        <Texture Name="gMapIStatic0ATex" OutName="map_0A" Format="i4" Width="32" Height="27" Offset="0x5670" />
+        <Texture Name="gMapIStatic0BTex" OutName="map_0B" Format="i4" Width="16" Height="14" Offset="0x5820" />
+        <Texture Name="gMapIStatic0CTex" OutName="map_0C" Format="i4" Width="32" Height="19" Offset="0x5890" />
+        <Texture Name="gMapIStatic0DTex" OutName="map_0D" Format="i4" Width="32" Height="26" Offset="0x59C0" />
+        <Texture Name="gMapIStatic0ETex" OutName="map_0E" Format="i4" Width="16" Height="32" Offset="0x5B60" />
+        <Texture Name="gMapIStatic0FTex" OutName="map_0F" Format="i4" Width="32" Height="27" Offset="0x5C60" />
+        <Texture Name="gMapIStatic10Tex" OutName="map_10" Format="i4" Width="16" Height="35" Offset="0x5E10" />
+        <Texture Name="gMapIStatic11Tex" OutName="map_11" Format="i4" Width="32" Height="18" Offset="0x5F30" />
+        <Texture Name="gMapIStatic12Tex" OutName="map_12" Format="i4" Width="32" Height="38" Offset="0x6050" />
+        <Texture Name="gMapIStatic13Tex" OutName="map_13" Format="i4" Width="32" Height="21" Offset="0x62B0" />
+        <Texture Name="gMapIStatic14Tex" OutName="map_14" Format="i4" Width="32" Height="34" Offset="0x6400" />
+        <Texture Name="gMapIStatic15Tex" OutName="map_15" Format="i4" Width="48" Height="32" Offset="0x6620" />
+        <Texture Name="gMapIStatic16Tex" OutName="map_16" Format="i4" Width="32" Height="17" Offset="0x6920" />
+        <Texture Name="gMapIStatic17Tex" OutName="map_17" Format="i4" Width="32" Height="17" Offset="0x6A30" />
+        <Texture Name="gMapIStatic18Tex" OutName="map_18" Format="i4" Width="32" Height="21" Offset="0x6B40" />
+        <Texture Name="gMapIStatic19Tex" OutName="map_19" Format="i4" Width="32" Height="18" Offset="0x6C90" />
+        <Texture Name="gMapIStatic1ATex" OutName="map_1A" Format="i4" Width="16" Height="24" Offset="0x6DB0" />
+        <Texture Name="gMapIStatic1BTex" OutName="map_1B" Format="i4" Width="16" Height="25" Offset="0x6E70" />
+        <Texture Name="gMapIStatic1CTex" OutName="map_1C" Format="i4" Width="32" Height="35" Offset="0x6F40" />
+        <Texture Name="gMapIStatic1DTex" OutName="map_1D" Format="i4" Width="16" Height="19" Offset="0x7170" />
+        <Texture Name="gMapIStatic1ETex" OutName="map_1E" Format="i4" Width="32" Height="28" Offset="0x7210" />
+        <Texture Name="gMapIStatic1FTex" OutName="map_1F" Format="i4" Width="32" Height="16" Offset="0x73D0" />
+        <Texture Name="gMapIStatic20Tex" OutName="map_20" Format="i4" Width="32" Height="24" Offset="0x74D0" />
+        <Texture Name="gMapIStatic21Tex" OutName="map_21" Format="i4" Width="32" Height="21" Offset="0x7650" />
+        <Texture Name="gMapIStatic22Tex" OutName="map_22" Format="i4" Width="16" Height="21" Offset="0x77A0" />
+        <Texture Name="gMapIStatic23Tex" OutName="map_23" Format="i4" Width="16" Height="10" Offset="0x7850" />
+        <Texture Name="gMapIStatic24Tex" OutName="map_24" Format="i4" Width="16" Height="7" Offset="0x78A0" />
+        <Texture Name="gMapIStatic25Tex" OutName="map_25" Format="i4" Width="32" Height="23" Offset="0x78E0" />
+        <Texture Name="gMapIStatic26Tex" OutName="map_26" Format="i4" Width="16" Height="16" Offset="0x7A50" />
+        <Texture Name="gMapIStatic27Tex" OutName="map_27" Format="i4" Width="16" Height="17" Offset="0x7AD0" />
+        <Texture Name="gMapIStatic28Tex" OutName="map_28" Format="i4" Width="16" Height="23" Offset="0x7B60" />
+        <Texture Name="gMapIStatic29Tex" OutName="map_29" Format="i4" Width="16" Height="15" Offset="0x7C20" />
+        <Texture Name="gMapIStatic2ATex" OutName="map_2A" Format="i4" Width="32" Height="15" Offset="0x7CA0" />
+        <Texture Name="gMapIStatic2BTex" OutName="map_2B" Format="i4" Width="32" Height="17" Offset="0x7D90" />
+        <Texture Name="gMapIStatic2CTex" OutName="map_2C" Format="i4" Width="32" Height="16" Offset="0x7EA0" />
+        <Texture Name="gMapIStatic2DTex" OutName="map_2D" Format="i4" Width="16" Height="10" Offset="0x7FA0" />
+        <Texture Name="gMapIStatic2ETex" OutName="map_2E" Format="i4" Width="16" Height="17" Offset="0x7FF0" />
+        <Texture Name="gMapIStatic2FTex" OutName="map_2F" Format="i4" Width="32" Height="17" Offset="0x8080" />
+        <Texture Name="gMapIStatic30Tex" OutName="map_30" Format="i4" Width="16" Height="11" Offset="0x8190" />
+        <Texture Name="gMapIStatic31Tex" OutName="map_31" Format="i4" Width="32" Height="17" Offset="0x81F0" />
+        <Texture Name="gMapIStatic32Tex" OutName="map_32" Format="i4" Width="16" Height="12" Offset="0x8300" />
+        <Texture Name="gMapIStatic33Tex" OutName="map_33" Format="i4" Width="16" Height="18" Offset="0x8360" />
+        <Texture Name="gMapIStatic34Tex" OutName="map_34" Format="i4" Width="32" Height="17" Offset="0x83F0" />
+        <Texture Name="gMapIStatic35Tex" OutName="map_35" Format="i4" Width="32" Height="15" Offset="0x8500" />
+        <Texture Name="gMapIStatic36Tex" OutName="map_36" Format="i4" Width="16" Height="18" Offset="0x85F0" />
+        <Texture Name="gMapIStatic37Tex" OutName="map_37" Format="i4" Width="16" Height="16" Offset="0x8680" />
+        <Texture Name="gMapIStatic38Tex" OutName="map_38" Format="i4" Width="16" Height="30" Offset="0x8700" />
+        <Texture Name="gMapIStatic39Tex" OutName="map_39" Format="i4" Width="16" Height="9" Offset="0x87F0" />
     </File>
 </Root>

--- a/mm/assets/xml/N64_US/archives/map_grand_static.xml
+++ b/mm/assets/xml/N64_US/archives/map_grand_static.xml
@@ -1,102 +1,102 @@
 <Root>
     <File Name="map_grand_static">
-        <Blob Name="map_grand_static_Blob_000000" Size="0x0FF0" Offset="0x0" />
-        <Blob Name="map_grand_static_Blob_000FF0" Size="0x0FF0" Offset="0xFF0" />
-        <Blob Name="map_grand_static_Blob_001FE0" Size="0x0FF0" Offset="0x1FE0" />
-        <Blob Name="map_grand_static_Blob_002FD0" Size="0x0FF0" Offset="0x2FD0" />
-        <Blob Name="map_grand_static_Blob_003FC0" Size="0x0FF0" Offset="0x3FC0" />
-        <Blob Name="map_grand_static_Blob_004FB0" Size="0x0B40" Offset="0x4FB0" />
-        <Blob Name="map_grand_static_Blob_005AF0" Size="0x0FF0" Offset="0x5AF0" />
-        <Blob Name="map_grand_static_Blob_006AE0" Size="0x0FF0" Offset="0x6AE0" />
-        <Blob Name="map_grand_static_Blob_007AD0" Size="0x0FF0" Offset="0x7AD0" />
-        <Blob Name="map_grand_static_Blob_008AC0" Size="0x0FF0" Offset="0x8AC0" />
-        <Blob Name="map_grand_static_Blob_009AB0" Size="0x0420" Offset="0x9AB0" />
-        <Blob Name="map_grand_static_Blob_009ED0" Size="0x0FF0" Offset="0x9ED0" />
-        <Blob Name="map_grand_static_Blob_00AEC0" Size="0x0450" Offset="0xAEC0" />
-        <Blob Name="map_grand_static_Blob_00B310" Size="0x07A0" Offset="0xB310" />
-        <Blob Name="map_grand_static_Blob_00BAB0" Size="0x0FF0" Offset="0xBAB0" />
-        <Blob Name="map_grand_static_Blob_00CAA0" Size="0x0FF0" Offset="0xCAA0" />
-        <Blob Name="map_grand_static_Blob_00DA90" Size="0x0FF0" Offset="0xDA90" />
-        <Blob Name="map_grand_static_Blob_00EA80" Size="0x0780" Offset="0xEA80" />
-        <Blob Name="map_grand_static_Blob_00F200" Size="0x0800" Offset="0xF200" />
-        <Blob Name="map_grand_static_Blob_00FA00" Size="0x0850" Offset="0xFA00" />
-        <Blob Name="map_grand_static_Blob_010250" Size="0x0510" Offset="0x10250" />
-        <Blob Name="map_grand_static_Blob_010760" Size="0x0710" Offset="0x10760" />
-        <Blob Name="map_grand_static_Blob_010E70" Size="0x0AE0" Offset="0x10E70" />
-        <Blob Name="map_grand_static_Blob_011950" Size="0x0660" Offset="0x11950" />
-        <Blob Name="map_grand_static_Blob_011FB0" Size="0x0C60" Offset="0x11FB0" />
-        <Blob Name="map_grand_static_Blob_012C10" Size="0x0E10" Offset="0x12C10" />
-        <Blob Name="map_grand_static_Blob_013A20" Size="0x03E0" Offset="0x13A20" />
-        <Blob Name="map_grand_static_Blob_013E00" Size="0x05A0" Offset="0x13E00" />
-        <Blob Name="map_grand_static_Blob_0143A0" Size="0x0820" Offset="0x143A0" />
-        <Blob Name="map_grand_static_Blob_014BC0" Size="0x0440" Offset="0x14BC0" />
-        <Blob Name="map_grand_static_Blob_015000" Size="0x0590" Offset="0x15000" />
-        <Blob Name="map_grand_static_Blob_015590" Size="0x05A0" Offset="0x15590" />
-        <Blob Name="map_grand_static_Blob_015B30" Size="0x07A0" Offset="0x15B30" />
-        <Blob Name="map_grand_static_Blob_0162D0" Size="0x07A0" Offset="0x162D0" />
-        <Blob Name="map_grand_static_Blob_016A70" Size="0x0DF0" Offset="0x16A70" />
-        <Blob Name="map_grand_static_Blob_017860" Size="0x0850" Offset="0x17860" />
-        <Blob Name="map_grand_static_Blob_0180B0" Size="0x09C0" Offset="0x180B0" />
-        <Blob Name="map_grand_static_Blob_018A70" Size="0x0880" Offset="0x18A70" />
-        <Blob Name="map_grand_static_Blob_0192F0" Size="0x0660" Offset="0x192F0" />
-        <Blob Name="map_grand_static_Blob_019950" Size="0x0360" Offset="0x19950" />
-        <Blob Name="map_grand_static_Blob_019CB0" Size="0x0260" Offset="0x19CB0" />
-        <Blob Name="map_grand_static_Blob_019F10" Size="0x0960" Offset="0x19F10" />
-        <Blob Name="map_grand_static_Blob_01A870" Size="0x0350" Offset="0x1A870" />
-        <Blob Name="map_grand_static_Blob_01ABC0" Size="0x09B0" Offset="0x1ABC0" />
-        <Blob Name="map_grand_static_Blob_01B570" Size="0x0980" Offset="0x1B570" />
-        <Blob Name="map_grand_static_Blob_01BEF0" Size="0x0FF0" Offset="0x1BEF0" />
-        <Blob Name="map_grand_static_Blob_01CEE0" Size="0x0B20" Offset="0x1CEE0" />
-        <Blob Name="map_grand_static_Blob_01DA00" Size="0x0DA0" Offset="0x1DA00" />
-        <Blob Name="map_grand_static_Blob_01E7A0" Size="0x0820" Offset="0x1E7A0" />
-        <Blob Name="map_grand_static_Blob_01EFC0" Size="0x03E0" Offset="0x1EFC0" />
-        <Blob Name="map_grand_static_Blob_01F3A0" Size="0x0980" Offset="0x1F3A0" />
-        <Blob Name="map_grand_static_Blob_01FD20" Size="0x0960" Offset="0x1FD20" />
-        <Blob Name="map_grand_static_Blob_020680" Size="0x0760" Offset="0x20680" />
-        <Blob Name="map_grand_static_Blob_020DE0" Size="0x0960" Offset="0x20DE0" />
-        <Blob Name="map_grand_static_Blob_021740" Size="0x01D0" Offset="0x21740" />
-        <Blob Name="map_grand_static_Blob_021910" Size="0x0630" Offset="0x21910" />
-        <Blob Name="map_grand_static_Blob_021F40" Size="0x0680" Offset="0x21F40" />
-        <Blob Name="map_grand_static_Blob_0225C0" Size="0x07D0" Offset="0x225C0" />
-        <Blob Name="map_grand_static_Blob_022D90" Size="0x0870" Offset="0x22D90" />
-        <Blob Name="map_grand_static_Blob_023600" Size="0x0E60" Offset="0x23600" />
-        <Blob Name="map_grand_static_Blob_024460" Size="0x0710" Offset="0x24460" />
-        <Blob Name="map_grand_static_Blob_024B70" Size="0x0620" Offset="0x24B70" />
-        <Blob Name="map_grand_static_Blob_025190" Size="0x0620" Offset="0x25190" />
-        <Blob Name="map_grand_static_Blob_0257B0" Size="0x0680" Offset="0x257B0" />
-        <Blob Name="map_grand_static_Blob_025E30" Size="0x0620" Offset="0x25E30" />
-        <Blob Name="map_grand_static_Blob_026450" Size="0x0210" Offset="0x26450" />
-        <Blob Name="map_grand_static_Blob_026660" Size="0x04B0" Offset="0x26660" />
-        <Blob Name="map_grand_static_Blob_026B10" Size="0x0680" Offset="0x26B10" />
-        <Blob Name="map_grand_static_Blob_027190" Size="0x0350" Offset="0x27190" />
-        <Blob Name="map_grand_static_Blob_0274E0" Size="0x0660" Offset="0x274E0" />
-        <Blob Name="map_grand_static_Blob_027B40" Size="0x0350" Offset="0x27B40" />
-        <Blob Name="map_grand_static_Blob_027E90" Size="0x0500" Offset="0x27E90" />
-        <Blob Name="map_grand_static_Blob_028390" Size="0x06A0" Offset="0x28390" />
-        <Blob Name="map_grand_static_Blob_028A30" Size="0x05E0" Offset="0x28A30" />
-        <Blob Name="map_grand_static_Blob_029010" Size="0x0680" Offset="0x29010" />
-        <Blob Name="map_grand_static_Blob_029690" Size="0x0480" Offset="0x29690" />
-        <Blob Name="map_grand_static_Blob_029B10" Size="0x0AE0" Offset="0x29B10" />
-        <Blob Name="map_grand_static_Blob_02A5F0" Size="0x02D0" Offset="0x2A5F0" />
-        <Blob Name="map_grand_static_Blob_02A8C0" Size="0x0B90" Offset="0x2A8C0" />
-        <Blob Name="map_grand_static_Blob_02B450" Size="0x0DA0" Offset="0x2B450" />
-        <Blob Name="map_grand_static_Blob_02C1F0" Size="0x08C0" Offset="0x2C1F0" />
-        <Blob Name="map_grand_static_Blob_02CAB0" Size="0x0A30" Offset="0x2CAB0" />
-        <Blob Name="map_grand_static_Blob_02D4E0" Size="0x0130" Offset="0x2D4E0" />
-        <Blob Name="map_grand_static_Blob_02D610" Size="0x0C30" Offset="0x2D610" />
-        <Blob Name="map_grand_static_Blob_02E240" Size="0x08A0" Offset="0x2E240" />
-        <Blob Name="map_grand_static_Blob_02EAE0" Size="0x0F50" Offset="0x2EAE0" />
-        <Blob Name="map_grand_static_Blob_02FA30" Size="0x09B0" Offset="0x2FA30" />
-        <Blob Name="map_grand_static_Blob_0303E0" Size="0x07B0" Offset="0x303E0" />
-        <Blob Name="map_grand_static_Blob_030B90" Size="0x0960" Offset="0x30B90" />
-        <Blob Name="map_grand_static_Blob_0314F0" Size="0x0740" Offset="0x314F0" />
-        <Blob Name="map_grand_static_Blob_031C30" Size="0x0A00" Offset="0x31C30" />
-        <Blob Name="map_grand_static_Blob_032630" Size="0x0640" Offset="0x32630" />
-        <Blob Name="map_grand_static_Blob_032C70" Size="0x0A30" Offset="0x32C70" />
-        <Blob Name="map_grand_static_Blob_0336A0" Size="0x03D0" Offset="0x336A0" />
-        <Blob Name="map_grand_static_Blob_033A70" Size="0x0D00" Offset="0x33A70" />
-        <Blob Name="map_grand_static_Blob_034770" Size="0x0440" Offset="0x34770" />
-        <Blob Name="map_grand_static_Blob_034BB0" Size="0x03A0" Offset="0x34BB0" />
-        <Blob Name="map_grand_static_Blob_034F50" Size="0x0960" Offset="0x34F50" />
+        <Texture Name="gMapGrandStatic100Tex" OutName="map_100" Format="i4" Width="96" Height="85" Offset="0x0" />
+        <Texture Name="gMapGrandStatic101Tex" OutName="map_101" Format="i4" Width="96" Height="85" Offset="0xFF0" />
+        <Texture Name="gMapGrandStatic102Tex" OutName="map_102" Format="i4" Width="96" Height="85" Offset="0x1FE0" />
+        <Texture Name="gMapGrandStatic103Tex" OutName="map_103" Format="i4" Width="96" Height="85" Offset="0x2FD0" />
+        <Texture Name="gMapGrandStatic104Tex" OutName="map_104" Format="i4" Width="96" Height="85" Offset="0x3FC0" />
+        <Texture Name="gMapGrandStatic105Tex" OutName="map_105" Format="i4" Width="80" Height="72" Offset="0x4FB0" />
+        <Texture Name="gMapGrandStatic106Tex" OutName="map_106" Format="i4" Width="96" Height="85" Offset="0x5AF0" />
+        <Texture Name="gMapGrandStatic107Tex" OutName="map_107" Format="i4" Width="96" Height="85" Offset="0x6AE0" />
+        <Texture Name="gMapGrandStatic108Tex" OutName="map_108" Format="i4" Width="96" Height="85" Offset="0x7AD0" />
+        <Texture Name="gMapGrandStatic109Tex" OutName="map_109" Format="i4" Width="96" Height="85" Offset="0x8AC0" />
+        <Texture Name="gMapGrandStatic10ATex" OutName="map_10A" Format="i4" Width="48" Height="44" Offset="0x9AB0" />
+        <Texture Name="gMapGrandStatic10BTex" OutName="map_10B" Format="i4" Width="96" Height="85" Offset="0x9ED0" />
+        <Texture Name="gMapGrandStatic10CTex" OutName="map_10C" Format="i4" Width="48" Height="46" Offset="0xAEC0" />
+        <Texture Name="gMapGrandStatic10DTex" OutName="map_10D" Format="i4" Width="64" Height="61" Offset="0xB310" />
+        <Texture Name="gMapGrandStatic10ETex" OutName="map_10E" Format="i4" Width="96" Height="85" Offset="0xBAB0" />
+        <Texture Name="gMapGrandStatic10FTex" OutName="map_10F" Format="i4" Width="96" Height="85" Offset="0xCAA0" />
+        <Texture Name="gMapGrandStatic110Tex" OutName="map_110" Format="i4" Width="96" Height="85" Offset="0xDA90" />
+        <Texture Name="gMapGrandStatic111Tex" OutName="map_111" Format="i4" Width="48" Height="80" Offset="0xEA80" />
+        <Texture Name="gMapGrandStatic112Tex" OutName="map_112" Format="i4" Width="32" Height="128" Offset="0xF200" />
+        <Texture Name="gMapGrandStatic113Tex" OutName="map_113" Format="i4" Width="80" Height="53" Offset="0xFA00" />
+        <Texture Name="gMapGrandStatic114Tex" OutName="map_114" Format="i4" Width="32" Height="81" Offset="0x10250" />
+        <Texture Name="gMapGrandStatic115Tex" OutName="map_115" Format="i4" Width="80" Height="45" Offset="0x10760" />
+        <Texture Name="gMapGrandStatic116Tex" OutName="map_116" Format="i4" Width="64" Height="87" Offset="0x10E70" />
+        <Texture Name="gMapGrandStatic117Tex" OutName="map_117" Format="i4" Width="64" Height="51" Offset="0x11950" />
+        <Texture Name="gMapGrandStatic118Tex" OutName="map_118" Format="i4" Width="80" Height="79" Offset="0x11FB0" />
+        <Texture Name="gMapGrandStatic119Tex" OutName="map_119" Format="i4" Width="96" Height="75" Offset="0x12C10" />
+        <Texture Name="gMapGrandStatic11ATex" OutName="map_11A" Format="i4" Width="48" Height="41" Offset="0x13A20" />
+        <Texture Name="gMapGrandStatic11BTex" OutName="map_11B" Format="i4" Width="64" Height="45" Offset="0x13E00" />
+        <Texture Name="gMapGrandStatic11CTex" OutName="map_11C" Format="i4" Width="80" Height="52" Offset="0x143A0" />
+        <Texture Name="gMapGrandStatic11DTex" OutName="map_11D" Format="i4" Width="48" Height="45" Offset="0x14BC0" />
+        <Texture Name="gMapGrandStatic11ETex" OutName="map_11E" Format="i4" Width="48" Height="59" Offset="0x15000" />
+        <Texture Name="gMapGrandStatic11FTex" OutName="map_11F" Format="i4" Width="48" Height="60" Offset="0x15590" />
+        <Texture Name="gMapGrandStatic120Tex" OutName="map_120" Format="i4" Width="48" Height="81" Offset="0x15B30" />
+        <Texture Name="gMapGrandStatic121Tex" OutName="map_121" Format="i4" Width="48" Height="81" Offset="0x162D0" />
+        <Texture Name="gMapGrandStatic122Tex" OutName="map_122" Format="i4" Width="80" Height="89" Offset="0x16A70" />
+        <Texture Name="gMapGrandStatic123Tex" OutName="map_123" Format="i4" Width="80" Height="53" Offset="0x17860" />
+        <Texture Name="gMapGrandStatic124Tex" OutName="map_124" Format="i4" Width="64" Height="78" Offset="0x180B0" />
+        <Texture Name="gMapGrandStatic125Tex" OutName="map_125" Format="i4" Width="64" Height="68" Offset="0x18A70" />
+        <Texture Name="gMapGrandStatic126Tex" OutName="map_126" Format="i4" Width="48" Height="68" Offset="0x192F0" />
+        <Texture Name="gMapGrandStatic127Tex" OutName="map_127" Format="i4" Width="48" Height="36" Offset="0x19950" />
+        <Texture Name="gMapGrandStatic128Tex" OutName="map_128" Format="i4" Width="48" Height="25" Offset="0x19CB0" />
+        <Texture Name="gMapGrandStatic129Tex" OutName="map_129" Format="i4" Width="64" Height="75" Offset="0x19F10" />
+        <Texture Name="gMapGrandStatic12ATex" OutName="map_12A" Format="i4" Width="32" Height="53" Offset="0x1A870" />
+        <Texture Name="gMapGrandStatic12BTex" OutName="map_12B" Format="i4" Width="80" Height="62" Offset="0x1ABC0" />
+        <Texture Name="gMapGrandStatic12CTex" OutName="map_12C" Format="i4" Width="64" Height="76" Offset="0x1B570" />
+        <Texture Name="gMapGrandStatic12DTex" OutName="map_12D" Format="i4" Width="96" Height="85" Offset="0x1BEF0" />
+        <Texture Name="gMapGrandStatic12ETex" OutName="map_12E" Format="i4" Width="80" Height="71" Offset="0x1CEE0" />
+        <Texture Name="gMapGrandStatic12FTex" OutName="map_12F" Format="i4" Width="80" Height="87" Offset="0x1DA00" />
+        <Texture Name="gMapGrandStatic130Tex" OutName="map_130" Format="i4" Width="64" Height="65" Offset="0x1E7A0" />
+        <Texture Name="gMapGrandStatic131Tex" OutName="map_131" Format="i4" Width="48" Height="41" Offset="0x1EFC0" />
+        <Texture Name="gMapGrandStatic132Tex" OutName="map_132" Format="i4" Width="64" Height="76" Offset="0x1F3A0" />
+        <Texture Name="gMapGrandStatic133Tex" OutName="map_133" Format="i4" Width="80" Height="60" Offset="0x1FD20" />
+        <Texture Name="gMapGrandStatic134Tex" OutName="map_134" Format="i4" Width="80" Height="47" Offset="0x20680" />
+        <Texture Name="gMapGrandStatic135Tex" OutName="map_135" Format="i4" Width="80" Height="60" Offset="0x20DE0" />
+        <Texture Name="gMapGrandStatic136Tex" OutName="map_136" Format="i4" Width="48" Height="19" Offset="0x21740" />
+        <Texture Name="gMapGrandStatic137Tex" OutName="map_137" Format="i4" Width="32" Height="99" Offset="0x21910" />
+        <Texture Name="gMapGrandStatic138Tex" OutName="map_138" Format="i4" Width="48" Height="69" Offset="0x21F40" />
+        <Texture Name="gMapGrandStatic139Tex" OutName="map_139" Format="i4" Width="48" Height="83" Offset="0x225C0" />
+        <Texture Name="gMapGrandStatic13ATex" OutName="map_13A" Format="i4" Width="80" Height="54" Offset="0x22D90" />
+        <Texture Name="gMapGrandStatic13BTex" OutName="map_13B" Format="i4" Width="80" Height="92" Offset="0x23600" />
+        <Texture Name="gMapGrandStatic13CTex" OutName="map_13C" Format="i4" Width="48" Height="75" Offset="0x24460" />
+        <Texture Name="gMapGrandStatic13DTex" OutName="map_13D" Format="i4" Width="64" Height="49" Offset="0x24B70" />
+        <Texture Name="gMapGrandStatic13ETex" OutName="map_13E" Format="i4" Width="64" Height="49" Offset="0x25190" />
+        <Texture Name="gMapGrandStatic13FTex" OutName="map_13F" Format="i4" Width="64" Height="52" Offset="0x257B0" />
+        <Texture Name="gMapGrandStatic140Tex" OutName="map_140" Format="i4" Width="64" Height="49" Offset="0x25E30" />
+        <Texture Name="gMapGrandStatic141Tex" OutName="map_141" Format="i4" Width="32" Height="33" Offset="0x26450" />
+        <Texture Name="gMapGrandStatic142Tex" OutName="map_142" Format="i4" Width="48" Height="50" Offset="0x26660" />
+        <Texture Name="gMapGrandStatic143Tex" OutName="map_143" Format="i4" Width="64" Height="52" Offset="0x26B10" />
+        <Texture Name="gMapGrandStatic144Tex" OutName="map_144" Format="i4" Width="48" Height="35" Offset="0x27190" />
+        <Texture Name="gMapGrandStatic145Tex" OutName="map_145" Format="i4" Width="64" Height="51" Offset="0x274E0" />
+        <Texture Name="gMapGrandStatic146Tex" OutName="map_146" Format="i4" Width="48" Height="35" Offset="0x27B40" />
+        <Texture Name="gMapGrandStatic147Tex" OutName="map_147" Format="i4" Width="48" Height="53" Offset="0x27E90" />
+        <Texture Name="gMapGrandStatic148Tex" OutName="map_148" Format="i4" Width="64" Height="53" Offset="0x28390" />
+        <Texture Name="gMapGrandStatic149Tex" OutName="map_149" Format="i4" Width="64" Height="47" Offset="0x28A30" />
+        <Texture Name="gMapGrandStatic14ATex" OutName="map_14A" Format="i4" Width="64" Height="52" Offset="0x29010" />
+        <Texture Name="gMapGrandStatic14BTex" OutName="map_14B" Format="i4" Width="48" Height="48" Offset="0x29690" />
+        <Texture Name="gMapGrandStatic14CTex" OutName="map_14C" Format="i4" Width="64" Height="87" Offset="0x29B10" />
+        <Texture Name="gMapGrandStatic14DTex" OutName="map_14D" Format="i4" Width="48" Height="30" Offset="0x2A5F0" />
+        <Texture Name="gMapGrandStatic14ETex" OutName="map_14E" Format="i4" Width="80" Height="74" Offset="0x2A8C0" />
+        <Texture Name="gMapGrandStatic14FTex" OutName="map_14F" Format="i4" Width="80" Height="87" Offset="0x2B450" />
+        <Texture Name="gMapGrandStatic150Tex" OutName="map_150" Format="i4" Width="80" Height="56" Offset="0x2C1F0" />
+        <Texture Name="gMapGrandStatic151Tex" OutName="map_151" Format="i4" Width="80" Height="65" Offset="0x2CAB0" />
+        <Texture Name="gMapGrandStatic152Tex" OutName="map_152" Format="i4" Width="16" Height="38" Offset="0x2D4E0" />
+        <Texture Name="gMapGrandStatic153Tex" OutName="map_153" Format="i4" Width="80" Height="78" Offset="0x2D610" />
+        <Texture Name="gMapGrandStatic154Tex" OutName="map_154" Format="i4" Width="80" Height="55" Offset="0x2E240" />
+        <Texture Name="gMapGrandStatic155Tex" OutName="map_155" Format="i4" Width="80" Height="98" Offset="0x2EAE0" />
+        <Texture Name="gMapGrandStatic156Tex" OutName="map_156" Format="i4" Width="80" Height="62" Offset="0x2FA30" />
+        <Texture Name="gMapGrandStatic157Tex" OutName="map_157" Format="i4" Width="32" Height="123" Offset="0x303E0" />
+        <Texture Name="gMapGrandStatic158Tex" OutName="map_158" Format="i4" Width="80" Height="60" Offset="0x30B90" />
+        <Texture Name="gMapGrandStatic159Tex" OutName="map_159" Format="i4" Width="48" Height="77" Offset="0x314F0" />
+        <Texture Name="gMapGrandStatic15ATex" OutName="map_15A" Format="i4" Width="80" Height="64" Offset="0x31C30" />
+        <Texture Name="gMapGrandStatic15BTex" OutName="map_15B" Format="i4" Width="64" Height="50" Offset="0x32630" />
+        <Texture Name="gMapGrandStatic15CTex" OutName="map_15C" Format="i4" Width="80" Height="65" Offset="0x32C70" />
+        <Texture Name="gMapGrandStatic15DTex" OutName="map_15D" Format="i4" Width="32" Height="61" Offset="0x336A0" />
+        <Texture Name="gMapGrandStatic15ETex" OutName="map_15E" Format="i4" Width="80" Height="83" Offset="0x33A70" />
+        <Texture Name="gMapGrandStatic15FTex" OutName="map_15F" Format="i4" Width="80" Height="27" Offset="0x34770" />
+        <Texture Name="gMapGrandStatic160Tex" OutName="map_160" Format="i4" Width="80" Height="23" Offset="0x34BB0" />
+        <Texture Name="gMapGrandStatic161Tex" OutName="map_161" Format="i4" Width="80" Height="60" Offset="0x34F50" />
     </File>
 </Root>

--- a/mm/assets/xml/N64_US/archives/map_i_static.xml
+++ b/mm/assets/xml/N64_US/archives/map_i_static.xml
@@ -1,62 +1,62 @@
 <Root>
     <File Name="map_i_static">
-        <Blob Name="map_i_static_Blob_000000" Size="0x0FF0" Offset="0x0" />
-        <Blob Name="map_i_static_Blob_000FF0" Size="0x0FF0" Offset="0xFF0" />
-        <Blob Name="map_i_static_Blob_001FE0" Size="0x0FF0" Offset="0x1FE0" />
-        <Blob Name="map_i_static_Blob_002FD0" Size="0x0FF0" Offset="0x2FD0" />
-        <Blob Name="map_i_static_Blob_003FC0" Size="0x0FF0" Offset="0x3FC0" />
-        <Blob Name="map_i_static_Blob_004FB0" Size="0x01D0" Offset="0x4FB0" />
-        <Blob Name="map_i_static_Blob_005180" Size="0x01B0" Offset="0x5180" />
-        <Blob Name="map_i_static_Blob_005330" Size="0x01E0" Offset="0x5330" />
-        <Blob Name="map_i_static_Blob_005510" Size="0x0100" Offset="0x5510" />
-        <Blob Name="map_i_static_Blob_005610" Size="0x0060" Offset="0x5610" />
-        <Blob Name="map_i_static_Blob_005670" Size="0x01B0" Offset="0x5670" />
-        <Blob Name="map_i_static_Blob_005820" Size="0x0070" Offset="0x5820" />
-        <Blob Name="map_i_static_Blob_005890" Size="0x0130" Offset="0x5890" />
-        <Blob Name="map_i_static_Blob_0059C0" Size="0x01A0" Offset="0x59C0" />
-        <Blob Name="map_i_static_Blob_005B60" Size="0x0100" Offset="0x5B60" />
-        <Blob Name="map_i_static_Blob_005C60" Size="0x01B0" Offset="0x5C60" />
-        <Blob Name="map_i_static_Blob_005E10" Size="0x0120" Offset="0x5E10" />
-        <Blob Name="map_i_static_Blob_005F30" Size="0x0120" Offset="0x5F30" />
-        <Blob Name="map_i_static_Blob_006050" Size="0x0260" Offset="0x6050" />
-        <Blob Name="map_i_static_Blob_0062B0" Size="0x0150" Offset="0x62B0" />
-        <Blob Name="map_i_static_Blob_006400" Size="0x0220" Offset="0x6400" />
-        <Blob Name="map_i_static_Blob_006620" Size="0x0300" Offset="0x6620" />
-        <Blob Name="map_i_static_Blob_006920" Size="0x0110" Offset="0x6920" />
-        <Blob Name="map_i_static_Blob_006A30" Size="0x0110" Offset="0x6A30" />
-        <Blob Name="map_i_static_Blob_006B40" Size="0x0150" Offset="0x6B40" />
-        <Blob Name="map_i_static_Blob_006C90" Size="0x0120" Offset="0x6C90" />
-        <Blob Name="map_i_static_Blob_006DB0" Size="0x00C0" Offset="0x6DB0" />
-        <Blob Name="map_i_static_Blob_006E70" Size="0x00D0" Offset="0x6E70" />
-        <Blob Name="map_i_static_Blob_006F40" Size="0x0230" Offset="0x6F40" />
-        <Blob Name="map_i_static_Blob_007170" Size="0x00A0" Offset="0x7170" />
-        <Blob Name="map_i_static_Blob_007210" Size="0x01C0" Offset="0x7210" />
-        <Blob Name="map_i_static_Blob_0073D0" Size="0x0100" Offset="0x73D0" />
-        <Blob Name="map_i_static_Blob_0074D0" Size="0x0180" Offset="0x74D0" />
-        <Blob Name="map_i_static_Blob_007650" Size="0x0150" Offset="0x7650" />
-        <Blob Name="map_i_static_Blob_0077A0" Size="0x00B0" Offset="0x77A0" />
-        <Blob Name="map_i_static_Blob_007850" Size="0x0050" Offset="0x7850" />
-        <Blob Name="map_i_static_Blob_0078A0" Size="0x0040" Offset="0x78A0" />
-        <Blob Name="map_i_static_Blob_0078E0" Size="0x0170" Offset="0x78E0" />
-        <Blob Name="map_i_static_Blob_007A50" Size="0x0080" Offset="0x7A50" />
-        <Blob Name="map_i_static_Blob_007AD0" Size="0x0090" Offset="0x7AD0" />
-        <Blob Name="map_i_static_Blob_007B60" Size="0x00C0" Offset="0x7B60" />
-        <Blob Name="map_i_static_Blob_007C20" Size="0x0080" Offset="0x7C20" />
-        <Blob Name="map_i_static_Blob_007CA0" Size="0x00F0" Offset="0x7CA0" />
-        <Blob Name="map_i_static_Blob_007D90" Size="0x0110" Offset="0x7D90" />
-        <Blob Name="map_i_static_Blob_007EA0" Size="0x0100" Offset="0x7EA0" />
-        <Blob Name="map_i_static_Blob_007FA0" Size="0x0050" Offset="0x7FA0" />
-        <Blob Name="map_i_static_Blob_007FF0" Size="0x0090" Offset="0x7FF0" />
-        <Blob Name="map_i_static_Blob_008080" Size="0x0110" Offset="0x8080" />
-        <Blob Name="map_i_static_Blob_008190" Size="0x0060" Offset="0x8190" />
-        <Blob Name="map_i_static_Blob_0081F0" Size="0x0110" Offset="0x81F0" />
-        <Blob Name="map_i_static_Blob_008300" Size="0x0060" Offset="0x8300" />
-        <Blob Name="map_i_static_Blob_008360" Size="0x0090" Offset="0x8360" />
-        <Blob Name="map_i_static_Blob_0083F0" Size="0x0110" Offset="0x83F0" />
-        <Blob Name="map_i_static_Blob_008500" Size="0x00F0" Offset="0x8500" />
-        <Blob Name="map_i_static_Blob_0085F0" Size="0x0090" Offset="0x85F0" />
-        <Blob Name="map_i_static_Blob_008680" Size="0x0080" Offset="0x8680" />
-        <Blob Name="map_i_static_Blob_008700" Size="0x00F0" Offset="0x8700" />
-        <Blob Name="map_i_static_Blob_0087F0" Size="0x0050" Offset="0x87F0" />
+        <Texture Name="gMapIStatic00Tex" OutName="map_00" Format="i4" Width="96" Height="85" Offset="0x0" />
+        <Texture Name="gMapIStatic01Tex" OutName="map_01" Format="i4" Width="96" Height="85" Offset="0xFF0" />
+        <Texture Name="gMapIStatic02Tex" OutName="map_02" Format="i4" Width="96" Height="85" Offset="0x1FE0" />
+        <Texture Name="gMapIStatic03Tex" OutName="map_03" Format="i4" Width="96" Height="85" Offset="0x2FD0" />
+        <Texture Name="gMapIStatic04Tex" OutName="map_04" Format="i4" Width="96" Height="85" Offset="0x3FC0" />
+        <Texture Name="gMapIStatic05Tex" OutName="map_05" Format="i4" Width="32" Height="29" Offset="0x4FB0" />
+        <Texture Name="gMapIStatic06Tex" OutName="map_06" Format="i4" Width="32" Height="27" Offset="0x5180" />
+        <Texture Name="gMapIStatic07Tex" OutName="map_07" Format="i4" Width="32" Height="30" Offset="0x5330" />
+        <Texture Name="gMapIStatic08Tex" OutName="map_08" Format="i4" Width="16" Height="32" Offset="0x5510" />
+        <Texture Name="gMapIStatic09Tex" OutName="map_09" Format="i4" Width="16" Height="12" Offset="0x5610" />
+        <Texture Name="gMapIStatic0ATex" OutName="map_0A" Format="i4" Width="32" Height="27" Offset="0x5670" />
+        <Texture Name="gMapIStatic0BTex" OutName="map_0B" Format="i4" Width="16" Height="14" Offset="0x5820" />
+        <Texture Name="gMapIStatic0CTex" OutName="map_0C" Format="i4" Width="32" Height="19" Offset="0x5890" />
+        <Texture Name="gMapIStatic0DTex" OutName="map_0D" Format="i4" Width="32" Height="26" Offset="0x59C0" />
+        <Texture Name="gMapIStatic0ETex" OutName="map_0E" Format="i4" Width="16" Height="32" Offset="0x5B60" />
+        <Texture Name="gMapIStatic0FTex" OutName="map_0F" Format="i4" Width="32" Height="27" Offset="0x5C60" />
+        <Texture Name="gMapIStatic10Tex" OutName="map_10" Format="i4" Width="16" Height="35" Offset="0x5E10" />
+        <Texture Name="gMapIStatic11Tex" OutName="map_11" Format="i4" Width="32" Height="18" Offset="0x5F30" />
+        <Texture Name="gMapIStatic12Tex" OutName="map_12" Format="i4" Width="32" Height="38" Offset="0x6050" />
+        <Texture Name="gMapIStatic13Tex" OutName="map_13" Format="i4" Width="32" Height="21" Offset="0x62B0" />
+        <Texture Name="gMapIStatic14Tex" OutName="map_14" Format="i4" Width="32" Height="34" Offset="0x6400" />
+        <Texture Name="gMapIStatic15Tex" OutName="map_15" Format="i4" Width="48" Height="32" Offset="0x6620" />
+        <Texture Name="gMapIStatic16Tex" OutName="map_16" Format="i4" Width="32" Height="17" Offset="0x6920" />
+        <Texture Name="gMapIStatic17Tex" OutName="map_17" Format="i4" Width="32" Height="17" Offset="0x6A30" />
+        <Texture Name="gMapIStatic18Tex" OutName="map_18" Format="i4" Width="32" Height="21" Offset="0x6B40" />
+        <Texture Name="gMapIStatic19Tex" OutName="map_19" Format="i4" Width="32" Height="18" Offset="0x6C90" />
+        <Texture Name="gMapIStatic1ATex" OutName="map_1A" Format="i4" Width="16" Height="24" Offset="0x6DB0" />
+        <Texture Name="gMapIStatic1BTex" OutName="map_1B" Format="i4" Width="16" Height="25" Offset="0x6E70" />
+        <Texture Name="gMapIStatic1CTex" OutName="map_1C" Format="i4" Width="32" Height="35" Offset="0x6F40" />
+        <Texture Name="gMapIStatic1DTex" OutName="map_1D" Format="i4" Width="16" Height="19" Offset="0x7170" />
+        <Texture Name="gMapIStatic1ETex" OutName="map_1E" Format="i4" Width="32" Height="28" Offset="0x7210" />
+        <Texture Name="gMapIStatic1FTex" OutName="map_1F" Format="i4" Width="32" Height="16" Offset="0x73D0" />
+        <Texture Name="gMapIStatic20Tex" OutName="map_20" Format="i4" Width="32" Height="24" Offset="0x74D0" />
+        <Texture Name="gMapIStatic21Tex" OutName="map_21" Format="i4" Width="32" Height="21" Offset="0x7650" />
+        <Texture Name="gMapIStatic22Tex" OutName="map_22" Format="i4" Width="16" Height="21" Offset="0x77A0" />
+        <Texture Name="gMapIStatic23Tex" OutName="map_23" Format="i4" Width="16" Height="10" Offset="0x7850" />
+        <Texture Name="gMapIStatic24Tex" OutName="map_24" Format="i4" Width="16" Height="7" Offset="0x78A0" />
+        <Texture Name="gMapIStatic25Tex" OutName="map_25" Format="i4" Width="32" Height="23" Offset="0x78E0" />
+        <Texture Name="gMapIStatic26Tex" OutName="map_26" Format="i4" Width="16" Height="16" Offset="0x7A50" />
+        <Texture Name="gMapIStatic27Tex" OutName="map_27" Format="i4" Width="16" Height="17" Offset="0x7AD0" />
+        <Texture Name="gMapIStatic28Tex" OutName="map_28" Format="i4" Width="16" Height="23" Offset="0x7B60" />
+        <Texture Name="gMapIStatic29Tex" OutName="map_29" Format="i4" Width="16" Height="15" Offset="0x7C20" />
+        <Texture Name="gMapIStatic2ATex" OutName="map_2A" Format="i4" Width="32" Height="15" Offset="0x7CA0" />
+        <Texture Name="gMapIStatic2BTex" OutName="map_2B" Format="i4" Width="32" Height="17" Offset="0x7D90" />
+        <Texture Name="gMapIStatic2CTex" OutName="map_2C" Format="i4" Width="32" Height="16" Offset="0x7EA0" />
+        <Texture Name="gMapIStatic2DTex" OutName="map_2D" Format="i4" Width="16" Height="10" Offset="0x7FA0" />
+        <Texture Name="gMapIStatic2ETex" OutName="map_2E" Format="i4" Width="16" Height="17" Offset="0x7FF0" />
+        <Texture Name="gMapIStatic2FTex" OutName="map_2F" Format="i4" Width="32" Height="17" Offset="0x8080" />
+        <Texture Name="gMapIStatic30Tex" OutName="map_30" Format="i4" Width="16" Height="11" Offset="0x8190" />
+        <Texture Name="gMapIStatic31Tex" OutName="map_31" Format="i4" Width="32" Height="17" Offset="0x81F0" />
+        <Texture Name="gMapIStatic32Tex" OutName="map_32" Format="i4" Width="16" Height="12" Offset="0x8300" />
+        <Texture Name="gMapIStatic33Tex" OutName="map_33" Format="i4" Width="16" Height="18" Offset="0x8360" />
+        <Texture Name="gMapIStatic34Tex" OutName="map_34" Format="i4" Width="32" Height="17" Offset="0x83F0" />
+        <Texture Name="gMapIStatic35Tex" OutName="map_35" Format="i4" Width="32" Height="15" Offset="0x8500" />
+        <Texture Name="gMapIStatic36Tex" OutName="map_36" Format="i4" Width="16" Height="18" Offset="0x85F0" />
+        <Texture Name="gMapIStatic37Tex" OutName="map_37" Format="i4" Width="16" Height="16" Offset="0x8680" />
+        <Texture Name="gMapIStatic38Tex" OutName="map_38" Format="i4" Width="16" Height="30" Offset="0x8700" />
+        <Texture Name="gMapIStatic39Tex" OutName="map_39" Format="i4" Width="16" Height="9" Offset="0x87F0" />
     </File>
 </Root>

--- a/mm/src/code/z_map_disp.c
+++ b/mm/src/code/z_map_disp.c
@@ -9,6 +9,7 @@
 
 #include "BenPort.h"
 #include "BenGui/HudEditor.h"
+#include "assets/2s2h_assets.h"
 
 void MapDisp_DestroyMapI(PlayState* play);
 void MapDisp_InitMapI(PlayState* play);
@@ -102,58 +103,41 @@ static Color_RGBA8 sMinimapActorCategoryColors[12] = {
 TransitionActorEntry sTransitionActors[ROOM_TRANSITION_MAX];
 PauseDungeonMap sPauseDungeonMap;
 
-static const char* sMapTextures[] = {
-    map_i_static_Blob_000000, map_i_static_Blob_000FF0, map_i_static_Blob_001FE0, map_i_static_Blob_002FD0,
-    map_i_static_Blob_003FC0, map_i_static_Blob_004FB0, map_i_static_Blob_005180, map_i_static_Blob_005330,
-    map_i_static_Blob_005510, map_i_static_Blob_005610, map_i_static_Blob_005670, map_i_static_Blob_005820,
-    map_i_static_Blob_005890, map_i_static_Blob_0059C0, map_i_static_Blob_005B60, map_i_static_Blob_005C60,
-    map_i_static_Blob_005E10, map_i_static_Blob_005F30, map_i_static_Blob_006050, map_i_static_Blob_0062B0,
-    map_i_static_Blob_006400, map_i_static_Blob_006620, map_i_static_Blob_006920, map_i_static_Blob_006A30,
-    map_i_static_Blob_006B40, map_i_static_Blob_006C90, map_i_static_Blob_006DB0, map_i_static_Blob_006E70,
-    map_i_static_Blob_006F40, map_i_static_Blob_007170, map_i_static_Blob_007210, map_i_static_Blob_0073D0,
-    map_i_static_Blob_0074D0, map_i_static_Blob_007650, map_i_static_Blob_0077A0, map_i_static_Blob_007850,
-    map_i_static_Blob_0078A0, map_i_static_Blob_0078E0, map_i_static_Blob_007A50, map_i_static_Blob_007AD0,
-    map_i_static_Blob_007B60, map_i_static_Blob_007C20, map_i_static_Blob_007CA0, map_i_static_Blob_007D90,
-    map_i_static_Blob_007EA0, map_i_static_Blob_007FA0, map_i_static_Blob_007FF0, map_i_static_Blob_008080,
-    map_i_static_Blob_008190, map_i_static_Blob_0081F0, map_i_static_Blob_008300, map_i_static_Blob_008360,
-    map_i_static_Blob_0083F0, map_i_static_Blob_008500, map_i_static_Blob_0085F0, map_i_static_Blob_008680,
-    map_i_static_Blob_008700, map_i_static_Blob_0087F0,
+// 2S2H [Port] Textures maps and extra variables for enhancement features
+static TexturePtr sMapITextures[] = {
+    gMapIStatic00Tex, gMapIStatic01Tex, gMapIStatic02Tex, gMapIStatic03Tex, gMapIStatic04Tex, gMapIStatic05Tex,
+    gMapIStatic06Tex, gMapIStatic07Tex, gMapIStatic08Tex, gMapIStatic09Tex, gMapIStatic0ATex, gMapIStatic0BTex,
+    gMapIStatic0CTex, gMapIStatic0DTex, gMapIStatic0ETex, gMapIStatic0FTex, gMapIStatic10Tex, gMapIStatic11Tex,
+    gMapIStatic12Tex, gMapIStatic13Tex, gMapIStatic14Tex, gMapIStatic15Tex, gMapIStatic16Tex, gMapIStatic17Tex,
+    gMapIStatic18Tex, gMapIStatic19Tex, gMapIStatic1ATex, gMapIStatic1BTex, gMapIStatic1CTex, gMapIStatic1DTex,
+    gMapIStatic1ETex, gMapIStatic1FTex, gMapIStatic20Tex, gMapIStatic21Tex, gMapIStatic22Tex, gMapIStatic23Tex,
+    gMapIStatic24Tex, gMapIStatic25Tex, gMapIStatic26Tex, gMapIStatic27Tex, gMapIStatic28Tex, gMapIStatic29Tex,
+    gMapIStatic2ATex, gMapIStatic2BTex, gMapIStatic2CTex, gMapIStatic2DTex, gMapIStatic2ETex, gMapIStatic2FTex,
+    gMapIStatic30Tex, gMapIStatic31Tex, gMapIStatic32Tex, gMapIStatic33Tex, gMapIStatic34Tex, gMapIStatic35Tex,
+    gMapIStatic36Tex, gMapIStatic37Tex, gMapIStatic38Tex, gMapIStatic39Tex,
 };
 
-static const char* sMapGrandTextures[] = {
-    map_grand_static_Blob_000000, map_grand_static_Blob_000FF0, map_grand_static_Blob_001FE0,
-    map_grand_static_Blob_002FD0, map_grand_static_Blob_003FC0, map_grand_static_Blob_004FB0,
-    map_grand_static_Blob_005AF0, map_grand_static_Blob_006AE0, map_grand_static_Blob_007AD0,
-    map_grand_static_Blob_008AC0, map_grand_static_Blob_009AB0, map_grand_static_Blob_009ED0,
-    map_grand_static_Blob_00AEC0, map_grand_static_Blob_00B310, map_grand_static_Blob_00BAB0,
-    map_grand_static_Blob_00CAA0, map_grand_static_Blob_00DA90, map_grand_static_Blob_00EA80,
-    map_grand_static_Blob_00F200, map_grand_static_Blob_00FA00, map_grand_static_Blob_010250,
-    map_grand_static_Blob_010760, map_grand_static_Blob_010E70, map_grand_static_Blob_011950,
-    map_grand_static_Blob_011FB0, map_grand_static_Blob_012C10, map_grand_static_Blob_013A20,
-    map_grand_static_Blob_013E00, map_grand_static_Blob_0143A0, map_grand_static_Blob_014BC0,
-    map_grand_static_Blob_015000, map_grand_static_Blob_015590, map_grand_static_Blob_015B30,
-    map_grand_static_Blob_0162D0, map_grand_static_Blob_016A70, map_grand_static_Blob_017860,
-    map_grand_static_Blob_0180B0, map_grand_static_Blob_018A70, map_grand_static_Blob_0192F0,
-    map_grand_static_Blob_019950, map_grand_static_Blob_019CB0, map_grand_static_Blob_019F10,
-    map_grand_static_Blob_01A870, map_grand_static_Blob_01ABC0, map_grand_static_Blob_01B570,
-    map_grand_static_Blob_01BEF0, map_grand_static_Blob_01CEE0, map_grand_static_Blob_01DA00,
-    map_grand_static_Blob_01E7A0, map_grand_static_Blob_01EFC0, map_grand_static_Blob_01F3A0,
-    map_grand_static_Blob_01FD20, map_grand_static_Blob_020680, map_grand_static_Blob_020DE0,
-    map_grand_static_Blob_021740, map_grand_static_Blob_021910, map_grand_static_Blob_021F40,
-    map_grand_static_Blob_0225C0, map_grand_static_Blob_022D90, map_grand_static_Blob_023600,
-    map_grand_static_Blob_024460, map_grand_static_Blob_024B70, map_grand_static_Blob_025190,
-    map_grand_static_Blob_0257B0, map_grand_static_Blob_025E30, map_grand_static_Blob_026450,
-    map_grand_static_Blob_026660, map_grand_static_Blob_026B10, map_grand_static_Blob_027190,
-    map_grand_static_Blob_0274E0, map_grand_static_Blob_027B40, map_grand_static_Blob_027E90,
-    map_grand_static_Blob_028390, map_grand_static_Blob_028A30, map_grand_static_Blob_029010,
-    map_grand_static_Blob_029690, map_grand_static_Blob_029B10, map_grand_static_Blob_02A5F0,
-    map_grand_static_Blob_02A8C0, map_grand_static_Blob_02B450, map_grand_static_Blob_02C1F0,
-    map_grand_static_Blob_02CAB0, map_grand_static_Blob_02D4E0, map_grand_static_Blob_02D610,
-    map_grand_static_Blob_02E240, map_grand_static_Blob_02EAE0, map_grand_static_Blob_02FA30,
-    map_grand_static_Blob_0303E0, map_grand_static_Blob_030B90, map_grand_static_Blob_0314F0,
-    map_grand_static_Blob_031C30, map_grand_static_Blob_032630, map_grand_static_Blob_032C70,
-    map_grand_static_Blob_0336A0, map_grand_static_Blob_033A70, map_grand_static_Blob_034770,
-    map_grand_static_Blob_034BB0, map_grand_static_Blob_034F50,
+static TexturePtr sMapGrandTextures[] = {
+    gMapGrandStatic100Tex, gMapGrandStatic101Tex, gMapGrandStatic102Tex, gMapGrandStatic103Tex, gMapGrandStatic104Tex,
+    gMapGrandStatic105Tex, gMapGrandStatic106Tex, gMapGrandStatic107Tex, gMapGrandStatic108Tex, gMapGrandStatic109Tex,
+    gMapGrandStatic10ATex, gMapGrandStatic10BTex, gMapGrandStatic10CTex, gMapGrandStatic10DTex, gMapGrandStatic10ETex,
+    gMapGrandStatic10FTex, gMapGrandStatic110Tex, gMapGrandStatic111Tex, gMapGrandStatic112Tex, gMapGrandStatic113Tex,
+    gMapGrandStatic114Tex, gMapGrandStatic115Tex, gMapGrandStatic116Tex, gMapGrandStatic117Tex, gMapGrandStatic118Tex,
+    gMapGrandStatic119Tex, gMapGrandStatic11ATex, gMapGrandStatic11BTex, gMapGrandStatic11CTex, gMapGrandStatic11DTex,
+    gMapGrandStatic11ETex, gMapGrandStatic11FTex, gMapGrandStatic120Tex, gMapGrandStatic121Tex, gMapGrandStatic122Tex,
+    gMapGrandStatic123Tex, gMapGrandStatic124Tex, gMapGrandStatic125Tex, gMapGrandStatic126Tex, gMapGrandStatic127Tex,
+    gMapGrandStatic128Tex, gMapGrandStatic129Tex, gMapGrandStatic12ATex, gMapGrandStatic12BTex, gMapGrandStatic12CTex,
+    gMapGrandStatic12DTex, gMapGrandStatic12ETex, gMapGrandStatic12FTex, gMapGrandStatic130Tex, gMapGrandStatic131Tex,
+    gMapGrandStatic132Tex, gMapGrandStatic133Tex, gMapGrandStatic134Tex, gMapGrandStatic135Tex, gMapGrandStatic136Tex,
+    gMapGrandStatic137Tex, gMapGrandStatic138Tex, gMapGrandStatic139Tex, gMapGrandStatic13ATex, gMapGrandStatic13BTex,
+    gMapGrandStatic13CTex, gMapGrandStatic13DTex, gMapGrandStatic13ETex, gMapGrandStatic13FTex, gMapGrandStatic140Tex,
+    gMapGrandStatic141Tex, gMapGrandStatic142Tex, gMapGrandStatic143Tex, gMapGrandStatic144Tex, gMapGrandStatic145Tex,
+    gMapGrandStatic146Tex, gMapGrandStatic147Tex, gMapGrandStatic148Tex, gMapGrandStatic149Tex, gMapGrandStatic14ATex,
+    gMapGrandStatic14BTex, gMapGrandStatic14CTex, gMapGrandStatic14DTex, gMapGrandStatic14ETex, gMapGrandStatic14FTex,
+    gMapGrandStatic150Tex, gMapGrandStatic151Tex, gMapGrandStatic152Tex, gMapGrandStatic153Tex, gMapGrandStatic154Tex,
+    gMapGrandStatic155Tex, gMapGrandStatic156Tex, gMapGrandStatic157Tex, gMapGrandStatic158Tex, gMapGrandStatic159Tex,
+    gMapGrandStatic15ATex, gMapGrandStatic15BTex, gMapGrandStatic15CTex, gMapGrandStatic15DTex, gMapGrandStatic15ETex,
+    gMapGrandStatic15FTex, gMapGrandStatic160Tex, gMapGrandStatic161Tex,
 };
 
 static bool sMirrorWorldActive = false;
@@ -181,13 +165,17 @@ void Ship_MapDispUpdateMirrorMode() {
     }
 }
 
-// BENTODO, can we just set dest insetead of doing a memcpy?
-void MapDisp_GetMapITexture(void* dst, s32 mapCompactId) {
+// 2S2H [Port] Changed dest to double pointer for assigning texture path string instead of Dma load
+void MapDisp_GetMapITexture(void** dst, s32 mapCompactId) {
     s32 mapSize = MapDisp_GetSizeOfMapITex(mapCompactId);
 
-    if (mapSize != 0) {
-        void* data = ResourceMgr_LoadTexOrDListByName(sMapTextures[mapCompactId]);
-        memcpy(dst, data, mapSize);
+    if (MapDisp_GetSizeOfMapITex(mapCompactId) != 0) {
+        if (mapCompactId < ARRAY_COUNT(sMapITextures)) {
+            *dst = sMapITextures[mapCompactId];
+        } else {
+            *dst = gEmptyTexture;
+        }
+
         // CmpDma_LoadFile(SEGMENT_ROM_START(map_i_static), mapCompactId, dst, MapDisp_GetSizeOfMapITex(mapCompactId));
     }
 }
@@ -1224,8 +1212,15 @@ void MapDisp_SwapRooms(s16 nextRoom) {
                         sMapDisp.minimapCurTex = sMapDisp.texBuff0;
                     }
                     if (MapData_GetSizeOfMapGrandTex(nextMapDataRoom->mapId) != 0) {
-                        sMapDisp.minimapCurTex = ResourceMgr_LoadTexOrDListByName(
-                            sMapGrandTextures[MAPDATA_GET_MAP_GRAND_ID_FROM_MAP_ID(nextMapDataRoom->mapId)]);
+                        // 2S2H [Port] Assign texture path string instead of a Dma load
+                        if (MAPDATA_GET_MAP_GRAND_ID_FROM_MAP_ID(nextMapDataRoom->mapId) <
+                            ARRAY_COUNTU(sMapGrandTextures)) {
+                            sMapDisp.minimapCurTex =
+                                sMapGrandTextures[MAPDATA_GET_MAP_GRAND_ID_FROM_MAP_ID(nextMapDataRoom->mapId)];
+                        } else {
+                            sMapDisp.minimapCurTex = gEmptyTexture;
+                        }
+
                         // CmpDma_LoadFile(SEGMENT_ROM_START(map_grand_static),
                         //                 MAPDATA_GET_MAP_GRAND_ID_FROM_MAP_ID(nextMapDataRoom->mapId),
                         //                 sMapDisp.minimapCurTex,
@@ -1481,8 +1476,8 @@ void* MapDisp_AllocDungeonMap(PlayState* play, void* heap) {
     for (dungeonMapRoomIter = 0; dungeonMapRoomIter < sPauseDungeonMap.textureCount; dungeonMapRoomIter++) {
         s32 mapCompactId = sPauseDungeonMap.mapI_mapCompactId[dungeonMapRoomIter];
 
-        // 2S2H [Port] directly set the pointer to the texture instead of using memcpy
-        MapDisp_GetMapITexture(sPauseDungeonMap.mapI_roomTextures[dungeonMapRoomIter], mapCompactId);
+        // 2S2H [Port] Pass the pointer of the array element to directly set texture
+        MapDisp_GetMapITexture(&sPauseDungeonMap.mapI_roomTextures[dungeonMapRoomIter], mapCompactId);
         if (dungeonMapRoomIter + 1 < sPauseDungeonMap.textureCount) {
             sPauseDungeonMap.mapI_roomTextures[dungeonMapRoomIter + 1] =
                 ALIGN16((intptr_t)sPauseDungeonMap.mapI_roomTextures[dungeonMapRoomIter] +


### PR DESCRIPTION
This PR makes it so we extract the pause menu maps and minimaps as actual textures instead of blobs. The map display now uses texture resource path strings instead of loading the raw bytes, allowing them to be overridden in texture packs and support HD sizes.

Also fixes missing door transition icons on the pause menu map due to a missing scene command callback.

![image](https://github.com/user-attachments/assets/6fdc3347-c47a-44ea-9ced-74235a59770f)


<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2025102389.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2025112530.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2025158127.zip)
<!--- section:artifacts:end -->