### PR TITLE
Add extended culling handling for special actors

### DIFF
--- a/mm/2s2h/ShipUtils.cpp
+++ b/mm/2s2h/ShipUtils.cpp
@@ -3,13 +3,52 @@
 #include "assets/2s2h_assets.h"
 
 extern "C" {
+#include "z64.h"
+#include "functions.h"
 #include "macros.h"
+
+extern float OTRGetAspectRatio();
 
 extern f32 sNESFontWidths[160];
 extern const char* fontTbl[156];
 extern TexturePtr gItemIcons[131];
 extern TexturePtr gQuestIcons[14];
 extern TexturePtr gBombersNotebookPhotos[24];
+}
+
+constexpr f32 fourByThree = 4.0f / 3.0f;
+
+// Gets the additional ratio of the screen compared to the original 4:3 ratio, clamping to 1 if smaller
+extern "C" f32 Ship_GetExtendedAspectRatioMultiplier() {
+    f32 currentRatio = OTRGetAspectRatio();
+    return MAX(currentRatio / fourByThree, 1.0f);
+}
+
+// Enables Extended Culling options on specific actors by applying an inverse ratio of the draw distance slider
+// to the projected Z value of the actor. This tricks distance checks without having to replace hardcoded values.
+// Requires that Ship_ExtendedCullingActorRestoreProjectedPos is called within the same function scope.
+extern "C" void Ship_ExtendedCullingActorAdjustProjectedZ(Actor* actor) {
+    s32 multiplier = CVarGetInteger("gEnhancements.Graphics.IncreaseActorDrawDistance", 1);
+    multiplier = MAX(multiplier, 1);
+    if (multiplier > 1) {
+        actor->projectedPos.z /= multiplier;
+    }
+}
+
+// Enables Extended Culling options on specific actors by applying an inverse ratio of the widescreen aspect ratio
+// to the projected X value of the actor. This tricks distance checks without having to replace hardcoded values.
+// Requires that Ship_ExtendedCullingActorRestoreProjectedPos is called within the same function scope.
+extern "C" void Ship_ExtendedCullingActorAdjustProjectedX(Actor* actor) {
+    if (CVarGetInteger("gEnhancements.Graphics.ActorCullingAccountsForWidescreen", 0)) {
+        f32 ratioAdjusted = Ship_GetExtendedAspectRatioMultiplier();
+        actor->projectedPos.x /= ratioAdjusted;
+    }
+}
+
+// Restores the projectedPos values on the actor after modifications from the Extended Culling hacks
+extern "C" void Ship_ExtendedCullingActorRestoreProjectedPos(PlayState* play, Actor* actor) {
+    f32 invW = 0.0f;
+    Actor_GetProjectedPos(play, &actor->world.pos, &actor->projectedPos, &invW);
 }
 
 extern "C" bool Ship_IsCStringEmpty(const char* str) {

--- a/mm/2s2h/ShipUtils.h
+++ b/mm/2s2h/ShipUtils.h
@@ -3,6 +3,7 @@
 
 #include <libultraship/libultraship.h>
 #include "PR/ultratypes.h"
+#include "z64.h"
 
 #ifdef __cplusplus
 
@@ -10,6 +11,11 @@ void LoadGuiTextures();
 
 extern "C" {
 #endif
+
+f32 Ship_GetExtendedAspectRatioMultiplier();
+void Ship_ExtendedCullingActorAdjustProjectedZ(Actor* actor);
+void Ship_ExtendedCullingActorAdjustProjectedX(Actor* actor);
+void Ship_ExtendedCullingActorRestoreProjectedPos(PlayState* play, Actor* actor);
 
 bool Ship_IsCStringEmpty(const char* str);
 void Ship_CreateQuadVertexGroup(Vtx* vtxList, s32 xStart, s32 yStart, s32 width, s32 height, u8 flippedH);

--- a/mm/2s2h/ShipUtils.h
+++ b/mm/2s2h/ShipUtils.h
@@ -3,7 +3,6 @@
 
 #include <libultraship/libultraship.h>
 #include "PR/ultratypes.h"
-#include "z64.h"
 
 #ifdef __cplusplus
 
@@ -11,6 +10,9 @@ void LoadGuiTextures();
 
 extern "C" {
 #endif
+
+struct PlayState;
+struct Actor;
 
 f32 Ship_GetExtendedAspectRatioMultiplier();
 void Ship_ExtendedCullingActorAdjustProjectedZ(Actor* actor);

--- a/mm/include/functions.h
+++ b/mm/include/functions.h
@@ -1342,6 +1342,8 @@ void Flags_SetWeekEventReg(s32 flag);
 void Flags_ClearWeekEventReg(s32 flag);
 void Flags_SetEventInf(s32 flag);
 void Flags_ClearEventInf(s32 flag);
+s32 Ship_CalcShouldDrawAndUpdate(PlayState* play, Actor* actor, Vec3f* projectedPos, f32 projectedW, bool* shouldDraw,
+                                 bool* shouldUpdate);
 // #endregion
 // #region 2S2H [Port] Stubbed methods
 void osSetThreadPri(OSThread* thread, OSPri p);

--- a/mm/src/code/z_actor.c
+++ b/mm/src/code/z_actor.c
@@ -3100,7 +3100,7 @@ s32 Ship_CalcShouldDrawAndUpdate(PlayState* play, Actor* actor, Vec3f* projected
     // Apply distance scale to forward cullzone check
     bool isWithingForwardCullZone =
         (-actor->uncullZoneScale < projectedPos->z) &&
-        (projectedPos->z < ((actor->uncullZoneForward * multiplier) + actor->uncullZoneScale));
+        (projectedPos->z < ((actor->uncullZoneForward + actor->uncullZoneScale) * multiplier));
 
     if (isWithingForwardCullZone) {
         // Ensure the projected W value is at least 1.0

--- a/mm/src/code/z_actor.c
+++ b/mm/src/code/z_actor.c
@@ -24,6 +24,7 @@
 #include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/BenPort.h"
+#include "2s2h/ShipUtils.h"
 
 // bss
 // FaultClient sActorFaultClient; // 2 funcs
@@ -3094,18 +3095,18 @@ s32 Ship_CalcShouldDrawAndUpdate(PlayState* play, Actor* actor, Vec3f* projected
         return true;
     }
 
-    s32 multiplier = CVarGetInteger("gEnhancements.Graphics.IncreaseActorDrawDistance", 1);
-    multiplier = MAX(multiplier, 1);
+    s32 distMultiplier = CVarGetInteger("gEnhancements.Graphics.IncreaseActorDrawDistance", 1);
+    distMultiplier = MAX(distMultiplier, 1);
 
     // Apply distance scale to forward cullzone check
     bool isWithingForwardCullZone =
         (-actor->uncullZoneScale < projectedPos->z) &&
-        (projectedPos->z < ((actor->uncullZoneForward + actor->uncullZoneScale) * multiplier));
+        (projectedPos->z < ((actor->uncullZoneForward + actor->uncullZoneScale) * distMultiplier));
 
     if (isWithingForwardCullZone) {
         // Ensure the projected W value is at least 1.0
         f32 clampedProjectedW = CLAMP_MIN(projectedW, 1.0f);
-        f32 ratioAdjusted = 1.0f;
+        f32 aspectMultiplier = 1.0f;
         f32 uncullZoneScaleDiagonal;
         f32 uncullZoneScaleVertical;
         f32 uncullZoneDownwardAdjusted;
@@ -3124,14 +3125,12 @@ s32 Ship_CalcShouldDrawAndUpdate(PlayState* play, Actor* actor, Vec3f* projected
         }
 
         if (CVarGetInteger("gEnhancements.Graphics.ActorCullingAccountsForWidescreen", 0)) {
-            float originalAspectRatio = 4.0f / 3.0f;
-            float currentAspectRatio = OTRGetAspectRatio();
-            ratioAdjusted = MAX(currentAspectRatio / originalAspectRatio, 1.0f);
+            aspectMultiplier = Ship_GetExtendedAspectRatioMultiplier();
         }
 
         // Apply adjsuted aspect ratio to just the horizontal cullzone check
         bool isWithinHorizontalCullZone =
-            ((fabsf(projectedPos->x) - uncullZoneScaleDiagonal) < (clampedProjectedW * ratioAdjusted));
+            ((fabsf(projectedPos->x) - uncullZoneScaleDiagonal) < (clampedProjectedW * aspectMultiplier));
         bool isAboveBottomOfCullZone = ((-clampedProjectedW < (projectedPos->y + uncullZoneScaleVertical)));
         bool isBelowTopOfCullZone = ((projectedPos->y - uncullZoneDownwardAdjusted) < clampedProjectedW);
 

--- a/mm/src/overlays/actors/ovl_En_Ishi/z_en_ishi.c
+++ b/mm/src/overlays/actors/ovl_En_Ishi/z_en_ishi.c
@@ -12,6 +12,8 @@
 #include "objects/object_ishi/object_ishi.h"
 #include "overlays/actors/ovl_En_Insect/z_en_insect.h"
 
+#include "2s2h/ShipUtils.h"
+
 #define FLAGS (ACTOR_FLAG_10 | ACTOR_FLAG_800000)
 
 #define THIS ((EnIshi*)thisx)
@@ -704,6 +706,8 @@ void func_8095F210(EnIshi* this, PlayState* play) {
     s32 pad;
     s32 sp28;
 
+    Ship_ExtendedCullingActorAdjustProjectedZ(&this->actor);
+
     if ((this->actor.projectedPos.z <= 1200.0f) || ((this->unk_197 & 1) && (this->actor.projectedPos.z < 1300.0f))) {
         Gfx_DrawDListOpa(play, gameplay_field_keep_DL_0066B0);
         return;
@@ -722,12 +726,16 @@ void func_8095F210(EnIshi* this, PlayState* play) {
 
         CLOSE_DISPS(play->state.gfxCtx);
     }
+
+    Ship_ExtendedCullingActorRestoreProjectedPos(play, &this->actor);
 }
 
 void func_8095F36C(EnIshi* this, PlayState* play) {
     s32 pad;
 
     OPEN_DISPS(play->state.gfxCtx);
+
+    Ship_ExtendedCullingActorAdjustProjectedZ(&this->actor);
 
     if ((this->actor.projectedPos.z <= 2150.0f) || ((this->unk_197 & 1) && (this->actor.projectedPos.z < 2250.0f))) {
         this->actor.shape.shadowAlpha = 160;
@@ -752,6 +760,8 @@ void func_8095F36C(EnIshi* this, PlayState* play) {
     } else {
         this->actor.shape.shadowAlpha = 0;
     }
+
+    Ship_ExtendedCullingActorRestoreProjectedPos(play, &this->actor);
 
     CLOSE_DISPS(play->state.gfxCtx);
 }

--- a/mm/src/overlays/actors/ovl_En_Kusa/z_en_kusa.c
+++ b/mm/src/overlays/actors/ovl_En_Kusa/z_en_kusa.c
@@ -10,6 +10,8 @@
 #include "objects/gameplay_field_keep/gameplay_field_keep.h"
 #include "overlays/actors/ovl_En_Insect/z_en_insect.h"
 
+#include "2s2h/ShipUtils.h"
+
 #define FLAGS (ACTOR_FLAG_10 | ACTOR_FLAG_800000)
 
 #define THIS ((EnKusa*)thisx)
@@ -706,6 +708,8 @@ void EnKusa_DrawBush(Actor* thisx, PlayState* play2) {
     PlayState* play = play2;
     EnKusa* this = THIS;
 
+    Ship_ExtendedCullingActorAdjustProjectedZ(&this->actor);
+
     if ((this->actor.projectedPos.z <= 1200.0f) || ((this->isInWater & 1) && (this->actor.projectedPos.z < 1300.0f))) {
 
         if ((play->roomCtx.curRoom.behaviorType1 == ROOM_BEHAVIOR_TYPE1_0) &&
@@ -730,6 +734,8 @@ void EnKusa_DrawBush(Actor* thisx, PlayState* play2) {
 
         CLOSE_DISPS(play->state.gfxCtx);
     }
+
+    Ship_ExtendedCullingActorRestoreProjectedPos(play, &this->actor);
 }
 
 void EnKusa_DrawGrass(Actor* thisx, PlayState* play) {

--- a/mm/src/overlays/actors/ovl_En_Kusa2/z_en_kusa2.c
+++ b/mm/src/overlays/actors/ovl_En_Kusa2/z_en_kusa2.c
@@ -8,6 +8,8 @@
 #include "z_en_kusa2.h"
 #include "objects/gameplay_field_keep/gameplay_field_keep.h"
 #include "objects/gameplay_keep/gameplay_keep.h"
+
+#include "2s2h/ShipUtils.h"
 #include <string.h>
 
 #define FLAGS (ACTOR_FLAG_10 | ACTOR_FLAG_800000)
@@ -920,6 +922,9 @@ void func_80A5D618(EnKusa2* this) {
 }
 
 void func_80A5D62C(EnKusa2* this, PlayState* play) {
+    Ship_ExtendedCullingActorAdjustProjectedX(&this->actor);
+    Ship_ExtendedCullingActorAdjustProjectedZ(&this->actor);
+
     if (this->unk_1BE != 0) {
         func_80A5B490(this, play);
         func_80A5D754(this);
@@ -927,6 +932,8 @@ void func_80A5D62C(EnKusa2* this, PlayState* play) {
         func_80A5B160(this, play);
         func_80A5D6B0(this);
     }
+
+    Ship_ExtendedCullingActorRestoreProjectedPos(play, &this->actor);
 }
 
 void func_80A5D6B0(EnKusa2* this) {
@@ -935,6 +942,10 @@ void func_80A5D6B0(EnKusa2* this) {
 
 void func_80A5D6C4(EnKusa2* this, PlayState* play) {
     func_80A5B3BC(this);
+
+    Ship_ExtendedCullingActorAdjustProjectedX(&this->actor);
+    Ship_ExtendedCullingActorAdjustProjectedZ(&this->actor);
+
     if (this->unk_1BE != 0) {
         func_80A5B490(this, play);
         func_80A5D754(this);
@@ -942,6 +953,8 @@ void func_80A5D6C4(EnKusa2* this, PlayState* play) {
         func_80A5B334(this, play);
         func_80A5D618(this);
     }
+
+    Ship_ExtendedCullingActorRestoreProjectedPos(play, &this->actor);
 }
 
 void func_80A5D754(EnKusa2* this) {
@@ -1357,6 +1370,8 @@ void func_80A5E80C(PlayState* play, s32 arg1) {
 void EnKusa2_Draw(Actor* thisx, PlayState* play) {
     EnKusa2* this = THIS;
 
+    Ship_ExtendedCullingActorAdjustProjectedZ(&this->actor);
+
     if (this->actor.projectedPos.z <= 1200.0f) {
         if ((play->roomCtx.curRoom.behaviorType1 == ROOM_BEHAVIOR_TYPE1_0) && (this->actor.projectedPos.z > -150.0f) &&
             (this->actor.projectedPos.z < 400.0f)) {
@@ -1366,6 +1381,8 @@ void EnKusa2_Draw(Actor* thisx, PlayState* play) {
     } else if (this->actor.projectedPos.z < 1300.0f) {
         func_80A5E80C(play, (1300.0f - this->actor.projectedPos.z) * 2.55f);
     }
+
+    Ship_ExtendedCullingActorRestoreProjectedPos(play, &this->actor);
 }
 
 void func_80A5E9B4(Actor* thisx, PlayState* play) {

--- a/mm/src/overlays/actors/ovl_En_Wood02/z_en_wood02.c
+++ b/mm/src/overlays/actors/ovl_En_Wood02/z_en_wood02.c
@@ -103,6 +103,15 @@ s32 EnWood02_SpawnZoneCheck(EnWood02* this, PlayState* play, Vec3f* arg2) {
 
     SkinMatrix_Vec3fMtxFMultXYZW(&play->viewProjectionMtxF, arg2, &this->actor.projectedPos, &this->actor.projectedW);
 
+    // 2S2H [Enhancement] Use the extended culling calculation
+    if (CVarGetInteger("gEnhancements.Graphics.IncreaseActorDrawDistance", 1) > 1 ||
+        CVarGetInteger("gEnhancements.Graphics.ActorCullingAccountsForWidescreen", 0)) {
+        bool shipShouldDraw = false;
+        bool shipShouldUpdate = false;
+        return Ship_CalcShouldDrawAndUpdate(play, &this->actor, &this->actor.projectedPos, this->actor.projectedW,
+                                            &shipShouldDraw, &shipShouldUpdate);
+    }
+
     if (this->actor.projectedW == 0.0f) {
         phi_f12 = 1000.0f;
     } else {

--- a/mm/src/overlays/actors/ovl_Obj_Bombiwa/z_obj_bombiwa.c
+++ b/mm/src/overlays/actors/ovl_Obj_Bombiwa/z_obj_bombiwa.c
@@ -453,16 +453,19 @@ void func_8093A418(Actor* thisx, PlayState* play) {
     ObjBombiwa* this = THIS;
     f32 sp28;
 
-    if ((this->actor.projectedPos.z <= 2200.0f) || ((this->unk_203 & 1) && (this->actor.projectedPos.z < 2300.0f))) {
+    s32 multiplier = CVarGetInteger("gEnhancements.Graphics.IncreaseActorDrawDistance", 1);
+    multiplier = MAX(multiplier, 1);
+
+    if ((this->actor.projectedPos.z <= (2200.0f * multiplier)) || ((this->unk_203 & 1) && (this->actor.projectedPos.z < (2300.0f * multiplier)))) {
         this->actor.shape.shadowAlpha = 160;
         Gfx_DrawDListOpa(play, object_bombiwa_DL_0009E0);
         return;
     }
 
-    if (this->actor.projectedPos.z < 2300.0f) {
+    if (this->actor.projectedPos.z < (2300.0f * multiplier)) {
         OPEN_DISPS(play->state.gfxCtx);
 
-        sp28 = (2300.0f - this->actor.projectedPos.z) * 2.55f;
+        sp28 = ((2300.0f * multiplier) - this->actor.projectedPos.z) * 2.55f / multiplier;
 
         this->actor.shape.shadowAlpha = sp28 * (32.0f / 51);
         Gfx_SetupDL25_Xlu(play->state.gfxCtx);
@@ -486,9 +489,12 @@ void func_8093A608(Actor* thisx, PlayState* play) {
 
     OPEN_DISPS(play->state.gfxCtx);
 
+    s32 multiplier = CVarGetInteger("gEnhancements.Graphics.IncreaseActorDrawDistance", 1);
+    multiplier = MAX(multiplier, 1);
+
     if (this->actionFunc == func_80939EF4) {
-        if ((this->actor.projectedPos.z <= 2200.0f) ||
-            ((this->unk_203 & 1) && (this->actor.projectedPos.z < 2300.0f))) {
+        if ((this->actor.projectedPos.z <= (2200.0f * multiplier)) ||
+            ((this->unk_203 & 1) && (this->actor.projectedPos.z < (2300.0f * multiplier)))) {
             Gfx_SetupDL25_Opa(play->state.gfxCtx);
 
             gSPSegment(POLY_OPA_DISP++, 0x08, D_801AEFA0);
@@ -500,8 +506,8 @@ void func_8093A608(Actor* thisx, PlayState* play) {
 
             gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(play->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
             gSPDisplayList(POLY_XLU_DISP++, object_bombiwa_DL_004688);
-        } else if (this->actor.projectedPos.z < 2300.0f) {
-            sp38 = (2300.0f - this->actor.projectedPos.z) * 2.55f;
+        } else if (this->actor.projectedPos.z < (2300.0f * multiplier)) {
+            sp38 = ((2300.0f * multiplier) - this->actor.projectedPos.z) * 2.55f / multiplier;
             Gfx_SetupDL25_Xlu(play->state.gfxCtx);
 
             gSPSegment(POLY_XLU_DISP++, 0x08, D_801AEF88);

--- a/mm/src/overlays/actors/ovl_Obj_Bombiwa/z_obj_bombiwa.c
+++ b/mm/src/overlays/actors/ovl_Obj_Bombiwa/z_obj_bombiwa.c
@@ -7,6 +7,8 @@
 #include "z_obj_bombiwa.h"
 #include "objects/object_bombiwa/object_bombiwa.h"
 
+#include "2s2h/ShipUtils.h"
+
 #define FLAGS 0x00000000
 
 #define THIS ((ObjBombiwa*)thisx)
@@ -453,19 +455,18 @@ void func_8093A418(Actor* thisx, PlayState* play) {
     ObjBombiwa* this = THIS;
     f32 sp28;
 
-    s32 multiplier = CVarGetInteger("gEnhancements.Graphics.IncreaseActorDrawDistance", 1);
-    multiplier = MAX(multiplier, 1);
+    Ship_ExtendedCullingActorAdjustProjectedZ(&this->actor);
 
-    if ((this->actor.projectedPos.z <= (2200.0f * multiplier)) || ((this->unk_203 & 1) && (this->actor.projectedPos.z < (2300.0f * multiplier)))) {
+    if ((this->actor.projectedPos.z <= 2200.0f) || ((this->unk_203 & 1) && (this->actor.projectedPos.z < 2300.0f))) {
         this->actor.shape.shadowAlpha = 160;
         Gfx_DrawDListOpa(play, object_bombiwa_DL_0009E0);
         return;
     }
 
-    if (this->actor.projectedPos.z < (2300.0f * multiplier)) {
+    if (this->actor.projectedPos.z < 2300.0f) {
         OPEN_DISPS(play->state.gfxCtx);
 
-        sp28 = ((2300.0f * multiplier) - this->actor.projectedPos.z) * 2.55f / multiplier;
+        sp28 = (2300.0f - this->actor.projectedPos.z) * 2.55f;
 
         this->actor.shape.shadowAlpha = sp28 * (32.0f / 51);
         Gfx_SetupDL25_Xlu(play->state.gfxCtx);
@@ -478,6 +479,8 @@ void func_8093A418(Actor* thisx, PlayState* play) {
     } else {
         this->actor.shape.shadowAlpha = 0;
     }
+
+    Ship_ExtendedCullingActorRestoreProjectedPos(play, &this->actor);
 }
 
 void func_8093A608(Actor* thisx, PlayState* play) {
@@ -489,12 +492,11 @@ void func_8093A608(Actor* thisx, PlayState* play) {
 
     OPEN_DISPS(play->state.gfxCtx);
 
-    s32 multiplier = CVarGetInteger("gEnhancements.Graphics.IncreaseActorDrawDistance", 1);
-    multiplier = MAX(multiplier, 1);
+    Ship_ExtendedCullingActorAdjustProjectedZ(&this->actor);
 
     if (this->actionFunc == func_80939EF4) {
-        if ((this->actor.projectedPos.z <= (2200.0f * multiplier)) ||
-            ((this->unk_203 & 1) && (this->actor.projectedPos.z < (2300.0f * multiplier)))) {
+        if ((this->actor.projectedPos.z <= 2200.0f) ||
+            ((this->unk_203 & 1) && (this->actor.projectedPos.z < 2300.0f))) {
             Gfx_SetupDL25_Opa(play->state.gfxCtx);
 
             gSPSegment(POLY_OPA_DISP++, 0x08, D_801AEFA0);
@@ -506,8 +508,8 @@ void func_8093A608(Actor* thisx, PlayState* play) {
 
             gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(play->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
             gSPDisplayList(POLY_XLU_DISP++, object_bombiwa_DL_004688);
-        } else if (this->actor.projectedPos.z < (2300.0f * multiplier)) {
-            sp38 = ((2300.0f * multiplier) - this->actor.projectedPos.z) * 2.55f / multiplier;
+        } else if (this->actor.projectedPos.z < 2300.0f) {
+            sp38 = (2300.0f - this->actor.projectedPos.z) * 2.55f;
             Gfx_SetupDL25_Xlu(play->state.gfxCtx);
 
             gSPSegment(POLY_XLU_DISP++, 0x08, D_801AEF88);
@@ -531,6 +533,8 @@ void func_8093A608(Actor* thisx, PlayState* play) {
             }
         }
     }
+
+    Ship_ExtendedCullingActorRestoreProjectedPos(play, &this->actor);
 
     CLOSE_DISPS(play->state.gfxCtx);
 }

--- a/mm/src/overlays/actors/ovl_Obj_Grass/z_obj_grass.c
+++ b/mm/src/overlays/actors/ovl_Obj_Grass/z_obj_grass.c
@@ -10,6 +10,8 @@
 #include "z_obj_grass.h"
 #include "overlays/actors/ovl_Obj_Grass_Carry/z_obj_grass_carry.h"
 #include "objects/gameplay_keep/gameplay_keep.h"
+
+#include "2s2h/ShipUtils.h"
 #include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
 
 #define FLAGS (ACTOR_FLAG_10 | ACTOR_FLAG_20)
@@ -75,16 +77,26 @@ s32 func_809A9110(PlayState* play, Vec3f* pos) {
 
     SkinMatrix_Vec3fMtxFMultXYZW(&play->viewProjectionMtxF, pos, &projectedPos, &w);
 
-    if ((play->projectionMtxFDiagonal.z * -130.13191f) < projectedPos.z) {
+    // #region 2S2H [Enhancement] Extended Culling handling for grass unit drawing
+    s32 distMultiplier = CVarGetInteger("gEnhancements.Graphics.IncreaseActorDrawDistance", 1);
+    distMultiplier = MAX(distMultiplier, 1);
+
+    f32 aspectMultiplier = 1.0f;
+    if (CVarGetInteger("gEnhancements.Graphics.ActorCullingAccountsForWidescreen", 0)) {
+        aspectMultiplier = Ship_GetExtendedAspectRatioMultiplier();
+    }
+
+    if ((play->projectionMtxFDiagonal.z * -130.13191f * distMultiplier) < projectedPos.z) {
         if (w < 1.0f) {
             w = 1.0f;
         }
 
-        if (((fabsf(projectedPos.x) - (130.13191f * play->projectionMtxFDiagonal.x)) < w) &&
+        if (((fabsf(projectedPos.x) - (130.13191f * play->projectionMtxFDiagonal.x)) < (w * aspectMultiplier)) &&
             ((fabsf(projectedPos.y) - (130.13191f * play->projectionMtxFDiagonal.y)) < w)) {
             return true;
         }
     }
+    // #endregion
     return false;
 }
 
@@ -402,10 +414,16 @@ void ObjGrass_InitDraw(ObjGrass* this, PlayState* play) {
     f32 distSq;
     f32 eyeDist;
 
+    // 2S2H [Enhancement] Extended Culling handling
+    // Recompute the eyeDist and distSq values below with the inverse distance multiplier to trick the checks
+    s32 multiplier = CVarGetInteger("gEnhancements.Graphics.IncreaseActorDrawDistance", 1);
+    multiplier = MAX(multiplier, 1);
+
     for (i = 0; i < this->activeGrassGroups; i++) {
         grassGroup = &this->grassGroups[i];
 
         eyeDist = Math3D_Vec3fDistSq(&grassGroup->homePos, &GET_ACTIVE_CAM(play)->eye);
+        eyeDist = SQ(sqrtf(eyeDist) / multiplier); // Hijacked
 
         if ((eyeDist < SQ(1280.0f)) && func_809A9110(play, &grassGroup->homePos)) {
             grassGroup->flags |= OBJ_GRASS_GROUP_DRAW;
@@ -422,6 +440,7 @@ void ObjGrass_InitDraw(ObjGrass* this, PlayState* play) {
                         grassElem->alpha = 255;
                     } else {
                         distSq = Math3D_Vec3fDistSq(&grassElem->pos, &GET_ACTIVE_CAM(play)->eye);
+                        distSq = SQ(sqrtf(distSq) / multiplier); // Hijacked
                         if ((distSq <= SQ(1080.0f)) ||
                             ((grassElem->flags & OBJ_GRASS_ELEM_UNDERWATER) && (distSq < SQ(1180.0f)))) {
                             grassElem->alpha = 255;

--- a/mm/src/overlays/actors/ovl_Obj_Hamishi/z_obj_hamishi.c
+++ b/mm/src/overlays/actors/ovl_Obj_Hamishi/z_obj_hamishi.c
@@ -7,6 +7,8 @@
 #include "z_obj_hamishi.h"
 #include "objects/gameplay_field_keep/gameplay_field_keep.h"
 
+#include "2s2h/ShipUtils.h"
+
 #define FLAGS (ACTOR_FLAG_10)
 
 #define THIS ((ObjHamishi*)thisx)
@@ -265,10 +267,7 @@ void ObjHamishi_Draw(Actor* thisx, PlayState* play) {
 
     OPEN_DISPS(play->state.gfxCtx);
 
-    f32 origProjZ = thisx->projectedPos.z;
-    s32 multiplier = CVarGetInteger("gEnhancements.Graphics.IncreaseActorDrawDistance", 1);
-    multiplier = MAX(multiplier, 1);
-    thisx->projectedPos.z /= multiplier;
+    Ship_ExtendedCullingActorAdjustProjectedZ(&this->actor);
 
     if ((thisx->projectedPos.z <= 2150.0f) || ((this->unk_1A2 & 1) && (thisx->projectedPos.z < 2250.0f))) {
         thisx->shape.shadowAlpha = 160;
@@ -292,7 +291,7 @@ void ObjHamishi_Draw(Actor* thisx, PlayState* play) {
         thisx->shape.shadowAlpha = 0;
     }
 
-    thisx->projectedPos.z = origProjZ;
+    Ship_ExtendedCullingActorRestoreProjectedPos(play, &this->actor);
 
     CLOSE_DISPS(play->state.gfxCtx);
 }

--- a/mm/src/overlays/actors/ovl_Obj_Hamishi/z_obj_hamishi.c
+++ b/mm/src/overlays/actors/ovl_Obj_Hamishi/z_obj_hamishi.c
@@ -265,6 +265,11 @@ void ObjHamishi_Draw(Actor* thisx, PlayState* play) {
 
     OPEN_DISPS(play->state.gfxCtx);
 
+    f32 origProjZ = thisx->projectedPos.z;
+    s32 multiplier = CVarGetInteger("gEnhancements.Graphics.IncreaseActorDrawDistance", 1);
+    multiplier = MAX(multiplier, 1);
+    thisx->projectedPos.z /= multiplier;
+
     if ((thisx->projectedPos.z <= 2150.0f) || ((this->unk_1A2 & 1) && (thisx->projectedPos.z < 2250.0f))) {
         thisx->shape.shadowAlpha = 160;
         Gfx_SetupDL25_Opa(play->state.gfxCtx);
@@ -286,6 +291,8 @@ void ObjHamishi_Draw(Actor* thisx, PlayState* play) {
     } else {
         thisx->shape.shadowAlpha = 0;
     }
+
+    thisx->projectedPos.z = origProjZ;
 
     CLOSE_DISPS(play->state.gfxCtx);
 }

--- a/mm/src/overlays/actors/ovl_Obj_Mure/z_obj_mure.c
+++ b/mm/src/overlays/actors/ovl_Obj_Mure/z_obj_mure.c
@@ -10,6 +10,8 @@
 #include "overlays/actors/ovl_En_Insect/z_en_insect.h"
 #include "overlays/actors/ovl_En_Kusa/z_en_kusa.h"
 
+#include "2s2h/ShipUtils.h"
+
 #define FLAGS 0x00000000
 
 #define THIS ((ObjMure*)thisx)
@@ -273,11 +275,15 @@ void ObjMure_InitialAction(ObjMure* this, PlayState* play) {
 }
 
 void ObjMure_CulledState(ObjMure* this, PlayState* play) {
+    Ship_ExtendedCullingActorAdjustProjectedZ(&this->actor);
+
     if (fabsf(this->actor.projectedPos.z) < sZClip[this->type]) {
         this->actionFunc = ObjMure_ActiveState;
         this->actor.flags |= ACTOR_FLAG_10;
         ObjMure_SpawnActors(this, play);
     }
+
+    Ship_ExtendedCullingActorRestoreProjectedPos(play, &this->actor);
 }
 
 void ObjMure_SetFollowTargets(ObjMure* this, f32 randMax) {
@@ -395,6 +401,8 @@ static ObjMureActionFunc sTypeGroupBehaviorFunc[] = {
 };
 
 void ObjMure_ActiveState(ObjMure* this, PlayState* play) {
+    Ship_ExtendedCullingActorAdjustProjectedZ(&this->actor);
+
     ObjMure_CheckChildren(this, play);
     if ((sZClip[this->type] + 40.0f) <= fabsf(this->actor.projectedPos.z)) {
         this->actionFunc = ObjMure_CulledState;
@@ -403,6 +411,8 @@ void ObjMure_ActiveState(ObjMure* this, PlayState* play) {
     } else if (sTypeGroupBehaviorFunc[this->type] != NULL) {
         sTypeGroupBehaviorFunc[this->type](this, play);
     }
+
+    Ship_ExtendedCullingActorRestoreProjectedPos(play, &this->actor);
 }
 
 void ObjMure_Update(Actor* thisx, PlayState* play) {

--- a/mm/src/overlays/actors/ovl_Obj_Mure2/z_obj_mure2.c
+++ b/mm/src/overlays/actors/ovl_Obj_Mure2/z_obj_mure2.c
@@ -6,6 +6,8 @@
 
 #include "z_obj_mure2.h"
 
+#include "2s2h/ShipUtils.h"
+
 #define FLAGS 0x00000000
 
 #define THIS ((ObjMure2*)thisx)
@@ -213,12 +215,17 @@ void func_809613E8(ObjMure2* this) {
 }
 
 void func_809613FC(ObjMure2* this, PlayState* play) {
+    Ship_ExtendedCullingActorAdjustProjectedX(&this->actor);
+    Ship_ExtendedCullingActorAdjustProjectedZ(&this->actor);
+
     if (Math3D_Dist1DSq(this->actor.projectedPos.x, this->actor.projectedPos.z) <
         D_80961590[this->actor.params & 3] * this->unk_17C) {
         this->actor.flags |= 0x10;
         func_8096104C(this, play);
         func_8096147C(this);
     }
+
+    Ship_ExtendedCullingActorRestoreProjectedPos(play, &this->actor);
 }
 
 void func_8096147C(ObjMure2* this) {
@@ -227,12 +234,18 @@ void func_8096147C(ObjMure2* this) {
 
 void func_80961490(ObjMure2* this, PlayState* play) {
     ObjMure2_ClearChildrenList(this);
+
+    Ship_ExtendedCullingActorAdjustProjectedX(&this->actor);
+    Ship_ExtendedCullingActorAdjustProjectedZ(&this->actor);
+
     if ((D_8096159C[this->actor.params & 3] * this->unk_17C) <=
         Math3D_Dist1DSq(this->actor.projectedPos.x, this->actor.projectedPos.z)) {
         this->actor.flags &= ~0x10;
         func_809611BC(this, play);
         func_809613E8(this);
     }
+
+    Ship_ExtendedCullingActorRestoreProjectedPos(play, &this->actor);
 }
 
 void ObjMure2_Update(Actor* thisx, PlayState* play) {


### PR DESCRIPTION
Applies extended culling rules to various actors that implement their own culling/fading logic.

This includes the following:
* Grass units (the groups in Termina field etc)
* Keaton grass
* Liftable rocks and silver boulders
* Bronze boulder
* Bombable boulder
* Rock circles
* Butterfly/insect spawners

This works by creating and using the following methods: `Ship_ExtendedCullingActorAdjustProjectedZ`, `Ship_ExtendedCullingActorAdjustProjectedX`, and `Ship_ExtendedCullingActorRestoreProjectedPos`, which temporarily modify the actor project pos values so that we can "trick" specific distance checks to account for widescreen/far distance without having to directly modify a bunch of src lines of code.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2300430268.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2300437830.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2300455014.zip)
<!--- section:artifacts:end -->