### PR TITLE
Fix actor mtx interpolation flag persisting through skipped frames

### DIFF
--- a/mm/2s2h/Enhancements/FrameInterpolation/FrameInterpolation.cpp
+++ b/mm/2s2h/Enhancements/FrameInterpolation/FrameInterpolation.cpp
@@ -474,6 +474,10 @@ void FrameInterpolation_StartRecord(void) {
     current_recording = {};
     current_path.clear();
     current_path.push_back(&current_recording.root_path);
+    has_inv_actor_mtx = false;
+    interpolate_wider_angles = false;
+    ignore_inv_actor_mtx = false;
+
     if (!camera_interpolation) {
         // default to interpolating
         camera_interpolation = true;
@@ -523,12 +527,16 @@ int FrameInterpolation_GetCameraEpoch(void) {
 // Marks the current record path and its children to not apply the matrix result
 // against the recorded actor inverted matrix
 void FrameInterpolation_IgnoreActorMtx() {
+    if (!is_recording)
+        return;
     ignore_inv_actor_mtx = true;
     ignore_inv_actor_mtx_path_index = current_path.size();
 }
 
 // Allows interpolating from angle changes that are up to 123º for the next SetTranslateRotateYXZ
 void FrameInterpolation_InterpolateWiderAngles() {
+    if (!is_recording)
+        return;
     interpolate_wider_angles = true;
 }
 


### PR DESCRIPTION
The `FrameInterpolation_IgnoreActorMtx` was missing a check for if the current frame was being recorded for interpolation or not, this meant the logic in RecordCloseChild was not executed and prevented the `ignore_inv_actor_mtx` from being cleared. It would then apply to every actor on the next recorded frame until the first `FrameInterpolation_IgnoreActorMtx` is encountered (usually links feet shadow).

Added flag clearing at the state of a frame as a backup to ensure nothing lingers from a previous frame.

Fixes #899 

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2356823118.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2356823533.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2356837379.zip)
<!--- section:artifacts:end -->