### PR TITLE
Fix clock spinning violently from undefined behavior with bad casting

### DIFF
--- a/mm/src/overlays/actors/ovl_Obj_Tokeidai/z_obj_tokeidai.c
+++ b/mm/src/overlays/actors/ovl_Obj_Tokeidai/z_obj_tokeidai.c
@@ -38,9 +38,12 @@
 
 #define GET_CURRENT_CLOCK_HOUR(this) ((s32)TIME_TO_HOURS_F((this)->clockTime))
 #define GET_CURRENT_CLOCK_MINUTE(this) ((s32)((this)->clockTime * (360 * 2.0f / 0x10000)) % 30)
-#define GET_CLOCK_FACE_ROTATION(currentClockHour) ((s16)(currentClockHour * (0x10000 / 24.0f)))
+// #region 2S2H [Port] Additional pre-cast to s32 prevents undefined behavior with casting float values larger than s16
+// This undefined behavior lead to the clock rings and face spinning violently on some compilers
+#define GET_CLOCK_FACE_ROTATION(currentClockHour) ((s16)(s32)(currentClockHour * (0x10000 / 24.0f)))
 #define GET_MINUTE_RING_OR_EXTERIOR_GEAR_ROTATION(currentClockMinute) \
-    ((s16)(currentClockMinute * (0x10000 * 12.0f / 360)))
+    ((s16)(s32)(currentClockMinute * (0x10000 * 12.0f / 360)))
+// #endregion
 
 void ObjTokeidai_Init(Actor* thisx, PlayState* play);
 void ObjTokeidai_Destroy(Actor* thisx, PlayState* play);


### PR DESCRIPTION
This fixes the clock rings and face from spinning rapidly on some platforms (Mac and Android). The issue is caused by undefined behavior from casting a float value that is larger than short_max into a s16. Simply adding casting to a s32 first deals with the large value correctly, then that can be cast to s16 without undefined behavior.

Fixes #437

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2180397251.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2180398654.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2180405951.zip)
<!--- section:artifacts:end -->