### PR TITLE
[Enhancement]: Add File Slot 3

### DIFF
--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -504,6 +504,9 @@ void DrawEnhancementsMenu() {
         if (UIWidgets::BeginMenu("Saving / Time Cycle")) {
 
             ImGui::SeparatorText("Saving");
+            UIWidgets::CVarCheckbox(
+                "3rd Save File Slot", "gEnhancements.Saving.FileSlot3",
+                { .tooltip = "Adds a 3rd file slot that can be used for saves", .defaultValue = true });
             UIWidgets::CVarCheckbox("Persistent Owl Saves", "gEnhancements.Saving.PersistentOwlSaves",
                                     { .tooltip = "Continuing a save will not remove the owl save. Playing Song of "
                                                  "Time, allowing the moon to crash or finishing the "

--- a/mm/2s2h/BenGui/SearchableMenuItems.h
+++ b/mm/2s2h/BenGui/SearchableMenuItems.h
@@ -1147,6 +1147,11 @@ void AddEnhancements() {
                   { 1, 16, 16 } },
             },
             { { .widgetName = "Saving", .widgetType = WIDGET_SEPARATOR_TEXT },
+              { "3rd Save File Slot",
+                "gEnhancements.Saving.FileSlot3",
+                "Adds a 3rd file slot that can be used for saves",
+                WIDGET_CVAR_CHECKBOX,
+                { .defaultVariant = true } },
               { "Persistent Owl Saves", "gEnhancements.Saving.PersistentOwlSaves",
                 "Continuing a save will not remove the owl save. Playing Song of "
                 "Time, allowing the moon to crash or finishing the "

--- a/mm/2s2h/Enhancements/Saving/FileSlot3.cpp
+++ b/mm/2s2h/Enhancements/Saving/FileSlot3.cpp
@@ -1,0 +1,21 @@
+#include <libultraship/libultraship.h>
+#include "2s2h/ShipInit.hpp"
+
+extern "C" {
+#include "src/overlays/gamestates/ovl_file_choose/z_file_select.h"
+
+extern FileSelectState* gFileSelectState;
+}
+
+#define CVAR_NAME "gEnhancements.Saving.FileSlot3"
+#define CVAR CVarGetInteger(CVAR_NAME, true)
+
+void RegisterFileSlot3() {
+    // Reset the file select state to reload the save metadata
+    if (gFileSelectState != NULL) {
+        STOP_GAMESTATE(&gFileSelectState->state);
+        SET_NEXT_GAMESTATE(&gFileSelectState->state, FileSelect_Init, sizeof(FileSelectState));
+    }
+}
+
+static RegisterShipInitFunc initFunc(RegisterFileSlot3, { CVAR_NAME });

--- a/mm/2s2h/SaveManager/BinarySaveConverter.cpp
+++ b/mm/2s2h/SaveManager/BinarySaveConverter.cpp
@@ -722,12 +722,15 @@ bool BinarySaveConverter_HandleFileDropped(std::string filePath) {
 
         SaveManager_WriteSaveFile(fileName, j);
 
+        // Reset the file select state to reload the save metadata
         if (gFileSelectState != NULL) {
-            func_801457CC(&gFileSelectState->state, &gFileSelectState->sramCtx);
-            if (gFileSelectState->menuMode == FS_MENU_MODE_CONFIG && gFileSelectState->configMode == CM_MAIN_MENU) {
-                gFileSelectState->configMode = CM_FADE_IN_START;
-            }
+            STOP_GAMESTATE(&gFileSelectState->state);
+            SET_NEXT_GAMESTATE(&gFileSelectState->state, FileSelect_Init, sizeof(FileSelectState));
         }
+
+        SPDLOG_INFO("Successfully imported save into slot {}", saveSlot);
+        auto gui = Ship::Context::GetInstance()->GetWindow()->GetGui();
+        gui->GetGameOverlay()->TextDrawNotification(30.0f, true, "Successfully imported save into slot %d", saveSlot);
 
         return true;
     } catch (std::exception& e) {

--- a/mm/2s2h/SaveManager/SaveManager.cpp
+++ b/mm/2s2h/SaveManager/SaveManager.cpp
@@ -274,12 +274,15 @@ bool SaveManager_HandleFileDropped(std::string filePath) {
 
         SaveManager_WriteSaveFile(fileName, j);
 
+        // Reset the file select state to reload the save metadata
         if (gFileSelectState != NULL) {
-            func_801457CC(&gFileSelectState->state, &gFileSelectState->sramCtx);
-            if (gFileSelectState->menuMode == FS_MENU_MODE_CONFIG && gFileSelectState->configMode == CM_MAIN_MENU) {
-                gFileSelectState->configMode = CM_FADE_IN_START;
-            }
+            STOP_GAMESTATE(&gFileSelectState->state);
+            SET_NEXT_GAMESTATE(&gFileSelectState->state, FileSelect_Init, sizeof(FileSelectState));
         }
+
+        SPDLOG_INFO("Successfully imported save into slot {}", saveSlot);
+        auto gui = Ship::Context::GetInstance()->GetWindow()->GetGui();
+        gui->GetGameOverlay()->TextDrawNotification(30.0f, true, "Successfully imported save into slot %d", saveSlot);
 
         return true;
     } catch (std::exception& e) {

--- a/mm/2s2h/SaveManager/SaveManager.cpp
+++ b/mm/2s2h/SaveManager/SaveManager.cpp
@@ -169,6 +169,11 @@ int SaveManager_GetOpenFileSlot() {
         return 2;
     }
 
+    fileName = "file3.json";
+    if (!std::filesystem::exists(savesFolderPath / fileName)) {
+        return 3;
+    }
+
     return -1;
 }
 
@@ -199,18 +204,38 @@ std::string SaveManager_GetFileNameFromFlashSave(FlashSave flashSave) {
         return "global.json";
     }
 
-    bool isBackup = flashSave == FLASH_SAVE_FILE_1_NEW_CYCLE_SAVE_BACKUP ||
-                    flashSave == FLASH_SAVE_FILE_2_NEW_CYCLE_SAVE_BACKUP ||
-                    flashSave == FLASH_SAVE_FILE_1_OWL_SAVE_BACKUP || flashSave == FLASH_SAVE_FILE_2_OWL_SAVE_BACKUP;
+    bool isBackup =
+        flashSave == FLASH_SAVE_FILE_1_NEW_CYCLE_SAVE_BACKUP || flashSave == FLASH_SAVE_FILE_1_OWL_SAVE_BACKUP ||
+        flashSave == FLASH_SAVE_FILE_2_NEW_CYCLE_SAVE_BACKUP || flashSave == FLASH_SAVE_FILE_2_OWL_SAVE_BACKUP ||
+        flashSave == FLASH_SAVE_FILE_3_NEW_CYCLE_SAVE_BACKUP || flashSave == FLASH_SAVE_FILE_3_OWL_SAVE_BACKUP;
 
-    int fileNum =
-        (flashSave == FLASH_SAVE_FILE_1_NEW_CYCLE_SAVE_BACKUP || flashSave == FLASH_SAVE_FILE_1_NEW_CYCLE_SAVE ||
-         flashSave == FLASH_SAVE_FILE_1_OWL_SAVE_BACKUP || flashSave == FLASH_SAVE_FILE_1_OWL_SAVE)
-            ? 1
-            : 2;
+    int fileNum = -1;
+    switch (flashSave) {
+        case FLASH_SAVE_FILE_1_NEW_CYCLE_SAVE:
+        case FLASH_SAVE_FILE_1_NEW_CYCLE_SAVE_BACKUP:
+        case FLASH_SAVE_FILE_1_OWL_SAVE:
+        case FLASH_SAVE_FILE_1_OWL_SAVE_BACKUP:
+            fileNum = 1;
+            break;
+        case FLASH_SAVE_FILE_2_NEW_CYCLE_SAVE:
+        case FLASH_SAVE_FILE_2_NEW_CYCLE_SAVE_BACKUP:
+        case FLASH_SAVE_FILE_2_OWL_SAVE:
+        case FLASH_SAVE_FILE_2_OWL_SAVE_BACKUP:
+            fileNum = 2;
+            break;
+        case FLASH_SAVE_FILE_3_NEW_CYCLE_SAVE:
+        case FLASH_SAVE_FILE_3_NEW_CYCLE_SAVE_BACKUP:
+        case FLASH_SAVE_FILE_3_OWL_SAVE:
+        case FLASH_SAVE_FILE_3_OWL_SAVE_BACKUP:
+            fileNum = 3;
+            break;
+        default:
+            break;
+    }
 
-    bool isOwlSave = (flashSave == FLASH_SAVE_FILE_1_OWL_SAVE || flashSave == FLASH_SAVE_FILE_1_OWL_SAVE_BACKUP ||
-                      flashSave == FLASH_SAVE_FILE_2_OWL_SAVE || flashSave == FLASH_SAVE_FILE_2_OWL_SAVE_BACKUP);
+    bool isOwlSave = flashSave == FLASH_SAVE_FILE_1_OWL_SAVE || flashSave == FLASH_SAVE_FILE_1_OWL_SAVE_BACKUP ||
+                     flashSave == FLASH_SAVE_FILE_2_OWL_SAVE || flashSave == FLASH_SAVE_FILE_2_OWL_SAVE_BACKUP ||
+                     flashSave == FLASH_SAVE_FILE_3_OWL_SAVE || flashSave == FLASH_SAVE_FILE_3_OWL_SAVE_BACKUP;
 
     return "file" + std::to_string(fileNum) + (isBackup ? "backup" : "") + ".json";
 }
@@ -292,7 +317,8 @@ extern "C" void SaveManager_SysFlashrom_WriteData(u8* saveBuffer, u32 pageNum, u
     // saved together. We replicate that here by running the save again on the matching backup slot.
     // Note: This is not accounting for the sram header writing a disk backup. It does not feel important to do so.
     // If we ever feel like we want a global save backup, then we just need to add it to this condition.
-    if ((flashSave == FLASH_SAVE_FILE_1_NEW_CYCLE_SAVE || flashSave == FLASH_SAVE_FILE_2_NEW_CYCLE_SAVE) &&
+    if ((flashSave == FLASH_SAVE_FILE_1_NEW_CYCLE_SAVE || flashSave == FLASH_SAVE_FILE_2_NEW_CYCLE_SAVE ||
+         flashSave == FLASH_SAVE_FILE_3_NEW_CYCLE_SAVE) &&
         pageCount == (u32)gFlashSpecialSaveNumPages[flashSave]) {
         SaveManager_SysFlashrom_WriteData(saveBuffer, gFlashSaveStartPages[flashSave + 1],
                                           gFlashSaveNumPages[flashSave + 1]);
@@ -301,10 +327,12 @@ extern "C" void SaveManager_SysFlashrom_WriteData(u8* saveBuffer, u32 pageNum, u
     switch (flashSave) {
         case FLASH_SAVE_FILE_1_NEW_CYCLE_SAVE_BACKUP:
         case FLASH_SAVE_FILE_2_NEW_CYCLE_SAVE_BACKUP:
+        case FLASH_SAVE_FILE_3_NEW_CYCLE_SAVE_BACKUP:
             isBackup = true;
             // fallthrough
         case FLASH_SAVE_FILE_1_NEW_CYCLE_SAVE:
-        case FLASH_SAVE_FILE_2_NEW_CYCLE_SAVE: {
+        case FLASH_SAVE_FILE_2_NEW_CYCLE_SAVE:
+        case FLASH_SAVE_FILE_3_NEW_CYCLE_SAVE: {
             Save save;
             memcpy(&save, saveBuffer, sizeof(Save));
 
@@ -340,10 +368,12 @@ extern "C" void SaveManager_SysFlashrom_WriteData(u8* saveBuffer, u32 pageNum, u
         }
         case FLASH_SAVE_FILE_1_OWL_SAVE_BACKUP:
         case FLASH_SAVE_FILE_2_OWL_SAVE_BACKUP:
+        case FLASH_SAVE_FILE_3_OWL_SAVE_BACKUP:
             isBackup = true;
             // fallthrough
         case FLASH_SAVE_FILE_1_OWL_SAVE:
-        case FLASH_SAVE_FILE_2_OWL_SAVE: {
+        case FLASH_SAVE_FILE_2_OWL_SAVE:
+        case FLASH_SAVE_FILE_3_OWL_SAVE: {
             SaveContext saveContext;
             memcpy(&saveContext, saveBuffer, offsetof(SaveContext, fileNum));
 
@@ -423,8 +453,9 @@ extern "C" s32 SaveManager_SysFlashrom_ReadData(void* saveBuffer, u32 pageNum, u
         }
     }
 
-    bool isOwlSave = (flashSave == FLASH_SAVE_FILE_1_OWL_SAVE || flashSave == FLASH_SAVE_FILE_1_OWL_SAVE_BACKUP ||
-                      flashSave == FLASH_SAVE_FILE_2_OWL_SAVE || flashSave == FLASH_SAVE_FILE_2_OWL_SAVE_BACKUP);
+    bool isOwlSave = flashSave == FLASH_SAVE_FILE_1_OWL_SAVE || flashSave == FLASH_SAVE_FILE_1_OWL_SAVE_BACKUP ||
+                     flashSave == FLASH_SAVE_FILE_2_OWL_SAVE || flashSave == FLASH_SAVE_FILE_2_OWL_SAVE_BACKUP ||
+                     flashSave == FLASH_SAVE_FILE_3_OWL_SAVE || flashSave == FLASH_SAVE_FILE_3_OWL_SAVE_BACKUP;
 
     nlohmann::json j;
     int result = SaveManager_ReadSaveFile(fileName, j);

--- a/mm/include/z64save.h
+++ b/mm/include/z64save.h
@@ -35,29 +35,37 @@ typedef enum RespawnMode {
 #define SAVE_BUFFER_SIZE 0x4000
 #define SAVE_BUFFER_SIZE_HALF (SAVE_BUFFER_SIZE / 2)
 
+// 2S2H [Enhancement] Extended for file 3 support
 typedef enum FileNum {
     /* 0 */ FILE_NUM_1,
     /* 1 */ FILE_NUM_2,
-    /* 2 */ FILE_NUM_MAX,
-    /* 2 */ FILE_NUM_1_OWL_SAVE = FILE_NUM_MAX,
-    /* 3 */ FILE_NUM_2_OWL_SAVE,
-    /* 4 */ FILE_NUM_MAX_WITH_OWL_SAVE,
+    /* 2 */ FILE_NUM_3,
+    /* 3 */ FILE_NUM_MAX,
+    /* 3 */ FILE_NUM_1_OWL_SAVE = FILE_NUM_MAX,
+    /* 4 */ FILE_NUM_2_OWL_SAVE,
+    /* 5 */ FILE_NUM_3_OWL_SAVE,
+    /* 6 */ FILE_NUM_MAX_WITH_OWL_SAVE,
 } FileNum;
 
 #define FILE_NUM_OWL_SAVE_OFFSET FILE_NUM_1_OWL_SAVE
 
+// 2S2H [Enhancement] Extended for file 3 support
 typedef enum FlashSave {
     /*  0 */ FLASH_SAVE_FILE_1_NEW_CYCLE_SAVE,
     /*  1 */ FLASH_SAVE_FILE_1_NEW_CYCLE_SAVE_BACKUP,
     /*  2 */ FLASH_SAVE_FILE_2_NEW_CYCLE_SAVE,
     /*  3 */ FLASH_SAVE_FILE_2_NEW_CYCLE_SAVE_BACKUP,
-    /*  4 */ FLASH_SAVE_FILE_1_OWL_SAVE,
-    /*  5 */ FLASH_SAVE_FILE_1_OWL_SAVE_BACKUP,
-    /*  6 */ FLASH_SAVE_FILE_2_OWL_SAVE,
-    /*  7 */ FLASH_SAVE_FILE_2_OWL_SAVE_BACKUP,
-    /*  8 */ FLASH_SAVE_SRAM_HEADER,
-    /*  9 */ FLASH_SAVE_SRAM_HEADER_BACKUP,
-    /* 10 */ FLASH_SAVE_MAX,
+    /*  4 */ FLASH_SAVE_FILE_3_NEW_CYCLE_SAVE,
+    /*  5 */ FLASH_SAVE_FILE_3_NEW_CYCLE_SAVE_BACKUP,
+    /*  6 */ FLASH_SAVE_FILE_1_OWL_SAVE,
+    /*  7 */ FLASH_SAVE_FILE_1_OWL_SAVE_BACKUP,
+    /*  8 */ FLASH_SAVE_FILE_2_OWL_SAVE,
+    /*  9 */ FLASH_SAVE_FILE_2_OWL_SAVE_BACKUP,
+    /* 10 */ FLASH_SAVE_FILE_3_OWL_SAVE,
+    /* 11 */ FLASH_SAVE_FILE_3_OWL_SAVE_BACKUP,
+    /* 12 */ FLASH_SAVE_SRAM_HEADER,
+    /* 13 */ FLASH_SAVE_SRAM_HEADER_BACKUP,
+    /* 14 */ FLASH_SAVE_MAX,
 } FlashSave;
 
 #define FLASH_SAVE_MAIN_MULTIPLIER 2

--- a/mm/src/code/z_sram_NES.c
+++ b/mm/src/code/z_sram_NES.c
@@ -304,43 +304,58 @@ u8 gAmmoItems[ITEM_NUM_SLOTS] = {
 };
 
 // Stores flash start page number
+// 2S2H [Enhancement] Extended for file 3 support
 s32 gFlashSaveStartPages[] = {
     0,     // File 1 New Cycle Save
     0x40,  // File 1 New Cycle Save Backup
     0x80,  // File 2 New Cycle Save
     0xC0,  // File 2 New Cycle Save Backup
+    0x400, // File 3 New Cycle Save
+    0x440, // File 3 New Cycle Save Backup
     0x100, // File 1 Owl Save
     0x180, // File 1 Owl Save Backup
     0x200, // File 2 Owl Save
     0x280, // File 2 Owl Save Backup
+    0x480, // File 3 Owl Save
+    0x500, // File 3 Owl Save Backup
     0x300, // Sram Header (SaveOptions)
     0x380, // Sram Header Backup (SaveOptions)
 };
 
 // Flash rom number of pages
+// 2S2H [Enhancement] Extended for file 3 support
 s32 gFlashSaveNumPages[] = {
     0x40, // File 1 New Cycle Save
     0x40, // File 1 New Cycle Save Backup
     0x40, // File 2 New Cycle Save
     0x40, // File 2 New Cycle Save Backup
+    0x40, // File 3 New Cycle Save
+    0x40, // File 3 New Cycle Save Backup
     0x80, // File 1 Owl Save
     0x80, // File 1 Owl Save Backup
     0x80, // File 2 Owl Save
     0x80, // File 2 Owl Save Backup
+    0x80, // File 3 Owl Save
+    0x80, // File 3 Owl Save Backup
     1,    // Sram Header (SaveOptions)
     1,    // Sram Header Backup (SaveOptions)
 };
 
 // Flash rom number of pages on very first time Player enters South Clock Town from the Clock Tower
+// 2S2H [Enhancement] Extended for file 3 support
 s32 gFlashSpecialSaveNumPages[] = {
     0x80, // File 1 New Cycle Save
     0x80, // File 1 New Cycle Save Backup
     0x80, // File 2 New Cycle Save
     0x80, // File 2 New Cycle Save Backup
+    0x80, // File 3 New Cycle Save
+    0x80, // File 3 New Cycle Save Backup
     0x80, // File 1 Owl Save
     0x80, // File 1 Owl Save Backup
     0x80, // File 2 Owl Save
     0x80, // File 2 Owl Save Backup
+    0x80, // File 3 Owl Save
+    0x80, // File 3 Owl Save Backup
     1,    // Sram Header (SaveOptions)
     1,    // Sram Header Backup (SaveOptions)
 };
@@ -351,6 +366,9 @@ s32 gFlashOwlSaveStartPages[] = {
     0x180, // File 1 Owl Save Backup
     0x200, // File 2 Owl Save
     0x280, // File 2 Owl Save Backup
+    // 2S2H [Enhancement] Extended for file 3 support
+    0x480, // File 3 Owl Save
+    0x500, // File 3 Owl Save Backup
 };
 
 // Owl Save flash rom number of pages
@@ -359,6 +377,9 @@ s32 gFlashOwlSaveNumPages[] = {
     0x80, // File 1 Owl Save Backup
     0x80, // File 2 Owl Save
     0x80, // File 2 Owl Save Backup
+    // 2S2H [Enhancement] Extended for file 3 support
+    0x80, // File 3 Owl Save
+    0x80, // File 3 Owl Save Backup
 };
 
 // Save Options Sram Header flash rom start page number
@@ -374,15 +395,20 @@ s32 gFlashOptionsSaveNumPages[] = {
 };
 
 // Flash rom actual size needed
+// 2S2H [Enhancement] Extended for file 3 support
 s32 gFlashSaveSizes[] = {
     sizeof(Save),                   // size = 0x100C - File 1 New Cycle Save
     sizeof(Save),                   // size = 0x100C - File 1 New Cycle Save Backup
     sizeof(Save),                   // size = 0x100C - File 2 New Cycle Save
     sizeof(Save),                   // size = 0x100C - File 2 New Cycle Save Backup
+    sizeof(Save),                   // size = 0x100C - File 3 New Cycle Save
+    sizeof(Save),                   // size = 0x100C - File 3 New Cycle Save Backup
     offsetof(SaveContext, fileNum), // size = 0x3CA0 - File 1 Owl Save
     offsetof(SaveContext, fileNum), // size = 0x3CA0 - File 1 Owl Save Backup
     offsetof(SaveContext, fileNum), // size = 0x3CA0 - File 2 Owl Save
     offsetof(SaveContext, fileNum), // size = 0x3CA0 - File 2 Owl Save Backup
+    offsetof(SaveContext, fileNum), // size = 0x3CA0 - File 3 Owl Save
+    offsetof(SaveContext, fileNum), // size = 0x3CA0 - File 3 Owl Save Backup
 };
 
 // Bit Flag array in which sBitFlags8[n] is (1 << n)

--- a/mm/src/overlays/gamestates/ovl_file_choose/z_file_choose_NES.c
+++ b/mm/src/overlays/gamestates/ovl_file_choose/z_file_choose_NES.c
@@ -24,6 +24,10 @@ s32 D_808144F1C = 0;
 
 FileSelectState* gFileSelectState = NULL;
 
+// 2S2H [Enhancement] To handle File 3 support and toggle, we undef the file num max and replace it for a CVar check
+#undef FILE_NUM_MAX
+#define FILE_NUM_MAX (CVarGetInteger("gEnhancements.Saving.FileSlot3", true) ? 3 : 2)
+
 static Gfx sScreenFillSetupDL[] = {
     gsDPPipeSync(),
     gsSPClearGeometryMode(G_ZBUFFER | G_SHADE | G_CULL_BOTH | G_FOG | G_LIGHTING | G_TEXTURE_GEN |
@@ -327,7 +331,8 @@ void FileSelect_UpdateMainMenu(GameState* thisx) {
             Audio_PlaySfx(NA_SE_SY_FSEL_CURSOR);
             if (this->stickAdjY > 30) {
                 this->buttonIndex--;
-                if (this->buttonIndex == FS_BTN_MAIN_FILE_3) {
+                if (!CVarGetInteger("gEnhancements.Saving.FileSlot3", true) &&
+                    this->buttonIndex == FS_BTN_MAIN_FILE_3) {
                     this->buttonIndex = FS_BTN_MAIN_FILE_2;
                 }
                 if (this->buttonIndex < FS_BTN_MAIN_FILE_1) {
@@ -335,7 +340,8 @@ void FileSelect_UpdateMainMenu(GameState* thisx) {
                 }
             } else {
                 this->buttonIndex++;
-                if (this->buttonIndex == FS_BTN_MAIN_FILE_3) {
+                if (!CVarGetInteger("gEnhancements.Saving.FileSlot3", true) &&
+                    this->buttonIndex == FS_BTN_MAIN_FILE_3) {
                     this->buttonIndex = FS_BTN_MAIN_COPY;
                 }
                 if (this->buttonIndex > FS_BTN_MAIN_OPTIONS) {

--- a/mm/src/overlays/gamestates/ovl_file_choose/z_file_copy_erase.c
+++ b/mm/src/overlays/gamestates/ovl_file_choose/z_file_copy_erase.c
@@ -104,7 +104,8 @@ void FileSelect_SelectCopySource(GameState* thisx) {
             if (this->stickAdjY >= 30) {
                 this->buttonIndex--;
                 // Instead of removing File 3 entirely, the index is manually adjusted to skip it
-                if (this->buttonIndex == FS_BTN_COPY_FILE_3) {
+                if (!CVarGetInteger("gEnhancements.Saving.FileSlot3", true) &&
+                    this->buttonIndex == FS_BTN_COPY_FILE_3) {
                     this->buttonIndex = FS_BTN_COPY_FILE_2;
                 }
                 if (this->buttonIndex < FS_BTN_COPY_FILE_1) {
@@ -113,7 +114,8 @@ void FileSelect_SelectCopySource(GameState* thisx) {
             } else {
                 this->buttonIndex++;
                 // Instead of removing File 3 entirely, the index is manually adjusted to skip it
-                if (this->buttonIndex == FS_BTN_COPY_FILE_3) {
+                if (!CVarGetInteger("gEnhancements.Saving.FileSlot3", true) &&
+                    this->buttonIndex == FS_BTN_COPY_FILE_3) {
                     this->buttonIndex = FS_BTN_COPY_QUIT;
                 }
                 if (this->buttonIndex > FS_BTN_COPY_QUIT) {
@@ -238,7 +240,8 @@ void FileSelect_SelectCopyDest(GameState* thisx) {
             if (this->stickAdjY >= 30) {
                 this->buttonIndex--;
                 // Instead of removing File 3 entirely, the index is manually adjusted to skip it
-                if (this->buttonIndex == FS_BTN_COPY_FILE_3) {
+                if (!CVarGetInteger("gEnhancements.Saving.FileSlot3", true) &&
+                    this->buttonIndex == FS_BTN_COPY_FILE_3) {
                     this->buttonIndex = FS_BTN_COPY_FILE_2;
                 }
                 if (this->buttonIndex == this->selectedFileIndex) {
@@ -247,7 +250,8 @@ void FileSelect_SelectCopyDest(GameState* thisx) {
                         this->buttonIndex = FS_BTN_COPY_QUIT;
                     }
                     // Instead of removing File 3 entirely, the index is manually adjusted to skip it
-                    if (this->buttonIndex == FS_BTN_COPY_FILE_3) {
+                    if (!CVarGetInteger("gEnhancements.Saving.FileSlot3", true) &&
+                        this->buttonIndex == FS_BTN_COPY_FILE_3) {
                         this->buttonIndex = FS_BTN_COPY_FILE_2;
                     }
                 } else if (this->buttonIndex < FS_BTN_COPY_FILE_1) {
@@ -262,7 +266,8 @@ void FileSelect_SelectCopyDest(GameState* thisx) {
                     this->buttonIndex++;
                 }
                 // Instead of removing File 3 entirely, the index is manually adjusted to skip it
-                if (this->buttonIndex == FS_BTN_COPY_FILE_3) {
+                if (!CVarGetInteger("gEnhancements.Saving.FileSlot3", true) &&
+                    this->buttonIndex == FS_BTN_COPY_FILE_3) {
                     this->buttonIndex = FS_BTN_COPY_QUIT;
                 }
             }
@@ -823,7 +828,8 @@ void FileSelect_EraseSelect(GameState* thisx) {
 
             if (this->stickAdjY >= 30) {
                 this->buttonIndex--;
-                if (this->buttonIndex == FS_BTN_ERASE_FILE_3) {
+                if (!CVarGetInteger("gEnhancements.Saving.FileSlot3", true) &&
+                    this->buttonIndex == FS_BTN_ERASE_FILE_3) {
                     this->buttonIndex = FS_BTN_ERASE_FILE_2;
                 }
                 if (this->buttonIndex < FS_BTN_ERASE_FILE_1) {
@@ -831,7 +837,8 @@ void FileSelect_EraseSelect(GameState* thisx) {
                 }
             } else {
                 this->buttonIndex++;
-                if (this->buttonIndex == FS_BTN_ERASE_FILE_3) {
+                if (!CVarGetInteger("gEnhancements.Saving.FileSlot3", true) &&
+                    this->buttonIndex == FS_BTN_ERASE_FILE_3) {
                     this->buttonIndex = FS_BTN_ERASE_QUIT;
                 }
                 if (this->buttonIndex > FS_BTN_ERASE_QUIT) {


### PR DESCRIPTION
Adds support for a 3rd file slot that can be used for saves.

The File Choose system largely already supported this (from JP 1.0), but just had early escapes for rendering and menu navigation.
The Sram system needed more work in terms of the actual management of the writing/reading processes and owl save management.

Opening as a draft to show what it looks like and pose some questions on implementation. Currently everything is behind a user toggle that is defaulted on.

~~Open Questions:~~
* Should this be a user facing toggle? **— Edit: Stick with a toggle for now for those that want to remove it**
* If it is user facing, should it default on? **— Edit: Consensus is to default on**
* Should we create/maintain separate structs, functions, and code paths for Sram related functions based on the toggle, or should we modify the originals, and only have the toggle visually hide the file slot on the File Choose menus? **— Edit: Modify existing structs, but first made enums to replace magic values to reduce surface area of code touched**

![image](https://github.com/user-attachments/assets/dd64a8b8-457a-4f13-b914-bc68f94d71a7)


<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2409809814.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2409811532.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2409825757.zip)
<!--- section:artifacts:end -->