### PR TITLE
Cleanup Controller Navigation Option in Menu

### DIFF
--- a/mm/2s2h/BenGui/SearchableMenuItems.h
+++ b/mm/2s2h/BenGui/SearchableMenuItems.h
@@ -452,7 +452,7 @@ void AddSettings() {
                 { .defaultVariant = COLOR_INDIGO, .comboBoxOptions = menuThemeOptions } },
 #if not defined(__SWITCH__) and not defined(__WIIU__)
               { "Menu Controller Navigation", CVAR_IMGUI_CONTROLLER_NAV,
-                "Allows controller navigation of the 2s2h menu (Settings, Enhancements,...)\nCAUTION: "
+                "Allows controller navigation of the 2Ship menu (Settings, Enhancements,...)\nCAUTION: "
                 "This will disable game inputs while the menu is visible.\n\nD-pad to move between "
                 "items, A to select, B to move up in scope.",
                 WIDGET_CVAR_CHECKBOX },

--- a/mm/2s2h/BenGui/SearchableMenuItems.h
+++ b/mm/2s2h/BenGui/SearchableMenuItems.h
@@ -451,11 +451,10 @@ void AddSettings() {
                 WIDGET_CVAR_COMBOBOX,
                 { .defaultVariant = COLOR_INDIGO, .comboBoxOptions = menuThemeOptions } },
 #if not defined(__SWITCH__) and not defined(__WIIU__)
-              { "Menubar Controller Navigation", CVAR_IMGUI_CONTROLLER_NAV,
-                "Allows controller navigation of the SOH menu bar (Settings, Enhancements,...)\nCAUTION: "
+              { "Menu Controller Navigation", CVAR_IMGUI_CONTROLLER_NAV,
+                "Allows controller navigation of the 2s2h menu (Settings, Enhancements,...)\nCAUTION: "
                 "This will disable game inputs while the menu is visible.\n\nD-pad to move between "
-                "items, A to select, B to move up in scope. DEV NOTE: SDL is weird currently, pad button only "
-                "works with menubar open.",
+                "items, A to select, B to move up in scope.",
                 WIDGET_CVAR_CHECKBOX },
               { "Cursor Always Visible",
                 "gSettings.CursorVisibility",


### PR DESCRIPTION
Change references of "menubar" in controller navigation option in the menu to "menu" and change "SOH" to "2Ship".

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2174431463.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2174433231.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2174439166.zip)
<!--- section:artifacts:end -->