### PR TITLE
Update the labels of flag checkboxes to hex values

### DIFF
--- a/mm/2s2h/BenGui/UIWidgets.cpp
+++ b/mm/2s2h/BenGui/UIWidgets.cpp
@@ -548,7 +548,6 @@ void DrawFlagArray32(const std::string& name, uint32_t& flags) {
     }
     ImGui::PopID();
 }
-// fmt::format("0x{:04X} ({})", (u16)actor->params, actor->params)
 void DrawFlagArray16(const std::string& name, uint16_t& flags) {
     ImGui::PushID(name.c_str());
     for (int16_t flagIndex = 0; flagIndex < 16; flagIndex++) {

--- a/mm/2s2h/BenGui/UIWidgets.cpp
+++ b/mm/2s2h/BenGui/UIWidgets.cpp
@@ -593,4 +593,27 @@ void DrawFlagArray8(const std::string& name, uint8_t& flags) {
     }
     ImGui::PopID();
 }
+
+void DrawFlagArray8Hex(const std::string& name, uint8_t& flags) {
+    ImGui::PushID(name.c_str());
+    for (int8_t flagIndex = 0; flagIndex < 8; flagIndex++) {
+        if ((flagIndex % 8) != 0) {
+            ImGui::SameLine();
+        }
+        ImGui::PushID(flagIndex);
+        uint8_t bitMask = 1 << flagIndex;
+        bool flag = (flags & bitMask) != 0;
+        std::string label = std::format("0x{:02x}", bitMask);
+        if (UIWidgets::Checkbox(label.c_str(), &flag,
+                                { .tooltip = label.c_str(), .labelPosition = LabelPosition::None })) {
+            if (flag) {
+                flags |= bitMask;
+            } else {
+                flags &= ~bitMask;
+            }
+        }
+        ImGui::PopID();
+    }
+    ImGui::PopID();
+}
 } // namespace UIWidgets

--- a/mm/2s2h/BenGui/UIWidgets.cpp
+++ b/mm/2s2h/BenGui/UIWidgets.cpp
@@ -535,7 +535,7 @@ void DrawFlagArray32(const std::string& name, uint32_t& flags) {
         ImGui::PushID(flagIndex);
         uint32_t bitMask = 1 << flagIndex;
         bool flag = (flags & bitMask) != 0;
-        std::string label = fmt::format("0x{:02x} ({})", flagIndex, flagIndex);
+        std::string label = fmt::format("0x{:02X} ({})", flagIndex, flagIndex);
         if (UIWidgets::Checkbox(label.c_str(), &flag,
                                 { .tooltip = label.c_str(), .labelPosition = LabelPosition::None })) {
             if (flag) {
@@ -558,7 +558,7 @@ void DrawFlagArray16(const std::string& name, uint16_t& flags) {
         ImGui::PushID(flagIndex);
         uint16_t bitMask = 1 << flagIndex;
         bool flag = (flags & bitMask) != 0;
-        std::string label = fmt::format("0x{:02x} ({})", flagIndex, flagIndex);
+        std::string label = fmt::format("0x{:02X} ({})", flagIndex, flagIndex);
         if (UIWidgets::Checkbox(label.c_str(), &flag,
                                 { .tooltip = label.c_str(), .labelPosition = LabelPosition::None })) {
             if (flag) {
@@ -581,7 +581,7 @@ void DrawFlagArray8(const std::string& name, uint8_t& flags) {
         ImGui::PushID(flagIndex);
         uint8_t bitMask = 1 << flagIndex;
         bool flag = (flags & bitMask) != 0;
-        std::string label = fmt::format("0x{:02x} ({})", flagIndex, flagIndex);
+        std::string label = fmt::format("0x{:02X} ({})", flagIndex, flagIndex);
         if (UIWidgets::Checkbox(label.c_str(), &flag,
                                 { .tooltip = label.c_str(), .labelPosition = LabelPosition::None })) {
             if (flag) {
@@ -604,7 +604,7 @@ void DrawFlagArray8Mask(const std::string& name, uint8_t& flags) {
         ImGui::PushID(flagIndex);
         uint8_t bitMask = 1 << flagIndex;
         bool flag = (flags & bitMask) != 0;
-        std::string label = fmt::format("0x{:02x} ({})", bitMask, flagIndex);
+        std::string label = fmt::format("0x{:02X} ({})", bitMask, flagIndex);
         if (UIWidgets::Checkbox(label.c_str(), &flag,
                                 { .tooltip = label.c_str(), .labelPosition = LabelPosition::None })) {
             if (flag) {

--- a/mm/2s2h/BenGui/UIWidgets.cpp
+++ b/mm/2s2h/BenGui/UIWidgets.cpp
@@ -534,7 +534,7 @@ void DrawFlagArray32(const std::string& name, uint32_t& flags) {
         ImGui::PushID(flagIndex);
         uint32_t bitMask = 1 << flagIndex;
         bool flag = (flags & bitMask) != 0;
-        std::string label = std::to_string(flagIndex);
+        std::string label = std::format("0x{:02x}", flagIndex);
         if (UIWidgets::Checkbox(label.c_str(), &flag,
                                 { .tooltip = label.c_str(), .labelPosition = LabelPosition::None })) {
             if (flag) {
@@ -557,7 +557,7 @@ void DrawFlagArray16(const std::string& name, uint16_t& flags) {
         ImGui::PushID(flagIndex);
         uint16_t bitMask = 1 << flagIndex;
         bool flag = (flags & bitMask) != 0;
-        std::string label = std::to_string(flagIndex);
+        std::string label = std::format("0x{:02x}", flagIndex);
         if (UIWidgets::Checkbox(label.c_str(), &flag,
                                 { .tooltip = label.c_str(), .labelPosition = LabelPosition::None })) {
             if (flag) {
@@ -571,7 +571,7 @@ void DrawFlagArray16(const std::string& name, uint16_t& flags) {
     ImGui::PopID();
 }
 
-void DrawFlagArray8(const std::string& name, uint8_t& flags) {
+void DrawFlagArray8Index(const std::string& name, uint8_t& flags) {
     ImGui::PushID(name.c_str());
     for (int8_t flagIndex = 0; flagIndex < 8; flagIndex++) {
         if ((flagIndex % 8) != 0) {
@@ -594,7 +594,7 @@ void DrawFlagArray8(const std::string& name, uint8_t& flags) {
     ImGui::PopID();
 }
 
-void DrawFlagArray8Hex(const std::string& name, uint8_t& flags) {
+void DrawFlagArray8Mask(const std::string& name, uint8_t& flags) {
     ImGui::PushID(name.c_str());
     for (int8_t flagIndex = 0; flagIndex < 8; flagIndex++) {
         if ((flagIndex % 8) != 0) {

--- a/mm/2s2h/BenGui/UIWidgets.cpp
+++ b/mm/2s2h/BenGui/UIWidgets.cpp
@@ -571,7 +571,7 @@ void DrawFlagArray16(const std::string& name, uint16_t& flags) {
     ImGui::PopID();
 }
 
-void DrawFlagArray8Index(const std::string& name, uint8_t& flags) {
+void DrawFlagArray8(const std::string& name, uint8_t& flags) {
     ImGui::PushID(name.c_str());
     for (int8_t flagIndex = 0; flagIndex < 8; flagIndex++) {
         if ((flagIndex % 8) != 0) {
@@ -580,7 +580,7 @@ void DrawFlagArray8Index(const std::string& name, uint8_t& flags) {
         ImGui::PushID(flagIndex);
         uint8_t bitMask = 1 << flagIndex;
         bool flag = (flags & bitMask) != 0;
-        std::string label = std::to_string(flagIndex);
+        std::string label = std::format("0x{:02x}", flagIndex);
         if (UIWidgets::Checkbox(label.c_str(), &flag,
                                 { .tooltip = label.c_str(), .labelPosition = LabelPosition::None })) {
             if (flag) {

--- a/mm/2s2h/BenGui/UIWidgets.cpp
+++ b/mm/2s2h/BenGui/UIWidgets.cpp
@@ -7,6 +7,7 @@
 #include <unordered_map>
 #include <libultraship/libultra/types.h>
 #include "2s2h/ShipUtils.h"
+#include <spdlog/fmt/fmt.h>
 
 namespace UIWidgets {
 // Automatically adds newlines to break up text longer than a specified number of characters
@@ -534,7 +535,7 @@ void DrawFlagArray32(const std::string& name, uint32_t& flags) {
         ImGui::PushID(flagIndex);
         uint32_t bitMask = 1 << flagIndex;
         bool flag = (flags & bitMask) != 0;
-        std::string label = std::format("0x{:02x}", flagIndex);
+        std::string label = fmt::format("0x{:02x} ({})", flagIndex, flagIndex);
         if (UIWidgets::Checkbox(label.c_str(), &flag,
                                 { .tooltip = label.c_str(), .labelPosition = LabelPosition::None })) {
             if (flag) {
@@ -547,7 +548,7 @@ void DrawFlagArray32(const std::string& name, uint32_t& flags) {
     }
     ImGui::PopID();
 }
-
+// fmt::format("0x{:04X} ({})", (u16)actor->params, actor->params)
 void DrawFlagArray16(const std::string& name, uint16_t& flags) {
     ImGui::PushID(name.c_str());
     for (int16_t flagIndex = 0; flagIndex < 16; flagIndex++) {
@@ -557,7 +558,7 @@ void DrawFlagArray16(const std::string& name, uint16_t& flags) {
         ImGui::PushID(flagIndex);
         uint16_t bitMask = 1 << flagIndex;
         bool flag = (flags & bitMask) != 0;
-        std::string label = std::format("0x{:02x}", flagIndex);
+        std::string label = fmt::format("0x{:02x} ({})", flagIndex, flagIndex);
         if (UIWidgets::Checkbox(label.c_str(), &flag,
                                 { .tooltip = label.c_str(), .labelPosition = LabelPosition::None })) {
             if (flag) {
@@ -580,7 +581,7 @@ void DrawFlagArray8(const std::string& name, uint8_t& flags) {
         ImGui::PushID(flagIndex);
         uint8_t bitMask = 1 << flagIndex;
         bool flag = (flags & bitMask) != 0;
-        std::string label = std::format("0x{:02x}", flagIndex);
+        std::string label = fmt::format("0x{:02x} ({})", flagIndex, flagIndex);
         if (UIWidgets::Checkbox(label.c_str(), &flag,
                                 { .tooltip = label.c_str(), .labelPosition = LabelPosition::None })) {
             if (flag) {
@@ -603,7 +604,7 @@ void DrawFlagArray8Mask(const std::string& name, uint8_t& flags) {
         ImGui::PushID(flagIndex);
         uint8_t bitMask = 1 << flagIndex;
         bool flag = (flags & bitMask) != 0;
-        std::string label = std::format("0x{:02x}", bitMask);
+        std::string label = fmt::format("0x{:02x} ({})", bitMask, flagIndex);
         if (UIWidgets::Checkbox(label.c_str(), &flag,
                                 { .tooltip = label.c_str(), .labelPosition = LabelPosition::None })) {
             if (flag) {

--- a/mm/2s2h/BenGui/UIWidgets.cpp
+++ b/mm/2s2h/BenGui/UIWidgets.cpp
@@ -548,6 +548,7 @@ void DrawFlagArray32(const std::string& name, uint32_t& flags) {
     }
     ImGui::PopID();
 }
+
 void DrawFlagArray16(const std::string& name, uint16_t& flags) {
     ImGui::PushID(name.c_str());
     for (int16_t flagIndex = 0; flagIndex < 16; flagIndex++) {

--- a/mm/2s2h/BenGui/UIWidgets.hpp
+++ b/mm/2s2h/BenGui/UIWidgets.hpp
@@ -417,6 +417,7 @@ namespace UIWidgets {
     void DrawFlagArray32(const std::string& name, uint32_t& flags);
     void DrawFlagArray16(const std::string& name, uint16_t& flags);
     void DrawFlagArray8(const std::string& name, uint8_t& flags);
+    void DrawFlagArray8Hex(const std::string& name, uint8_t& flags);
 }
 
 #endif /* UIWidgets_hpp */

--- a/mm/2s2h/BenGui/UIWidgets.hpp
+++ b/mm/2s2h/BenGui/UIWidgets.hpp
@@ -416,8 +416,8 @@ namespace UIWidgets {
     bool CVarColorPicker(const char* label, const char* cvarName, Color_RGBA8 defaultColor);
     void DrawFlagArray32(const std::string& name, uint32_t& flags);
     void DrawFlagArray16(const std::string& name, uint16_t& flags);
-    void DrawFlagArray8(const std::string& name, uint8_t& flags);
-    void DrawFlagArray8Hex(const std::string& name, uint8_t& flags);
+    void DrawFlagArray8Index(const std::string& name, uint8_t& flags);
+    void DrawFlagArray8Mask(const std::string& name, uint8_t& flags);
 }
 
 #endif /* UIWidgets_hpp */

--- a/mm/2s2h/BenGui/UIWidgets.hpp
+++ b/mm/2s2h/BenGui/UIWidgets.hpp
@@ -416,7 +416,7 @@ namespace UIWidgets {
     bool CVarColorPicker(const char* label, const char* cvarName, Color_RGBA8 defaultColor);
     void DrawFlagArray32(const std::string& name, uint32_t& flags);
     void DrawFlagArray16(const std::string& name, uint16_t& flags);
-    void DrawFlagArray8Index(const std::string& name, uint8_t& flags);
+    void DrawFlagArray8(const std::string& name, uint8_t& flags);
     void DrawFlagArray8Mask(const std::string& name, uint8_t& flags);
 }
 

--- a/mm/2s2h/DeveloperTools/SaveEditor.cpp
+++ b/mm/2s2h/DeveloperTools/SaveEditor.cpp
@@ -1722,7 +1722,7 @@ void DrawFlagsTab() {
                 ImGui::PushID(i);
                 ImGui::Text("%02d", i);
                 ImGui::SameLine();
-                UIWidgets::DrawFlagArray8Hex("##", gSaveContext.save.saveInfo.weekEventReg[i]);
+                UIWidgets::DrawFlagArray8Mask("##", gSaveContext.save.saveInfo.weekEventReg[i]);
                 ImGui::PopID();
             }
             break;
@@ -1731,7 +1731,7 @@ void DrawFlagsTab() {
                 ImGui::PushID(i);
                 ImGui::Text("%02d", i);
                 ImGui::SameLine();
-                UIWidgets::DrawFlagArray8("##", gSaveContext.eventInf[i]);
+                UIWidgets::DrawFlagArray8Index("##", gSaveContext.eventInf[i]);
                 ImGui::PopID();
             }
             break;

--- a/mm/2s2h/DeveloperTools/SaveEditor.cpp
+++ b/mm/2s2h/DeveloperTools/SaveEditor.cpp
@@ -1731,7 +1731,7 @@ void DrawFlagsTab() {
                 ImGui::PushID(i);
                 ImGui::Text("%02d", i);
                 ImGui::SameLine();
-                UIWidgets::DrawFlagArray8Index("##", gSaveContext.eventInf[i]);
+                UIWidgets::DrawFlagArray8("##", gSaveContext.eventInf[i]);
                 ImGui::PopID();
             }
             break;

--- a/mm/2s2h/DeveloperTools/SaveEditor.cpp
+++ b/mm/2s2h/DeveloperTools/SaveEditor.cpp
@@ -1722,7 +1722,7 @@ void DrawFlagsTab() {
                 ImGui::PushID(i);
                 ImGui::Text("%02d", i);
                 ImGui::SameLine();
-                UIWidgets::DrawFlagArray8("##", gSaveContext.save.saveInfo.weekEventReg[i]);
+                UIWidgets::DrawFlagArray8Hex("##", gSaveContext.save.saveInfo.weekEventReg[i]);
                 ImGui::PopID();
             }
             break;


### PR DESCRIPTION
This updates the flag checkbox labels for weekEventReg in the Save Editor to its mask in hex. This will make it easier to relate the Save Editor flags to the definitions in the code and entries from the Event Log.

![hexMask](https://github.com/user-attachments/assets/e5af4ec0-0a30-4ffd-8e75-44c22c6b45b9)


Also updates other flag checkboxes in the Save Editor > Flags tab and the Actor Viewer to display hex values, which I think would be more useful. 


<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2219335566.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2219337567.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2219357865.zip)
<!--- section:artifacts:end -->