### PR TITLE
Add reset func for Bomb Shop

### DIFF
--- a/mm/src/overlays/actors/ovl_En_Sob1/z_en_sob1.c
+++ b/mm/src/overlays/actors/ovl_En_Sob1/z_en_sob1.c
@@ -17,6 +17,7 @@
 void EnSob1_Init(Actor* thisx, PlayState* play);
 void EnSob1_Destroy(Actor* thisx, PlayState* play);
 void EnSob1_Update(Actor* thisx, PlayState* play);
+void EnSob1_Reset(void);
 
 void EnSob1_ZoraShopkeeper_Draw(Actor* thisx, PlayState* play);
 void EnSob1_GoronShopkeeper_Draw(Actor* thisx, PlayState* play);
@@ -75,6 +76,7 @@ ActorInit En_Sob1_InitVars = {
     /**/ EnSob1_Destroy,
     /**/ EnSob1_Update,
     /**/ NULL,
+    /**/ EnSob1_Reset,
 };
 
 static s16 sObjectIds[][3] = {
@@ -1750,4 +1752,8 @@ void EnSob1_BombShopkeeper_Draw(Actor* thisx, PlayState* play) {
     gDPSetEnvColor(POLY_XLU_DISP++, 255, 0, 0, 0);
 
     CLOSE_DISPS(play->state.gfxCtx);
+}
+
+void EnSob1_Reset(void) {
+    sShops[BOMB_SHOP][0].shopItemId = SI_BOMB_BAG_20_2;
 }


### PR DESCRIPTION
If the player enters the Bomb Shop after saving the Bomb Shop lady and her bomb bag, the Big Bomb Bag will replace the normal one in the shop's inventory. This is supposed to only last for the current cycle, but in 2ship it will remain a Big Bomb Bag across any instance until the application is closed, regardless of flags. This corrects the shop actor to have the intended behavior.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2367279104.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2367281835.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2367283384.zip)
<!--- section:artifacts:end -->