### PR TITLE
Handle Great Bay Coast for pause warp with index warp

### DIFF
--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -770,8 +770,12 @@ void DrawEnhancementsMenu() {
             UIWidgets::CVarCheckbox("Skip Scarecrow Song", "gEnhancements.Playback.SkipScarecrowSong",
                                     { .tooltip = "Pierre appears when the Ocarina is pulled out." });
             UIWidgets::CVarCheckbox("Pause Owl Warp", "gEnhancements.Songs.PauseOwlWarp",
-                                    { .tooltip = "Allows the player to use the pause menu map to owl warp instead of "
-                                                 "having to play the Song of Soaring." });
+                                    { .tooltip =
+                                          "Allows warping to registered Owl Statues from the pause menu map screen. "
+                                          "Requires that you can play Song of Soaring normally.\n\n"
+                                          "Accounts for Index-Warp being active, by presenting all valid warps for "
+                                          "the registered map points. "
+                                          "Great Bay Coast warp is always given for index 0 warp as a convenience." });
             UIWidgets::CVarSliderInt("Zora Eggs For Bossa Nova", "gEnhancements.Songs.ZoraEggCount", 1, 7, 7,
                                      { .tooltip = "The number of eggs required to unlock new wave bossa nova." });
 

--- a/mm/2s2h/BenGui/SearchableMenuItems.h
+++ b/mm/2s2h/BenGui/SearchableMenuItems.h
@@ -1295,8 +1295,10 @@ void AddEnhancements() {
               { "Dpad Ocarina", "gEnhancements.Playback.DpadOcarina", "Enables using the Dpad for Ocarina playback.",
                 WIDGET_CVAR_CHECKBOX },
               { "Pause Owl Warp", "gEnhancements.Songs.PauseOwlWarp",
-                "Allows the player to use the pause menu map to owl warp instead of "
-                "having to play the Song of Soaring.",
+                "Allows warping to registered Owl Statues from the pause menu map screen. "
+                "Requires that you can play Song of Soaring normally.\n\n"
+                "Accounts for Index-Warp being active, by presenting all valid warps for the registered map points. "
+                "Great Bay Coast warp is always given for index 0 warp as a convenience.",
                 WIDGET_CVAR_CHECKBOX },
               { "Zora Eggs For Bossa Nova",
                 "gEnhancements.Songs.ZoraEggCount",

--- a/mm/2s2h/Enhancements/Songs/PauseOwlWarp.cpp
+++ b/mm/2s2h/Enhancements/Songs/PauseOwlWarp.cpp
@@ -157,6 +157,10 @@ void HandlePauseOwlWarp(PauseContext* pauseCtx) {
                 pauseCtx->worldMapPoints[i] = true;
             }
         }
+
+        // Always set Great Bay since that is accessible from the "default index" for index warp
+        // when loading from a save/scene change and never touching the pause map screen
+        pauseCtx->worldMapPoints[OWL_WARP_GREAT_BAY_COAST] = true;
     }
 
     // Ensure cursor starts at an activated point and is not on the broken stone tower region point


### PR DESCRIPTION
When using Index-Warp, after loading from a save or a scene change, the pause cursor for the pause menu defaults to an index of 0, which correlates to the "Great Bay Coast". This means that it is free to be able to warp to Great Bay with Index-Warp active.

This PR makes the pause owl warp feature just give the Greay Bay Coast warp point for free as a convenience, and updates the wording of the enhancement tooltip to explain the Index-Warp behavior better.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2314363285.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2314364796.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2314373611.zip)
<!--- section:artifacts:end -->