### PR TITLE
Fix alpha on the edge of the telescope vignette

### DIFF
--- a/mm/src/code/z_fbdemo_circle.c
+++ b/mm/src/code/z_fbdemo_circle.c
@@ -120,11 +120,8 @@ void TransitionCircle_LoadAndSetTexture(Gfx** gfxp, TexturePtr texture, s32 fmt,
     }
 
     // #region 2S2H [Cosmetic] Adjust circle overlay to support widescreen
-    // The first wide rectangle instruction renders the tile information on the extra space on the left edge
-    // The second instruction renders the original overlay in the center and has it extend to the right edge
-    // gSPTextureRectangle(gfx++, 0, 0, xh << 2, yh << 2, G_TX_RENDERTILE, (s32)(s * (1 << 5)), (s32)(t * (1 << 5)),
-    // dsdx,
-    //                     dtdy);
+    // The first wide rectangle instruction renders the tile information on the extra space off the left edge
+    // The second instruction renders the original overlay in the center and has it extended to the right edge
     s32 x = OTRGetRectDimensionFromLeftEdge(0) << 2;
     if (x < 0) {
         // Only render if the screen is wider then original
@@ -152,6 +149,9 @@ void TransitionCircle_Draw(void* thisx, Gfx** gfxp) {
         gDPSetCombineLERP(gfx++, 0, 0, 0, PRIMITIVE, 1, TEXEL0, PRIM_LOD_FRAC, PRIMITIVE, 0, 0, 0, PRIMITIVE, 1, TEXEL0,
                           PRIM_LOD_FRAC, PRIMITIVE);
     }
+    // 2S2H [Port] We need to set the render mode to XLU_SURF for alpha logic to be used in Fast3D
+    // If Fast3D changes how it decides alpha in the future, we may be able to remove this line
+    gDPSetRenderMode(gfx++, G_RM_XLU_SURF, G_RM_XLU_SURF2);
     TransitionCircle_LoadAndSetTexture(&gfx, this->texture, G_IM_FMT_I, 0, this->masks, this->maskt,
                                        this->referenceRadius);
     gDPPipeSync(gfx++);


### PR DESCRIPTION
The telescope overlay uses a render mode that does not activate alpha logic in our Fast3D renderer currently.
Until we implement a fix in LUS for that, I'm adding a temporary work around that sets the render mode to `G_RM_XLU_SURF` so that the alpha on the edge of the overlay works correctly.

![Screenshot 2024-11-25 at 6 14 54 PM](https://github.com/user-attachments/assets/208b7e4e-7f59-4de4-893e-c572569c6a65)


<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2236255219.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2236259660.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2236260541.zip)
<!--- section:artifacts:end -->