### PR TITLE
Fix UB with Japas jam session

### DIFF
--- a/mm/src/code/z_message.c
+++ b/mm/src/code/z_message.c
@@ -4532,7 +4532,10 @@ void Message_DrawMain(PlayState* play, Gfx** gfxP) {
                     if ((msgCtx->ocarinaAction == OCARINA_ACTION_PROMPT_EVAN_PART1_SECOND_HALF) ||
                         (msgCtx->ocarinaAction == OCARINA_ACTION_PROMPT_EVAN_PART2_SECOND_HALF)) {
                         AudioOcarina_StartForSongCheck(
-                            (1 << (OCARINA_ACTION_PROMPT_SONATA + msgCtx->ocarinaAction)) | 0x80000000, 4);
+                            (1 << ((msgCtx->ocarinaAction - OCARINA_ACTION_PROMPT_EVAN_PART1_SECOND_HALF) +
+                                   OCARINA_SONG_EVAN_PART1)) |
+                                0x80000000,
+                            4);
                         msgCtx->msgMode = MSGMODE_SONG_PROMPT;
                     } else {
                         if ((msgCtx->ocarinaAction >= OCARINA_ACTION_PROMPT_WIND_FISH_HUMAN) &&


### PR DESCRIPTION
Fixes an issue where the Japas jam session could not be performed on Linux due to UB with an expression that starts the ocarina song section. This expression was left shifting by 83, which can't fit in a u32. On some platforms this would roll over to 19 (83-32-32), but linux would get some other value, which lead to the ocarina flags not being set with the proper prompt.

Reworking this expression to be similar to the surrounding code prevents the UB while maintaining rom matching for decomp. Submitted a PR upstream for this.

Fixes #680 

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2197073087.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2197076055.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2197104482.zip)
<!--- section:artifacts:end -->