### PR TITLE
Fix GfxPrint for Japanese UTF8 characters

### DIFF
--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -1533,7 +1533,6 @@ extern "C" void OTRGfxPrint(const char* str, void* printer, void (*printImpl)(vo
     std::wstring wstr = StringToU16(str);
 
     for (const auto& c : wstr) {
-        unsigned char convt = ' ';
         if (c < 0x80) {
             printImpl(printer, c);
         } else if (c >= u'｡' && c <= u'ﾟ') { // katakana

--- a/mm/src/boot/O2/gfxprint.c
+++ b/mm/src/boot/O2/gfxprint.c
@@ -323,16 +323,20 @@ void GfxPrint_PrintStringWithSize(GfxPrint* this, const void* buffer, size_t cha
     const char* str = (const char*)buffer;
     size_t count = charSize * charCount;
 
-    while (count != 0) {
-        GfxPrint_PrintChar(this, *str++);
-        count--;
-    }
+    // 2S2H [Port] Process the string with our wrapper that converts Japanese UTF8 characters for the print system
+    OTRGfxPrint(str, this, GfxPrint_PrintChar);
+    // while (count != 0) {
+    //     GfxPrint_PrintChar(this, *str++);
+    //     count--;
+    // }
 }
 
 void GfxPrint_PrintString(GfxPrint* this, const char* str) {
-    while (*str != '\0') {
-        GfxPrint_PrintChar(this, *str++);
-    }
+    // 2S2H [Port] Process the string with our wrapper that converts Japanese UTF8 characters for the print system
+    OTRGfxPrint(str, this, GfxPrint_PrintChar);
+    // while (*str != '\0') {
+    //     GfxPrint_PrintChar(this, *str++);
+    // }
 }
 
 void* GfxPrint_Callback(void* arg, const char* str, size_t size) {


### PR DESCRIPTION
This fixes the GfxPrint system to correctly print out Japanese characters from UTF8 strings in the source code.
We already had the string convert funcs from SoH, they just weren't hooked up.

Before and After:
![image](https://github.com/user-attachments/assets/5bb0d49a-cbbb-4518-a649-fe23e6ebea6b)
![image](https://github.com/user-attachments/assets/0db5927d-f844-4912-a461-e0cdb8187f2f)


<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2174311432.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2174313048.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2174315520.zip)
<!--- section:artifacts:end -->