### PR TITLE
Cleanup some things around the SaveManager

### DIFF
--- a/mm/2s2h/BenJsonConversions.hpp
+++ b/mm/2s2h/BenJsonConversions.hpp
@@ -1,8 +1,12 @@
 #ifndef BenJsonConversions_hpp
 #define BenJsonConversions_hpp
 
-#include "z64.h"
 #include <nlohmann/json.hpp>
+
+extern "C" {
+#include "z64save.h"
+#include "macros.h"
+}
 
 using json = nlohmann::json;
 

--- a/mm/include/z64save.h
+++ b/mm/include/z64save.h
@@ -1762,7 +1762,7 @@ void func_80147314(SramContext* sramCtx, s32 fileNum); // Removes Owl Saves
 
 extern u32 gSramSlotOffsets[];
 extern u8 gAmmoItems[];
-extern s32 gFlashSaveStartPages[10];
+extern s32 gFlashSaveStartPages[];
 extern s32 gFlashSaveNumPages[];
 extern s32 gFlashSpecialSaveNumPages[];
 extern s32 gFlashOwlSaveStartPages[];

--- a/mm/src/code/z_sram_NES.c
+++ b/mm/src/code/z_sram_NES.c
@@ -304,7 +304,7 @@ u8 gAmmoItems[ITEM_NUM_SLOTS] = {
 };
 
 // Stores flash start page number
-s32 gFlashSaveStartPages[10] = {
+s32 gFlashSaveStartPages[] = {
     0,     // File 1 New Cycle Save
     0x40,  // File 1 New Cycle Save Backup
     0x80,  // File 2 New Cycle Save


### PR DESCRIPTION
This is just a precursor PR to file slot 3 logic that aims to clean up in the save manager and revert some things back to decomp source.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2403690521.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2403695734.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2403698616.zip)
<!--- section:artifacts:end -->