### PR TITLE
Fix pr-artifacts fetch script after version update

### DIFF
--- a/.github/workflows/pr-artifacts.yml
+++ b/.github/workflows/pr-artifacts.yml
@@ -20,8 +20,9 @@ jobs:
             const pullHeadSHA = '${{github.event.workflow_run.head_sha}}';
             const pullUserId = ${{github.event.sender.id}};
             const prNumber = await (async () => {
-              const pulls = await github.rest.pulls.list({owner, repo});
-              for await (const {data} of github.paginate.iterator(pulls)) {
+              for await (const { data } of github.paginate.iterator(
+                github.rest.pulls.list, { owner, repo }
+              )) {
                 for (const pull of data) {
                   if (pull.head.sha === pullHeadSHA && pull.user.id === pullUserId) {
                     return pull.number;


### PR DESCRIPTION
The underlying octokit api changed when bumping github-script to v7

This updates the pagination to now take in the method and params directly. Successful run of this can be seen on my fork here https://github.com/Archez/2ship2harkinian/actions/runs/11131292890/job/30932534468