### PR TITLE
[Enhancement] Receive oceanside spider house wallet reward on any day

### DIFF
--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -784,6 +784,11 @@ void DrawEnhancementsMenu() {
                                                      "swords. It may still steal other items." })) {
                 RegisterDisableTakkuriSteal();
             }
+
+            UIWidgets::CVarCheckbox(
+                "Receive Oceanside Spider House Wallet Reward Any Day", "gEnhancements.Cheats.OceansideWalletAnyDay",
+                { .tooltip = "The wallet reward for clearing the oceanside spider house can be received on any day." });
+
             ImGui::EndMenu();
         }
 

--- a/mm/2s2h/BenGui/SearchableMenuItems.h
+++ b/mm/2s2h/BenGui/SearchableMenuItems.h
@@ -1406,7 +1406,10 @@ void AddEnhancements() {
                 "Prevents the Takkuri from stealing key items like bottles and swords. It may still steal other items.",
                 WIDGET_CVAR_CHECKBOX,
                 {},
-                [](widgetInfo& info) { RegisterDisableTakkuriSteal(); } } } } });
+                [](widgetInfo& info) { RegisterDisableTakkuriSteal(); } },
+              { "Receive Oceanside Spider House Wallet Reward Any Day", "gEnhancements.Cheats.OceansideWalletAnyDay",
+                "The wallet reward for clearing the oceanside spider house can be received on any day.",
+                WIDGET_CVAR_CHECKBOX } } } });
     enhancementsSidebar.push_back({ "HUD Editor",
                                     1,
                                     { // HUD Editor

--- a/mm/src/overlays/actors/ovl_En_Sth/z_en_sth.c
+++ b/mm/src/overlays/actors/ovl_En_Sth/z_en_sth.c
@@ -369,34 +369,34 @@ void EnSth_HandleOceansideSpiderHouseConversation(EnSth* this, PlayState* play) 
                         // This flag prevents multiple rewards, switching to secondary dialogue after
                         SET_WEEKEVENTREG(WEEKEVENTREG_OCEANSIDE_SPIDER_HOUSE_COLLECTED_REWARD);
 
-                        switch (day) {
-                            case 0: // first day
-                                if (CHECK_WEEKEVENTREG(WEEKEVENTREG_RECEIVED_OCEANSIDE_WALLET_UPGRADE)) {
+                        if (!CHECK_WEEKEVENTREG(WEEKEVENTREG_RECEIVED_OCEANSIDE_WALLET_UPGRADE) &&
+                            (day == 0 || CVarGetInteger("gEnhancements.Cheats.OceansideWalletAnyDay", 0))) {
+                            // This flag prevents getting two wallets from the same place.
+                            //   Instead, getting a rupee award below.
+                            SET_WEEKEVENTREG(WEEKEVENTREG_RECEIVED_OCEANSIDE_WALLET_UPGRADE);
+                            switch (CUR_UPG_VALUE(UPG_WALLET)) {
+                                case 0:
+                                    STH_GI_ID(&this->actor) = GI_WALLET_ADULT;
+                                    break;
+
+                                case 1:
+                                    STH_GI_ID(&this->actor) = GI_WALLET_GIANT;
+                                    break;
+                            }
+                        } else {
+                            switch (day) {
+                                case 0: // first day
                                     STH_GI_ID(&this->actor) = GI_RUPEE_SILVER;
-                                } else {
-                                    // This flag prevents getting two wallets from the same place.
-                                    //   Instead, getting silver rupee above.
-                                    SET_WEEKEVENTREG(WEEKEVENTREG_RECEIVED_OCEANSIDE_WALLET_UPGRADE);
-                                    switch (CUR_UPG_VALUE(UPG_WALLET)) {
-                                        case 0:
-                                            STH_GI_ID(&this->actor) = GI_WALLET_ADULT;
-                                            break;
-
-                                        case 1:
-                                            STH_GI_ID(&this->actor) = GI_WALLET_GIANT;
-                                            break;
-                                    }
-                                }
-                                break;
-
-                            case 1: // second day
-                                STH_GI_ID(&this->actor) = GI_RUPEE_PURPLE;
-                                break;
-
-                            default: // final day
-                                STH_GI_ID(&this->actor) = GI_RUPEE_RED;
-                                break;
+                                    break;
+                                case 1: // second day
+                                    STH_GI_ID(&this->actor) = GI_RUPEE_PURPLE;
+                                    break;
+                                default: // final day
+                                    STH_GI_ID(&this->actor) = GI_RUPEE_RED;
+                                    break;
+                            }
                         }
+
                         Message_CloseTextbox(play);
                         this->actionFunc = EnSth_GiveOceansideSpiderHouseReward;
                         EnSth_GiveOceansideSpiderHouseReward(this, play);


### PR DESCRIPTION
The wallet reward for clearing the oceanside spider house is normally only obtainable on the first day. This enhancement will allow the wallet reward to be collected on any day.

I'm also not sure if this would better in a different section. Perhaps restorations because this enhancement does recreate MM3D behaviour?

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2196890159.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2196890653.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2196898084.zip)
<!--- section:artifacts:end -->