### PR TITLE
Fix bug with two-handed sword magic and Kamaro's Mask dance

### DIFF
--- a/mm/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/mm/src/overlays/actors/ovl_player_actor/z_player.c
@@ -14568,9 +14568,7 @@ void Player_Action_12(Player* this, PlayState* play) {
     if (!func_80847880(play, this)) {
         if (!Player_TryActionChangeList(play, this, sPlayerActionChangeList7, false) ||
             (Player_Action_12 == this->actionFunc)) {
-            if (!GameInteractor_Should(VB_CHECK_HELD_ITEM_BUTTON_PRESS,
-                                       CHECK_BTN_ALL(sPlayerControlInput->cur.button, BTN_B), sDpadItemButtons,
-                                       sPlayerItemButtons)) {
+            if (!CHECK_BTN_ALL(sPlayerControlInput->cur.button, BTN_B)) {
                 func_80839E74(this, play);
             }
         }


### PR DESCRIPTION
[The two-handed sword magic enhancement](https://github.com/HarbourMasters/2ship2harkinian/pull/679) introduced a bug with Kamaro's Mask. I overzealously applied the hook to the B button held check that applies to the dance. The enhancement changes logic so that it checks the button of the currently assigned item, rather than always B, for a held press. When using Kamaro's Mask to dance, there is no held item to check for a button press, so Link would cut out of the animation a couple frames into it if this enhancement was enabled.

This PR removes the erroneous hook point.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2138021103.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2138023845.zip)
<!--- section:artifacts:end -->