### PR TITLE
Fix skip intro and skip first cycle logic running when it shouldn't

### DIFF
--- a/mm/2s2h/Enhancements/Cutscenes/SkipIntroSequence.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/SkipIntroSequence.cpp
@@ -12,8 +12,10 @@ void Flags_SetWeekEventReg(s32 flag);
 void RegisterSkipIntroSequence() {
     REGISTER_VB_SHOULD(VB_PLAY_TRANSITION_CS, {
         // Intro cutscene
-        if (!(gSaveContext.save.entrance == ENTRANCE(CUTSCENE, 0) && gSaveContext.save.cutsceneIndex == 0))
+        if (!(gSaveContext.save.entrance == ENTRANCE(CUTSCENE, 0) && gSaveContext.save.cutsceneIndex == 0) ||
+            gSaveContext.save.isFirstCycle) {
             return;
+        }
 
         if (CVarGetInteger("gEnhancements.Cutscenes.SkipIntroSequence", 0)) {
             gSaveContext.save.entrance = ENTRANCE(SOUTH_CLOCK_TOWN, 0);
@@ -22,6 +24,10 @@ void RegisterSkipIntroSequence() {
             gSaveContext.cycleSceneFlags[SCENE_OPENINGDAN].switch0 |= (1 << 2);
             gSaveContext.cycleSceneFlags[SCENE_OPENINGDAN].switch0 |= (1 << 0);
             gSaveContext.save.playerForm = PLAYER_FORM_DEKU;
+
+            // Marks when Link enters clock town for the first time.
+            // This should be true forever, it is not "just" for "first cycle". Don't unset it in the first cycle skip.
+            gSaveContext.save.isFirstCycle = true;
 
             // Mark chest as opened and give the player the Deku Nuts
             gSaveContext.cycleSceneFlags[SCENE_OPENINGDAN].chest |= (1 << 0);
@@ -32,11 +38,8 @@ void RegisterSkipIntroSequence() {
                 gSaveContext.save.saveInfo.playerData.isMagicAcquired = true;
                 Item_Give(gPlayState, ITEM_OCARINA_OF_TIME);
                 Item_Give(gPlayState, ITEM_MASK_DEKU);
-                gSaveContext.save.saveInfo.inventory.questItems = (1 << QUEST_SONG_TIME) | (1 << QUEST_SONG_HEALING);
-                if (gSaveContext.save.saveInfo.playerData.threeDayResetCount < 1) {
-                    gSaveContext.save.saveInfo.playerData.threeDayResetCount = 1;
-                }
-                gSaveContext.save.isFirstCycle = false;
+                gSaveContext.save.saveInfo.inventory.questItems |= (1 << QUEST_SONG_TIME) | (1 << QUEST_SONG_HEALING);
+                gSaveContext.save.saveInfo.playerData.threeDayResetCount = 1;
 
                 // Lose nuts
                 AMMO(ITEM_DEKU_NUT) = 0;
@@ -44,26 +47,16 @@ void RegisterSkipIntroSequence() {
                 // Tatl's text at seeing the broken great fairy
                 gSaveContext.cycleSceneFlags[SCENE_YOUSEI_IZUMI].switch0 |= (1 << 10);
 
-                // Tatl's text when first entering South Clock Town if not already set
-                if (!CHECK_WEEKEVENTREG(WEEKEVENTREG_59_04)) {
-                    SET_WEEKEVENTREG(WEEKEVENTREG_59_04);
-                }
+                // Tatl's text when first entering South Clock Town
+                SET_WEEKEVENTREG(WEEKEVENTREG_59_04);
 
-                // Set Tatl second cycle (?) text if not already set
-                if (!CHECK_WEEKEVENTREG(WEEKEVENTREG_31_04)) {
-                    SET_WEEKEVENTREG(WEEKEVENTREG_31_04);
-                }
+                // Set Tatl second cycle (?)
+                SET_WEEKEVENTREG(WEEKEVENTREG_31_04);
 
-                // Set Entrance Cutscene flags for Clock Town if not already set
-                if (!CHECK_WEEKEVENTREG(WEEKEVENTREG_ENTERED_EAST_CLOCK_TOWN)) {
-                    SET_WEEKEVENTREG(WEEKEVENTREG_ENTERED_EAST_CLOCK_TOWN);
-                }
-                if (!CHECK_WEEKEVENTREG(WEEKEVENTREG_ENTERED_WEST_CLOCK_TOWN)) {
-                    SET_WEEKEVENTREG(WEEKEVENTREG_ENTERED_WEST_CLOCK_TOWN);
-                }
-                if (!CHECK_WEEKEVENTREG(WEEKEVENTREG_ENTERED_NORTH_CLOCK_TOWN)) {
-                    SET_WEEKEVENTREG(WEEKEVENTREG_ENTERED_NORTH_CLOCK_TOWN);
-                }
+                // Set Entrance Cutscene flags for Clock Town
+                SET_WEEKEVENTREG(WEEKEVENTREG_ENTERED_EAST_CLOCK_TOWN);
+                SET_WEEKEVENTREG(WEEKEVENTREG_ENTERED_WEST_CLOCK_TOWN);
+                SET_WEEKEVENTREG(WEEKEVENTREG_ENTERED_NORTH_CLOCK_TOWN);
             }
         }
     });


### PR DESCRIPTION
The Skip Intro and Skip First Cycle enhancements were running every time a save was loaded from File Select that previously used the enhancements. This is because in `Sram_OpenSave` the following check is performed which decides where the player should load in.

```c
if (gSaveContext.save.isFirstCycle) {
    gSaveContext.save.entrance = ENTRANCE(SOUTH_CLOCK_TOWN, 0);
    gSaveContext.save.day = 0;
    gSaveContext.save.time = CLOCK_TIME(6, 0) - 1;
} else {
    gSaveContext.save.entrance = ENTRANCE(CUTSCENE, 0);
    gSaveContext.nextCutsceneIndex = 0;
    gSaveContext.save.playerForm = PLAYER_FORM_HUMAN;
}
```

What was happening is that `save.isFirstCycle` was not properly set by our enhancements, which meant the intro cutscene entrance is set, triggering our enhancements over and over.

This `save.isFirstCycle` is poorly named, it doesn't mean "currently in the first cycle", rather it means "link has entered clock town at least once". Basically it is just set once the game auto saves after entering clock town for the first time.

I've reworked both enhancements to bail out early if this flag is already set, and made it so the Skip Intro portion correctly sets the flag, while removing an incorrect unsetting of this flag in the Skip First Cycle portion.

Also removed needless conditional checks for setting flags since the operations will only run once.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2174379479.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2174381442.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2174384294.zip)
<!--- section:artifacts:end -->