### PR TITLE
Adds an option to the save editor to invert Stone Tower

### DIFF
--- a/mm/2s2h/DeveloperTools/SaveEditor.cpp
+++ b/mm/2s2h/DeveloperTools/SaveEditor.cpp
@@ -302,13 +302,38 @@ void DrawTempleClears() {
     }
 
     // Stone Tower
-    // Stone Tower Temple is always open so there is no need to have an option to open it.
     cleared = CHECK_WEEKEVENTREG(WEEKEVENTREG_CLEARED_STONE_TOWER_TEMPLE);
     if (UIWidgets::Checkbox("Stone Tower cleared", &cleared)) {
         if (cleared) {
             SET_WEEKEVENTREG(WEEKEVENTREG_CLEARED_STONE_TOWER_TEMPLE);
         } else {
             CLEAR_WEEKEVENTREG(WEEKEVENTREG_CLEARED_STONE_TOWER_TEMPLE);
+        }
+    }
+
+    if (gPlayState == NULL) {
+        return;
+    }
+
+    ImGui::SameLine();
+
+    if (Play_GetOriginalSceneId(gPlayState->sceneId) == SCENE_F40) {
+        cleared = Flags_GetSwitch(gPlayState, 20);
+        if (UIWidgets::Checkbox("Stone Tower Inverted", &cleared)) {
+            if (cleared) {
+                Flags_SetSwitch(gPlayState, 20);
+            } else {
+                Flags_UnsetSwitch(gPlayState, 20);
+            }
+        }
+    } else {
+        cleared = gSaveContext.cycleSceneFlags[SCENE_F40].switch0 & (1 << 20);
+        if (UIWidgets::Checkbox("Stone Tower Inverted", &cleared)) {
+            if (cleared) {
+                gSaveContext.cycleSceneFlags[SCENE_F40].switch0 |= 1 << 20;
+            } else {
+                gSaveContext.cycleSceneFlags[SCENE_F40].switch0 &= ~(1 << 20);
+            }
         }
     }
 }

--- a/mm/2s2h/DeveloperTools/SaveEditor.cpp
+++ b/mm/2s2h/DeveloperTools/SaveEditor.cpp
@@ -217,6 +217,8 @@ void UpdateGameTime(u16 gameTime) {
 void DrawTempleClears() {
     bool cleared;
     bool open;
+    bool inverted = false;
+    bool inStoneTower = false;
 
     // Woodfall
     cleared = CHECK_WEEKEVENTREG(WEEKEVENTREG_CLEARED_WOODFALL_TEMPLE);
@@ -311,29 +313,19 @@ void DrawTempleClears() {
         }
     }
 
-    if (gPlayState == NULL) {
-        return;
+    if (gPlayState != NULL) {
+        inStoneTower = Play_GetOriginalSceneId(gPlayState->sceneId) == SCENE_F40;
+        inverted = Flags_GetSwitch(gPlayState, 20);
     }
 
     ImGui::SameLine();
 
-    if (Play_GetOriginalSceneId(gPlayState->sceneId) == SCENE_F40) {
-        cleared = Flags_GetSwitch(gPlayState, 20);
-        if (UIWidgets::Checkbox("Stone Tower Inverted", &cleared)) {
-            if (cleared) {
-                Flags_SetSwitch(gPlayState, 20);
-            } else {
-                Flags_UnsetSwitch(gPlayState, 20);
-            }
-        }
-    } else {
-        cleared = gSaveContext.cycleSceneFlags[SCENE_F40].switch0 & (1 << 20);
-        if (UIWidgets::Checkbox("Stone Tower Inverted", &cleared)) {
-            if (cleared) {
-                gSaveContext.cycleSceneFlags[SCENE_F40].switch0 |= 1 << 20;
-            } else {
-                gSaveContext.cycleSceneFlags[SCENE_F40].switch0 &= ~(1 << 20);
-            }
+    if (UIWidgets::Checkbox("Stone Tower Inverted", &inverted,
+                            { .tooltip = "Can only invert while in Stone Tower", .disabled = !inStoneTower })) {
+        if (inverted) {
+            Flags_SetSwitch(gPlayState, 20);
+        } else {
+            Flags_UnsetSwitch(gPlayState, 20);
         }
     }
 }

--- a/mm/2s2h/DeveloperTools/SaveEditor.cpp
+++ b/mm/2s2h/DeveloperTools/SaveEditor.cpp
@@ -321,7 +321,7 @@ void DrawTempleClears() {
     ImGui::SameLine();
 
     if (UIWidgets::Checkbox("Stone Tower Inverted", &inverted,
-                            { .tooltip = "Can only invert while in Stone Tower", .disabled = !inStoneTower })) {
+                            { .disabled = !inStoneTower, .disabledTooltip = "Can only invert while in Stone Tower" })) {
         if (inverted) {
             Flags_SetSwitch(gPlayState, 20);
         } else {


### PR DESCRIPTION
This PR adds a checkbox for inverting the Stone Tower in the Save Editor next to the Clear Stone Tower checkbox, so you won't need to know which specific scene flag triggers inverting Stone Tower.

I've set the checkbox to be disabled when not in Stone Tower or Inverted Stone Tower because there isn't really a point to inverting when not in those scenes, and the game will "uninvert" when leaving the tower normally anyway. 

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2126387121.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2126394334.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2126499126.zip)
<!--- section:artifacts:end -->