### PR TITLE
Fix Sidebar Search

### DIFF
--- a/mm/2s2h/BenGui/SearchableMenuItems.h
+++ b/mm/2s2h/BenGui/SearchableMenuItems.h
@@ -406,7 +406,7 @@ void FreeLookPitchMinMax() {
 
 void InsertSidebarSearch() {
     menuEntries[0].sidebarEntries.insert(menuEntries[0].sidebarEntries.begin() + searchSidebarIndex,
-        searchSidebarEntry);
+                                         searchSidebarEntry);
     CVarSetInteger(menuEntries[0].sidebarCvar, CVarGetInteger(menuEntries[0].sidebarCvar, 0) + 1);
 }
 

--- a/mm/2s2h/BenGui/SearchableMenuItems.h
+++ b/mm/2s2h/BenGui/SearchableMenuItems.h
@@ -404,6 +404,12 @@ void FreeLookPitchMinMax() {
     CVarSetFloat("gEnhancements.Camera.FreeLook.MinPitch", std::min(maxY, minY));
 }
 
+void InsertSidebarSearch() {
+    menuEntries[0].sidebarEntries.insert(menuEntries[0].sidebarEntries.begin() + searchSidebarIndex,
+        searchSidebarEntry);
+    CVarSetInteger(menuEntries[0].sidebarCvar, CVarGetInteger(menuEntries[0].sidebarCvar, 0) + 1);
+}
+
 void AddSettings() {
     // General Settings
     settingsSidebar.push_back(
@@ -448,12 +454,18 @@ void AddSettings() {
                 {},
                 [](widgetInfo& info) {
                     if (CVarGetInteger("gSettings.SidebarSearch", 0)) {
-                        menuEntries[0].sidebarEntries.insert(menuEntries[0].sidebarEntries.begin() + searchSidebarIndex,
-                                                             searchSidebarEntry);
-                        CVarSetInteger(menuEntries[0].sidebarCvar, CVarGetInteger(menuEntries[0].sidebarCvar, 0) + 1);
+                        InsertSidebarSearch();
                     } else {
-                        menuEntries[0].sidebarEntries.erase(menuEntries[0].sidebarEntries.begin() + searchSidebarIndex);
-                        CVarSetInteger(menuEntries[0].sidebarCvar, CVarGetInteger(menuEntries[0].sidebarCvar, 0) - 1);
+                        std::erase_if(menuEntries[0].sidebarEntries, [](SidebarEntry entry) {
+                            return strncmp(entry.label.c_str(), searchSidebarEntry.label.c_str(), 5) == 0;
+                        });
+                        int32_t sidebarVal = CVarGetInteger(menuEntries[0].sidebarCvar, 0);
+                        if (sidebarVal < menuEntries.size()) {
+                            sidebarVal -= 1;
+                        } else {
+                            sidebarVal = menuEntries.size() - 1;
+                        }
+                        CVarSetInteger(menuEntries[0].sidebarCvar, sidebarVal);
                     }
                 } },
               { "Search Input Autofocus", "gSettings.SearchAutofocus",
@@ -680,6 +692,10 @@ void AddSettings() {
                                       "Enables the separate Input Editor window.",
                                       WIDGET_WINDOW_BUTTON,
                                       { .size = UIWidgets::Sizes::Inline, .windowName = "2S2H Input Editor" } } } } });
+
+    if (CVarGetInteger("gSettings.SidebarSearch", 0)) {
+        settingsSidebar.insert(settingsSidebar.begin() + searchSidebarIndex, searchSidebarEntry);
+    }
 }
 int32_t motionBlurStrength;
 


### PR DESCRIPTION
Ensures the sidebar search gets added if enabled at boot.
Searches the sidebar entries to find an entry with a label that matches the searchSidebarEntry label to delete when disabling sidebar search, just in case something goes wrong and it's not actually where it's supposed to be (sidebarSearchIndex).

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2019349548.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2019352884.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2019363703.zip)
<!--- section:artifacts:end -->