### PR TITLE
Improve extended culling options and account for song cutscene fading

### DIFF
--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -662,23 +662,9 @@ void DrawEnhancementsMenu() {
                                     "gEnhancements.Graphics.ActorCullingAccountsForWidescreen",
                                     { .tooltip = "Adjusts the culling planes to account for widescreen resolutions. "
                                                  "This may have unintended side effects." });
-            if (UIWidgets::CVarSliderInt(
-                    "Increase Actor Draw Distance: %dx", "gEnhancements.Graphics.IncreaseActorDrawDistance", 1, 5, 1,
-                    { .tooltip =
-                          "Increase the range in which Actors are drawn. This may have unintended side effects." })) {
-                CVarSetInteger("gEnhancements.Graphics.IncreaseActorUpdateDistance",
-                               MIN(CVarGetInteger("gEnhancements.Graphics.IncreaseActorDrawDistance", 1),
-                                   CVarGetInteger("gEnhancements.Graphics.IncreaseActorUpdateDistance", 1)));
-            }
-            if (UIWidgets::CVarSliderInt(
-                    "Increase Actor Update Distance: %dx", "gEnhancements.Graphics.IncreaseActorUpdateDistance", 1, 5,
-                    1,
-                    { .tooltip =
-                          "Increase the range in which Actors are updated. This may have unintended side effects." })) {
-                CVarSetInteger("gEnhancements.Graphics.IncreaseActorDrawDistance",
-                               MAX(CVarGetInteger("gEnhancements.Graphics.IncreaseActorDrawDistance", 1),
-                                   CVarGetInteger("gEnhancements.Graphics.IncreaseActorUpdateDistance", 1)));
-            }
+            UIWidgets::CVarSliderInt(
+                "Increase Actor Draw Distance: %dx", "gEnhancements.Graphics.IncreaseActorDrawDistance", 1, 5, 1,
+                { .tooltip = "Increase the range in which Actors are drawn. This may have unintended side effects." });
 
             ImGui::EndMenu();
         }

--- a/mm/2s2h/BenGui/SearchableMenuItems.h
+++ b/mm/2s2h/BenGui/SearchableMenuItems.h
@@ -1166,7 +1166,8 @@ void AddEnhancements() {
     enhancementsSidebar.push_back(
         { "Graphics",
           3,
-          { { { .widgetName = "Clock", .widgetType = WIDGET_SEPARATOR_TEXT },
+          { {
+              { .widgetName = "Clock", .widgetType = WIDGET_SEPARATOR_TEXT },
               { "Clock Type",
                 "gEnhancements.Graphics.ClockType",
                 "Swaps between Graphical and Text only Clock types.",
@@ -1254,26 +1255,14 @@ void AddEnhancements() {
                 "Adjusts the culling planes to account for widescreen resolutions. "
                 "This may have unintended side effects.",
                 WIDGET_CVAR_CHECKBOX },
-              { "Increase Actor Draw Distance: %dx",
-                "gEnhancements.Graphics.IncreaseActorDrawDistance",
-                "Increase the range in which Actors are drawn. This may have unintended side effects.",
-                WIDGET_CVAR_SLIDER_INT,
-                { 1, 5, 1 },
-                [](widgetInfo& info) {
-                    CVarSetInteger("gEnhancements.Graphics.IncreaseActorUpdateDistance",
-                                   MIN(CVarGetInteger("gEnhancements.Graphics.IncreaseActorDrawDistance", 1),
-                                       CVarGetInteger("gEnhancements.Graphics.IncreaseActorUpdateDistance", 1)));
-                } },
-              { "Increase Actor Update Distance: %dx",
-                "gEnhancements.Graphics.IncreaseActorUpdateDistance",
-                "Increase the range in which Actors are updated. This may have unintended side effects.",
-                WIDGET_CVAR_SLIDER_INT,
-                { 1, 5, 1 },
-                [](widgetInfo& info) {
-                    CVarSetInteger("gEnhancements.Graphics.IncreaseActorDrawDistance",
-                                   MAX(CVarGetInteger("gEnhancements.Graphics.IncreaseActorDrawDistance", 1),
-                                       CVarGetInteger("gEnhancements.Graphics.IncreaseActorUpdateDistance", 1)));
-                } } } } });
+              {
+                  "Increase Actor Draw Distance: %dx",
+                  "gEnhancements.Graphics.IncreaseActorDrawDistance",
+                  "Increase the range in which Actors are drawn. This may have unintended side effects.",
+                  WIDGET_CVAR_SLIDER_INT,
+                  { 1, 5, 1 },
+              },
+          } } });
     enhancementsSidebar.push_back(
         { "Items/Songs",
           3,

--- a/mm/src/code/z_actor.c
+++ b/mm/src/code/z_actor.c
@@ -3088,17 +3088,15 @@ s32 Ship_CalcShouldDrawAndUpdate(PlayState* play, Actor* actor, Vec3f* projected
         return true;
     }
 
-    s32 updateMulti = CVarGetInteger("gEnhancements.Graphics.IncreaseActorUpdateDistance", 1);
-    s32 drawMulti = CVarGetInteger("gEnhancements.Graphics.IncreaseActorDrawDistance", 1);
-    updateMulti = MAX(updateMulti, 1);
-    drawMulti = MAX(drawMulti, 1);
-    // Apply distance scale to forward cullzone check
-    bool updateCheck = (-actor->uncullZoneScale < projectedPos->z) &&
-                       (projectedPos->z < ((actor->uncullZoneForward * updateMulti) + actor->uncullZoneScale));
-    bool drawCheck = (-actor->uncullZoneScale < projectedPos->z) &&
-                     (projectedPos->z < ((actor->uncullZoneForward * drawMulti) + actor->uncullZoneScale));
+    s32 multiplier = CVarGetInteger("gEnhancements.Graphics.IncreaseActorDrawDistance", 1);
+    multiplier = MAX(multiplier, 1);
 
-    if (updateCheck || drawCheck) {
+    // Apply distance scale to forward cullzone check
+    bool isWithingForwardCullZone =
+        (-actor->uncullZoneScale < projectedPos->z) &&
+        (projectedPos->z < ((actor->uncullZoneForward * multiplier) + actor->uncullZoneScale));
+
+    if (isWithingForwardCullZone) {
         // Ensure the projected W value is at least 1.0
         f32 clampedProjectedW = CLAMP_MIN(projectedW, 1.0f);
         f32 ratioAdjusted = 1.0f;
@@ -3132,8 +3130,10 @@ s32 Ship_CalcShouldDrawAndUpdate(PlayState* play, Actor* actor, Vec3f* projected
         bool isBelowTopOfCullZone = ((projectedPos->y - uncullZoneDownwardAdjusted) < clampedProjectedW);
 
         if (isWithinHorizontalCullZone && isAboveBottomOfCullZone && isBelowTopOfCullZone) {
-            *shouldDraw = drawCheck;
-            *shouldUpdate = updateCheck;
+            // Add additional overries here for glitch useful actors when those are reported
+
+            *shouldDraw = true;
+            *shouldUpdate = true;
             return true;
         }
     }
@@ -3181,7 +3181,6 @@ void Actor_DrawAll(PlayState* play, ActorContext* actorCtx) {
             bool shipShouldDraw = false;
             bool shipShouldUpdate = false;
             if (CVarGetInteger("gEnhancements.Graphics.IncreaseActorDrawDistance", 1) > 1 ||
-                CVarGetInteger("gEnhancements.Graphics.IncreaseActorUpdateDistance", 1) > 1 ||
                 CVarGetInteger("gEnhancements.Graphics.ActorCullingAccountsForWidescreen", 0)) {
                 Ship_CalcShouldDrawAndUpdate(play, actor, &actor->projectedPos, actor->projectedW, &shipShouldDraw,
                                              &shipShouldUpdate);

--- a/mm/src/code/z_actor.c
+++ b/mm/src/code/z_actor.c
@@ -3079,20 +3079,29 @@ s32 func_800BA2FC(PlayState* play, Actor* actor, Vec3f* projectedPos, f32 projec
 
 // #region 2S2H [Enhancements] Allows us to increase the draw and update distance independently, mostly a modified
 // version of the function above
-void Ship_CalcShouldDrawAndUpdate(PlayState* play, Actor* actor, Vec3f* projectedPos, f32 projectedW, bool* shouldDraw,
-                                  bool* shouldUpdate) {
+s32 Ship_CalcShouldDrawAndUpdate(PlayState* play, Actor* actor, Vec3f* projectedPos, f32 projectedW, bool* shouldDraw,
+                                 bool* shouldUpdate) {
+    // Check if the actor passes its original/vanilla culling requirements
+    if (func_800BA2FC(play, actor, projectedPos, projectedW)) {
+        *shouldUpdate = true;
+        *shouldDraw = true;
+        return true;
+    }
+
     s32 updateMulti = CVarGetInteger("gEnhancements.Graphics.IncreaseActorUpdateDistance", 1);
     s32 drawMulti = CVarGetInteger("gEnhancements.Graphics.IncreaseActorDrawDistance", 1);
-    bool updateCheck =
-        (-(actor->uncullZoneScale * updateMulti) < projectedPos->z) &&
-        (projectedPos->z < ((actor->uncullZoneForward * updateMulti) + (actor->uncullZoneScale * updateMulti)));
-    bool drawCheck =
-        (-(actor->uncullZoneScale * drawMulti) < projectedPos->z) &&
-        (projectedPos->z < ((actor->uncullZoneForward * drawMulti) + (actor->uncullZoneScale * drawMulti)));
+    updateMulti = MAX(updateMulti, 1);
+    drawMulti = MAX(drawMulti, 1);
+    // Apply distance scale to forward cullzone check
+    bool updateCheck = (-actor->uncullZoneScale < projectedPos->z) &&
+                       (projectedPos->z < ((actor->uncullZoneForward * updateMulti) + actor->uncullZoneScale));
+    bool drawCheck = (-actor->uncullZoneScale < projectedPos->z) &&
+                     (projectedPos->z < ((actor->uncullZoneForward * drawMulti) + actor->uncullZoneScale));
 
     if (updateCheck || drawCheck) {
         // Ensure the projected W value is at least 1.0
         f32 clampedProjectedW = CLAMP_MIN(projectedW, 1.0f);
+        f32 ratioAdjusted = 1.0f;
         f32 uncullZoneScaleDiagonal;
         f32 uncullZoneScaleVertical;
         f32 uncullZoneDownwardAdjusted;
@@ -3113,20 +3122,23 @@ void Ship_CalcShouldDrawAndUpdate(PlayState* play, Actor* actor, Vec3f* projecte
         if (CVarGetInteger("gEnhancements.Graphics.ActorCullingAccountsForWidescreen", 0)) {
             float originalAspectRatio = 4.0f / 3.0f;
             float currentAspectRatio = OTRGetAspectRatio();
-            float aspectRatioMultiplier = MAX(currentAspectRatio / originalAspectRatio, 1.0f);
-
-            clampedProjectedW *= aspectRatioMultiplier;
+            ratioAdjusted = MAX(currentAspectRatio / originalAspectRatio, 1.0f);
         }
 
-        bool isWithinHorizontalCullZone = ((fabsf(projectedPos->x) - uncullZoneScaleDiagonal) < clampedProjectedW);
+        // Apply adjsuted aspect ratio to just the horizontal cullzone check
+        bool isWithinHorizontalCullZone =
+            ((fabsf(projectedPos->x) - uncullZoneScaleDiagonal) < (clampedProjectedW * ratioAdjusted));
         bool isAboveBottomOfCullZone = ((-clampedProjectedW < (projectedPos->y + uncullZoneScaleVertical)));
         bool isBelowTopOfCullZone = ((projectedPos->y - uncullZoneDownwardAdjusted) < clampedProjectedW);
 
         if (isWithinHorizontalCullZone && isAboveBottomOfCullZone && isBelowTopOfCullZone) {
             *shouldDraw = drawCheck;
             *shouldUpdate = updateCheck;
+            return true;
         }
     }
+
+    return false;
 }
 // #endregion
 
@@ -3165,7 +3177,7 @@ void Actor_DrawAll(PlayState* play, ActorContext* actorCtx) {
                 Actor_UpdateFlaggedAudio(actor);
             }
 
-            // #region 2S2H
+            // #region 2S2H [Enhancement] Extended culling updates
             bool shipShouldDraw = false;
             bool shipShouldUpdate = false;
             if (CVarGetInteger("gEnhancements.Graphics.IncreaseActorDrawDistance", 1) > 1 ||
@@ -3187,8 +3199,15 @@ void Actor_DrawAll(PlayState* play, ActorContext* actorCtx) {
                 }
             }
 
+            // Copied flags so we can set the "is active" flag for the draw check below without modifying the actor.
+            // This ensures that overrides for song of soaring or song of time cutscenes still hide actors.
+            s32 shipActorFlagsCopy = actor->flags;
+            if (shipShouldDraw) {
+                shipActorFlagsCopy |= ACTOR_FLAG_40;
+            }
+
             actor->isDrawn = false;
-            if ((actor->init == NULL) && (actor->draw != NULL) && ((actor->flags & actorFlags) || shipShouldDraw)) {
+            if ((actor->init == NULL) && (actor->draw != NULL) && (shipActorFlagsCopy & actorFlags)) {
                 // #endregion
                 if ((actor->flags & ACTOR_FLAG_REACT_TO_LENS) &&
                     ((play->roomCtx.curRoom.lensMode == LENS_MODE_HIDE_ACTORS) ||


### PR DESCRIPTION
This improves the extended culling options with the following changes:
* Unifies the "draw distance" and "update distance" sliders into one slider for the user. It is not expensive to only do one over the other, so this simplifies the user experience.
  * We can still add conditional overrides for preventing actor updates when ever we end up adding a "exclude glitch useful actors" option like on SoH
 * Previously we were extending the Z based culling both backwards and forwards, as well as scaling multiple values when we shouldn't have. Now we only scale the forward cull check, so things behind the camera remain culled at normal distance.
 * The aspect ratio multiplier was being applied to the "is above" and "is below" cullzone checks, when it shouldn't. Now only the horizontal check is scaled by the aspect ratio.
 * Our `shipShouldDraw` override for the actor draw check was bypassing the actor flags check entirely. The `actorFlags` is how the game hides actors when Song of Soaring or Song of Time songs are played. Now we take a copy of the actor flags and apply the "is actor active" flag to it so that flag checking logic is still performed.
 * `Ship_CalcShouldDrawAndUpdate` now performs the vanilla cull checks first and bails out early if the actor would draw normally for vanilla.

Fixes #835 

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2183890649.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2183894943.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2183905424.zip)
<!--- section:artifacts:end -->