### PR TITLE
Skip Monkey Encounter

### DIFF
--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipBothersomeMonkey.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipBothersomeMonkey.cpp
@@ -6,7 +6,6 @@ extern "C" {
 #include "variables.h"
 #include "functions.h"
 #include "src/overlays/actors/ovl_En_Mnk/z_en_mnk.h"
-void EnMnk_Monkey_SetupDrop(EnMnk* thisx);
 void EnMnk_Monkey_SetupRunAfterTalk(EnMnk* thisx, PlayState* play);
 void EnMnk_Monkey_ApproachPlayer(EnMnk* thisx, PlayState* play);
 void EnMnk_Monkey_WaitOutsideWoods(EnMnk* thisx, PlayState* play);
@@ -16,8 +15,8 @@ void EnMnk_Monkey_WaitOutsideWoods(EnMnk* thisx, PlayState* play);
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 void RegisterSkipBothersomeMonkey() {
-    COND_HOOK(OnActorUpdate, CVAR, [](Actor* actor) {
-        if (actor->id == ACTOR_EN_MNK && MONKEY_GET_TYPE(actor) == MONKEY_OUTSIDEWOODS) {
+    COND_ID_HOOK(OnActorUpdate, ACTOR_EN_MNK, CVAR, [](Actor* actor) {
+        if (MONKEY_GET_TYPE(actor) == MONKEY_OUTSIDEWOODS) {
             EnMnk* monkey = (EnMnk*)actor;
             PlayState* play = gPlayState;
 

--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipBothersomeMonkey.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipBothersomeMonkey.cpp
@@ -1,0 +1,39 @@
+#include <libultraship/bridge.h>
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/ShipInit.hpp"
+
+extern "C" {
+#include "variables.h"
+#include "functions.h"
+#include "src/overlays/actors/ovl_En_Mnk/z_en_mnk.h"
+void EnMnk_Monkey_SetupDrop(EnMnk* thisx);
+void EnMnk_Monkey_SetupRunAfterTalk(EnMnk* thisx, PlayState* play);
+void EnMnk_Monkey_ApproachPlayer(EnMnk* thisx, PlayState* play);
+void EnMnk_Monkey_WaitOutsideWoods(EnMnk* thisx, PlayState* play);
+}
+
+#define CVAR_NAME "gEnhancements.Cutscenes.SkipMiscInteractions"
+#define CVAR CVarGetInteger(CVAR_NAME, 0)
+
+void RegisterSkipBothersomeMonkey() {
+    COND_HOOK(OnActorUpdate, CVAR, [](Actor* actor) {
+        if (actor->id == ACTOR_EN_MNK && MONKEY_GET_TYPE(actor) == MONKEY_OUTSIDEWOODS) {
+            EnMnk* monkey = (EnMnk*)actor;
+            PlayState* play = gPlayState;
+
+            if (monkey->actionFunc == EnMnk_Monkey_WaitOutsideWoods) {
+                // Trigger monkey approach
+                SET_EVENTINF(EVENTINF_26);
+                EnMnk_Monkey_ApproachPlayer(monkey, play);
+            } else if (monkey->actionFunc == EnMnk_Monkey_ApproachPlayer) {
+                // Skip dialogue and make monkey run
+                SET_EVENTINF(EVENTINF_25);
+                SET_WEEKEVENTREG(WEEKEVENTREG_79_02);
+                EnMnk_Monkey_SetupRunAfterTalk(monkey, play);
+                Flags_SetSwitch(play, MONKEY_GET_SWITCH_FLAG(&monkey->picto.actor));
+            }
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterSkipBothersomeMonkey, { CVAR_NAME });


### PR DESCRIPTION
Adds to the existing SkipMiscInteractions setting to skip the monkey's dialogue sequence outside Woods of Mystery.  The monkey will immediately approach and run off after setting the necessary flags.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2386156738.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2386157463.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2386160979.zip)
<!--- section:artifacts:end -->