### PR TITLE
Add IgnoreActorMtx for interpolation and fix bunny hood + other interpolation issues

### DIFF
--- a/mm/2s2h/Enhancements/FrameInterpolation/FrameInterpolation.cpp
+++ b/mm/2s2h/Enhancements/FrameInterpolation/FrameInterpolation.cpp
@@ -194,6 +194,7 @@ Recording previous_recording;
 
 bool next_is_actor_pos_rot_matrix;
 bool has_inv_actor_mtx;
+bool ignore_inv_actor_mtx;
 MtxF inv_actor_mtx;
 size_t inv_actor_mtx_path_index;
 
@@ -494,6 +495,7 @@ void FrameInterpolation_RecordCloseChild(void) {
     if (has_inv_actor_mtx && current_path.size() == inv_actor_mtx_path_index) {
         has_inv_actor_mtx = false;
     }
+    ignore_inv_actor_mtx = false;
     current_path.pop_back();
 }
 
@@ -503,6 +505,10 @@ void FrameInterpolation_DontInterpolateCamera(void) {
 
 int FrameInterpolation_GetCameraEpoch(void) {
     return (int)camera_epoch;
+}
+
+void FrameInterpolation_IgnoreActorMtx() {
+    ignore_inv_actor_mtx = true;
 }
 
 void FrameInterpolation_RecordActorPosRotMatrix(void) {
@@ -590,7 +596,7 @@ void FrameInterpolation_RecordMatrixToMtx(Mtx* dest, char* file, s32 line) {
     if (!is_recording)
         return;
     auto& d = append(Op::MatrixToMtx).matrix_to_mtx = { dest };
-    if (has_inv_actor_mtx) {
+    if (has_inv_actor_mtx && !ignore_inv_actor_mtx) {
         d.has_adjusted = true;
         SkinMatrix_MtxFMtxFMult(&inv_actor_mtx, Matrix_GetCurrent(), &d.src);
     } else {

--- a/mm/2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h
+++ b/mm/2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h
@@ -26,6 +26,8 @@ void FrameInterpolation_DontInterpolateCamera(void);
 
 int FrameInterpolation_GetCameraEpoch(void);
 
+void FrameInterpolation_IgnoreActorMtx(void);
+
 void FrameInterpolation_RecordActorPosRotMatrix(void);
 
 void FrameInterpolation_RecordMatrixPush(void);

--- a/mm/src/code/z_player_lib.c
+++ b/mm/src/code/z_player_lib.c
@@ -46,6 +46,7 @@
 
 #include "2s2h/BenPort.h"
 #include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
 
 void PlayerCall_Init(Actor* thisx, PlayState* play);
 void PlayerCall_Destroy(Actor* thisx, PlayState* play);
@@ -3185,6 +3186,9 @@ void Player_DrawBunnyHood(PlayState* play) {
     Vec3s earRot;
 
     OPEN_DISPS(play->state.gfxCtx);
+
+    // Ignoring the players actor mtx allows the bunny hood to render interpolated without issues
+    FrameInterpolation_IgnoreActorMtx();
 
     gSPSegment(POLY_OPA_DISP++, 0x0B, mtx);
 


### PR DESCRIPTION
With our interpolation system, for each actor we track their starting matrix and then each child interpolation path applies matrix calculations against that matrix.

For whatever reason, bunny hood does not like this. So I've added a new method `FrameInterpolation_IgnoreActorMtx()` that allows us to specify for the current interpolation record child to skip using the actor matrix. Upon closing the record child, the flag will become unset. This fixes the bunny hood jumping with interpolation when changing links position abruptly.

I don't really understand what the actor matrix specific handling does, but I know removing it is not good as then link will look flat when changing 180º

Fixes #412

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2230257950.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2230258781.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2230263766.zip)
<!--- section:artifacts:end -->