### PR TITLE
[PoC] Mouse Gyro support (Primarily for steam deck)

### DIFF
--- a/mm/2s2h/BenGui/Menu.cpp
+++ b/mm/2s2h/BenGui/Menu.cpp
@@ -134,8 +134,10 @@ bool ModernMenuHeaderEntry(std::string label) {
 
 void BenMenu::Draw() {
     if (!IsVisible()) {
+        Ship::Context::GetInstance()->GetWindow()->SetMouseCapture(true);
         return;
     }
+    Ship::Context::GetInstance()->GetWindow()->SetMouseCapture(false);
     DrawElement();
     // Sync up the IsVisible flag if it was changed by ImGui
     SyncVisibilityConsoleVariable();

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -1766,3 +1766,9 @@ extern "C" int Controller_ShouldRumble(size_t slot) {
 
     return 0;
 }
+
+extern "C" void Controller_ApplyMouseInput(OSContPad* pad) {
+    auto coords = Ship::Context::GetInstance()->GetWindow()->GetMouseDelta();
+    pad[0].gyro_x += coords.y * -0.05f;
+    pad[0].gyro_y += coords.x * -0.05f;
+}

--- a/mm/2s2h/BenPort.h
+++ b/mm/2s2h/BenPort.h
@@ -134,6 +134,7 @@ void AudioMgr_CreateNextAudioBuffer(s16* samples, u32 num_samples);
 int Controller_ShouldRumble(size_t slot);
 void Controller_BlockGameInput();
 void Controller_UnblockGameInput();
+void Controller_ApplyMouseInput(OSContPad* data);
 void Overlay_DisplayText(float duration, const char* text);
 void Overlay_DisplayText_Seconds(int seconds, const char* text);
 uint32_t Ship_GetInterpolationFPS();

--- a/mm/src/code/padmgr.c
+++ b/mm/src/code/padmgr.c
@@ -37,6 +37,7 @@
 #include "fault.h"
 #include <stdio.h>
 #include <string.h>
+#include "2s2h/BenPort.h"
 // extern FaultMgr gFaultMgr;
 
 #define PADMGR_RETRACE_MSG (1 << 0)
@@ -612,6 +613,7 @@ void PadMgr_HandleRetrace(void) {
     // Wait for controller data
     // osRecvMesg(serialEventQueue, NULL, OS_MESG_BLOCK);
     osContGetReadData(sPadMgrInstance->pads);
+    Controller_ApplyMouseInput(sPadMgrInstance->pads);
 
     // Clear all but controller 1
     memset(&sPadMgrInstance->pads[1], 0, sizeof(*sPadMgrInstance->pads) * (MAXCONTROLLERS - 1));


### PR DESCRIPTION
This injects the mouse delta as a gyro input, allowing the steam deck Gyro functionality to be used with our gyro functionality. Currently the window now captures the mouse unless the new modern menu is open. You would need to opt into this behavior.

The PR itself is hacky, I'd be interested in hearing what this may look like to get truly integrated into LUS cc @Archez @Kenix3 @briaguya-ai 


https://github.com/user-attachments/assets/74550a34-6d0a-4e5c-a644-8b25e76a1005



<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2297158169.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2297161946.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2297168662.zip)
<!--- section:artifacts:end -->