### PR TITLE
[Enhancement] Persist entrance and respawn information in saves

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1036,14 +1036,17 @@ void BenMenu::AddEnhancements() {
             "Re-introduce the pause menu save system. Pressing B in the pause menu will give you the "
             "option to create a persistent Owl Save from your current location.\n\nWhen loading back "
             "into the game, you will be placed either at the entrance of the dungeon you saved in, or "
-            "in South Clock Town."));
+            "in South Clock Town, unless Remember Save Location is enabled."));
+    AddWidget(path, "Remember Save Location", WIDGET_CVAR_CHECKBOX)
+        .CVar("gEnhancements.Saving.RememberSaveLocation")
+        .Options(CheckboxOptions().Tooltip("When loading a save, places Link at the last entrance he went through."));
     AddWidget(path, "Autosave", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Saving.Autosave")
         .Callback([](WidgetInfo& info) { RegisterAutosave(); })
         .Options(CheckboxOptions().Tooltip(
             "Automatically create a persistent Owl Save on the chosen interval.\n\nWhen loading "
             "back into the game, you will be placed either at the entrance of the dungeon you "
-            "saved in, or in South Clock Town."));
+            "saved in, or in South Clock Town, unless Remember Save Location is enabled."));
     AddWidget(path, "Autosave Interval: %d minutes", WIDGET_CVAR_SLIDER_INT)
         .CVar("gEnhancements.Saving.AutosaveInterval")
         .PreFunc([](WidgetInfo& info) {

--- a/mm/2s2h/BenJsonConversions.hpp
+++ b/mm/2s2h/BenJsonConversions.hpp
@@ -76,6 +76,46 @@ void from_json(const json& j, RandoSaveInfo& rando) {
     j.at("foundTriforcePieces").get_to(rando.foundTriforcePieces);
 }
 
+void to_json(json& j, const Vec3f& vec) {
+    j = json{
+        { "x", vec.x },
+        { "y", vec.y },
+        { "z", vec.z },
+    };
+}
+
+void from_json(const json& j, Vec3f& vec) {
+    j.at("x").get_to(vec.x);
+    j.at("y").get_to(vec.y);
+    j.at("z").get_to(vec.z);
+}
+
+void to_json(json& j, const RespawnData& respawnData) {
+    j = json{
+        { "pos", respawnData.pos },
+        { "yaw", respawnData.yaw },
+        { "playerParams", respawnData.playerParams },
+        { "entrance", respawnData.entrance },
+        { "roomIndex", respawnData.roomIndex },
+        { "data", respawnData.data },
+        { "tempSwitchFlags", respawnData.tempSwitchFlags },
+        { "unk_18", respawnData.unk_18 },
+        { "tempCollectFlags", respawnData.tempCollectFlags },
+    };
+}
+
+void from_json(const json& j, RespawnData& respawnData) {
+    j.at("pos").get_to(respawnData.pos);
+    j.at("yaw").get_to(respawnData.yaw);
+    j.at("playerParams").get_to(respawnData.playerParams);
+    j.at("entrance").get_to(respawnData.entrance);
+    j.at("roomIndex").get_to(respawnData.roomIndex);
+    j.at("data").get_to(respawnData.data);
+    j.at("tempSwitchFlags").get_to(respawnData.tempSwitchFlags);
+    j.at("unk_18").get_to(respawnData.unk_18);
+    j.at("tempCollectFlags").get_to(respawnData.tempCollectFlags);
+}
+
 void to_json(json& j, const ShipSaveInfo& shipSaveInfo) {
     uint8_t commitHash[8];
     memcpy(commitHash, shipSaveInfo.commitHash, sizeof(commitHash));
@@ -87,6 +127,7 @@ void to_json(json& j, const ShipSaveInfo& shipSaveInfo) {
         { "fileCreatedAt", shipSaveInfo.fileCreatedAt },
         { "fileCompletedAt", shipSaveInfo.fileCompletedAt },
         { "filePlaytime", shipSaveInfo.filePlaytime },
+        { "respawn", shipSaveInfo.respawn },
         { "commitHash", commitHash },
     };
 
@@ -102,6 +143,7 @@ void from_json(const json& j, ShipSaveInfo& shipSaveInfo) {
     j.at("fileCreatedAt").get_to(shipSaveInfo.fileCreatedAt);
     j.at("fileCompletedAt").get_to(shipSaveInfo.fileCompletedAt);
     j.at("filePlaytime").get_to(shipSaveInfo.filePlaytime);
+    j.at("respawn").get_to(shipSaveInfo.respawn);
     j.at("commitHash").get_to(shipSaveInfo.commitHash);
 
     if (shipSaveInfo.saveType == SAVETYPE_RANDO) {

--- a/mm/2s2h/Enhancements/Saving/SavingEnhancements.cpp
+++ b/mm/2s2h/Enhancements/Saving/SavingEnhancements.cpp
@@ -14,31 +14,41 @@ static uint64_t lastSaveTimestamp = GetUnixTimestamp();
 
 static HOOK_ID autosaveGameStateUpdateHookId = 0;
 static HOOK_ID autosaveGameStateDrawFinishHookId = 0;
+static HOOK_ID skipEntranceCutsceneHookId = 0;
+static HOOK_ID killSkipEntranceCutsceneHookId = 0;
 
 // Used for saving through Autosaves and Pause Menu saves.
 extern "C" int SavingEnhancements_GetSaveEntrance() {
-    switch (gPlayState->sceneId) {
-        // Woodfall Temple + Odolwa
-        case SCENE_MITURIN:
-        case SCENE_MITURIN_BS:
-            return ENTRANCE(WOODFALL_TEMPLE, 0);
-        // Snowhead Temple + Goht
-        case SCENE_HAKUGIN:
-        case SCENE_HAKUGIN_BS:
-            return ENTRANCE(SNOWHEAD_TEMPLE, 0);
-        // Great Bay Temple + Gyorg
-        case SCENE_SEA:
-        case SCENE_SEA_BS:
-            return ENTRANCE(GREAT_BAY_TEMPLE, 0);
-        // Stone Tower Temple
-        case SCENE_INISIE_N:
-            return ENTRANCE(STONE_TOWER_TEMPLE, 0);
-        // Stone Tower Temple (inverted) + Twinmold
-        case SCENE_INISIE_R:
-        case SCENE_INISIE_BS:
-            return ENTRANCE(STONE_TOWER_TEMPLE_INVERTED, 0);
-        default:
-            return ENTRANCE(SOUTH_CLOCK_TOWN, 0);
+    if (CVarGetInteger("gEnhancements.Saving.RememberSaveLocation", 0)) {
+        // Maintain respawn information, used for grottos
+        for (int i = 0; i < RESPAWN_MODE_MAX; i++) {
+            gSaveContext.save.shipSaveInfo.respawn[i] = gSaveContext.respawn[i];
+        }
+        return gSaveContext.save.entrance;
+    } else {
+        switch (gPlayState->sceneId) {
+            // Woodfall Temple + Odolwa
+            case SCENE_MITURIN:
+            case SCENE_MITURIN_BS:
+                return ENTRANCE(WOODFALL_TEMPLE, 0);
+            // Snowhead Temple + Goht
+            case SCENE_HAKUGIN:
+            case SCENE_HAKUGIN_BS:
+                return ENTRANCE(SNOWHEAD_TEMPLE, 0);
+            // Great Bay Temple + Gyorg
+            case SCENE_SEA:
+            case SCENE_SEA_BS:
+                return ENTRANCE(GREAT_BAY_TEMPLE, 0);
+            // Stone Tower Temple
+            case SCENE_INISIE_N:
+                return ENTRANCE(STONE_TOWER_TEMPLE, 0);
+            // Stone Tower Temple (inverted) + Twinmold
+            case SCENE_INISIE_R:
+            case SCENE_INISIE_BS:
+                return ENTRANCE(STONE_TOWER_TEMPLE, 0);
+            default:
+                return ENTRANCE(SOUTH_CLOCK_TOWN, 0);
+        }
     }
 }
 
@@ -158,6 +168,53 @@ void HandleAutoSave() {
     }
 }
 
+/*
+ * This respawn data is used for multiple things. Beyond the obvious usage for handling player respawns, this structure
+ * also maintains state information when entering shared grottos. This code executes from OnSaveLoad, which runs after
+ * save data is populated. This must run after that, otherwise the RESPAWN_MODE_DOWN entrance would get set to
+ * ENTR_LOAD_OPENING, which in turn would lead to a crash if the save is within a grotto and the player dies before
+ * leaving.
+ */
+void loadRespawnData(s16 fileNum) {
+    for (int i = 0; i < RESPAWN_MODE_MAX; i++) {
+        gSaveContext.respawn[i] = gSaveContext.save.shipSaveInfo.respawn[i];
+    }
+}
+
+/*
+ * Upon loading a save, skip any cutscenes that would play if the save is from a cutscene entrance (e.g. owl warps, Link
+ * bowing at Mikau's grave, etc.). An OnPassPlayerInputs hook is then used to unregister the entrance cutscene skip
+ * hook so that subsequent cutscenes are not also skipped.
+ */
+void skipEntranceCutsceneOnLoad(s16 fileNum) {
+    if (!killSkipEntranceCutsceneHookId) {
+        // Create hook to kill cutscene hook once player assumes control
+        killSkipEntranceCutsceneHookId =
+            GameInteractor::Instance->RegisterGameHook<GameInteractor::OnPassPlayerInputs>([](Input* input) {
+                // We have reached gameplay. The cutscene skip hook must not be used anymore, so kill it.
+                if (skipEntranceCutsceneHookId) {
+                    GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::ShouldVanillaBehavior>(
+                        skipEntranceCutsceneHookId);
+                    skipEntranceCutsceneHookId = 0;
+                }
+                // And now kill the kill hook itself since it does not need to run more than once.
+                GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnPassPlayerInputs>(
+                    killSkipEntranceCutsceneHookId);
+                killSkipEntranceCutsceneHookId = 0;
+            });
+    }
+
+    // If there is a cutscene upon load (i.e. entrance cutscene), just skip it
+    if (!skipEntranceCutsceneHookId) {
+        skipEntranceCutsceneHookId = REGISTER_VB_SHOULD(VB_START_CUTSCENE, {
+            // Only skip normal cutscenes
+            if (gSaveContext.gameMode == GAMEMODE_NORMAL && gPlayState->sceneId != SCENE_SPOT00) {
+                *should = false;
+            }
+        });
+    }
+}
+
 void RegisterSavingEnhancements() {
     REGISTER_VB_SHOULD(VB_DELETE_OWL_SAVE, {
         if (CVarGetInteger("gEnhancements.Saving.PersistentOwlSaves", 0) ||
@@ -191,6 +248,10 @@ void RegisterSavingEnhancements() {
     });
 
     GameInteractor::Instance->RegisterGameHook<GameInteractor::BeforeMoonCrashSaveReset>([]() { DeleteOwlSave(); });
+
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSaveLoad>(loadRespawnData);
+
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSaveLoad>(skipEntranceCutsceneOnLoad);
 }
 
 void RegisterAutosave() {

--- a/mm/2s2h/Enhancements/Saving/SavingEnhancements.cpp
+++ b/mm/2s2h/Enhancements/Saving/SavingEnhancements.cpp
@@ -1,6 +1,7 @@
 #include <libultraship/bridge/consolevariablebridge.h>
 #include "BenPort.h"
 #include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/ShipInit.hpp"
 
 extern "C" {
 #include <variables.h>
@@ -14,8 +15,8 @@ static uint32_t autosaveInterval = 0;
 static uint32_t iconTimer = 0;
 static uint64_t currentTimestamp = 0;
 static uint64_t lastSaveTimestamp = GetUnixTimestamp();
-static uint32_t lastEntrance = -1;
-static uint32_t entranceToSave = -1;
+static int lastEntrance = -1;
+static int entranceToSave = -1;
 
 static HOOK_ID autosaveGameStateUpdateHookId = 0;
 static HOOK_ID autosaveGameStateDrawFinishHookId = 0;
@@ -234,19 +235,6 @@ void RegisterSavingEnhancements() {
         }
     });
 
-    COND_VB_SHOULD(VB_PLAY_TRANSITION_CS, CVAR_REMEMBER_SAVE_LOCATION, {
-        /*
-         * Update the entrance to save, unless we're leaving a grotto. Grottos exit to entrance 0 of the destination
-         * scene and adjust the position manually. In effect, there is no real entrance to target for loading purposes,
-         * so we just load into the last grotto instead under those circumstances.
-         */
-        if (lastEntrance != -1 && !(Entrance_GetSceneIdAbsolute(gSaveContext.save.entrance) != SCENE_KAKUSIANA &&
-                                    Entrance_GetSceneIdAbsolute(lastEntrance) == SCENE_KAKUSIANA)) {
-            entranceToSave = gSaveContext.save.entrance;
-        }
-        lastEntrance = gSaveContext.save.entrance;
-    });
-
     COND_HOOK(OnSaveLoad, true, [](s16 fileNum) {
         if (gSaveContext.save.shipSaveInfo.fileCreatedAt == 0) {
             gSaveContext.save.shipSaveInfo.fileCreatedAt = GetUnixTimestamp();
@@ -275,8 +263,6 @@ void RegisterSavingEnhancements() {
     GameInteractor::Instance->RegisterGameHook<GameInteractor::BeforeMoonCrashSaveReset>([]() { DeleteOwlSave(); });
 
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSaveLoad>(loadRespawnData);
-
-    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSaveLoad>(skipEntranceCutsceneOnLoad);
 }
 
 void RegisterAutosave() {
@@ -311,3 +297,22 @@ void RegisterAutosave() {
             });
     }
 }
+
+void RegisterRememberSaveLocation() {
+    COND_VB_SHOULD(VB_PLAY_TRANSITION_CS, CVAR_REMEMBER_SAVE_LOCATION, {
+        /*
+         * Update the entrance to save, unless we're leaving a grotto. Grottos exit to entrance 0 of the destination
+         * scene and adjust the position manually. In effect, there is no real entrance to target for loading purposes,
+         * so we just load into the last grotto instead under those circumstances.
+         */
+        if (lastEntrance != -1 && !(Entrance_GetSceneIdAbsolute(gSaveContext.save.entrance) != SCENE_KAKUSIANA &&
+                                    Entrance_GetSceneIdAbsolute(lastEntrance) == SCENE_KAKUSIANA)) {
+            entranceToSave = gSaveContext.save.entrance;
+        }
+        lastEntrance = gSaveContext.save.entrance;
+    });
+
+    COND_HOOK(OnSaveLoad, CVAR_REMEMBER_SAVE_LOCATION, skipEntranceCutsceneOnLoad);
+}
+
+static RegisterShipInitFunc initFunc(RegisterRememberSaveLocation, { CVAR_REMEMBER_SAVE_LOCATION_NAME });

--- a/mm/2s2h/Enhancements/Saving/SavingEnhancements.cpp
+++ b/mm/2s2h/Enhancements/Saving/SavingEnhancements.cpp
@@ -7,10 +7,15 @@ extern "C" {
 #include <functions.h>
 }
 
+#define CVAR_REMEMBER_SAVE_LOCATION_NAME "gEnhancements.Saving.RememberSaveLocation"
+#define CVAR_REMEMBER_SAVE_LOCATION CVarGetInteger(CVAR_REMEMBER_SAVE_LOCATION_NAME, 0)
+
 static uint32_t autosaveInterval = 0;
 static uint32_t iconTimer = 0;
 static uint64_t currentTimestamp = 0;
 static uint64_t lastSaveTimestamp = GetUnixTimestamp();
+static uint32_t lastEntrance = -1;
+static uint32_t entranceToSave = -1;
 
 static HOOK_ID autosaveGameStateUpdateHookId = 0;
 static HOOK_ID autosaveGameStateDrawFinishHookId = 0;
@@ -19,12 +24,12 @@ static HOOK_ID gameplayStartHookId = 0;
 
 // Used for saving through Autosaves and Pause Menu saves.
 extern "C" int SavingEnhancements_GetSaveEntrance() {
-    if (CVarGetInteger("gEnhancements.Saving.RememberSaveLocation", 0)) {
+    if (CVAR_REMEMBER_SAVE_LOCATION) {
         // Maintain respawn information, used for grottos
         for (int i = 0; i < RESPAWN_MODE_MAX; i++) {
             gSaveContext.save.shipSaveInfo.respawn[i] = gSaveContext.respawn[i];
         }
-        return gSaveContext.save.entrance;
+        return entranceToSave;
     } else {
         switch (gPlayState->sceneId) {
             // Woodfall Temple + Odolwa
@@ -229,11 +234,25 @@ void RegisterSavingEnhancements() {
         }
     });
 
+    COND_VB_SHOULD(VB_PLAY_TRANSITION_CS, CVAR_REMEMBER_SAVE_LOCATION, {
+        /*
+         * Update the entrance to save, unless we're leaving a grotto. Grottos exit to entrance 0 of the destination
+         * scene and adjust the position manually. In effect, there is no real entrance to target for loading purposes,
+         * so we just load into the last grotto instead under those circumstances.
+         */
+        if (lastEntrance != -1 && !(Entrance_GetSceneIdAbsolute(gSaveContext.save.entrance) != SCENE_KAKUSIANA &&
+                                    Entrance_GetSceneIdAbsolute(lastEntrance) == SCENE_KAKUSIANA)) {
+            entranceToSave = gSaveContext.save.entrance;
+        }
+        lastEntrance = gSaveContext.save.entrance;
+    });
+
     COND_HOOK(OnSaveLoad, true, [](s16 fileNum) {
         if (gSaveContext.save.shipSaveInfo.fileCreatedAt == 0) {
             gSaveContext.save.shipSaveInfo.fileCreatedAt = GetUnixTimestamp();
         }
         gSaveContext.shipSaveContext.lastTimeLog = GetUnixTimestamp();
+        lastEntrance = entranceToSave = gSaveContext.save.shipSaveInfo.pauseSaveEntrance;
     });
 
     // Owl statue prompt

--- a/mm/2s2h/Enhancements/Saving/SavingEnhancements.cpp
+++ b/mm/2s2h/Enhancements/Saving/SavingEnhancements.cpp
@@ -15,7 +15,7 @@ static uint64_t lastSaveTimestamp = GetUnixTimestamp();
 static HOOK_ID autosaveGameStateUpdateHookId = 0;
 static HOOK_ID autosaveGameStateDrawFinishHookId = 0;
 static HOOK_ID skipEntranceCutsceneHookId = 0;
-static HOOK_ID killSkipEntranceCutsceneHookId = 0;
+static HOOK_ID gameplayStartHookId = 0;
 
 // Used for saving through Autosaves and Pause Menu saves.
 extern "C" int SavingEnhancements_GetSaveEntrance() {
@@ -45,7 +45,7 @@ extern "C" int SavingEnhancements_GetSaveEntrance() {
             // Stone Tower Temple (inverted) + Twinmold
             case SCENE_INISIE_R:
             case SCENE_INISIE_BS:
-                return ENTRANCE(STONE_TOWER_TEMPLE, 0);
+                return ENTRANCE(STONE_TOWER_TEMPLE_INVERTED, 0);
             default:
                 return ENTRANCE(SOUTH_CLOCK_TOWN, 0);
         }
@@ -183,36 +183,42 @@ void loadRespawnData(s16 fileNum) {
 
 /*
  * Upon loading a save, skip any cutscenes that would play if the save is from a cutscene entrance (e.g. owl warps, Link
- * bowing at Mikau's grave, etc.). An OnPassPlayerInputs hook is then used to unregister the entrance cutscene skip
- * hook so that subsequent cutscenes are not also skipped.
+ * bowing at Mikau's grave, etc.). An OnPassPlayerInputs hook is used to detect when gameplay actually starts (any
+ * entrance cutscenes are done), at which point the cutscene skip hook is unregistered. This handles any potential cases
+ * where multiple cutscenes play in succession.
  */
-void skipEntranceCutsceneOnLoad(s16 fileNum) {
-    if (!killSkipEntranceCutsceneHookId) {
-        // Create hook to kill cutscene hook once player assumes control
-        killSkipEntranceCutsceneHookId =
-            GameInteractor::Instance->RegisterGameHook<GameInteractor::OnPassPlayerInputs>([](Input* input) {
-                // We have reached gameplay. The cutscene skip hook must not be used anymore, so kill it.
-                if (skipEntranceCutsceneHookId) {
-                    GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::ShouldVanillaBehavior>(
-                        skipEntranceCutsceneHookId);
-                    skipEntranceCutsceneHookId = 0;
-                }
-                // And now kill the kill hook itself since it does not need to run more than once.
-                GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnPassPlayerInputs>(
-                    killSkipEntranceCutsceneHookId);
-                killSkipEntranceCutsceneHookId = 0;
-            });
+static void UnregisterEntranceCutsceneSkip() {
+    if (skipEntranceCutsceneHookId) {
+        GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::ShouldVanillaBehavior>(
+            skipEntranceCutsceneHookId);
+        skipEntranceCutsceneHookId = 0;
     }
 
-    // If there is a cutscene upon load (i.e. entrance cutscene), just skip it
-    if (!skipEntranceCutsceneHookId) {
-        skipEntranceCutsceneHookId = REGISTER_VB_SHOULD(VB_START_CUTSCENE, {
-            // Only skip normal cutscenes
-            if (gSaveContext.gameMode == GAMEMODE_NORMAL && gPlayState->sceneId != SCENE_SPOT00) {
-                *should = false;
-            }
-        });
+    if (gameplayStartHookId) {
+        GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnPassPlayerInputs>(gameplayStartHookId);
+        gameplayStartHookId = 0;
     }
+}
+
+void skipEntranceCutsceneOnLoad(s16 fileNum) {
+    // Clean up any existing hooks first
+    UnregisterEntranceCutsceneSkip();
+    // Register hook to skip entrance cutscenes - may skip multiple if they chain
+    skipEntranceCutsceneHookId = REGISTER_VB_SHOULD(VB_START_CUTSCENE, {
+        // Only skip normal cutscenes
+        if (gSaveContext.gameMode == GAMEMODE_NORMAL && gPlayState != nullptr && gPlayState->sceneId != SCENE_SPOT00) {
+            *should = false;
+        }
+    });
+
+    // Register hook to detect when gameplay starts (all cutscenes done)
+    // OnPassPlayerInputs only fires during normal gameplay, not during cutscenes
+    gameplayStartHookId =
+        GameInteractor::Instance->RegisterGameHook<GameInteractor::OnPassPlayerInputs>([](Input* input) {
+            // Gameplay has started; any entrance cutscenes are done
+            // Now unregister both hooks so normal cutscenes can play
+            UnregisterEntranceCutsceneSkip();
+        });
 }
 
 void RegisterSavingEnhancements() {

--- a/mm/2s2h/SaveManager/Migrations/7.cpp
+++ b/mm/2s2h/SaveManager/Migrations/7.cpp
@@ -1,8 +1,31 @@
 #include "2s2h/SaveManager/SaveManager.h"
 #include "z64.h"
 
+// Add respawn and playtime info to saves
 void SaveManager_Migration_7(nlohmann::json& j) {
     if (!j["save"]["shipSaveInfo"].contains("filePlaytime")) {
         j["save"]["shipSaveInfo"]["filePlaytime"] = 0;
+    }
+    if (!j["save"]["shipSaveInfo"].contains("respawn")) {
+        j["save"]["shipSaveInfo"]["respawn"] = {};
+    }
+
+    for (int i = 0; i < RESPAWN_MODE_MAX; i++) {
+        j["save"]["shipSaveInfo"]["respawn"][i] = {
+            { "pos",
+              {
+                  { "x", 0.0 },
+                  { "y", 0.0 },
+                  { "z", 0.0 },
+              } },
+            { "yaw", 0 },
+            { "playerParams", 0 },
+            { "entrance", 0 },
+            { "roomIndex", 0 },
+            { "data", 0 },
+            { "tempSwitchFlags", 0 },
+            { "unk_18", 0 },
+            { "tempCollectFlags", 0 },
+        };
     }
 }

--- a/mm/include/z64save.h
+++ b/mm/include/z64save.h
@@ -399,6 +399,7 @@ typedef struct ShipSaveInfo {
     uint64_t fileCreatedAt;
     uint64_t fileCompletedAt;
     uint64_t filePlaytime;
+    RespawnData respawn[RESPAWN_MODE_MAX];
     char commitHash[8];
     RandoSaveInfo rando;
 } ShipSaveInfo;


### PR DESCRIPTION
Pause saves almost already worked well enough, but shared grottos and cutscene entrances made that a no-go. This PR addresses those hurdles.

- Add `RespawnData` to `ShipSaveInfo`, using it to persist `gSaveContext.respawn`. This affects multiple things. The most obvious is that it maintains respawn information, i.e. where a player will reload if they die. Less obvious is that this data is also used to handle shared grotto scenes, their chest contents, and their exit destinations. Persisting this allows pause saves to work from within grottos.
- To ensure that *only* a possible entrance cutscene gets skipped on load, I used `OnPassPlayerInputs` as the entry point for unregistering the entrance cutscene skip hook. This seemed like the best existing hook to say "the player has assumed control, so don't skip any more cutscenes now". I tested various combinations of loading an entrance cutscene save and trying other cutscenes, as well as loading a non-entrance cutscene save and trying other cutscenes. This seems to work as I intended.
- Add "Remember Save Location" setting that affects whether `SavingEnhancements_GetSaveEntrance` works as it did before (Clock Town, dungeon entrances) or uses the immediate last entrance.
- Added migration for old saves that do not have respawn information

This has worked remarkably well from testing, both via resets and cold boots. However, there are hundreds of entrances in the game, so I welcome any additional eyes on this.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4675473476.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4675585254.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4676219685.zip)
<!--- section:artifacts:end -->