### PR TITLE
Fix two-handed sword magic crash

### DIFF
--- a/mm/2s2h/Enhancements/Equipment/TwoHandedSwordSpinAttack.cpp
+++ b/mm/2s2h/Enhancements/Equipment/TwoHandedSwordSpinAttack.cpp
@@ -34,8 +34,8 @@ void RegisterTwoHandedSwordSpinAttack() {
     REGISTER_VB_SHOULD(VB_MAGIC_SPIN_ATTACK_CHECK_FORM, {
         if (CVarGetInteger("gEnhancements.Equipment.TwoHandedSwordSpinAttack", 0)) {
             // Additionally allow the Fierce Deity form to use charged spin attacks
-            PlayerTransformation form = va_arg(args, PlayerTransformation);
-            if (form == PLAYER_FORM_FIERCE_DEITY) {
+            Player* player = GET_PLAYER(gPlayState);
+            if (player->transformation == PLAYER_FORM_FIERCE_DEITY) {
                 *should = true;
             }
         }

--- a/mm/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/mm/src/overlays/actors/ovl_player_actor/z_player.c
@@ -5269,8 +5269,8 @@ void func_808332A0(PlayState* play, Player* this, s32 magicCost, s32 isSwordBeam
 
     this->stateFlags1 |= PLAYER_STATE1_1000;
     if ((this->actor.id == ACTOR_PLAYER) &&
-        (isSwordBeam || (GameInteractor_Should(VB_MAGIC_SPIN_ATTACK_CHECK_FORM,
-                                               this->transformation == PLAYER_FORM_HUMAN, this->transformation)))) {
+        (isSwordBeam ||
+         (GameInteractor_Should(VB_MAGIC_SPIN_ATTACK_CHECK_FORM, this->transformation == PLAYER_FORM_HUMAN)))) {
         s16 pitch = 0;
         Actor* thunder;
 


### PR DESCRIPTION
It turns out that some environments may not like it if you pass small numbers through `va_arg`. This fixes #827 by doing away with an argument and using the global `Player` instead.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2167715873.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2167717508.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2167725564.zip)
<!--- section:artifacts:end -->