### PR TITLE
Convert u16 to ItemId for persistent masks

### DIFF
--- a/mm/2s2h/Enhancements/Masks/PersistentMasks.cpp
+++ b/mm/2s2h/Enhancements/Masks/PersistentMasks.cpp
@@ -189,8 +189,8 @@ void RegisterPersistentMasks() {
 
     // Override "A" press behavior on kaleido scope to toggle the mask state
     REGISTER_VB_SHOULD(VB_KALEIDO_DISPLAY_ITEM_TEXT, {
-        ItemId* itemId = va_arg(args, ItemId*);
-        if (CVarGetInteger("gEnhancements.Masks.PersistentBunnyHood.Enabled", 0) && *itemId == ITEM_MASK_BUNNY) {
+        ItemId itemId = (ItemId)*va_arg(args, u16*);
+        if (CVarGetInteger("gEnhancements.Masks.PersistentBunnyHood.Enabled", 0) && itemId == ITEM_MASK_BUNNY) {
             *should = false;
             CVarSetInteger("gEnhancements.Masks.PersistentBunnyHood.State",
                            !CVarGetInteger("gEnhancements.Masks.PersistentBunnyHood.State", 0));
@@ -200,7 +200,7 @@ void RegisterPersistentMasks() {
                 Audio_PlaySfx(NA_SE_SY_CAMERA_ZOOM_UP);
             }
         } else if (CVarGetInteger("gEnhancements.Masks.PersistentGreatFairyMask.Enabled", 0) &&
-                   *itemId == ITEM_MASK_GREAT_FAIRY) {
+                   itemId == ITEM_MASK_GREAT_FAIRY) {
             *should = false;
             CVarSetInteger("gEnhancements.Masks.PersistentGreatFairyMask.State",
                            !CVarGetInteger("gEnhancements.Masks.PersistentGreatFairyMask.State", 0));


### PR DESCRIPTION
There are no reported bugs with this, but it probably needs changed anyway. The argument passed in to this hook is of type `u16*`, while the enhancement file converts it to an `ItemId*`. `ItemId` is an enum that goes up to 255, meaning it could be 8 bits instead of a full 16 bits.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2190646739.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2190651566.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2190657731.zip)
<!--- section:artifacts:end -->