### PR TITLE
Fix bow reticle showing on certain collisions

### DIFF
--- a/mm/2s2h/Enhancements/Enhancements.cpp
+++ b/mm/2s2h/Enhancements/Enhancements.cpp
@@ -37,6 +37,7 @@ void InitEnhancements() {
     RegisterTwoHandedSwordSpinAttack();
 
     // Graphics
+    RegisterBowReticle();
     RegisterDisableBlackBars();
     Register3DItemDrops();
 

--- a/mm/2s2h/Enhancements/Graphics/BowReticle.cpp
+++ b/mm/2s2h/Enhancements/Graphics/BowReticle.cpp
@@ -59,8 +59,9 @@ void RegisterBowReticle() {
 
                 if (func_800B7128(player) != 0) {
                     // Rotation from link's right hand that aligns with arrow projection
-                    Matrix_RotateZYX(0, -0x3B70, -0x4458, MTXMODE_APPLY);
-                    Matrix_Translate(500.0f, 300.0f, 0.0f, MTXMODE_APPLY);
+                    Matrix_RotateZYX(0, -0x3B33, -0x4423, MTXMODE_APPLY);
+                    Matrix_Translate(575.0f, 345.0f, 0.0f, MTXMODE_APPLY);
+
                     // 341000 as a value is selected roughly as a ratio of the hookshot value to maximum hookshot
                     // distance from player, multiplied by maximum arrow distance from player -- (77600 / 770) * 3385
                     DrawBowReticle(gPlayState, player, 341000.0f);

--- a/mm/2s2h/Enhancements/Graphics/BowReticle.cpp
+++ b/mm/2s2h/Enhancements/Graphics/BowReticle.cpp
@@ -1,0 +1,70 @@
+#include "libultraship/libultraship.h"
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
+
+extern "C" {
+#include "functions.h"
+#include "variables.h"
+#include "objects/gameplay_keep/gameplay_keep.h"
+}
+
+void DrawBowReticle(PlayState* play, Player* player, f32 bowDistance) {
+    static Vec3f D_801C094C = { -500.0f, -100.0f, 0.0f };
+    CollisionPoly* poly;
+    s32 bgId;
+    Vec3f posA;
+    Vec3f posB;
+    Vec3f pos;
+    Vec3f projectedPos;
+    f32 projectedW;
+    f32 scale;
+
+    D_801C094C.z = 0.0f;
+    Matrix_MultVec3f(&D_801C094C, &posA);
+    D_801C094C.z = bowDistance;
+    Matrix_MultVec3f(&D_801C094C, &posB);
+
+    // If the line test doesn't hit a valid polygon, use the "farthest" point as the reticle position.
+    // This ensures that the reticle is always visible even when looking at the sky
+    if (!BgCheck_ProjectileLineTest(&play->colCtx, &posA, &posB, &pos, &poly, true, true, true, true, &bgId)) {
+        pos = posB;
+    }
+
+    OPEN_DISPS(play->state.gfxCtx);
+
+    OVERLAY_DISP = Gfx_SetupDL(OVERLAY_DISP, SETUPDL_7);
+
+    SkinMatrix_Vec3fMtxFMultXYZW(&play->viewProjectionMtxF, &pos, &projectedPos, &projectedW);
+
+    scale = (projectedW < 500.0f) ? 0.075f : (projectedW / 500.0f) * 0.075f;
+
+    Matrix_Translate(pos.x, pos.y, pos.z, MTXMODE_NEW);
+    Matrix_Scale(scale, scale, scale, MTXMODE_APPLY);
+
+    gSPMatrix(OVERLAY_DISP++, Matrix_NewMtx(play->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+
+    gSPSegment(OVERLAY_DISP++, 0x06, (uintptr_t)play->objectCtx.slots[player->actor.objectSlot].segment);
+    gSPDisplayList(OVERLAY_DISP++, (Gfx*)gHookshotReticleDL);
+
+    CLOSE_DISPS(play->state.gfxCtx);
+}
+
+void RegisterBowReticle() {
+    GameInteractor::Instance->RegisterGameHookForID<GameInteractor::OnPlayerPostLimbDraw>(
+        PLAYER_LIMB_RIGHT_HAND, [](Player* player, s32 limbIndex) {
+            if (player->actor.scale.y >= 0.0f &&
+                ((player->heldItemAction == PLAYER_IA_BOW_FIRE) || (player->heldItemAction == PLAYER_IA_BOW_ICE) ||
+                 (player->heldItemAction == PLAYER_IA_BOW_LIGHT) || (player->heldItemAction == PLAYER_IA_BOW)) &&
+                CVarGetInteger("gEnhancements.Graphics.BowReticle", 0)) {
+
+                if (func_800B7128(player) != 0) {
+                    // Rotation from link's right hand that aligns with arrow projection
+                    Matrix_RotateZYX(0, -0x3B70, -0x4458, MTXMODE_APPLY);
+                    Matrix_Translate(500.0f, 300.0f, 0.0f, MTXMODE_APPLY);
+                    // 341000 as a value is selected roughly as a ratio of the hookshot value to maximum hookshot
+                    // distance from player, multiplied by maximum arrow distance from player -- (77600 / 770) * 3385
+                    DrawBowReticle(gPlayState, player, 341000.0f);
+                }
+            }
+        });
+}

--- a/mm/2s2h/Enhancements/Graphics/Graphics.h
+++ b/mm/2s2h/Enhancements/Graphics/Graphics.h
@@ -3,6 +3,7 @@
 
 void Register3DItemDrops();
 void Register3DSClock();
+void RegisterBowReticle();
 void RegisterDisableBlackBars();
 void MotionBlur_RenderMenuOptions();
 void RegisterPlayAsKafei();

--- a/mm/src/code/z_player_lib.c
+++ b/mm/src/code/z_player_lib.c
@@ -3681,21 +3681,6 @@ void Player_PostLimbDrawGameplay(PlayState* play, s32 limbIndex, Gfx** dList1, G
                         Player_DrawHookshotReticle(play, player, 77600.0f);
                     }
                 }
-            } else if (CVarGetInteger("gEnhancements.Graphics.BowReticle", 0) &&
-                       ((player->heldItemAction == PLAYER_IA_BOW_FIRE) ||
-                        (player->heldItemAction == PLAYER_IA_BOW_ICE) ||
-                        (player->heldItemAction == PLAYER_IA_BOW_LIGHT) || (player->heldItemAction == PLAYER_IA_BOW))) {
-                if (heldActor != NULL) {
-                    MtxF sp44;
-
-                    Matrix_RotateZYX(0, -15216, -17496, MTXMODE_APPLY);
-                    Matrix_Get(&sp44);
-
-                    if (func_800B7128(player) != 0) {
-                        Matrix_Translate(500.0f, 300.0f, 0.0f, MTXMODE_APPLY);
-                        Player_DrawHookshotReticle(play, player, 776000.0f);
-                    }
-                }
             } else if (player->meleeWeaponState != PLAYER_MELEE_WEAPON_STATE_0) {
                 if (player->meleeWeaponAnimation == PLAYER_MWA_GORON_PUNCH_RIGHT) {
                     func_80126B8C(play, player);


### PR DESCRIPTION
This moves the bow reticle logic to a dedicated .cpp file and implements a custom reticle test function, instead of re-using the hookshot one, which performs different line tests. Arrows can pass through certain collisions that the hookshot cannot.

Additionally I made it so the bow reticle will always draw, regardless if it the line test hits a polygon, where it will just use the "far" position value of the line test as the dot location. This should make the bow easier to aim in the sky with a constant reticle.

Fixes #698 

(And yes, I'll ShipInit this when merging back to develop)

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2367300131.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2367300996.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2367305805.zip)
<!--- section:artifacts:end -->