### PR TITLE
Fix linux auto rom detection for built-in extractor

### DIFF
--- a/mm/2s2h/Extractor/Extract.cpp
+++ b/mm/2s2h/Extractor/Extract.cpp
@@ -215,14 +215,18 @@ void Extractor::GetRoms(std::vector<std::string>& roms) {
         while ((dir = readdir(d)) != NULL) {
             struct stat path;
 
+            auto fullPath = std::filesystem::path(mSearchPath) / dir->d_name;
+            auto fullPathString = fullPath.string();
+            const char* fullPathCStr = fullPathString.c_str();
+
             // Check if current entry is not folder
-            stat(dir->d_name, &path);
+            stat(fullPathCStr, &path);
             if (S_ISREG(path.st_mode)) {
 
                 // Get the position of the extension character.
                 char* ext = strrchr(dir->d_name, '.');
                 if (ext != NULL && (strcmp(ext, ".z64") == 0 || strcmp(ext, ".n64") == 0 || strcmp(ext, ".v64") == 0)) {
-                    roms.push_back(dir->d_name);
+                    roms.push_back(fullPathCStr);
                 }
             }
         }


### PR DESCRIPTION
Linux has special handling for directory searching that relies on `stat`. The issue was that the item names returned by `dirent` were just the name of the file itself, not a real path. So `stat` was always returning an error when trying to search for rom flies. This would lead to "No roms found" modal even if there was a rom file next to the .appimage.

This fixes it by building a real path using the passed in search path before querying `stat` and appending the path to the roms list.

I'm not entirely sure why we search directories differently for each platform, as the `else` case uses `std::filesystem::directory_iterator` which was standardized in C++17, so a future improvement would be to drop the platform handling for the simple case.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2173896941.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2173897794.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2173903299.zip)
<!--- section:artifacts:end -->