### PR TITLE
Proper fix to masks showing in first person

### DIFF
--- a/mm/2s2h/Enhancements/Masks/PersistentMasks.cpp
+++ b/mm/2s2h/Enhancements/Masks/PersistentMasks.cpp
@@ -54,8 +54,14 @@ void UpdatePersistentMasksState() {
                 return;
             }
 
-            if (player->transformation == PLAYER_FORM_DEKU && player->stateFlags1 & PLAYER_STATE1_100000) {
-                return;
+            // This emulates the vanilla check for if the masks should be drawn, specifically around
+            // z_player.c 12923 (Player_Draw)
+            if (player->stateFlags1 & PLAYER_STATE1_100000) {
+                Vec3f temp;
+                SkinMatrix_Vec3fMtxFMultXYZ(&gPlayState->viewProjectionMtxF, &player->actor.focus.pos, &temp);
+                if (temp.z < -4.0f) {
+                    return;
+                }
             }
 
             OPEN_DISPS(gPlayState->state.gfxCtx);

--- a/mm/2s2h/Enhancements/Modes/HyruleWarriorsStyledLink.cpp
+++ b/mm/2s2h/Enhancements/Modes/HyruleWarriorsStyledLink.cpp
@@ -14,6 +14,16 @@ extern const char* D_801C0B20[28];
 
 void RegisterHyruleWarriorsStyledLink() {
     COND_ID_HOOK(OnPlayerPostLimbDraw, PLAYER_LIMB_HEAD, CVAR, [](Player* player, s32 limbIndex) {
+        // This emulates the vanilla check for if the masks should be drawn, specifically around
+        // z_player.c 12923 (Player_Draw)
+        if (player->stateFlags1 & PLAYER_STATE1_100000) {
+            Vec3f temp;
+            SkinMatrix_Vec3fMtxFMultXYZ(&gPlayState->viewProjectionMtxF, &player->actor.focus.pos, &temp);
+            if (temp.z < -4.0f) {
+                return;
+            }
+        }
+
         if (player->currentMask == PLAYER_MASK_NONE && player->transformation == PLAYER_FORM_HUMAN &&
             INV_CONTENT(ITEM_MASK_KEATON) == ITEM_MASK_KEATON) {
             OPEN_DISPS(gPlayState->state.gfxCtx);


### PR DESCRIPTION
Proper fix over https://github.com/HarbourMasters/2ship2harkinian/pull/924, using the same conditional check the player code uses.

also apply it to hyrule warriors enhancement

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2404165250.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2404176730.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2404182994.zip)
<!--- section:artifacts:end -->