### PR TITLE
Fix installed macports detection for github runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -192,15 +192,17 @@ jobs:
         key: ${{ runner.os }}-14-macports-${{ hashFiles('.github/workflows/macports-deps.txt') }}
         restore-keys: |
           ${{ runner.os }}-14-macports-
+    # Updated PATH applies to the next step and onwards
     - name: Install MacPorts (if necessary)
       run: |
-        if [ command -v port &>/dev/null ]; then
+        if command -v /opt/local/bin/port 2>&1 >/dev/null; then
           echo "MacPorts already installed"
         else
+          echo "Installing MacPorts"
           wget https://github.com/macports/macports-base/releases/download/v2.9.3/MacPorts-2.9.3-14-Sonoma.pkg
           sudo installer -pkg ./MacPorts-2.9.3-14-Sonoma.pkg -target /
         fi
-        echo "/opt/local/bin:/opt/local/sbin" >> $GITHUB_PATH
+        echo "/opt/local/bin:/opt/local/sbin" >> "$GITHUB_PATH"
     - name: Install dependencies
       run: |
         brew uninstall --ignore-dependencies libpng


### PR DESCRIPTION
The check for if the macports `port` command exists or not was always failing because at this point we have not updated the env PATH for macports installation. This lead to the workflow to try installing macports again, which would lead to failures.

Hardcoding the full path for checking existence of the port command should fix this.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2150320215.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2150328409.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2150342857.zip)
<!--- section:artifacts:end -->