### PR TITLE
Fix crashing with modern menu and UIWidgets with no tooltips

### DIFF
--- a/mm/2s2h/BenGui/Menu.cpp
+++ b/mm/2s2h/BenGui/Menu.cpp
@@ -400,7 +400,8 @@ void BenMenu::DrawElement() {
                             info.isHidden) {
                             continue;
                         }
-                        std::string widgetStr = std::string(info.widgetName) + std::string(info.widgetTooltip);
+                        std::string widgetStr = std::string(info.widgetName) +
+                                                std::string(info.widgetTooltip != NULL ? info.widgetTooltip : "");
                         std::transform(menuSearchText.begin(), menuSearchText.end(), menuSearchText.begin(), ::tolower);
                         std::transform(widgetStr.begin(), widgetStr.end(), widgetStr.begin(), ::tolower);
                         widgetStr.erase(std::remove(widgetStr.begin(), widgetStr.end(), ' '), widgetStr.end());

--- a/mm/2s2h/BenGui/SearchableMenuItems.h
+++ b/mm/2s2h/BenGui/SearchableMenuItems.h
@@ -1958,7 +1958,9 @@ void SearchMenuGetItem(widgetInfo& widget) {
                                     info.widgetType == WIDGET_SEPARATOR_TEXT || info.isHidden) {
                                     continue;
                                 }
-                                std::string widgetStr = std::string(info.widgetName) + std::string(info.widgetTooltip);
+                                std::string widgetStr =
+                                    std::string(info.widgetName) +
+                                    std::string(info.widgetTooltip != NULL ? info.widgetTooltip : "");
                                 std::transform(menuSearchText.begin(), menuSearchText.end(), menuSearchText.begin(),
                                                ::tolower);
                                 menuSearchText.erase(std::remove(menuSearchText.begin(), menuSearchText.end(), ' '),

--- a/mm/2s2h/BenGui/UIWidgets.cpp
+++ b/mm/2s2h/BenGui/UIWidgets.cpp
@@ -6,13 +6,9 @@
 #include <string>
 #include <unordered_map>
 #include <libultraship/libultra/types.h>
+#include "2s2h/ShipUtils.h"
 
 namespace UIWidgets {
-
-bool IsCStringEmpty(const char* str) {
-    return str == NULL || str[0] == '\0';
-}
-
 // Automatically adds newlines to break up text longer than a specified number of characters
 // Manually included newlines will still be respected and reset the line length
 // If line is midword when it hits the limit, text should break at the last encountered space
@@ -118,9 +114,9 @@ bool Button(const char* label, const ButtonOptions& options) {
     PopStyleButton();
     ImGui::EndDisabled();
     if (options.disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) &&
-        !IsCStringEmpty(options.disabledTooltip)) {
+        !Ship_IsCStringEmpty(options.disabledTooltip)) {
         ImGui::SetTooltip("%s", WrappedText(options.disabledTooltip).c_str());
-    } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !IsCStringEmpty(options.tooltip)) {
+    } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !Ship_IsCStringEmpty(options.tooltip)) {
         ImGui::SetTooltip("%s", WrappedText(options.tooltip).c_str());
     }
     return dirty;
@@ -265,9 +261,9 @@ bool Checkbox(const char* _label, bool* value, const CheckboxOptions& options) {
     PopStyleCheckbox();
     ImGui::EndDisabled();
     if (options.disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) &&
-        !IsCStringEmpty(options.disabledTooltip)) {
+        !Ship_IsCStringEmpty(options.disabledTooltip)) {
         ImGui::SetTooltip("%s", WrappedText(options.disabledTooltip).c_str());
-    } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !IsCStringEmpty(options.tooltip)) {
+    } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !Ship_IsCStringEmpty(options.tooltip)) {
         ImGui::SetTooltip("%s", WrappedText(options.tooltip).c_str());
     }
     return pressed;
@@ -374,9 +370,9 @@ bool SliderInt(const char* label, int32_t* value, int32_t min, int32_t max, cons
     ImGui::EndDisabled();
     ImGui::EndGroup();
     if (options.disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) &&
-        !IsCStringEmpty(options.disabledTooltip)) {
+        !Ship_IsCStringEmpty(options.disabledTooltip)) {
         ImGui::SetTooltip("%s", WrappedText(options.disabledTooltip).c_str());
-    } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !IsCStringEmpty(options.tooltip)) {
+    } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !Ship_IsCStringEmpty(options.tooltip)) {
         ImGui::SetTooltip("%s", WrappedText(options.tooltip).c_str());
     }
     ImGui::PopID();
@@ -490,9 +486,9 @@ bool SliderFloat(const char* label, float* value, float min, float max, const Fl
     ImGui::EndDisabled();
     ImGui::EndGroup();
     if (options.disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) &&
-        !IsCStringEmpty(options.disabledTooltip)) {
+        !Ship_IsCStringEmpty(options.disabledTooltip)) {
         ImGui::SetTooltip("%s", WrappedText(options.disabledTooltip).c_str());
-    } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !IsCStringEmpty(options.tooltip)) {
+    } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !Ship_IsCStringEmpty(options.tooltip)) {
         ImGui::SetTooltip("%s", WrappedText(options.tooltip).c_str());
     }
     ImGui::PopID();

--- a/mm/2s2h/BenGui/UIWidgets.cpp
+++ b/mm/2s2h/BenGui/UIWidgets.cpp
@@ -8,6 +8,11 @@
 #include <libultraship/libultra/types.h>
 
 namespace UIWidgets {
+
+bool IsCStringEmpty(const char* str) {
+    return str == NULL || str[0] == '\0';
+}
+
 // Automatically adds newlines to break up text longer than a specified number of characters
 // Manually included newlines will still be respected and reset the line length
 // If line is midword when it hits the limit, text should break at the last encountered space
@@ -113,9 +118,9 @@ bool Button(const char* label, const ButtonOptions& options) {
     PopStyleButton();
     ImGui::EndDisabled();
     if (options.disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) &&
-        strcmp(options.disabledTooltip, "") != 0) {
+        !IsCStringEmpty(options.disabledTooltip)) {
         ImGui::SetTooltip("%s", WrappedText(options.disabledTooltip).c_str());
-    } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && strcmp(options.tooltip, "") != 0) {
+    } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !IsCStringEmpty(options.tooltip)) {
         ImGui::SetTooltip("%s", WrappedText(options.tooltip).c_str());
     }
     return dirty;
@@ -260,9 +265,9 @@ bool Checkbox(const char* _label, bool* value, const CheckboxOptions& options) {
     PopStyleCheckbox();
     ImGui::EndDisabled();
     if (options.disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) &&
-        strcmp(options.disabledTooltip, "") != 0) {
+        !IsCStringEmpty(options.disabledTooltip)) {
         ImGui::SetTooltip("%s", WrappedText(options.disabledTooltip).c_str());
-    } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && strcmp(options.tooltip, "") != 0) {
+    } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !IsCStringEmpty(options.tooltip)) {
         ImGui::SetTooltip("%s", WrappedText(options.tooltip).c_str());
     }
     return pressed;
@@ -369,9 +374,9 @@ bool SliderInt(const char* label, int32_t* value, int32_t min, int32_t max, cons
     ImGui::EndDisabled();
     ImGui::EndGroup();
     if (options.disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) &&
-        strcmp(options.disabledTooltip, "") != 0) {
+        !IsCStringEmpty(options.disabledTooltip)) {
         ImGui::SetTooltip("%s", WrappedText(options.disabledTooltip).c_str());
-    } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && strcmp(options.tooltip, "") != 0) {
+    } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !IsCStringEmpty(options.tooltip)) {
         ImGui::SetTooltip("%s", WrappedText(options.tooltip).c_str());
     }
     ImGui::PopID();
@@ -485,9 +490,9 @@ bool SliderFloat(const char* label, float* value, float min, float max, const Fl
     ImGui::EndDisabled();
     ImGui::EndGroup();
     if (options.disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) &&
-        strcmp(options.disabledTooltip, "") != 0) {
+        !IsCStringEmpty(options.disabledTooltip)) {
         ImGui::SetTooltip("%s", WrappedText(options.disabledTooltip).c_str());
-    } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && strcmp(options.tooltip, "") != 0) {
+    } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !IsCStringEmpty(options.tooltip)) {
         ImGui::SetTooltip("%s", WrappedText(options.tooltip).c_str());
     }
     ImGui::PopID();

--- a/mm/2s2h/BenGui/UIWidgets.hpp
+++ b/mm/2s2h/BenGui/UIWidgets.hpp
@@ -31,6 +31,7 @@ namespace UIWidgets {
         }
     };
 
+    bool IsCStringEmpty(const char* str);
     std::string WrappedText(const char* text, unsigned int charactersPerLine = 60);
     std::string WrappedText(const std::string& text, unsigned int charactersPerLine = 60);
     void Tooltip(const char* text);
@@ -129,7 +130,7 @@ namespace UIWidgets {
         PushStyleCombobox(options.color);
         if (options.alignment == ComponentAlignment::Left) {
             if (options.labelPosition == LabelPosition::Above) {
-                ImGui::Text(label);
+                ImGui::Text("%s", label);
                 ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
             } else if (options.labelPosition == LabelPosition::Near) {
                 ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - ImGui::CalcTextSize(label).x - ImGui::GetStyle().ItemSpacing.x * 2);
@@ -140,7 +141,7 @@ namespace UIWidgets {
             if (options.labelPosition == LabelPosition::Above) {
                 ImGui::NewLine();
                 ImGui::SameLine(ImGui::GetContentRegionAvail().x - ImGui::CalcTextSize(label).x);
-                ImGui::Text(label);
+                ImGui::Text("%s", label);
                 ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
             } else if (options.labelPosition == LabelPosition::Near) {
                 ImGui::SameLine(ImGui::CalcTextSize(label).x + ImGui::GetStyle().ItemSpacing.x * 2);
@@ -167,23 +168,23 @@ namespace UIWidgets {
         if (options.alignment == ComponentAlignment::Left) {
             if (options.labelPosition == LabelPosition::Near) {
                 ImGui::SameLine();
-                ImGui::Text(label);
+                ImGui::Text("%s", label);
             } else if (options.labelPosition == LabelPosition::Far) {
                 ImGui::SameLine(ImGui::GetContentRegionAvail().x - ImGui::CalcTextSize(label).x);
-                ImGui::Text(label);
+                ImGui::Text("%s", label);
             }
         } else if (options.alignment == ComponentAlignment::Right) {
             if (options.labelPosition == LabelPosition::Near || options.labelPosition == LabelPosition::Far) {
                 ImGui::SameLine(startX);
-                ImGui::Text(label);
+                ImGui::Text("%s", label);
             }
         }
         PopStyleCombobox();
         ImGui::EndDisabled();
         ImGui::EndGroup();
-        if (options.disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && strcmp(options.disabledTooltip, "") != 0) {
+        if (options.disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !IsCStringEmpty(options.disabledTooltip)) {
             ImGui::SetTooltip("%s", WrappedText(options.disabledTooltip).c_str());
-        } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && strcmp(options.tooltip, "") != 0) {
+        } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !IsCStringEmpty(options.tooltip)) {
             ImGui::SetTooltip("%s", WrappedText(options.tooltip).c_str());
         }
         ImGui::PopID();
@@ -256,9 +257,9 @@ namespace UIWidgets {
         PopStyleCombobox();
         ImGui::EndDisabled();
         ImGui::EndGroup();
-        if (options.disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && strcmp(options.disabledTooltip, "") != 0) {
+        if (options.disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !IsCStringEmpty(options.disabledTooltip)) {
             ImGui::SetTooltip("%s", WrappedText(options.disabledTooltip).c_str());
-        } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && strcmp(options.tooltip, "") != 0) {
+        } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !IsCStringEmpty(options.tooltip)) {
             ImGui::SetTooltip("%s", WrappedText(options.tooltip).c_str());
         }
         ImGui::PopID();
@@ -281,7 +282,7 @@ namespace UIWidgets {
         PushStyleCombobox(options.color);
         if (options.alignment == ComponentAlignment::Left) {
             if (options.labelPosition == LabelPosition::Above) {
-                ImGui::Text(label);
+                ImGui::Text("%s", label);
                 ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
             } else if (options.labelPosition == LabelPosition::Near) {
                 ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - ImGui::CalcTextSize(label).x - ImGui::GetStyle().ItemSpacing.x * 2);
@@ -292,7 +293,7 @@ namespace UIWidgets {
             if (options.labelPosition == LabelPosition::Above) {
                 ImGui::NewLine();
                 ImGui::SameLine(ImGui::GetContentRegionAvail().x - ImGui::CalcTextSize(label).x);
-                ImGui::Text(label);
+                ImGui::Text("%s", label);
                 ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
             } else if (options.labelPosition == LabelPosition::Near) {
                 ImGui::SameLine(ImGui::CalcTextSize(label).x + ImGui::GetStyle().ItemSpacing.x * 2);
@@ -320,23 +321,23 @@ namespace UIWidgets {
         if (options.alignment == ComponentAlignment::Left) {
             if (options.labelPosition == LabelPosition::Near) {
                 ImGui::SameLine();
-                ImGui::Text(label);
+                ImGui::Text("%s", label);
             } else if (options.labelPosition == LabelPosition::Far) {
                 ImGui::SameLine(ImGui::GetContentRegionAvail().x - ImGui::CalcTextSize(label).x);
-                ImGui::Text(label);
+                ImGui::Text("%s", label);
             }
         } else if (options.alignment == ComponentAlignment::Right) {
             if (options.labelPosition == LabelPosition::Near || options.labelPosition == LabelPosition::Far) {
                 ImGui::SameLine(startX);
-                ImGui::Text(label);
+                ImGui::Text("%s", label);
             }
         }
         PopStyleCombobox();
         ImGui::EndDisabled();
         ImGui::EndGroup();
-        if (options.disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && strcmp(options.disabledTooltip, "") != 0) {
+        if (options.disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !IsCStringEmpty(options.disabledTooltip)) {
             ImGui::SetTooltip("%s", WrappedText(options.disabledTooltip).c_str());
-        } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && strcmp(options.tooltip, "") != 0) {
+        } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !IsCStringEmpty(options.tooltip)) {
             ImGui::SetTooltip("%s", WrappedText(options.tooltip).c_str());
         }
         ImGui::PopID();

--- a/mm/2s2h/BenGui/UIWidgets.hpp
+++ b/mm/2s2h/BenGui/UIWidgets.hpp
@@ -9,6 +9,7 @@
 #include <imgui.h>
 #include <libultraship/libultraship.h>
 #include <unordered_map>
+#include "2s2h/ShipUtils.h"
 
 namespace UIWidgets {
 
@@ -31,7 +32,6 @@ namespace UIWidgets {
         }
     };
 
-    bool IsCStringEmpty(const char* str);
     std::string WrappedText(const char* text, unsigned int charactersPerLine = 60);
     std::string WrappedText(const std::string& text, unsigned int charactersPerLine = 60);
     void Tooltip(const char* text);
@@ -182,9 +182,9 @@ namespace UIWidgets {
         PopStyleCombobox();
         ImGui::EndDisabled();
         ImGui::EndGroup();
-        if (options.disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !IsCStringEmpty(options.disabledTooltip)) {
+        if (options.disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !Ship_IsCStringEmpty(options.disabledTooltip)) {
             ImGui::SetTooltip("%s", WrappedText(options.disabledTooltip).c_str());
-        } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !IsCStringEmpty(options.tooltip)) {
+        } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !Ship_IsCStringEmpty(options.tooltip)) {
             ImGui::SetTooltip("%s", WrappedText(options.tooltip).c_str());
         }
         ImGui::PopID();
@@ -257,9 +257,9 @@ namespace UIWidgets {
         PopStyleCombobox();
         ImGui::EndDisabled();
         ImGui::EndGroup();
-        if (options.disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !IsCStringEmpty(options.disabledTooltip)) {
+        if (options.disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !Ship_IsCStringEmpty(options.disabledTooltip)) {
             ImGui::SetTooltip("%s", WrappedText(options.disabledTooltip).c_str());
-        } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !IsCStringEmpty(options.tooltip)) {
+        } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !Ship_IsCStringEmpty(options.tooltip)) {
             ImGui::SetTooltip("%s", WrappedText(options.tooltip).c_str());
         }
         ImGui::PopID();
@@ -335,9 +335,9 @@ namespace UIWidgets {
         PopStyleCombobox();
         ImGui::EndDisabled();
         ImGui::EndGroup();
-        if (options.disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !IsCStringEmpty(options.disabledTooltip)) {
+        if (options.disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !Ship_IsCStringEmpty(options.disabledTooltip)) {
             ImGui::SetTooltip("%s", WrappedText(options.disabledTooltip).c_str());
-        } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !IsCStringEmpty(options.tooltip)) {
+        } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !Ship_IsCStringEmpty(options.tooltip)) {
             ImGui::SetTooltip("%s", WrappedText(options.tooltip).c_str());
         }
         ImGui::PopID();

--- a/mm/2s2h/DeveloperTools/SaveEditor.cpp
+++ b/mm/2s2h/DeveloperTools/SaveEditor.cpp
@@ -559,13 +559,15 @@ void DrawGeneralTab() {
     if (ImGui::SliderInt("##setBank", &bankedRupees, 0, 5000, "Banked Rupees: %d")) {
         HS_SET_BANK_RUPEES(bankedRupees);
     }
-    UIWidgets::Tooltip("To recieve the rewards, set the bank to 199, 999, or 4,999 then deposit a single rupee");
+    UIWidgets::Tooltip("To receive the rewards, set the bank to 199, 999, or 4,999 then deposit a single rupee");
     UIWidgets::PopStyleSlider();
 
     DrawTempleClears();
 
     UIWidgets::Checkbox("Has Tatl", (bool*)&gSaveContext.save.hasTatl, { .color = UIWidgets::Colors::Gray });
     UIWidgets::Checkbox("Is Owl Save", (bool*)&gSaveContext.save.isOwlSave, { .color = UIWidgets::Colors::Gray });
+    UIWidgets::Checkbox("Finished Intro Sequence", (bool*)&gSaveContext.save.isFirstCycle,
+                        { .color = UIWidgets::Colors::Gray });
     ImGui::EndGroup();
 
     ImGui::PopItemWidth();

--- a/mm/2s2h/ShipUtils.cpp
+++ b/mm/2s2h/ShipUtils.cpp
@@ -12,6 +12,10 @@ extern TexturePtr gQuestIcons[14];
 extern TexturePtr gBombersNotebookPhotos[24];
 }
 
+extern "C" bool Ship_IsCStringEmpty(const char* str) {
+    return str == NULL || str[0] == '\0';
+}
+
 // Build vertex coordinates for a quad command
 // In order of top left, top right, bottom left, then bottom right
 // Supports flipping the texture horizontally

--- a/mm/2s2h/ShipUtils.h
+++ b/mm/2s2h/ShipUtils.h
@@ -11,6 +11,7 @@ void LoadGuiTextures();
 extern "C" {
 #endif
 
+bool Ship_IsCStringEmpty(const char* str);
 void Ship_CreateQuadVertexGroup(Vtx* vtxList, s32 xStart, s32 yStart, s32 width, s32 height, u8 flippedH);
 f32 Ship_GetCharFontWidthNES(u8 character);
 TexturePtr Ship_GetCharFontTextureNES(u8 character);


### PR DESCRIPTION
Doing a couple things in here, mainly found a crash scenario with the modern menu if tooltips aren't provided. There is no current instance of a widget without a tooltip, just figured I get this in since I ran into it with some dummy toggles I was playing around with.

I also exposed the `save.isFirstCycle` flag in the save editor in case we need it to help trouble shoot broken saves after the update (I think the saves should automatically fix themselves with the previous changes, but just in case).

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2185246612.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2185246617.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2185254126.zip)
<!--- section:artifacts:end -->