### PR TITLE
Allow reset when in any game state

### DIFF
--- a/mm/2s2h/DeveloperTools/DebugConsole.cpp
+++ b/mm/2s2h/DeveloperTools/DebugConsole.cpp
@@ -119,14 +119,13 @@ static bool SetPosHandler(std::shared_ptr<Ship::Console> Console, const std::vec
 }
 
 static bool ResetHandler(std::shared_ptr<Ship::Console> Console, std::vector<std::string> args, std::string* output) {
-    if (gPlayState == nullptr) {
-        ERROR_MESSAGE("PlayState == nullptr");
+    if (gGameState == nullptr) {
+        ERROR_MESSAGE("gGameState == nullptr");
         return 1;
     }
 
-    gPlayState->gameplayFrames = 0;
-    STOP_GAMESTATE(&gPlayState->state);
-    SET_NEXT_GAMESTATE(&gPlayState->state, ConsoleLogo_Init, sizeof(ConsoleLogoState));
+    STOP_GAMESTATE(gGameState);
+    SET_NEXT_GAMESTATE(gGameState, ConsoleLogo_Init, sizeof(ConsoleLogoState));
     // GI-TODO
     // GameInteractor::Instance->ExecuteHooks<GameInteractor::OnExitGame>(gSaveContext.fileNum);
     return 0;


### PR DESCRIPTION
There is no reason why we should only be allowed to reset when in a `PlayState`. One of my longest pet peeves across the projects.

Simply updates the reset command to use the master `GameState` instead 🙂 

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2403558051.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2403567114.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2403571587.zip)
<!--- section:artifacts:end -->