### PR TITLE
Various fixes for spelling and save editor time change lightning state

### DIFF
--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -356,9 +356,8 @@ void DrawEnhancementsMenu() {
         if (UIWidgets::BeginMenu("Camera")) {
             ImGui::SeparatorText("Fixes");
             UIWidgets::CVarCheckbox(
-                "Fix Targetting Camera Snap", "gEnhancements.Camera.FixTargettingCameraSnap",
-                { .tooltip =
-                      "Fixes the camera snap that occurs when you are moving and press the targetting button." });
+                "Fix Targeting Camera Snap", "gEnhancements.Camera.FixTargettingCameraSnap",
+                { .tooltip = "Fixes the camera snap that occurs when you are moving and press the targeting button." });
 
             ImGui::SeparatorText("First Person");
             UIWidgets::CVarCheckbox("Disable Auto-Centering",
@@ -559,8 +558,9 @@ void DrawEnhancementsMenu() {
         if (UIWidgets::BeginMenu("Dialogue")) {
             UIWidgets::CVarCheckbox(
                 "Fast Bank Selection", "gEnhancements.Dialogue.FastBankSelection",
-                { .tooltip = "Pressing the Z or R buttons while the Deposit/Withdrawl Rupees dialogue is open will set "
-                             "the Rupees to Links current Rupees or 0 respectively." });
+                { .tooltip =
+                      "Pressing the Z or R buttons while the Deposit/Withdrawal Rupees dialogue is open will set "
+                      "the Rupees to Links current Rupees or 0 respectively." });
             UIWidgets::CVarCheckbox(
                 "Fast Text", "gEnhancements.Dialogue.FastText",
                 { .tooltip = "Speeds up text rendering, and enables holding of B progress to next message" });
@@ -688,7 +688,7 @@ void DrawEnhancementsMenu() {
                                     { .tooltip = "Allow using Fierce Deity's mask outside of boss rooms." });
             UIWidgets::CVarCheckbox("No Blast Mask Cooldown", "gEnhancements.Masks.NoBlastMaskCooldown", {});
             if (UIWidgets::CVarCheckbox("Persistent Bunny Hood", "gEnhancements.Masks.PersistentBunnyHood.Enabled",
-                                        { .tooltip = "Permanantly toggle a speed boost from the bunny hood by pressing "
+                                        { .tooltip = "Permanently toggle a speed boost from the bunny hood by pressing "
                                                      "'A' on it in the mask menu." })) {
                 UpdatePersistentMasksState();
             }
@@ -902,7 +902,7 @@ void DrawDeveloperToolsMenu() {
                           "Change the behavior of creating saves while debug mode is enabled:\n\n"
                           "- Empty Save: The default 3 heart save file in first cycle\n"
                           "- Vanilla Debug Save: Uses the title screen save info (8 hearts, all items and masks)\n"
-                          "- 100\% Save: All items, equipment, mask, quast status and bombers notebook complete",
+                          "- 100\% Save: All items, equipment, mask, quest status and bombers notebook complete",
                       .defaultIndex = DEBUG_SAVE_INFO_NONE })) {
                 RegisterDebugSaveCreate();
             }

--- a/mm/2s2h/BenGui/SearchableMenuItems.h
+++ b/mm/2s2h/BenGui/SearchableMenuItems.h
@@ -218,7 +218,7 @@ struct widgetInfo {
 // `evaluation` returns a bool which can be determined by whatever code you want that changes its status
 // `reason` is the text displayed in the disabledTooltip when a widget is disabled by a particular DisableReason
 // `active` is what's referenced when determining disabled status for a widget that uses this This can also be used to
-// hold reasons to hide widgets so taht their evaluations are also only run once per frame
+// hold reasons to hide widgets so that their evaluations are also only run once per frame
 struct disabledInfo {
     DisableInfoFunc evaluation;
     const char* reason;
@@ -778,9 +778,9 @@ void AddEnhancements() {
           3,
           { {
                 { .widgetName = "Fixes", .widgetType = WIDGET_SEPARATOR_TEXT },
-                { "Fix Targetting Camera Snap",
+                { "Fix Targeting Camera Snap",
                   "gEnhancements.Camera.FixTargettingCameraSnap",
-                  "Fixes the camera snap that occurs when you are moving and press the targetting button.",
+                  "Fixes the camera snap that occurs when you are moving and press the targeting button.",
                   WIDGET_CVAR_CHECKBOX,
                   {} },
                 { .widgetName = "First Person", .widgetType = WIDGET_SEPARATOR_TEXT },
@@ -1280,12 +1280,12 @@ void AddEnhancements() {
               { "Blast Mask has Powder Keg Force", "gEnhancements.Masks.BlastMaskKeg",
                 "Blast Mask can also destroy objects only the Powder Keg can.", WIDGET_CVAR_CHECKBOX },
               { "Fast Transformation", "gEnhancements.Masks.FastTransformation",
-                "Removes the delay when using transormation masks.", WIDGET_CVAR_CHECKBOX },
+                "Removes the delay when using transformation masks.", WIDGET_CVAR_CHECKBOX },
               { "Fierce Deity's Mask Anywhere", "gEnhancements.Masks.FierceDeitysAnywhere",
                 "Allow using Fierce Deity's mask outside of boss rooms.", WIDGET_CVAR_CHECKBOX },
               { "Persistent Bunny Hood",
                 "gEnhancements.Masks.PersistentBunnyHood.Enabled",
-                "Permanantly toggle a speed boost from the bunny hood by pressing "
+                "Permanently toggle a speed boost from the bunny hood by pressing "
                 "'A' on it in the mask menu.",
                 WIDGET_CVAR_CHECKBOX,
                 {},
@@ -1352,7 +1352,7 @@ void AddEnhancements() {
             // Dialogue Enhancements
             { { .widgetName = "Dialogue", .widgetType = WIDGET_SEPARATOR_TEXT },
               { "Fast Bank Selection", "gEnhancements.Dialogue.FastBankSelection",
-                "Pressing the Z or R buttons while the Deposit/Withdrawl Rupees dialogue is open will set "
+                "Pressing the Z or R buttons while the Deposit/Withdrawal Rupees dialogue is open will set "
                 "the Rupees to Links current Rupees or 0 respectively.",
                 WIDGET_CVAR_CHECKBOX },
               { "Fast Text", "gEnhancements.Dialogue.FastText",
@@ -1535,7 +1535,7 @@ void AddDevTools() {
                 "Change the behavior of creating saves while debug mode is enabled:\n\n"
                 "- Empty Save: The default 3 heart save file in first cycle\n"
                 "- Vanilla Debug Save: Uses the title screen save info (8 hearts, all items and masks)\n"
-                "- 100\% Save: All items, equipment, mask, quast status and bombers notebook complete",
+                "- 100\% Save: All items, equipment, mask, quest status and bombers notebook complete",
                 WIDGET_CVAR_COMBOBOX,
                 { 0, 0, 0, debugSaveOptions },
                 [](widgetInfo& info) { RegisterDebugSaveCreate(); },

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -1396,7 +1396,7 @@ extern "C" SkeletonHeader* ResourceMgr_LoadSkeletonByName(const char* path, Skel
     }
 
     // This function is only called when a skeleton is initialized.
-    // Therefore we can take this oppurtunity to take note of the Skeleton that is created...
+    // Therefore we can take this opportunity to take note of the Skeleton that is created...
     if (skelAnime != nullptr) {
         auto stringPath = std::string(path);
         // Ship::SkeletonPatcher::RegisterSkeleton(stringPath, skelAnime);

--- a/mm/2s2h/DeveloperTools/CollisionViewer.cpp
+++ b/mm/2s2h/DeveloperTools/CollisionViewer.cpp
@@ -122,7 +122,7 @@ void CalcTriNorm(const Vec3f& v1, const Vec3f& v2, const Vec3f& v3, Vec3f& norm)
     }
 }
 
-// Various macros used for creating verticies and rendering that aren't in gbi.h
+// Various macros used for creating vertices and rendering that aren't in gbi.h
 #define G_CC_MODULATERGB_PRIM_ENVA PRIMITIVE, 0, SHADE, 0, 0, 0, 0, ENVIRONMENT
 #define G_CC_PRIMITIVE_ENVA 0, 0, 0, PRIMITIVE, 0, 0, 0, ENVIRONMENT
 #define qs105(n) ((int16_t)((n)*0x0020))
@@ -179,8 +179,8 @@ void CreateCylinderData() {
     cylinderGfx.push_back(gsSPEndDisplayList());
 }
 
-// This subdivides a face into four tris by placing new verticies at the midpoints of the sides (Like a triforce!), then
-// blowing up the verticies so they are on the unit sphere
+// This subdivides a face into four tris by placing new vertices at the midpoints of the sides (Like a triforce!), then
+// blowing up the vertices so they are on the unit sphere
 void CreateSphereFace(std::vector<std::tuple<size_t, size_t, size_t>>& faces, int32_t v0Index, int32_t v1Index,
                       int32_t v2Index) {
     size_t nextIndex = sphereVtx.size();
@@ -198,7 +198,7 @@ void CreateSphereFace(std::vector<std::tuple<size_t, size_t, size_t>>& faces, in
     const Vtx& v1 = sphereVtx[v1Index];
     const Vtx& v2 = sphereVtx[v2Index];
 
-    // Create 3 new verticies at the midpoints
+    // Create 3 new vertices at the midpoints
     Vec3f vs[3] = {
         Vec3f{ (v0.n.ob[0] + v1.n.ob[0]) / 2.0f, (v0.n.ob[1] + v1.n.ob[1]) / 2.0f, (v0.n.ob[2] + v1.n.ob[2]) / 2.0f },
         Vec3f{ (v1.n.ob[0] + v2.n.ob[0]) / 2.0f, (v1.n.ob[1] + v2.n.ob[1]) / 2.0f, (v1.n.ob[2] + v2.n.ob[2]) / 2.0f },

--- a/mm/2s2h/DeveloperTools/SaveEditor.cpp
+++ b/mm/2s2h/DeveloperTools/SaveEditor.cpp
@@ -175,7 +175,7 @@ void UpdateGameTime(u16 gameTime) {
 
     // Clear weather from day 2
     gWeatherMode = WEATHER_MODE_CLEAR;
-    gPlayState->envCtx.lightningState = LIGHTNING_LAST;
+    gPlayState->envCtx.lightningState = LIGHTNING_OFF;
 
     // When transitioning over night boundaries, stop the sequences and ask to replay, then respawn actors
     if (newTimeIsNight != prevTimeIsNight) {
@@ -448,7 +448,7 @@ void DrawGeneralTab() {
             func_800FEAF4(&gPlayState->envCtx);
             // Clear weather from day 2
             gWeatherMode = WEATHER_MODE_CLEAR;
-            gPlayState->envCtx.lightningState = LIGHTNING_LAST;
+            gPlayState->envCtx.lightningState = LIGHTNING_OFF;
         }
     }
     // Time speed slider

--- a/mm/2s2h/DeveloperTools/WarpPoint.cpp
+++ b/mm/2s2h/DeveloperTools/WarpPoint.cpp
@@ -49,9 +49,9 @@ void Warp() {
         gSaveContext.fileNum = 0xFF;
         MapSelect_LoadGame((MapSelectState*)gGameState, CVarGetInteger(WARP_POINT_CVAR "Entrance", 0), 0);
     } else {
-        // The else case, and the rest of this function is primarly relevant code copied from Play_SetRespawnData and
+        // The else case, and the rest of this function is primarily relevant code copied from Play_SetRespawnData and
         // func_80169EFC, minus the parts that copy scene flags to scene we are warping to (this is obviously
-        // undesireable)
+        // undesirable)
         gPlayState->nextEntrance = Entrance_Create(entrance >> 9, 0, entrance & 0xF);
         gPlayState->transitionTrigger = TRANS_TRIGGER_START;
         gPlayState->transitionType = TRANS_TYPE_INSTANT;

--- a/mm/2s2h/Enhancements/Trackers/ItemTracker.cpp
+++ b/mm/2s2h/Enhancements/Trackers/ItemTracker.cpp
@@ -396,11 +396,11 @@ void ItemTrackerWindow::DrawItemsInRows(int columns) {
         return;
     }
     if (mItemDrawModes[SECTION_INVENTORY] != ItemTrackerDisplayType::Hidden) {
-        if (mItemDrawModes[SECTION_INVENTORY] == ItemTrackerDisplayType::Seperate) {
+        if (mItemDrawModes[SECTION_INVENTORY] == ItemTrackerDisplayType::Separate) {
             BeginFloatingWindows("Items");
         }
         advancedBy = DrawItems(6, mainWindowPos);
-        if (mItemDrawModes[SECTION_INVENTORY] == ItemTrackerDisplayType::Seperate) {
+        if (mItemDrawModes[SECTION_INVENTORY] == ItemTrackerDisplayType::Separate) {
             EndFloatingWindows();
         } else {
             mainWindowPos += advancedBy;
@@ -409,12 +409,12 @@ void ItemTrackerWindow::DrawItemsInRows(int columns) {
 
     if (mItemDrawModes[SECTION_MASKS] != ItemTrackerDisplayType::Hidden) {
         int drawPos = mainWindowPos;
-        if (mItemDrawModes[SECTION_MASKS] == ItemTrackerDisplayType::Seperate) {
+        if (mItemDrawModes[SECTION_MASKS] == ItemTrackerDisplayType::Separate) {
             drawPos = 0;
             BeginFloatingWindows("Masks");
         }
         advancedBy = DrawMasks(6, drawPos);
-        if (mItemDrawModes[SECTION_MASKS] == ItemTrackerDisplayType::Seperate) {
+        if (mItemDrawModes[SECTION_MASKS] == ItemTrackerDisplayType::Separate) {
             EndFloatingWindows();
         } else {
             mainWindowPos += advancedBy;
@@ -423,12 +423,12 @@ void ItemTrackerWindow::DrawItemsInRows(int columns) {
 
     if (mItemDrawModes[SECTION_SONGS] != ItemTrackerDisplayType::Hidden) {
         int drawPos = mainWindowPos;
-        if (mItemDrawModes[SECTION_SONGS] == ItemTrackerDisplayType::Seperate) {
+        if (mItemDrawModes[SECTION_SONGS] == ItemTrackerDisplayType::Separate) {
             drawPos = 0;
             BeginFloatingWindows("Songs");
         }
         advancedBy = DrawSongs(5, drawPos);
-        if (mItemDrawModes[SECTION_SONGS] == ItemTrackerDisplayType::Seperate) {
+        if (mItemDrawModes[SECTION_SONGS] == ItemTrackerDisplayType::Separate) {
             EndFloatingWindows();
         } else {
             mainWindowPos += advancedBy;
@@ -437,12 +437,12 @@ void ItemTrackerWindow::DrawItemsInRows(int columns) {
 
     if (mItemDrawModes[SECTION_DUNGEON] != ItemTrackerDisplayType::Hidden) {
         int drawPos = mainWindowPos;
-        if (mItemDrawModes[SECTION_DUNGEON] == ItemTrackerDisplayType::Seperate) {
+        if (mItemDrawModes[SECTION_DUNGEON] == ItemTrackerDisplayType::Separate) {
             drawPos = 0;
             BeginFloatingWindows("Dungeon Items");
         }
         advancedBy = DrawDungeonItemsVert(6, drawPos);
-        if (mItemDrawModes[SECTION_DUNGEON] == ItemTrackerDisplayType::Seperate) {
+        if (mItemDrawModes[SECTION_DUNGEON] == ItemTrackerDisplayType::Separate) {
             EndFloatingWindows();
         } else {
             mainWindowPos += advancedBy;

--- a/mm/2s2h/Enhancements/Trackers/ItemTracker.h
+++ b/mm/2s2h/Enhancements/Trackers/ItemTracker.h
@@ -10,7 +10,7 @@ typedef enum class TrackerWindowType : uint8_t {
 typedef enum class ItemTrackerDisplayType : int8_t {
     Hidden,
     MainWindow,
-    Seperate,
+    Separate,
 } ItemTrackerDisplayType;
 
 typedef enum {


### PR DESCRIPTION
Includes various fixes for spelling mistakes in comments, menu items, and an enum.

I'm also including a tiny tweak to how the save editor clears lightning when changing time. Before we set the state to `_LAST` which meant that it lightning will stop after _one more_ lightning bolt, but this is a random amount of time (sometimes 15+ seconds). Not sure why I originally used this state, but simply setting to `_OFF` is sufficient and avoids the lingering lightning bolt.

Closes #829

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2174259180.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2174261108.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2174267784.zip)
<!--- section:artifacts:end -->