### PR TITLE
Add enums for sram and save file magic values

### DIFF
--- a/mm/2s2h/Enhancements/Saving/SavingEnhancements.cpp
+++ b/mm/2s2h/Enhancements/Saving/SavingEnhancements.cpp
@@ -138,8 +138,9 @@ void HandleAutoSave() {
         Play_SaveCycleSceneFlags(&gPlayState->state);
         gSaveContext.save.saveInfo.playerData.savedSceneId = gPlayState->sceneId;
         func_8014546C(&gPlayState->sramCtx);
-        Sram_SetFlashPagesOwlSave(&gPlayState->sramCtx, gFlashOwlSaveStartPages[gSaveContext.fileNum * 2],
-                                  gFlashOwlSaveNumPages[gSaveContext.fileNum * 2]);
+        Sram_SetFlashPagesOwlSave(&gPlayState->sramCtx,
+                                  gFlashOwlSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER],
+                                  gFlashOwlSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER]);
         Sram_StartWriteToFlashOwlSave(&gPlayState->sramCtx);
         gSaveContext.save.isOwlSave = false;
         gSaveContext.save.shipSaveInfo.pauseSaveEntrance = -1;

--- a/mm/include/z64save.h
+++ b/mm/include/z64save.h
@@ -33,6 +33,35 @@ typedef enum RespawnMode {
 } RespawnMode;
 
 #define SAVE_BUFFER_SIZE 0x4000
+#define SAVE_BUFFER_SIZE_HALF (SAVE_BUFFER_SIZE / 2)
+
+typedef enum FileNum {
+    /* 0 */ FILE_NUM_1,
+    /* 1 */ FILE_NUM_2,
+    /* 2 */ FILE_NUM_MAX,
+    /* 2 */ FILE_NUM_1_OWL_SAVE = FILE_NUM_MAX,
+    /* 3 */ FILE_NUM_2_OWL_SAVE,
+    /* 4 */ FILE_NUM_MAX_WITH_OWL_SAVE,
+} FileNum;
+
+#define FILE_NUM_OWL_SAVE_OFFSET FILE_NUM_1_OWL_SAVE
+
+typedef enum FlashSave {
+    /*  0 */ FLASH_SAVE_FILE_1_NEW_CYCLE_SAVE,
+    /*  1 */ FLASH_SAVE_FILE_1_NEW_CYCLE_SAVE_BACKUP,
+    /*  2 */ FLASH_SAVE_FILE_2_NEW_CYCLE_SAVE,
+    /*  3 */ FLASH_SAVE_FILE_2_NEW_CYCLE_SAVE_BACKUP,
+    /*  4 */ FLASH_SAVE_FILE_1_OWL_SAVE,
+    /*  5 */ FLASH_SAVE_FILE_1_OWL_SAVE_BACKUP,
+    /*  6 */ FLASH_SAVE_FILE_2_OWL_SAVE,
+    /*  7 */ FLASH_SAVE_FILE_2_OWL_SAVE_BACKUP,
+    /*  8 */ FLASH_SAVE_SRAM_HEADER,
+    /*  9 */ FLASH_SAVE_SRAM_HEADER_BACKUP,
+    /* 10 */ FLASH_SAVE_MAX,
+} FlashSave;
+
+#define FLASH_SAVE_MAIN_MULTIPLIER 2
+#define FLASH_SAVE_BACKUP_OFFSET 1
 
 typedef enum {
     /* 0  */ MAGIC_STATE_IDLE, // Regular gameplay

--- a/mm/src/code/z_message.c
+++ b/mm/src/code/z_message.c
@@ -6157,8 +6157,9 @@ void Message_Update(PlayState* play) {
             gSaveContext.save.cutsceneIndex = sp44;
 
             if (gSaveContext.fileNum != 0xFF) {
-                Sram_SetFlashPagesDefault(&play->sramCtx, gFlashSaveStartPages[gSaveContext.fileNum * 2],
-                                          gFlashSpecialSaveNumPages[gSaveContext.fileNum * 2]);
+                Sram_SetFlashPagesDefault(&play->sramCtx,
+                                          gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER],
+                                          gFlashSpecialSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER]);
                 Sram_StartWriteToFlashDefault(&play->sramCtx);
             }
             msgCtx->msgMode = MSGMODE_NEW_CYCLE_1;
@@ -6184,8 +6185,9 @@ void Message_Update(PlayState* play) {
             func_8014546C(&play->sramCtx);
 
             if (gSaveContext.fileNum != 0xFF) {
-                Sram_SetFlashPagesOwlSave(&play->sramCtx, gFlashOwlSaveStartPages[gSaveContext.fileNum * 2],
-                                          gFlashOwlSaveNumPages[gSaveContext.fileNum * 2]);
+                Sram_SetFlashPagesOwlSave(&play->sramCtx,
+                                          gFlashOwlSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER],
+                                          gFlashOwlSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER]);
                 Sram_StartWriteToFlashOwlSave(&play->sramCtx);
             }
             msgCtx->msgMode = MSGMODE_OWL_SAVE_1;

--- a/mm/src/overlays/gamestates/ovl_file_choose/z_file_choose_NES.c
+++ b/mm/src/overlays/gamestates/ovl_file_choose/z_file_choose_NES.c
@@ -859,8 +859,8 @@ void FileSelect_SetWindowContentVtx(GameState* thisx) {
         // Account for owl-save offset
 
         spAC = j;
-        if (this->isOwlSave[j + 2]) {
-            spAC = j + 2;
+        if (this->isOwlSave[j + FILE_NUM_OWL_SAVE_OFFSET]) {
+            spAC = j + FILE_NUM_OWL_SAVE_OFFSET;
         }
 
         /* File name */
@@ -1419,8 +1419,8 @@ void FileSelect_DrawFileInfo(GameState* thisx, s16 fileIndex) {
     }
 
     if ((fileIndex == this->selectedFileIndex) || (fileIndex == this->copyDestFileIndex)) {
-        if (this->isOwlSave[fileIndex + 2]) {
-            sp20C = fileIndex + 2;
+        if (this->isOwlSave[fileIndex + FILE_NUM_OWL_SAVE_OFFSET]) {
+            sp20C = fileIndex + FILE_NUM_OWL_SAVE_OFFSET;
         }
 
         gDPPipeSync(POLY_OPA_DISP++);
@@ -1562,7 +1562,7 @@ void FileSelect_DrawFileInfo(GameState* thisx, s16 fileIndex) {
         }
     }
 
-    if (this->isOwlSave[fileIndex + 2]) {
+    if (this->isOwlSave[fileIndex + FILE_NUM_OWL_SAVE_OFFSET]) {
         gDPPipeSync(POLY_OPA_DISP++);
         gDPSetCombineMode(POLY_OPA_DISP++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
 
@@ -1705,14 +1705,14 @@ void FileSelect_DrawWindowContents(GameState* thisx) {
 
     // draw file info box (large box when a file is selected)
     for (fileIndex = 0; fileIndex < 3; fileIndex++, temp += 28) {
-        if (fileIndex < 2) {
+        if (fileIndex < FILE_NUM_MAX) {
             gDPPipeSync(POLY_OPA_DISP++);
             gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, this->windowColor[0], this->windowColor[1], this->windowColor[2],
                             this->fileInfoAlpha[fileIndex]);
             gSPVertex(POLY_OPA_DISP++, &this->windowContentVtx[temp], 28, 0);
 
             for (quadVtxIndex = 0, i = 0; i < 7; i++, quadVtxIndex += 4) {
-                if ((i < 5) || (this->isOwlSave[fileIndex + 2] && (i >= 5))) {
+                if ((i < 5) || (this->isOwlSave[fileIndex + FILE_NUM_OWL_SAVE_OFFSET] && (i >= 5))) {
                     gDPLoadTextureBlock(POLY_OPA_DISP++, sFileInfoBoxTextures[i], G_IM_FMT_IA, G_IM_SIZ_16b,
                                         sFileInfoBoxPartWidths[i], 56, 0, G_TX_NOMIRROR | G_TX_WRAP,
                                         G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
@@ -1726,7 +1726,7 @@ void FileSelect_DrawWindowContents(GameState* thisx) {
     gDPPipeSync(POLY_OPA_DISP++);
 
     for (i = 0; i < 3; i++, temp += 16) {
-        if (i < 2) {
+        if (i < FILE_NUM_MAX) {
             // draw file button
             gSPVertex(POLY_OPA_DISP++, &this->windowContentVtx[temp], 16, 0);
 
@@ -1752,7 +1752,7 @@ void FileSelect_DrawWindowContents(GameState* thisx) {
                                 G_TX_NOLOD, G_TX_NOLOD);
             gSP1Quadrangle(POLY_OPA_DISP++, 8, 10, 11, 9, 0);
 
-            if (this->isOwlSave[i + 2]) {
+            if (this->isOwlSave[i + FILE_NUM_OWL_SAVE_OFFSET]) {
                 gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, sWindowContentColors[0], sWindowContentColors[1],
                                 sWindowContentColors[2], this->nameBoxAlpha[i]);
                 gDPLoadTextureBlock(POLY_OPA_DISP++, gFileSelBlankButtonTex, G_IM_FMT_IA, G_IM_SIZ_16b, 52, 16, 0,
@@ -1764,7 +1764,7 @@ void FileSelect_DrawWindowContents(GameState* thisx) {
     }
 
     // draw file info
-    for (fileIndex = 0; fileIndex < 2; fileIndex++) {
+    for (fileIndex = 0; fileIndex < FILE_NUM_MAX; fileIndex++) {
         FileSelect_DrawFileInfo(&this->state, fileIndex);
     }
 

--- a/mm/src/overlays/gamestates/ovl_file_choose/z_file_copy_erase.c
+++ b/mm/src/overlays/gamestates/ovl_file_choose/z_file_copy_erase.c
@@ -433,8 +433,9 @@ void FileSelect_CopyConfirm(GameState* thisx) {
         if (!gSaveContext.flashSaveAvailable) {
             this->configMode = CM_COPY_ANIM_1;
         } else {
-            Sram_SetFlashPagesDefault(sramCtx, gFlashSaveStartPages[this->copyDestFileIndex * 2],
-                                      gFlashSpecialSaveNumPages[this->copyDestFileIndex * 2]);
+            Sram_SetFlashPagesDefault(sramCtx,
+                                      gFlashSaveStartPages[this->copyDestFileIndex * FLASH_SAVE_MAIN_MULTIPLIER],
+                                      gFlashSpecialSaveNumPages[this->copyDestFileIndex * FLASH_SAVE_MAIN_MULTIPLIER]);
             Sram_StartWriteToFlashDefault(sramCtx);
             this->configMode = CM_COPY_WAIT_FOR_FLASH_SAVE;
         }
@@ -972,8 +973,9 @@ void FileSelect_EraseConfirm(GameState* thisx) {
         if (!gSaveContext.flashSaveAvailable) {
             this->configMode = CM_ERASE_ANIM_1;
         } else {
-            Sram_SetFlashPagesDefault(sramCtx, gFlashSaveStartPages[this->selectedFileIndex * 2],
-                                      gFlashSpecialSaveNumPages[this->selectedFileIndex * 2]);
+            Sram_SetFlashPagesDefault(sramCtx,
+                                      gFlashSaveStartPages[this->selectedFileIndex * FLASH_SAVE_MAIN_MULTIPLIER],
+                                      gFlashSpecialSaveNumPages[this->selectedFileIndex * FLASH_SAVE_MAIN_MULTIPLIER]);
             Sram_StartWriteToFlashDefault(sramCtx);
             this->configMode = CM_ERASE_WAIT_FOR_FLASH_SAVE;
         }

--- a/mm/src/overlays/gamestates/ovl_file_choose/z_file_nameset_NES.c
+++ b/mm/src/overlays/gamestates/ovl_file_choose/z_file_nameset_NES.c
@@ -520,8 +520,9 @@ void FileSelect_DrawNameEntry(GameState* thisx) {
                                 if (!gSaveContext.flashSaveAvailable) {
                                     this->configMode = CM_NAME_ENTRY_TO_MAIN;
                                 } else {
-                                    Sram_SetFlashPagesDefault(sramCtx, gFlashSaveStartPages[this->buttonIndex * 2],
-                                                              gFlashSpecialSaveNumPages[this->buttonIndex * 2]);
+                                    Sram_SetFlashPagesDefault(
+                                        sramCtx, gFlashSaveStartPages[this->buttonIndex * FLASH_SAVE_MAIN_MULTIPLIER],
+                                        gFlashSpecialSaveNumPages[this->buttonIndex * FLASH_SAVE_MAIN_MULTIPLIER]);
                                     Sram_StartWriteToFlashDefault(sramCtx);
                                     this->configMode = CM_NAME_ENTRY_WAIT_FOR_FLASH_SAVE;
                                 }
@@ -767,7 +768,8 @@ void FileSelect_UpdateOptionsMenu(GameState* thisx) {
         if (!gSaveContext.flashSaveAvailable) {
             this->configMode = CM_OPTIONS_TO_MAIN;
         } else {
-            Sram_SetFlashPagesDefault(sramCtx, gFlashSaveStartPages[8], gFlashSpecialSaveNumPages[8]);
+            Sram_SetFlashPagesDefault(sramCtx, gFlashSaveStartPages[FLASH_SAVE_SRAM_HEADER],
+                                      gFlashSpecialSaveNumPages[FLASH_SAVE_SRAM_HEADER]);
             Sram_StartWriteToFlashDefault(sramCtx);
             this->configMode = CM_OPTIONS_WAIT_FOR_FLASH_SAVE;
         }

--- a/mm/src/overlays/gamestates/ovl_file_choose/z_file_select.h
+++ b/mm/src/overlays/gamestates/ovl_file_choose/z_file_select.h
@@ -196,20 +196,20 @@ typedef struct FileSelectState {
     /* 0x243E8 */ Vtx* keyboardVtx;
     /* 0x243EC */ Vtx* nameEntryVtx;
     /* 0x243F0 */ Vtx* keyboard2Vtx;
-    /* 0x243F4 */ u8 newf[4][6];
-    /* 0x2440C */ u16 threeDayResetCount[4];
-    /* 0x24414 */ char fileNames[4][8];
-    /* 0x24434 */ s16 healthCapacity[4];
-    /* 0x2443C */ s16 health[4];
-    /* 0x24444 */ u32 questItems[4];
-    /* 0x24454 */ s8 defenseHearts[4];
-    /* 0x24458 */ u16 time[4];
-    /* 0x24460 */ s16 day[4];
-    /* 0x24468 */ u8 isOwlSave[4];
-    /* 0x2446C */ s16 rupees[4];
-    /* 0x24474 */ u8 walletUpgrades[4];
-    /* 0x24478 */ u8 maskCount[4];
-    /* 0x2447C */ u8 heartPieceCount[4];
+    /* 0x243F4 */ u8 newf[FILE_NUM_MAX_WITH_OWL_SAVE][6];
+    /* 0x2440C */ u16 threeDayResetCount[FILE_NUM_MAX_WITH_OWL_SAVE];
+    /* 0x24414 */ char fileNames[FILE_NUM_MAX_WITH_OWL_SAVE][8];
+    /* 0x24434 */ s16 healthCapacity[FILE_NUM_MAX_WITH_OWL_SAVE];
+    /* 0x2443C */ s16 health[FILE_NUM_MAX_WITH_OWL_SAVE];
+    /* 0x24444 */ u32 questItems[FILE_NUM_MAX_WITH_OWL_SAVE];
+    /* 0x24454 */ s8 defenseHearts[FILE_NUM_MAX_WITH_OWL_SAVE];
+    /* 0x24458 */ u16 time[FILE_NUM_MAX_WITH_OWL_SAVE];
+    /* 0x24460 */ s16 day[FILE_NUM_MAX_WITH_OWL_SAVE];
+    /* 0x24468 */ u8 isOwlSave[FILE_NUM_MAX_WITH_OWL_SAVE];
+    /* 0x2446C */ s16 rupees[FILE_NUM_MAX_WITH_OWL_SAVE];
+    /* 0x24474 */ u8 walletUpgrades[FILE_NUM_MAX_WITH_OWL_SAVE];
+    /* 0x24478 */ u8 maskCount[FILE_NUM_MAX_WITH_OWL_SAVE];
+    /* 0x2447C */ u8 heartPieceCount[FILE_NUM_MAX_WITH_OWL_SAVE];
     /* 0x24480 */ s16 buttonIndex; // enum will depend on `ConfigMode`
     /* 0x24482 */ s16 confirmButtonIndex; // see `ConfirmButtonIndex` enum
     /* 0x24484 */ s16 menuMode; // see `MenuMode` enum

--- a/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_scope_NES.c
+++ b/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_scope_NES.c
@@ -3575,9 +3575,10 @@ void KaleidoScope_Update(PlayState* play) {
                                 pauseCtx->savePromptState = PAUSE_SAVEPROMPT_STATE_5;
                             } else {
                                 if (CVarGetInteger("gEnhancements.Saving.PauseSave", 0)) {
-                                    Sram_SetFlashPagesOwlSave(sramCtx,
-                                                              gFlashOwlSaveStartPages[gSaveContext.fileNum * 2],
-                                                              gFlashOwlSaveNumPages[gSaveContext.fileNum * 2]);
+                                    Sram_SetFlashPagesOwlSave(
+                                        sramCtx,
+                                        gFlashOwlSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER],
+                                        gFlashOwlSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER]);
                                     Sram_StartWriteToFlashOwlSave(sramCtx);
                                     gSaveContext.save.isOwlSave = false;
                                     gSaveContext.save.shipSaveInfo.pauseSaveEntrance = -1;


### PR DESCRIPTION
This is a part 1 of #900 to enum-ify various magic values used around file save and flash save handling to make it easier to add file 3 support without touching much source code.

Moves `FlashSlotFile` to mm source and renames to `FlashSave`, and renames the variables/funcs in SaveManager to align with it.

Adds `FIleNum` enums and couple defines for offset values. and uses these in the source.

The names are a little verbose, so clang-format got really happy with all the changes 🙂 

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2404544669.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2404546851.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2404551649.zip)
<!--- section:artifacts:end -->