### PR TITLE
Add alt assets toggle to menus

### DIFF
--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -620,6 +620,12 @@ void DrawEnhancementsMenu() {
             ImGui::SeparatorText("Clock");
             UIWidgets::CVarCombobox("Clock Type", "gEnhancements.Graphics.ClockType", clockTypeOptions);
             UIWidgets::CVarCheckbox("24 Hours Clock", "gEnhancements.Graphics.24HoursClock");
+
+            ImGui::SeparatorText("Mods");
+            UIWidgets::CVarCheckbox("Use Alternate Assets", "gEnhancements.Mods.AlternateAssets",
+                                    { .tooltip = "Toggle between standard assets and alternate assets. Usually mods "
+                                                 "will indicate if this setting has to be used or not." });
+
             MotionBlur_RenderMenuOptions();
             ImGui::SeparatorText("Other");
             UIWidgets::CVarCheckbox("Authentic logo", "gEnhancements.Graphics.AuthenticLogo",

--- a/mm/2s2h/BenGui/SearchableMenuItems.h
+++ b/mm/2s2h/BenGui/SearchableMenuItems.h
@@ -449,7 +449,7 @@ void AddSettings() {
                 "gSettings.MenuTheme",
                 "Changes the Theme of the Menu Widgets.",
                 WIDGET_CVAR_COMBOBOX,
-                { .comboBoxOptions = menuThemeOptions } },
+                { .defaultVariant = COLOR_INDIGO, .comboBoxOptions = menuThemeOptions } },
 #if not defined(__SWITCH__) and not defined(__WIIU__)
               { "Menubar Controller Navigation", CVAR_IMGUI_CONTROLLER_NAV,
                 "Allows controller navigation of the SOH menu bar (Settings, Enhancements,...)\nCAUTION: "
@@ -467,15 +467,6 @@ void AddSettings() {
                         CVarGetInteger("gSettings.CursorVisibility", 0));
                 } },
 #endif
-              { "Open App Files Folder",
-                "",
-                "Opens the folder that contains the save and mods folders, etc.",
-                WIDGET_BUTTON,
-                {},
-                [](widgetInfo& info) {
-                    std::string filesPath = Ship::Context::GetInstance()->GetAppDirectoryPath();
-                    SDL_OpenURL(std::string("file:///" + std::filesystem::absolute(filesPath).string()).c_str());
-                } },
               { "Search In Sidebar",
                 "gSettings.SidebarSearch",
                 "Displays the Search menu as a sidebar entry in Settings instead of in the header.",
@@ -500,6 +491,20 @@ void AddSettings() {
               { "Search Input Autofocus", "gSettings.SearchAutofocus",
                 "Search input box gets autofocus when visible. Does not affect using other widgets.",
                 WIDGET_CVAR_CHECKBOX },
+              { .widgetName = "Alt Assets Tab hotkey",
+                .widgetCVar = "gEnhancements.Mods.AlternateAssetsHotkey",
+                .widgetTooltip = "Allows pressing the Tab key to toggle alternate assets",
+                .widgetType = WIDGET_CVAR_CHECKBOX,
+                .widgetOptions = { .defaultVariant = true } },
+              { "Open App Files Folder",
+                "",
+                "Opens the folder that contains the save and mods folders, etc.",
+                WIDGET_BUTTON,
+                {},
+                [](widgetInfo& info) {
+                    std::string filesPath = Ship::Context::GetInstance()->GetAppDirectoryPath();
+                    SDL_OpenURL(std::string("file:///" + std::filesystem::absolute(filesPath).string()).c_str());
+                } },
           } } });
     // Audio Settings
     settingsSidebar.push_back(

--- a/mm/2s2h/BenGui/SearchableMenuItems.h
+++ b/mm/2s2h/BenGui/SearchableMenuItems.h
@@ -1170,6 +1170,12 @@ void AddEnhancements() {
                 { .comboBoxOptions = clockTypeOptions } },
               { "24 Hours Clock", "gEnhancements.Graphics.24HoursClock", "Changes from a 12 Hour to a 24 Hour Clock",
                 WIDGET_CVAR_CHECKBOX },
+              { .widgetName = "Mods", .widgetType = WIDGET_SEPARATOR_TEXT },
+              { .widgetName = "Use Alternate Assets",
+                .widgetCVar = "gEnhancements.Mods.AlternateAssets",
+                .widgetTooltip = "Toggle between standard assets and alternate assets. Usually mods will indicate if "
+                                 "this setting has to be used or not.",
+                .widgetType = WIDGET_CVAR_CHECKBOX },
               { .widgetName = "Motion Blur", .widgetType = WIDGET_SEPARATOR_TEXT },
               { "Motion Blur Mode",
                 "gEnhancements.Graphics.MotionBlur.Mode",

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -154,7 +154,7 @@ OTRGlobals::OTRGlobals() {
         Ship::Context::CreateInstance("2 Ship 2 Harkinian", appShortName, "2ship2harkinian.json", archiveFiles, {}, 3,
                                       { .SampleRate = 44100, .SampleLength = 1024, .DesiredBuffered = 2480 });
 
-    prevAltAssets = CVarGetInteger("gAltAssets", 0);
+    prevAltAssets = CVarGetInteger("gEnhancements.Mods.AlternateAssets", 0);
     context->GetResourceManager()->SetAltAssetsEnabled(prevAltAssets);
 
     // Override LUS defaults
@@ -688,8 +688,8 @@ extern "C" void Graph_StartFrame() {
 #endif
         case KbScancode::LUS_KB_TAB: {
             // Toggle HD Assets
-            CVarSetInteger("gAltAssets", !CVarGetInteger("gAltAssets", 0));
-            // ShouldClearTextureCacheAtEndOfFrame = true;
+            CVarSetInteger("gEnhancements.Mods.AlternateAssets",
+                           !CVarGetInteger("gEnhancements.Mods.AlternateAssets", 0));
             break;
         }
     }
@@ -778,7 +778,7 @@ extern "C" void Graph_ProcessGfxCommands(Gfx* commands) {
         }
     }
 
-    bool curAltAssets = CVarGetInteger("gAltAssets", 0);
+    bool curAltAssets = CVarGetInteger("gEnhancements.Mods.AlternateAssets", 0);
     if (prevAltAssets != curAltAssets) {
         prevAltAssets = curAltAssets;
         Ship::Context::GetInstance()->GetResourceManager()->SetAltAssetsEnabled(curAltAssets);

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -688,8 +688,10 @@ extern "C" void Graph_StartFrame() {
 #endif
         case KbScancode::LUS_KB_TAB: {
             // Toggle HD Assets
-            CVarSetInteger("gEnhancements.Mods.AlternateAssets",
-                           !CVarGetInteger("gEnhancements.Mods.AlternateAssets", 0));
+            if (CVarGetInteger("gEnhancements.Mods.AlternateAssetsHotkey", 1)) {
+                CVarSetInteger("gEnhancements.Mods.AlternateAssets",
+                               !CVarGetInteger("gEnhancements.Mods.AlternateAssets", 0));
+            }
             break;
         }
     }


### PR DESCRIPTION
Adds the alt assets toggle to the menus (_finally!_). I stuck it in graphics > mods to align with SoH.

![image](https://github.com/user-attachments/assets/d790a97a-4ecd-4c63-9a2a-3d31f77f73db)


<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2160407418.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2160409747.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2160423202.zip)
<!--- section:artifacts:end -->