### PR TITLE
Add HD support for Igos room curtains

### DIFF
--- a/mm/src/overlays/actors/ovl_Boss_06/z_boss_06.h
+++ b/mm/src/overlays/actors/ovl_Boss_06/z_boss_06.h
@@ -48,6 +48,8 @@ typedef struct Boss06 {
     /* 0xA1C */ Vec3f unk_A1C;
     /* 0xA28 */ f32 unk_A28;
     /* 0xA2C */ f32 unk_A2C;
+    // 2S2H [Port]
+    /*       */ u8 curtainTexMask[64 * 64]; // [HD Textures] Mask for CPU modified texture
 } Boss06; // size = 0xA30
 
 #endif // Z_BOSS_06_H


### PR DESCRIPTION
This PR brings HD support to CPU modified textures used by the Igos curtains in the boss room fight.

Originally the game works by copying the texture data to the actor struct so that each curtain can have their own unique copy of the texture. As the curtain burns, the actor blacks out pixels in their copy. This texture is loaded as a segment value for the general display list.

To support HD textures and to avoid complex memory allocation/copying in the actor for different HD texture sizes, I've opted to leverage the existing Blended texture registration system which allows us to use a texture mask to avoid modifying the original texture. Because there are two curtains with separate mask, and the blended system only supports one mask per resource string, a new opcode was added to allow registering a blended texture as part of a graphics instruction instead of having to register in code before rendering.

In these demo shots, I have removed the lens flare and fire effect so it is easier to see the curtain itself

![image](https://github.com/user-attachments/assets/057046cf-e75a-4c64-9717-17a302622953)

https://github.com/user-attachments/assets/17ff2ff2-fa83-4c0c-83a3-d713761bfae3


<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2002666556.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2002685585.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2002737219.zip)
<!--- section:artifacts:end -->