### PR TITLE
[Timesaver] Faster Swamp Boat

### DIFF
--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -565,7 +565,15 @@ void DrawEnhancementsMenu() {
                       "the Rupees to Links current Rupees or 0 respectively." });
             UIWidgets::CVarCheckbox(
                 "Fast Text", "gEnhancements.Dialogue.FastText",
-                { .tooltip = "Speeds up text rendering, and enables holding of B progress to next message" });
+                { .tooltip = "Speeds up text rendering, and enables holding of B progress to next message." });
+
+            ImGui::EndMenu();
+        }
+
+        if (UIWidgets::BeginMenu("TimeSavers")) {
+            UIWidgets::CVarCheckbox(
+                "Faster Swamp Boat", "gEnhancements.Timesavers.SwampBoatSpeed",
+                { .tooltip = "Hold Z to speed up boat rides. For archery, requires a score of 20+ first." });
 
             ImGui::EndMenu();
         }

--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -572,8 +572,10 @@ void DrawEnhancementsMenu() {
 
         if (UIWidgets::BeginMenu("TimeSavers")) {
             UIWidgets::CVarCheckbox(
-                "Faster Swamp Boat", "gEnhancements.Timesavers.SwampBoatSpeed",
-                { .tooltip = "Hold Z to speed up boat rides. For archery, requires a score of 20+ first." });
+                "Swamp Boat Timesaver", "gEnhancements.Timesavers.SwampBoatSpeed",
+                { .tooltip = "Pictograph Tour: Hold Z to speed up the boat. Archery: Score 20 points to unlock boat "
+                             "speed up for future attempts. When reaching 20 points, you'll be automatically "
+                             "transported back to Koume, completing the minigame." });
 
             ImGui::EndMenu();
         }

--- a/mm/2s2h/BenGui/SearchableMenuItems.h
+++ b/mm/2s2h/BenGui/SearchableMenuItems.h
@@ -1347,6 +1347,11 @@ void AddEnhancements() {
                 WIDGET_CVAR_CHECKBOX },
               { "Fast Text", "gEnhancements.Dialogue.FastText",
                 "Speeds up text rendering, and enables holding of B progress to next message.",
+                WIDGET_CVAR_CHECKBOX } },
+            // Other
+            { { .widgetName = "Other", .widgetType = WIDGET_SEPARATOR_TEXT },
+              { "Faster Swamp Boat", "gEnhancements.Timesavers.SwampBoatSpeed",
+                "Hold Z to speed up boat rides. For archery, requires a score of 20+ first.",
                 WIDGET_CVAR_CHECKBOX } } } });
     enhancementsSidebar.push_back(
         { "Fixes",

--- a/mm/2s2h/BenGui/SearchableMenuItems.h
+++ b/mm/2s2h/BenGui/SearchableMenuItems.h
@@ -1350,8 +1350,10 @@ void AddEnhancements() {
                 WIDGET_CVAR_CHECKBOX } },
             // Other
             { { .widgetName = "Other", .widgetType = WIDGET_SEPARATOR_TEXT },
-              { "Faster Swamp Boat", "gEnhancements.Timesavers.SwampBoatSpeed",
-                "Hold Z to speed up boat rides. For archery, requires a score of 20+ first.",
+              { "Swamp Boat Timesaver", "gEnhancements.Timesavers.SwampBoatSpeed",
+                "Pictograph Tour: Hold Z to speed up the boat. Archery: Score 20 points to unlock boat speed up for "
+                "future attempts. When reaching 20 points, you'll be automatically transported back to Koume, "
+                "completing the minigame.",
                 WIDGET_CVAR_CHECKBOX } } } });
     enhancementsSidebar.push_back(
         { "Fixes",

--- a/mm/2s2h/Enhancements/Timesavers/SwampBoatSkip.cpp
+++ b/mm/2s2h/Enhancements/Timesavers/SwampBoatSkip.cpp
@@ -1,0 +1,52 @@
+#include <libultraship/bridge.h>
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/ShipInit.hpp"
+
+extern "C" {
+#include "overlays/actors/ovl_Bg_Ingate/z_bg_ingate.h"
+}
+
+#define CVAR_NAME "gEnhancements.Timesavers.SwampBoatSpeed"
+#define CVAR CVarGetInteger(CVAR_NAME, 5)
+
+void RegisterSwampBoatSpeed() {
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnActorUpdate>([](Actor* actor) {
+        if (actor->id == ACTOR_BG_INGATE) {
+            BgIngate* boat = (BgIngate*)actor;
+            if (CVAR >= 1 && DynaPolyActor_IsPlayerOnTop(&boat->dyna)) {
+                if (!CHECK_EVENTINF(EVENTINF_35)) {
+                    // Pictograph Tour
+                    if (CHECK_BTN_ALL(CONTROLLER1(&gPlayState->state)->cur.button, BTN_Z)) {
+                        boat->timePathTimeSpeed = (s16)(4 * CVAR);
+                    } else {
+                        boat->timePathTimeSpeed = 4; // Default speed
+                    }
+                } else if (CHECK_EVENTINF(EVENTINF_35) && HS_GET_BOAT_ARCHERY_HIGH_SCORE() >= 20) {
+                    // Archery Minigame
+                    if (CHECK_BTN_ALL(CONTROLLER1(&gPlayState->state)->cur.button, BTN_Z)) {
+                        boat->timePathTimeSpeed = (s16)(1 * CVAR);
+                    } else {
+                        boat->timePathTimeSpeed = 1; // Default speed
+                    }
+                } else if (CHECK_EVENTINF(EVENTINF_35) && gSaveContext.minigameScore >= 20) { // Current score
+                    // Update boat archery high score early
+                    // Leaving minigame early prevents the score from being updated
+                    if (gSaveContext.minigameScore > HS_GET_BOAT_ARCHERY_HIGH_SCORE()) {
+                        HS_SET_BOAT_ARCHERY_HIGH_SCORE(gSaveContext.minigameScore);
+                        SET_EVENTINF(EVENTINF_37);
+                    }
+
+                    // Leave the minigame
+                    gPlayState->nextEntrance = ENTRANCE(TOURIST_INFORMATION, 1); // 1 = Koume
+                    gSaveContext.nextCutsceneIndex = 0;
+                    gPlayState->transitionTrigger = TRANS_TRIGGER_START;
+                    gPlayState->transitionType = TRANS_TYPE_FADE_WHITE;
+                    gSaveContext.nextTransitionType = TRANS_TYPE_FADE_WHITE;
+                    return;
+                }
+            }
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterSwampBoatSpeed, { CVAR_NAME });

--- a/mm/2s2h/Enhancements/Timesavers/SwampBoatSkip.cpp
+++ b/mm/2s2h/Enhancements/Timesavers/SwampBoatSkip.cpp
@@ -7,43 +7,41 @@ extern "C" {
 }
 
 #define CVAR_NAME "gEnhancements.Timesavers.SwampBoatSpeed"
-#define CVAR CVarGetInteger(CVAR_NAME, 5)
+#define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 void RegisterSwampBoatSpeed() {
-    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnActorUpdate>([](Actor* actor) {
-        if (actor->id == ACTOR_BG_INGATE) {
-            BgIngate* boat = (BgIngate*)actor;
-            if (CVAR >= 1 && DynaPolyActor_IsPlayerOnTop(&boat->dyna)) {
-                if (!CHECK_EVENTINF(EVENTINF_35)) {
-                    // Pictograph Tour
-                    if (CHECK_BTN_ALL(CONTROLLER1(&gPlayState->state)->cur.button, BTN_Z)) {
-                        boat->timePathTimeSpeed = (s16)(4 * CVAR);
-                    } else {
-                        boat->timePathTimeSpeed = 4; // Default speed
-                    }
-                } else if (CHECK_EVENTINF(EVENTINF_35) && HS_GET_BOAT_ARCHERY_HIGH_SCORE() >= 20) {
-                    // Archery Minigame
-                    if (CHECK_BTN_ALL(CONTROLLER1(&gPlayState->state)->cur.button, BTN_Z)) {
-                        boat->timePathTimeSpeed = (s16)(1 * CVAR);
-                    } else {
-                        boat->timePathTimeSpeed = 1; // Default speed
-                    }
-                } else if (CHECK_EVENTINF(EVENTINF_35) && gSaveContext.minigameScore >= 20) { // Current score
-                    // Update boat archery high score early
-                    // Leaving minigame early prevents the score from being updated
-                    if (gSaveContext.minigameScore > HS_GET_BOAT_ARCHERY_HIGH_SCORE()) {
-                        HS_SET_BOAT_ARCHERY_HIGH_SCORE(gSaveContext.minigameScore);
-                        SET_EVENTINF(EVENTINF_37);
-                    }
-
-                    // Leave the minigame
-                    gPlayState->nextEntrance = ENTRANCE(TOURIST_INFORMATION, 1); // 1 = Koume
-                    gSaveContext.nextCutsceneIndex = 0;
-                    gPlayState->transitionTrigger = TRANS_TRIGGER_START;
-                    gPlayState->transitionType = TRANS_TYPE_FADE_WHITE;
-                    gSaveContext.nextTransitionType = TRANS_TYPE_FADE_WHITE;
-                    return;
+    COND_ID_HOOK(OnActorUpdate, ACTOR_BG_INGATE, CVAR, [](Actor* actor) {
+        BgIngate* boat = (BgIngate*)actor;
+        if (DynaPolyActor_IsPlayerOnTop(&boat->dyna)) {
+            if (!CHECK_EVENTINF(EVENTINF_35)) {
+                // Pictograph Tour
+                if (CHECK_BTN_ALL(CONTROLLER1(&gPlayState->state)->cur.button, BTN_Z)) {
+                    boat->timePathTimeSpeed = (s16)(4 * 5);
+                } else {
+                    boat->timePathTimeSpeed = 4; // Default speed
                 }
+            } else if (CHECK_EVENTINF(EVENTINF_35) && HS_GET_BOAT_ARCHERY_HIGH_SCORE() >= 20) {
+                // Archery Minigame
+                if (CHECK_BTN_ALL(CONTROLLER1(&gPlayState->state)->cur.button, BTN_Z)) {
+                    boat->timePathTimeSpeed = (s16)(1 * 5);
+                } else {
+                    boat->timePathTimeSpeed = 1; // Default speed
+                }
+            } else if (CHECK_EVENTINF(EVENTINF_35) && gSaveContext.minigameScore >= 20) { // Current score
+                // Update boat archery high score early
+                // Leaving minigame early prevents the score from being updated
+                if (gSaveContext.minigameScore > HS_GET_BOAT_ARCHERY_HIGH_SCORE()) {
+                    HS_SET_BOAT_ARCHERY_HIGH_SCORE(gSaveContext.minigameScore);
+                    SET_EVENTINF(EVENTINF_37);
+                }
+
+                // Leave the minigame
+                gPlayState->nextEntrance = ENTRANCE(TOURIST_INFORMATION, 1); // 1 = Koume
+                gSaveContext.nextCutsceneIndex = 0;
+                gPlayState->transitionTrigger = TRANS_TRIGGER_START;
+                gPlayState->transitionType = TRANS_TYPE_FADE_WHITE;
+                gSaveContext.nextTransitionType = TRANS_TYPE_FADE_WHITE;
+                return;
             }
         }
     });


### PR DESCRIPTION
Add a x5 multiplier to the boat cruise speed. Hold Z to go vroom vroom. Not allowed during archery minigame UNLESS you have the highscore. During the archery minigame, once you reach a score of 20 it automatically ends the minigame for you as a additional timesaver.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2390931363.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2390935550.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2390946025.zip)
<!--- section:artifacts:end -->