### PR TITLE
Fix crash when toggling alt assets while paused

### DIFF
--- a/mm/src/code/z_play.c
+++ b/mm/src/code/z_play.c
@@ -1184,16 +1184,17 @@ void Play_DrawMain(PlayState* this) {
     // Track render size when paused and that a copy was performed
     static u32 lastPauseWidth;
     static u32 lastPauseHeight;
-    static u8 hasCapturedPauseBuffer;
+    static bool lastAltAssets;
+    static bool hasCapturedPauseBuffer;
     u8 recapturePauseBuffer = false;
 
-    // If the size has changed or dropped frames leading to the buffer not being copied,
+    // If the size has changed, alt assets toggled or dropped frames leading to the buffer not being copied,
     // set the prerender state back to setup to copy a new frame.
-    // This requires not rendering kaleido during this copy to avoid kaleido being copied
+    // This requires not rendering kaleido during this copy to avoid kaleido itself being copied too.
     if ((R_PAUSE_BG_PRERENDER_STATE == PAUSE_BG_PRERENDER_PROCESS ||
          R_PAUSE_BG_PRERENDER_STATE == PAUSE_BG_PRERENDER_READY) &&
         (lastPauseWidth != OTRGetGameRenderWidth() || lastPauseHeight != OTRGetGameRenderHeight() ||
-         !hasCapturedPauseBuffer || sJustClosedBomberNotebook)) {
+         lastAltAssets != ResourceMgr_IsAltAssetsEnabled() || !hasCapturedPauseBuffer || sJustClosedBomberNotebook)) {
         R_PAUSE_BG_PRERENDER_STATE = PAUSE_BG_PRERENDER_SETUP;
         recapturePauseBuffer = true;
     }
@@ -1487,6 +1488,7 @@ void Play_DrawMain(PlayState* this) {
                     // #region 2S2H [Port] Custom handling for pause prerender background capture
                     lastPauseWidth = OTRGetGameRenderWidth();
                     lastPauseHeight = OTRGetGameRenderHeight();
+                    lastAltAssets = ResourceMgr_IsAltAssetsEnabled();
                     hasCapturedPauseBuffer = false;
 
                     FB_CopyToFramebuffer(&sp74, 0, gPauseFrameBuffer, false, &hasCapturedPauseBuffer);


### PR DESCRIPTION
This fixes a crash identified by #838 when toggling alt assets while the pause menu is up.

A proper fix will most likely need to happen in LUS pertaining to the texture cache clearing and framebuffer draw rectangle not setting up the rendering state again.

This intermediate fix checks when alt assets get toggled, and when it does, force a new pause menu background to be captured. By doing this we render the game world for one frame, which will leave the render state in a "good" state for the framebuffer draw to rely on. This has the added benefit of having the pause menu background "update" for any new textures applied by alt toggling.

Closes #838

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2169629053.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2169632844.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2169633434.zip)
<!--- section:artifacts:end -->