### PR TITLE
Fix item id type

### DIFF
--- a/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_item.c
+++ b/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_item.c
@@ -322,9 +322,7 @@ void KaleidoScope_DrawItemSelect(PlayState* play) {
                         pauseCtx->itemVtx[j + 0].v.ob[1] - 32;
                 }
             }
-            // #region 2S2H [Port] Originally this was done in KaleidoScope_Update, but now we are using gSPGrayscale on
-            // the fly It reads odd here to assign a u8 to a u16, then cast it to s32 for gPlayerFormItemRestrictions
-            // but this matches the behavior of the original code
+            // #region 2S2H [Port] Originally this was done in KaleidoScope_Update, but now we are using gSPGrayscale.
             ItemId itemId = gSaveContext.save.saveInfo.inventory.items[i];
             u8 itemRestricted = GameInteractor_Should(
                 GI_VB_ITEM_BE_RESTRICTED, !gPlayerFormItemRestrictions[GET_PLAYER_FORM][(s32)itemId], &itemId);

--- a/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_item.c
+++ b/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_item.c
@@ -325,7 +325,7 @@ void KaleidoScope_DrawItemSelect(PlayState* play) {
             // #region 2S2H [Port] Originally this was done in KaleidoScope_Update, but now we are using gSPGrayscale on
             // the fly It reads odd here to assign a u8 to a u16, then cast it to s32 for gPlayerFormItemRestrictions
             // but this matches the behavior of the original code
-            u16 itemId = gSaveContext.save.saveInfo.inventory.items[i];
+            ItemId itemId = gSaveContext.save.saveInfo.inventory.items[i];
             u8 itemRestricted = GameInteractor_Should(
                 GI_VB_ITEM_BE_RESTRICTED, !gPlayerFormItemRestrictions[GET_PLAYER_FORM][(s32)itemId], &itemId);
             if (itemRestricted) {


### PR DESCRIPTION
This was causing a crash when using the address sanitizer. Originally `itemId` was a u16, but when read in `GameInteractor_Should` it was being treated as a s32.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2079483038.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2079491160.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2079497740.zip)
<!--- section:artifacts:end -->