### PR TITLE
Fix some issues caused by the extended scene geometry enhancement by patching DLs

### DIFF
--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -651,11 +651,13 @@ void DrawEnhancementsMenu() {
             ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(255, 255, 0, 255));
             ImGui::SeparatorText("Unstable");
             ImGui::PopStyleColor();
-            UIWidgets::CVarCheckbox(
-                "Disable Scene Geometry Distance Check", "gEnhancements.Graphics.DisableSceneGeometryDistanceCheck",
-                { .tooltip =
-                      "Disables the distance check for scene geometry, allowing it to be drawn no matter how far "
-                      "away it is from the player. This may have unintended side effects." });
+            if (UIWidgets::CVarCheckbox(
+                    "Disable Scene Geometry Distance Check", "gEnhancements.Graphics.DisableSceneGeometryDistanceCheck",
+                    { .tooltip =
+                          "Disables the distance check for scene geometry, allowing it to be drawn no matter how far "
+                          "away it is from the player. This may have unintended side effects." })) {
+                GfxPatcher_ApplyGeometryIssuePatches();
+            }
             UIWidgets::CVarCheckbox("Widescreen Actor Culling",
                                     "gEnhancements.Graphics.ActorCullingAccountsForWidescreen",
                                     { .tooltip = "Adjusts the culling planes to account for widescreen resolutions. "

--- a/mm/2s2h/BenGui/SearchableMenuItems.h
+++ b/mm/2s2h/BenGui/SearchableMenuItems.h
@@ -1244,10 +1244,13 @@ void AddEnhancements() {
               { .widgetName = "Unstable",
                 .widgetType = WIDGET_SEPARATOR_TEXT,
                 .widgetOptions = { .color = UIWidgets::Colors::Yellow } },
-              { "Disable Scene Geometry Distance Check", "gEnhancements.Graphics.DisableSceneGeometryDistanceCheck",
+              { "Disable Scene Geometry Distance Check",
+                "gEnhancements.Graphics.DisableSceneGeometryDistanceCheck",
                 "Disables the distance check for scene geometry, allowing it to be drawn no matter how far "
                 "away it is from the player. This may have unintended side effects.",
-                WIDGET_CVAR_CHECKBOX },
+                WIDGET_CVAR_CHECKBOX,
+                {},
+                [](widgetInfo& info) { GfxPatcher_ApplyGeometryIssuePatches(); } },
               { "Widescreen Actor Culling", "gEnhancements.Graphics.ActorCullingAccountsForWidescreen",
                 "Adjusts the culling planes to account for widescreen resolutions. "
                 "This may have unintended side effects.",

--- a/mm/2s2h/Enhancements/GfxPatcher/AuthenticGfxPatches.cpp
+++ b/mm/2s2h/Enhancements/GfxPatcher/AuthenticGfxPatches.cpp
@@ -265,9 +265,58 @@ void PatchMiniGameCrossAndCircleSymbols() {
     }
 }
 
+void PatchKnifeChamberRoomGeometry() {
+    if (CVarGetInteger("gEnhancements.Graphics.DisableSceneGeometryDistanceCheck", 0)) {
+        ResourceMgr_PatchGfxByName("scenes/nonmq/Z2_YADOYA/Z2_YADOYA_room_00DL_012280", "disableDistanceCheck1", 5,
+                                   gsSPNoOp());
+        ResourceMgr_PatchGfxByName("scenes/nonmq/Z2_YADOYA/Z2_YADOYA_room_00DL_012280", "disableDistanceCheck2", 6,
+                                   gsSPNoOp());
+    } else {
+        ResourceMgr_UnpatchGfxByName("scenes/nonmq/Z2_YADOYA/Z2_YADOYA_room_00DL_012280", "disableDistanceCheck1");
+        ResourceMgr_UnpatchGfxByName("scenes/nonmq/Z2_YADOYA/Z2_YADOYA_room_00DL_012280", "disableDistanceCheck2");
+    }
+}
+
+void PatchClockTownBuildingGeometry() {
+    if (CVarGetInteger("gEnhancements.Graphics.DisableSceneGeometryDistanceCheck", 0)) {
+        ResourceMgr_PatchGfxByName("scenes/nonmq/Z2_00KEIKOKU/Z2_00KEIKOKU_room_00DL_00D490", "disableDistanceCheck1",
+                                   5, gsSPNoOp());
+        ResourceMgr_PatchGfxByName("scenes/nonmq/Z2_00KEIKOKU/Z2_00KEIKOKU_room_00DL_00D490", "disableDistanceCheck2",
+                                   6, gsSPNoOp());
+        ResourceMgr_PatchGfxByName("scenes/nonmq/Z2_00KEIKOKU/Z2_00KEIKOKU_room_00DL_00CD70", "disableDistanceCheck1",
+                                   5, gsSPNoOp());
+        ResourceMgr_PatchGfxByName("scenes/nonmq/Z2_00KEIKOKU/Z2_00KEIKOKU_room_00DL_00CD70", "disableDistanceCheck2",
+                                   6, gsSPNoOp());
+        ResourceMgr_PatchGfxByName("scenes/nonmq/Z2_00KEIKOKU/Z2_00KEIKOKU_room_00DL_00D9C8", "disableDistanceCheck1",
+                                   5, gsSPNoOp());
+        ResourceMgr_PatchGfxByName("scenes/nonmq/Z2_00KEIKOKU/Z2_00KEIKOKU_room_00DL_00D9C8", "disableDistanceCheck2",
+                                   6, gsSPNoOp());
+    } else {
+        ResourceMgr_UnpatchGfxByName("scenes/nonmq/Z2_00KEIKOKU/Z2_00KEIKOKU_room_00DL_00D490",
+                                     "disableDistanceCheck1");
+        ResourceMgr_UnpatchGfxByName("scenes/nonmq/Z2_00KEIKOKU/Z2_00KEIKOKU_room_00DL_00D490",
+                                     "disableDistanceCheck2");
+        ResourceMgr_UnpatchGfxByName("scenes/nonmq/Z2_00KEIKOKU/Z2_00KEIKOKU_room_00DL_00CD70",
+                                     "disableDistanceCheck1");
+        ResourceMgr_UnpatchGfxByName("scenes/nonmq/Z2_00KEIKOKU/Z2_00KEIKOKU_room_00DL_00CD70",
+                                     "disableDistanceCheck2");
+        ResourceMgr_UnpatchGfxByName("scenes/nonmq/Z2_00KEIKOKU/Z2_00KEIKOKU_room_00DL_00D9C8",
+                                     "disableDistanceCheck1");
+        ResourceMgr_UnpatchGfxByName("scenes/nonmq/Z2_00KEIKOKU/Z2_00KEIKOKU_room_00DL_00D9C8",
+                                     "disableDistanceCheck2");
+    }
+}
+
+void GfxPatcher_ApplyGeometryIssuePatches() {
+    PatchKnifeChamberRoomGeometry();
+    PatchClockTownBuildingGeometry();
+}
+
 // Applies required patches for authentic bugs to allow the game to play and render properly
 void GfxPatcher_ApplyNecessaryAuthenticPatches() {
     PatchMiniGameCrossAndCircleSymbols();
 
     GfxPatcher_ApplyOverflowTexturePatches();
+
+    GfxPatcher_ApplyGeometryIssuePatches();
 }

--- a/mm/2s2h/Enhancements/GfxPatcher/AuthenticGfxPatches.h
+++ b/mm/2s2h/Enhancements/GfxPatcher/AuthenticGfxPatches.h
@@ -3,5 +3,6 @@
 
 void GfxPatcher_ApplyNecessaryAuthenticPatches();
 void GfxPatcher_ApplyOverflowTexturePatches();
+void GfxPatcher_ApplyGeometryIssuePatches();
 
 #endif // AUTHENTIC_GFX_PATCHES_H


### PR DESCRIPTION
Referenced Recomp to find the culprit DL's for the clock town, and our GFX debugger to find the DL associated with the knife chamber (thanks to retroben for calling this out)

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2167811820.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2167814730.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2167817039.zip)
<!--- section:artifacts:end -->