### PR TITLE
Float Slider Fix and Cleanup

### DIFF
--- a/mm/2s2h/BenGui/SearchableMenuItems.h
+++ b/mm/2s2h/BenGui/SearchableMenuItems.h
@@ -727,43 +727,44 @@ void AddSettings() {
                                       WIDGET_WINDOW_BUTTON,
                                       { .size = UIWidgets::Sizes::Inline, .windowName = "2S2H Input Editor" } } } } });
 
-    settingsSidebar.push_back({ "Notifications",
-                                1,
-                                { {
-                                    { "Position",
-                                      "gNotifications.Position",
-                                      "Which corner of the screen notifications appear in.",
-                                      WIDGET_CVAR_COMBOBOX,
-                                      { .defaultVariant = 3, .comboBoxOptions = notificationPosition } },
-                                    { "Duration: %.0f seconds",
-                                      "gNotifications.Duration",
-                                      "How long notifications are displayed for.",
-                                      WIDGET_CVAR_SLIDER_FLOAT,
-                                      { .min = 3.0f, .max = 30.0f, .defaultVariant = 10.0f, .format = "%.1f", .step = 0.1f } },
-                                    { "Background Opacity: %.0f%%",
-                                      "gNotifications.BgOpacity",
-                                      "How opaque the background of notifications is.",
-                                      WIDGET_CVAR_SLIDER_FLOAT,
-                                      { .min = 0.0f, .max = 1.0f, .defaultVariant = 0.5f, .format = "%.0f%%", .isPercentage = true } },
-                                    { "Size %.1f",
-                                      "gNotifications.Size",
-                                      "How large notifications are.",
-                                      WIDGET_CVAR_SLIDER_FLOAT,
-                                      { .min = 1.0f, .max = 5.0f, .defaultVariant = 1.8f, .format = "%.1f", .step = 0.1f } },
-                                    { "Test Notification",
-                                      "",
-                                      "Displays a test notification.",
-                                      WIDGET_BUTTON,
-                                      {},
-                                      [](widgetInfo& info) {
-                                          Notification::Emit({
-                                              .itemIcon = "__OTR__icon_item_24_static_yar/gQuestIconGoldSkulltulaTex",
-                                              .prefix = "This",
-                                              .message = "is a",
-                                              .suffix = "test.",
-                                          });
-                                      } },
-                                } } });
+    settingsSidebar.push_back(
+        { "Notifications",
+          1,
+          { {
+              { "Position",
+                "gNotifications.Position",
+                "Which corner of the screen notifications appear in.",
+                WIDGET_CVAR_COMBOBOX,
+                { .defaultVariant = 3, .comboBoxOptions = notificationPosition } },
+              { "Duration: %.0f seconds",
+                "gNotifications.Duration",
+                "How long notifications are displayed for.",
+                WIDGET_CVAR_SLIDER_FLOAT,
+                { .min = 3.0f, .max = 30.0f, .defaultVariant = 10.0f, .format = "%.1f", .step = 0.1f } },
+              { "Background Opacity: %.0f%%",
+                "gNotifications.BgOpacity",
+                "How opaque the background of notifications is.",
+                WIDGET_CVAR_SLIDER_FLOAT,
+                { .min = 0.0f, .max = 1.0f, .defaultVariant = 0.5f, .format = "%.0f%%", .isPercentage = true } },
+              { "Size %.1f",
+                "gNotifications.Size",
+                "How large notifications are.",
+                WIDGET_CVAR_SLIDER_FLOAT,
+                { .min = 1.0f, .max = 5.0f, .defaultVariant = 1.8f, .format = "%.1f", .step = 0.1f } },
+              { "Test Notification",
+                "",
+                "Displays a test notification.",
+                WIDGET_BUTTON,
+                {},
+                [](widgetInfo& info) {
+                    Notification::Emit({
+                        .itemIcon = "__OTR__icon_item_24_static_yar/gQuestIconGoldSkulltulaTex",
+                        .prefix = "This",
+                        .message = "is a",
+                        .suffix = "test.",
+                    });
+                } },
+          } } });
 
     if (CVarGetInteger("gSettings.SidebarSearch", 0)) {
         settingsSidebar.insert(settingsSidebar.begin() + searchSidebarIndex, searchSidebarEntry);
@@ -919,14 +920,14 @@ void AddEnhancements() {
                 "gEnhancements.Camera.FreeLook.MaxPitch",
                 "Maximum Height of the Camera.",
                 WIDGET_CVAR_SLIDER_FLOAT,
-                {.min = -89.0f, .max = 89.0f, .defaultVariant = 72.0f, .format = "%.0f\xC2\xB0"},
+                { .min = -89.0f, .max = 89.0f, .defaultVariant = 72.0f, .format = "%.0f\xC2\xB0" },
                 [](widgetInfo& info) { FreeLookPitchMinMax(); },
                 [](widgetInfo& info) { info.isHidden = disabledMap.at(DISABLE_FOR_FREE_LOOK_OFF).active; } },
               { "Min Camera Height Angle: %.0f\xC2\xB0",
                 "gEnhancements.Camera.FreeLook.MinPitch",
                 "Minimum Height of the Camera.",
                 WIDGET_CVAR_SLIDER_FLOAT,
-                {.min = -89.0f, .max = 89.0f, .defaultVariant = -49.0f, .format = "%.0f\xC2\xB0"},
+                { .min = -89.0f, .max = 89.0f, .defaultVariant = -49.0f, .format = "%.0f\xC2\xB0" },
                 [](widgetInfo& info) { FreeLookPitchMinMax(); },
                 [](widgetInfo& info) { info.isHidden = disabledMap.at(DISABLE_FOR_FREE_LOOK_OFF).active; } },
               { "Debug Camera",
@@ -966,7 +967,7 @@ void AddEnhancements() {
                 "gEnhancements.Camera.RightStick.CameraSensitivity.X",
                 "Adjust the Sensitivity of the x axis when in Third Person.",
                 WIDGET_CVAR_SLIDER_FLOAT,
-                {.min = 0.01f, .max = 5.0f, .defaultVariant = 1.0f, .format = "%.0f%%", .isPercentage = true },
+                { .min = 0.01f, .max = 5.0f, .defaultVariant = 1.0f, .format = "%.0f%%", .isPercentage = true },
                 nullptr,
                 [](widgetInfo& info) {
                     if (disabledMap.at(DISABLE_FOR_CAMERAS_OFF).active) {
@@ -977,7 +978,7 @@ void AddEnhancements() {
                 "gEnhancements.Camera.RightStick.CameraSensitivity.Y",
                 "Adjust the Sensitivity of the x axis when in Third Person.",
                 WIDGET_CVAR_SLIDER_FLOAT,
-                {.min = 0.01f, .max = 5.0f, .defaultVariant = 1.0f, .format = "%.0f%%", .isPercentage = true },
+                { .min = 0.01f, .max = 5.0f, .defaultVariant = 1.0f, .format = "%.0f%%", .isPercentage = true },
                 nullptr,
                 [](widgetInfo& info) {
                     if (disabledMap.at(DISABLE_FOR_CAMERAS_OFF).active) {
@@ -997,7 +998,7 @@ void AddEnhancements() {
                 "gEnhancements.Camera.DebugCam.CameraSpeed",
                 "Adjusts the speed of the Camera.",
                 WIDGET_CVAR_SLIDER_FLOAT,
-                {.min = 0.1f, .max = 3.0f, .defaultVariant = 0.5f, .format = "%.0f%%", .isPercentage = true },
+                { .min = 0.1f, .max = 3.0f, .defaultVariant = 0.5f, .format = "%.0f%%", .isPercentage = true },
                 nullptr,
                 [](widgetInfo& info) { info.isHidden = disabledMap.at(DISABLE_FOR_DEBUG_CAM_OFF).active; } } } } });
     // Cheats
@@ -1819,16 +1820,15 @@ void SearchMenuGetItem(widgetInfo& widget) {
                     assert(false);
                     return;
                 }
-                if (UIWidgets::SliderInt(
-                        widget.widgetName.c_str(), pointer,
-                        std::get<int32_t>(widget.widgetOptions.min),
-                        std::get<int32_t>(widget.widgetOptions.max),
-                        {
-                            .color = menuTheme[menuThemeIndex],
-                            .tooltip = widget.widgetTooltip,
-                            .disabled = disabledValue,
-                            .disabledTooltip = disabledTooltip,
-                        })) {
+                if (UIWidgets::SliderInt(widget.widgetName.c_str(), pointer,
+                                         std::get<int32_t>(widget.widgetOptions.min),
+                                         std::get<int32_t>(widget.widgetOptions.max),
+                                         {
+                                             .color = menuTheme[menuThemeIndex],
+                                             .tooltip = widget.widgetTooltip,
+                                             .disabled = disabledValue,
+                                             .disabledTooltip = disabledTooltip,
+                                         })) {
                     if (widget.widgetCallback != nullptr) {
                         widget.widgetCallback(widget);
                     }
@@ -1842,35 +1842,33 @@ void SearchMenuGetItem(widgetInfo& widget) {
                     assert(false);
                     return;
                 }
-                if (UIWidgets::SliderFloat(
-                        widget.widgetName.c_str(), pointer,
-                        std::get<float>(widget.widgetOptions.min),
-                        std::get<float>(widget.widgetOptions.max),
-                        { .color = menuTheme[menuThemeIndex],
-                            .tooltip = widget.widgetTooltip,
-                            .disabled = disabledValue,
-                            .disabledTooltip = disabledTooltip,
-                            .showButtons = widget.widgetOptions.showButtons,
-                            .format = widget.widgetOptions.format,
-                            .step = widget.widgetOptions.step,
-                            .isPercentage = widget.widgetOptions.isPercentage })) {
+                if (UIWidgets::SliderFloat(widget.widgetName.c_str(), pointer,
+                                           std::get<float>(widget.widgetOptions.min),
+                                           std::get<float>(widget.widgetOptions.max),
+                                           { .color = menuTheme[menuThemeIndex],
+                                             .tooltip = widget.widgetTooltip,
+                                             .disabled = disabledValue,
+                                             .disabledTooltip = disabledTooltip,
+                                             .showButtons = widget.widgetOptions.showButtons,
+                                             .format = widget.widgetOptions.format,
+                                             .step = widget.widgetOptions.step,
+                                             .isPercentage = widget.widgetOptions.isPercentage })) {
                     if (widget.widgetCallback != nullptr) {
                         widget.widgetCallback(widget);
                     }
                 }
             } break;
             case WIDGET_CVAR_SLIDER_INT:
-                if (UIWidgets::CVarSliderInt(
-                        widget.widgetName.c_str(), widget.widgetCVar,
-                        std::get<int32_t>(widget.widgetOptions.min),
-                        std::get<int32_t>(widget.widgetOptions.max),
-                        std::get<int32_t>(widget.widgetOptions.defaultVariant),
-                        {
-                            .color = menuTheme[menuThemeIndex],
-                            .tooltip = widget.widgetTooltip,
-                            .disabled = disabledValue,
-                            .disabledTooltip = disabledTooltip,
-                        })) {
+                if (UIWidgets::CVarSliderInt(widget.widgetName.c_str(), widget.widgetCVar,
+                                             std::get<int32_t>(widget.widgetOptions.min),
+                                             std::get<int32_t>(widget.widgetOptions.max),
+                                             std::get<int32_t>(widget.widgetOptions.defaultVariant),
+                                             {
+                                                 .color = menuTheme[menuThemeIndex],
+                                                 .tooltip = widget.widgetTooltip,
+                                                 .disabled = disabledValue,
+                                                 .disabledTooltip = disabledTooltip,
+                                             })) {
                     if (widget.widgetCallback != nullptr) {
                         widget.widgetCallback(widget);
                     }

--- a/mm/2s2h/BenGui/SearchableMenuItems.h
+++ b/mm/2s2h/BenGui/SearchableMenuItems.h
@@ -137,6 +137,7 @@ struct WidgetOptions {
     bool sameLine = false;
     bool showButtons = true;
     const char* format = "%f";
+    float step = 0.01f;
     bool isPercentage = false;
 };
 
@@ -514,8 +515,8 @@ void AddSettings() {
                 "Adjust overall sound volume.",
                 WIDGET_CVAR_SLIDER_FLOAT,
                 { .min = 0.0f,
-                  .max = 100.0f,
-                  .defaultVariant = 100.0f,
+                  .max = 1.0f,
+                  .defaultVariant = 1.0f,
                   .showButtons = false,
                   .format = "",
                   .isPercentage = true } },
@@ -524,8 +525,8 @@ void AddSettings() {
                 "Adjust the Background Music volume.",
                 WIDGET_CVAR_SLIDER_FLOAT,
                 { .min = 0.0f,
-                  .max = 100.0f,
-                  .defaultVariant = 100.0f,
+                  .max = 1.0f,
+                  .defaultVariant = 1.0f,
                   .showButtons = false,
                   .format = "",
                   .isPercentage = true },
@@ -538,8 +539,8 @@ void AddSettings() {
                 "Adjust the Sub Music volume.",
                 WIDGET_CVAR_SLIDER_FLOAT,
                 { .min = 0.0f,
-                  .max = 100.0f,
-                  .defaultVariant = 100.0f,
+                  .max = 1.0f,
+                  .defaultVariant = 1.0f,
                   .showButtons = false,
                   .format = "",
                   .isPercentage = true },
@@ -552,8 +553,8 @@ void AddSettings() {
                 "Adjust the Sound Effects volume.",
                 WIDGET_CVAR_SLIDER_FLOAT,
                 { .min = 0.0f,
-                  .max = 100.0f,
-                  .defaultVariant = 100.0f,
+                  .max = 1.0f,
+                  .defaultVariant = 1.0f,
                   .showButtons = false,
                   .format = "",
                   .isPercentage = true },
@@ -566,8 +567,8 @@ void AddSettings() {
                 "Adjust the Fanfare volume.",
                 WIDGET_CVAR_SLIDER_FLOAT,
                 { .min = 0.0f,
-                  .max = 100.0f,
-                  .defaultVariant = 100.0f,
+                  .max = 1.0f,
+                  .defaultVariant = 1.0f,
                   .showButtons = false,
                   .format = "",
                   .isPercentage = true },
@@ -580,8 +581,8 @@ void AddSettings() {
                 "Adjust the Ambient Sound volume.",
                 WIDGET_CVAR_SLIDER_FLOAT,
                 { .min = 0.0f,
-                  .max = 100.0f,
-                  .defaultVariant = 100.0f,
+                  .max = 1.0f,
+                  .defaultVariant = 1.0f,
                   .showButtons = false,
                   .format = "",
                   .isPercentage = true },
@@ -619,9 +620,9 @@ void AddSettings() {
                 "Multiplies your output resolution by the value inputted, as a more intensive but effective "
                 "form of anti-aliasing.",
                 WIDGET_CVAR_SLIDER_FLOAT,
-                { .min = 50.0f,
-                  .max = 200.0f,
-                  .defaultVariant = 100.0f,
+                { .min = 0.5f,
+                  .max = 2.0f,
+                  .defaultVariant = 1.0f,
                   .showButtons = false,
                   .format = "",
                   .isPercentage = true },
@@ -738,17 +739,17 @@ void AddSettings() {
                                       "gNotifications.Duration",
                                       "How long notifications are displayed for.",
                                       WIDGET_CVAR_SLIDER_FLOAT,
-                                      { .min = 300.0f, .max = 3000.0f, .defaultVariant = 1000.0f } },
+                                      { .min = 3.0f, .max = 30.0f, .defaultVariant = 10.0f, .format = "%.1f", .step = 0.1f } },
                                     { "Background Opacity: %.0f%%",
                                       "gNotifications.BgOpacity",
                                       "How opaque the background of notifications is.",
                                       WIDGET_CVAR_SLIDER_FLOAT,
-                                      { .min = 0.0f, .max = 100.0f, .defaultVariant = 50.0f, .isPercentage = true } },
+                                      { .min = 0.0f, .max = 1.0f, .defaultVariant = 0.5f, .format = "%.0f%%", .isPercentage = true } },
                                     { "Size %.1f",
                                       "gNotifications.Size",
                                       "How large notifications are.",
                                       WIDGET_CVAR_SLIDER_FLOAT,
-                                      { .min = 100.0f, .max = 500.0f, .defaultVariant = 180.0f } },
+                                      { .min = 1.0f, .max = 5.0f, .defaultVariant = 1.8f, .format = "%.1f", .step = 0.1f } },
                                     { "Test Notification",
                                       "",
                                       "Displays a test notification.",
@@ -804,13 +805,13 @@ void AddEnhancements() {
                   "gEnhancements.Camera.FirstPerson.SensitivityX",
                   "Adjusts the Sensitivity of the X Axis in First Person Mode.",
                   WIDGET_CVAR_SLIDER_FLOAT,
-                  { .min = 10.0f, .max = 200.0f, .defaultVariant = 100.0f, .format = "%.0f%%", .isPercentage = true },
+                  { .min = 0.01f, .max = 2.0f, .defaultVariant = 1.0f, .format = "%.0f%%", .isPercentage = true },
                   nullptr },
                 { "Y Axis Sensitivity: %.0f%%",
                   "gEnhancements.Camera.FirstPerson.SensitivityY",
                   "Adjusts the Sensitivity of the Y Axis in First Person Mode.",
                   WIDGET_CVAR_SLIDER_FLOAT,
-                  { .min = 10.0f, .max = 200.0f, .defaultVariant = 100.0f, .format = "%.0f%%", .isPercentage = true },
+                  { .min = 0.01f, .max = 2.0f, .defaultVariant = 1.0f, .format = "%.0f%%", .isPercentage = true },
                   nullptr },
                 { "Gyro Aiming",
                   "gEnhancements.Camera.FirstPerson.GyroEnabled",
@@ -836,14 +837,14 @@ void AddEnhancements() {
                   "gEnhancements.Camera.FirstPerson.GyroSensitivityX",
                   "Adjusts the Sensitivity of the X Axis of the Gyro in First Person Mode.",
                   WIDGET_CVAR_SLIDER_FLOAT,
-                  { .min = 10.0f, .max = 200.0f, .defaultVariant = 100.0f, .format = "%.0f%%", .isPercentage = true },
+                  { .min = 0.01f, .max = 2.0f, .defaultVariant = 1.0f, .format = "%.0f%%", .isPercentage = true },
                   nullptr,
                   [](widgetInfo& info) { info.isHidden = disabledMap.at(DISABLE_FOR_GYRO_OFF).active; } },
                 { "Gyro Y Axis Sensitivity: %.0f%%",
                   "gEnhancements.Camera.FirstPerson.GyroSensitivityY",
                   "Adjusts the Sensitivity of the Y Axis of the Gyro in First Person Mode.",
                   WIDGET_CVAR_SLIDER_FLOAT,
-                  { .min = 10.0f, .max = 200.0f, .defaultVariant = 100.0f, .format = "%.0f%%", .isPercentage = true },
+                  { .min = 0.01f, .max = 2.0f, .defaultVariant = 1.0f, .format = "%.0f%%", .isPercentage = true },
                   nullptr,
                   [](widgetInfo& info) { info.isHidden = disabledMap.at(DISABLE_FOR_GYRO_OFF).active; } },
                 { "Right Stick Aiming", "gEnhancements.Camera.FirstPerson.RightStickEnabled",
@@ -876,14 +877,14 @@ void AddEnhancements() {
                   "gEnhancements.Camera.FirstPerson.RightStickSensitivityX",
                   "Adjusts the Sensitivity of the X Axis of the Right Stick in First Person Mode.",
                   WIDGET_CVAR_SLIDER_FLOAT,
-                  { .min = 10.0f, .max = 200.0f, .defaultVariant = 100.0f, .format = "%.0f%%", .isPercentage = true },
+                  { .min = 0.01f, .max = 2.0f, .defaultVariant = 1.0f, .format = "%.0f%%", .isPercentage = true },
                   nullptr,
                   [](widgetInfo& info) { info.isHidden = disabledMap.at(DISABLE_FOR_RIGHT_STICK_OFF).active; } },
                 { "Right Stick Y Axis Sensitivity: %.0f%%",
                   "gEnhancements.Camera.FirstPerson.RightStickSensitivityY",
                   "Adjusts the Sensitivity of the Y Axis of the Right Stick in First Person Mode.",
                   WIDGET_CVAR_SLIDER_FLOAT,
-                  { .min = 10.0f, .max = 200.0f, .defaultVariant = 100.0f, .format = "%.0f%%", .isPercentage = true },
+                  { .min = 0.01f, .max = 2.0f, .defaultVariant = 1.0f, .format = "%.0f%%", .isPercentage = true },
                   nullptr,
                   [](widgetInfo& info) { info.isHidden = disabledMap.at(DISABLE_FOR_RIGHT_STICK_OFF).active; } },
             },
@@ -918,14 +919,14 @@ void AddEnhancements() {
                 "gEnhancements.Camera.FreeLook.MaxPitch",
                 "Maximum Height of the Camera.",
                 WIDGET_CVAR_SLIDER_FLOAT,
-                { -8900.0f, 8900.0f, 7200.0f },
+                {.min = -89.0f, .max = 89.0f, .defaultVariant = 72.0f, .format = "%.0f\xC2\xB0"},
                 [](widgetInfo& info) { FreeLookPitchMinMax(); },
                 [](widgetInfo& info) { info.isHidden = disabledMap.at(DISABLE_FOR_FREE_LOOK_OFF).active; } },
               { "Min Camera Height Angle: %.0f\xC2\xB0",
                 "gEnhancements.Camera.FreeLook.MinPitch",
                 "Minimum Height of the Camera.",
                 WIDGET_CVAR_SLIDER_FLOAT,
-                { -8900.0f, 8900.0f, -4900.0f },
+                {.min = -89.0f, .max = 89.0f, .defaultVariant = -49.0f, .format = "%.0f\xC2\xB0"},
                 [](widgetInfo& info) { FreeLookPitchMinMax(); },
                 [](widgetInfo& info) { info.isHidden = disabledMap.at(DISABLE_FOR_FREE_LOOK_OFF).active; } },
               { "Debug Camera",
@@ -965,7 +966,7 @@ void AddEnhancements() {
                 "gEnhancements.Camera.RightStick.CameraSensitivity.X",
                 "Adjust the Sensitivity of the x axis when in Third Person.",
                 WIDGET_CVAR_SLIDER_FLOAT,
-                { 1.0f, 500.0f, 100.0f },
+                {.min = 0.01f, .max = 5.0f, .defaultVariant = 1.0f, .format = "%.0f%%", .isPercentage = true },
                 nullptr,
                 [](widgetInfo& info) {
                     if (disabledMap.at(DISABLE_FOR_CAMERAS_OFF).active) {
@@ -976,7 +977,7 @@ void AddEnhancements() {
                 "gEnhancements.Camera.RightStick.CameraSensitivity.Y",
                 "Adjust the Sensitivity of the x axis when in Third Person.",
                 WIDGET_CVAR_SLIDER_FLOAT,
-                { 1.0f, 500.0f, 100.0f },
+                {.min = 0.01f, .max = 5.0f, .defaultVariant = 1.0f, .format = "%.0f%%", .isPercentage = true },
                 nullptr,
                 [](widgetInfo& info) {
                     if (disabledMap.at(DISABLE_FOR_CAMERAS_OFF).active) {
@@ -996,7 +997,7 @@ void AddEnhancements() {
                 "gEnhancements.Camera.DebugCam.CameraSpeed",
                 "Adjusts the speed of the Camera.",
                 WIDGET_CVAR_SLIDER_FLOAT,
-                { 10.0f, 300.0f, 50.0f },
+                {.min = 0.1f, .max = 3.0f, .defaultVariant = 0.5f, .format = "%.0f%%", .isPercentage = true },
                 nullptr,
                 [](widgetInfo& info) { info.isHidden = disabledMap.at(DISABLE_FOR_DEBUG_CAM_OFF).active; } } } } });
     // Cheats
@@ -1818,24 +1819,22 @@ void SearchMenuGetItem(widgetInfo& widget) {
                     assert(false);
                     return;
                 }
-                if (UIWidgets::SliderInt(widget.widgetName.c_str(), pointer,
-                                         std::get<int32_t>(widget.widgetOptions.min),
-                                         std::get<int32_t>(widget.widgetOptions.max),
-                                         {
-                                             .color = menuTheme[menuThemeIndex],
-                                             .tooltip = widget.widgetTooltip,
-                                             .disabled = disabledValue,
-                                             .disabledTooltip = disabledTooltip,
-                                         })) {
+                if (UIWidgets::SliderInt(
+                        widget.widgetName.c_str(), pointer,
+                        std::get<int32_t>(widget.widgetOptions.min),
+                        std::get<int32_t>(widget.widgetOptions.max),
+                        {
+                            .color = menuTheme[menuThemeIndex],
+                            .tooltip = widget.widgetTooltip,
+                            .disabled = disabledValue,
+                            .disabledTooltip = disabledTooltip,
+                        })) {
                     if (widget.widgetCallback != nullptr) {
                         widget.widgetCallback(widget);
                     }
                 };
             } break;
             case WIDGET_SLIDER_FLOAT: {
-                float floatMin = (std::get<float>(widget.widgetOptions.min) / 100);
-                float floatMax = (std::get<float>(widget.widgetOptions.max) / 100);
-                float floatDefault = (std::get<float>(widget.widgetOptions.defaultVariant) / 100);
                 float* pointer = std::get<float*>(widget.widgetOptions.valuePointer);
 
                 if (pointer == nullptr) {
@@ -1843,48 +1842,52 @@ void SearchMenuGetItem(widgetInfo& widget) {
                     assert(false);
                     return;
                 }
-                if (UIWidgets::SliderFloat(widget.widgetName.c_str(), pointer, floatMin, floatMax,
-                                           { .color = menuTheme[menuThemeIndex],
-                                             .tooltip = widget.widgetTooltip,
-                                             .disabled = disabledValue,
-                                             .disabledTooltip = disabledTooltip,
-                                             .showButtons = widget.widgetOptions.showButtons,
-                                             .format = widget.widgetOptions.format,
-                                             .isPercentage = widget.widgetOptions.isPercentage })) {
+                if (UIWidgets::SliderFloat(
+                        widget.widgetName.c_str(), pointer,
+                        std::get<float>(widget.widgetOptions.min),
+                        std::get<float>(widget.widgetOptions.max),
+                        { .color = menuTheme[menuThemeIndex],
+                            .tooltip = widget.widgetTooltip,
+                            .disabled = disabledValue,
+                            .disabledTooltip = disabledTooltip,
+                            .showButtons = widget.widgetOptions.showButtons,
+                            .format = widget.widgetOptions.format,
+                            .step = widget.widgetOptions.step,
+                            .isPercentage = widget.widgetOptions.isPercentage })) {
                     if (widget.widgetCallback != nullptr) {
                         widget.widgetCallback(widget);
                     }
                 }
             } break;
             case WIDGET_CVAR_SLIDER_INT:
-                if (UIWidgets::CVarSliderInt(widget.widgetName.c_str(), widget.widgetCVar,
-                                             std::get<int32_t>(widget.widgetOptions.min),
-                                             std::get<int32_t>(widget.widgetOptions.max),
-                                             std::get<int32_t>(widget.widgetOptions.defaultVariant),
-                                             {
-                                                 .color = menuTheme[menuThemeIndex],
-                                                 .tooltip = widget.widgetTooltip,
-                                                 .disabled = disabledValue,
-                                                 .disabledTooltip = disabledTooltip,
-                                             })) {
+                if (UIWidgets::CVarSliderInt(
+                        widget.widgetName.c_str(), widget.widgetCVar,
+                        std::get<int32_t>(widget.widgetOptions.min),
+                        std::get<int32_t>(widget.widgetOptions.max),
+                        std::get<int32_t>(widget.widgetOptions.defaultVariant),
+                        {
+                            .color = menuTheme[menuThemeIndex],
+                            .tooltip = widget.widgetTooltip,
+                            .disabled = disabledValue,
+                            .disabledTooltip = disabledTooltip,
+                        })) {
                     if (widget.widgetCallback != nullptr) {
                         widget.widgetCallback(widget);
                     }
                 };
                 break;
             case WIDGET_CVAR_SLIDER_FLOAT: {
-                float floatMin = (std::get<float>(widget.widgetOptions.min) / 100);
-                float floatMax = (std::get<float>(widget.widgetOptions.max) / 100);
-                float floatDefault = (std::get<float>(widget.widgetOptions.defaultVariant) / 100);
-                if (UIWidgets::CVarSliderFloat(widget.widgetName.c_str(), widget.widgetCVar, floatMin, floatMax,
-                                               floatDefault,
-                                               { .color = menuTheme[menuThemeIndex],
-                                                 .tooltip = widget.widgetTooltip,
-                                                 .disabled = disabledValue,
-                                                 .disabledTooltip = disabledTooltip,
-                                                 .showButtons = widget.widgetOptions.showButtons,
-                                                 .format = widget.widgetOptions.format,
-                                                 .isPercentage = widget.widgetOptions.isPercentage })) {
+                if (UIWidgets::CVarSliderFloat(
+                        widget.widgetName.c_str(), widget.widgetCVar, std::get<float>(widget.widgetOptions.min),
+                        std::get<float>(widget.widgetOptions.max), std::get<float>(widget.widgetOptions.defaultVariant),
+                        { .color = menuTheme[menuThemeIndex],
+                          .tooltip = widget.widgetTooltip,
+                          .disabled = disabledValue,
+                          .disabledTooltip = disabledTooltip,
+                          .showButtons = widget.widgetOptions.showButtons,
+                          .format = widget.widgetOptions.format,
+                          .step = widget.widgetOptions.step,
+                          .isPercentage = widget.widgetOptions.isPercentage })) {
                     if (widget.widgetCallback != nullptr) {
                         widget.widgetCallback(widget);
                     }

--- a/mm/2s2h/BenGui/UIWidgets.cpp
+++ b/mm/2s2h/BenGui/UIWidgets.cpp
@@ -426,13 +426,13 @@ void ClampFloat(float* value, float min, float max, float step) {
         *value = max;
     } else {
         *value = std::round(*value * factor) / factor;
-        std::string msg = fmt::format("Value after round: {}", (float)*value);
-        SPDLOG_ERROR(msg.c_str());
         std::stringstream ss;
         ss << std::setprecision(ticks) << std::setiosflags(std::ios_base::fixed) << (float)*value;
-        msg = fmt::format("String value: {}", ss.str());
+        std::string msg = fmt::format("String value: {}", ss.str());
         SPDLOG_ERROR(msg.c_str());
         float str = std::stof(ss.str());
+        msg = fmt::format("stof: {}", str);
+        SPDLOG_ERROR(msg.c_str());
         *value = str;
     }
 }
@@ -474,11 +474,8 @@ bool SliderFloat(const char* label, float* value, float min, float max, const Fl
     if (ImGui::SliderScalar(invisibleLabel, ImGuiDataType_Float, &valueToDisplay, &minToDisplay, &maxToDisplay,
                             options.format, options.flags)) {
         *value = options.isPercentage ? valueToDisplay / 100.0f : valueToDisplay;
-        std::string msg = fmt::format("Val: {}; ValDisp: {}; Max: {}; MaxDisp: {}; Min: {}; MinDisp: {}", (float)*value,
-                                      valueToDisplay, max, maxToDisplay, min, minToDisplay);
-        SPDLOG_ERROR(msg.c_str());
         ClampFloat(value, min, max, options.step);
-        msg = fmt::format("After clamp -  Val: {}; Max: {}; Min: {}", (float)*value, max, min);
+        std::string msg = fmt::format("After clamp -  Val: {}; Max: {}; Min: {}", (float)*value, max, min);
         SPDLOG_ERROR(msg.c_str());
         Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
         dirty = true;

--- a/mm/2s2h/BenGui/UIWidgets.cpp
+++ b/mm/2s2h/BenGui/UIWidgets.cpp
@@ -425,15 +425,8 @@ void ClampFloat(float* value, float min, float max, float step) {
     } else if (*value > max) {
         *value = max;
     } else {
-        *value = std::round(*value * factor) / factor;
-        std::stringstream ss;
-        ss << std::setprecision(ticks) << std::setiosflags(std::ios_base::fixed) << (float)*value;
-        std::string msg = fmt::format("String value: {}", ss.str());
-        SPDLOG_ERROR(msg.c_str());
-        float str = float(std::stod(ss.str()));
-        msg = fmt::format("stod: {}", str);
-        SPDLOG_ERROR(msg.c_str());
-        *value = str;
+        int trunc = (int)std::round(*value * factor);
+        *value =  (float)trunc / factor;
     }
 }
 

--- a/mm/2s2h/BenGui/UIWidgets.cpp
+++ b/mm/2s2h/BenGui/UIWidgets.cpp
@@ -7,7 +7,7 @@
 #include <unordered_map>
 #include <libultraship/libultra/types.h>
 #include "2s2h/ShipUtils.h"
-#include <fmt/format.h>
+#include <spdlog/fmt/fmt.h>
 
 namespace UIWidgets {
 // Automatically adds newlines to break up text longer than a specified number of characters
@@ -115,9 +115,9 @@ bool Button(const char* label, const ButtonOptions& options) {
     PopStyleButton();
     ImGui::EndDisabled();
     if (options.disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) &&
-        !Ship_IsCStringEmpty(options.disabledTooltip)) {
+        strcmp(options.disabledTooltip, "") != 0) {
         ImGui::SetTooltip("%s", WrappedText(options.disabledTooltip).c_str());
-    } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !Ship_IsCStringEmpty(options.tooltip)) {
+    } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && strcmp(options.tooltip, "") != 0) {
         ImGui::SetTooltip("%s", WrappedText(options.tooltip).c_str());
     }
     return dirty;
@@ -262,9 +262,9 @@ bool Checkbox(const char* _label, bool* value, const CheckboxOptions& options) {
     PopStyleCheckbox();
     ImGui::EndDisabled();
     if (options.disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) &&
-        !Ship_IsCStringEmpty(options.disabledTooltip)) {
+        strcmp(options.disabledTooltip, "") != 0) {
         ImGui::SetTooltip("%s", WrappedText(options.disabledTooltip).c_str());
-    } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !Ship_IsCStringEmpty(options.tooltip)) {
+    } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && strcmp(options.tooltip, "") != 0) {
         ImGui::SetTooltip("%s", WrappedText(options.tooltip).c_str());
     }
     return pressed;
@@ -371,9 +371,9 @@ bool SliderInt(const char* label, int32_t* value, int32_t min, int32_t max, cons
     ImGui::EndDisabled();
     ImGui::EndGroup();
     if (options.disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) &&
-        !Ship_IsCStringEmpty(options.disabledTooltip)) {
+        strcmp(options.disabledTooltip, "") != 0) {
         ImGui::SetTooltip("%s", WrappedText(options.disabledTooltip).c_str());
-    } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !Ship_IsCStringEmpty(options.tooltip)) {
+    } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && strcmp(options.tooltip, "") != 0) {
         ImGui::SetTooltip("%s", WrappedText(options.tooltip).c_str());
     }
     ImGui::PopID();
@@ -497,9 +497,9 @@ bool SliderFloat(const char* label, float* value, float min, float max, const Fl
     ImGui::EndDisabled();
     ImGui::EndGroup();
     if (options.disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) &&
-        !Ship_IsCStringEmpty(options.disabledTooltip)) {
+        strcmp(options.disabledTooltip, "") != 0) {
         ImGui::SetTooltip("%s", WrappedText(options.disabledTooltip).c_str());
-    } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !Ship_IsCStringEmpty(options.tooltip)) {
+    } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && strcmp(options.tooltip, "") != 0) {
         ImGui::SetTooltip("%s", WrappedText(options.tooltip).c_str());
     }
     ImGui::PopID();

--- a/mm/2s2h/BenGui/UIWidgets.cpp
+++ b/mm/2s2h/BenGui/UIWidgets.cpp
@@ -430,8 +430,8 @@ void ClampFloat(float* value, float min, float max, float step) {
         ss << std::setprecision(ticks) << std::setiosflags(std::ios_base::fixed) << (float)*value;
         std::string msg = fmt::format("String value: {}", ss.str());
         SPDLOG_ERROR(msg.c_str());
-        float str = std::stof(ss.str());
-        msg = fmt::format("stof: {}", str);
+        float str = float(std::stod(ss.str()));
+        msg = fmt::format("stod: {}", str);
         SPDLOG_ERROR(msg.c_str());
         *value = str;
     }

--- a/mm/2s2h/BenGui/UIWidgets.cpp
+++ b/mm/2s2h/BenGui/UIWidgets.cpp
@@ -426,7 +426,7 @@ void ClampFloat(float* value, float min, float max, float step) {
         *value = max;
     } else {
         int trunc = (int)std::round(*value * factor);
-        *value =  (float)trunc / factor;
+        *value = (float)trunc / factor;
     }
 }
 
@@ -467,9 +467,6 @@ bool SliderFloat(const char* label, float* value, float min, float max, const Fl
     if (ImGui::SliderScalar(invisibleLabel, ImGuiDataType_Float, &valueToDisplay, &minToDisplay, &maxToDisplay,
                             options.format, options.flags)) {
         *value = options.isPercentage ? valueToDisplay / 100.0f : valueToDisplay;
-        ClampFloat(value, min, max, options.step);
-        std::string msg = fmt::format("After clamp -  Val: {}; Max: {}; Min: {}", (float)*value, max, min);
-        SPDLOG_ERROR(msg.c_str());
         Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
         dirty = true;
     }

--- a/mm/2s2h/BenGui/UIWidgets.cpp
+++ b/mm/2s2h/BenGui/UIWidgets.cpp
@@ -7,6 +7,7 @@
 #include <unordered_map>
 #include <libultraship/libultra/types.h>
 #include "2s2h/ShipUtils.h"
+#include <fmt/format.h>
 
 namespace UIWidgets {
 // Automatically adds newlines to break up text longer than a specified number of characters
@@ -425,9 +426,14 @@ void ClampFloat(float* value, float min, float max, float step) {
         *value = max;
     } else {
         *value = std::round(*value * factor) / factor;
+        std::string msg = fmt::format("Value after round: {}", (float)*value);
+        SPDLOG_ERROR(msg.c_str());
         std::stringstream ss;
-        ss << std::setprecision(ticks) << std::setiosflags(std::ios_base::fixed) << *value;
-        *value = std::stof(ss.str());
+        ss << std::setprecision(ticks) << std::setiosflags(std::ios_base::fixed) << (float)*value;
+        msg = fmt::format("String value: {}", ss.str());
+        SPDLOG_ERROR(msg.c_str());
+        float str = std::stof(ss.str());
+        *value = str;
     }
 }
 
@@ -456,7 +462,7 @@ bool SliderFloat(const char* label, float* value, float min, float max, const Fl
     if (options.showButtons) {
         if (Button("-", { .color = options.color, .size = Sizes::Inline }) && *value > min) {
             *value -= options.step;
-            // ClampFloat(value, min, max, options.step);
+            ClampFloat(value, min, max, options.step);
             Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
             dirty = true;
         }
@@ -468,7 +474,12 @@ bool SliderFloat(const char* label, float* value, float min, float max, const Fl
     if (ImGui::SliderScalar(invisibleLabel, ImGuiDataType_Float, &valueToDisplay, &minToDisplay, &maxToDisplay,
                             options.format, options.flags)) {
         *value = options.isPercentage ? valueToDisplay / 100.0f : valueToDisplay;
-        // ClampFloat(value, min, max, options.step);
+        std::string msg = fmt::format("Val: {}; ValDisp: {}; Max: {}; MaxDisp: {}; Min: {}; MinDisp: {}", (float)*value,
+                                      valueToDisplay, max, maxToDisplay, min, minToDisplay);
+        SPDLOG_ERROR(msg.c_str());
+        ClampFloat(value, min, max, options.step);
+        msg = fmt::format("After clamp -  Val: {}; Max: {}; Min: {}", (float)*value, max, min);
+        SPDLOG_ERROR(msg.c_str());
         Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
         dirty = true;
     }
@@ -477,7 +488,7 @@ bool SliderFloat(const char* label, float* value, float min, float max, const Fl
         ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
         if (Button("+", { .color = options.color, .size = Sizes::Inline }) && *value < max) {
             *value += options.step;
-            // ClampFloat(value, min, max, options.step);
+            ClampFloat(value, min, max, options.step);
             Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
             dirty = true;
         }

--- a/mm/2s2h/BenGui/UIWidgets.cpp
+++ b/mm/2s2h/BenGui/UIWidgets.cpp
@@ -456,7 +456,7 @@ bool SliderFloat(const char* label, float* value, float min, float max, const Fl
     if (options.showButtons) {
         if (Button("-", { .color = options.color, .size = Sizes::Inline }) && *value > min) {
             *value -= options.step;
-            ClampFloat(value, min, max, options.step);
+            // ClampFloat(value, min, max, options.step);
             Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
             dirty = true;
         }
@@ -468,7 +468,7 @@ bool SliderFloat(const char* label, float* value, float min, float max, const Fl
     if (ImGui::SliderScalar(invisibleLabel, ImGuiDataType_Float, &valueToDisplay, &minToDisplay, &maxToDisplay,
                             options.format, options.flags)) {
         *value = options.isPercentage ? valueToDisplay / 100.0f : valueToDisplay;
-        ClampFloat(value, min, max, options.step);
+        // ClampFloat(value, min, max, options.step);
         Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
         dirty = true;
     }
@@ -477,7 +477,7 @@ bool SliderFloat(const char* label, float* value, float min, float max, const Fl
         ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
         if (Button("+", { .color = options.color, .size = Sizes::Inline }) && *value < max) {
             *value += options.step;
-            ClampFloat(value, min, max, options.step);
+            // ClampFloat(value, min, max, options.step);
             Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
             dirty = true;
         }

--- a/mm/2s2h/BenGui/UIWidgets.cpp
+++ b/mm/2s2h/BenGui/UIWidgets.cpp
@@ -7,7 +7,6 @@
 #include <unordered_map>
 #include <libultraship/libultra/types.h>
 #include "2s2h/ShipUtils.h"
-#include <spdlog/fmt/fmt.h>
 
 namespace UIWidgets {
 // Automatically adds newlines to break up text longer than a specified number of characters
@@ -115,9 +114,9 @@ bool Button(const char* label, const ButtonOptions& options) {
     PopStyleButton();
     ImGui::EndDisabled();
     if (options.disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) &&
-        strcmp(options.disabledTooltip, "") != 0) {
+        !Ship_IsCStringEmpty(options.disabledTooltip)) {
         ImGui::SetTooltip("%s", WrappedText(options.disabledTooltip).c_str());
-    } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && strcmp(options.tooltip, "") != 0) {
+    } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !Ship_IsCStringEmpty(options.tooltip)) {
         ImGui::SetTooltip("%s", WrappedText(options.tooltip).c_str());
     }
     return dirty;
@@ -262,9 +261,9 @@ bool Checkbox(const char* _label, bool* value, const CheckboxOptions& options) {
     PopStyleCheckbox();
     ImGui::EndDisabled();
     if (options.disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) &&
-        strcmp(options.disabledTooltip, "") != 0) {
+        !Ship_IsCStringEmpty(options.disabledTooltip)) {
         ImGui::SetTooltip("%s", WrappedText(options.disabledTooltip).c_str());
-    } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && strcmp(options.tooltip, "") != 0) {
+    } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !Ship_IsCStringEmpty(options.tooltip)) {
         ImGui::SetTooltip("%s", WrappedText(options.tooltip).c_str());
     }
     return pressed;
@@ -371,9 +370,9 @@ bool SliderInt(const char* label, int32_t* value, int32_t min, int32_t max, cons
     ImGui::EndDisabled();
     ImGui::EndGroup();
     if (options.disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) &&
-        strcmp(options.disabledTooltip, "") != 0) {
+        !Ship_IsCStringEmpty(options.disabledTooltip)) {
         ImGui::SetTooltip("%s", WrappedText(options.disabledTooltip).c_str());
-    } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && strcmp(options.tooltip, "") != 0) {
+    } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !Ship_IsCStringEmpty(options.tooltip)) {
         ImGui::SetTooltip("%s", WrappedText(options.tooltip).c_str());
     }
     ImGui::PopID();
@@ -467,6 +466,7 @@ bool SliderFloat(const char* label, float* value, float min, float max, const Fl
     if (ImGui::SliderScalar(invisibleLabel, ImGuiDataType_Float, &valueToDisplay, &minToDisplay, &maxToDisplay,
                             options.format, options.flags)) {
         *value = options.isPercentage ? valueToDisplay / 100.0f : valueToDisplay;
+        ClampFloat(value, min, max, options.step);
         Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesOnNextTick();
         dirty = true;
     }
@@ -484,9 +484,9 @@ bool SliderFloat(const char* label, float* value, float min, float max, const Fl
     ImGui::EndDisabled();
     ImGui::EndGroup();
     if (options.disabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) &&
-        strcmp(options.disabledTooltip, "") != 0) {
+        !Ship_IsCStringEmpty(options.disabledTooltip)) {
         ImGui::SetTooltip("%s", WrappedText(options.disabledTooltip).c_str());
-    } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && strcmp(options.tooltip, "") != 0) {
+    } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !Ship_IsCStringEmpty(options.tooltip)) {
         ImGui::SetTooltip("%s", WrappedText(options.tooltip).c_str());
     }
     ImGui::PopID();


### PR DESCRIPTION
Fixes the issue on some platforms with the float sliders jumping between 100 and 0.

Also unifies some widget value display formats for some sliders, and implements configurable float step for the menu widgets.

Fixes #854

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2195551501.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2195555702.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2195560886.zip)
<!--- section:artifacts:end -->