### PR TITLE
Fix linux crash with KeepExpressMail

### DIFF
--- a/mm/2s2h/Enhancements/Cycle/KeepExpressMail.cpp
+++ b/mm/2s2h/Enhancements/Cycle/KeepExpressMail.cpp
@@ -16,7 +16,7 @@ void CheckScene(s16 sceneId) {
 
     onItemDeleteID = REGISTER_VB_SHOULD(VB_MSG_SCRIPT_DEL_ITEM, {
         Actor* actor = va_arg(args, Actor*);
-        ItemId itemId = va_arg(args, ItemId);
+        ItemId itemId = (ItemId)va_arg(args, int);
 
         // Keep the express mail only on the first trade for the cycle
         // Postman checking for Madame Aroma trade cycle flag


### PR DESCRIPTION
Similar to #828 bad type used with `va_args`

```
2ship2harkinian/mm/2s2h/Enhancements/Cycle/KeepExpressMail.cpp:19:38:
   19 |         ItemId itemId = va_arg(args, ItemId);
      |                                      ^
warning: ‘ItemId’ is promoted to ‘int’ when passed through ‘...’
note: (so you should pass ‘int’ not ‘ItemId’ to ‘va_arg’)
note: if this code is reached, the program will abort
```

Switching to read as int and allow cast to enum through assignment.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2172028240.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2172038313.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2172040418.zip)
<!--- section:artifacts:end -->