### PR TITLE
Prevent Faster Song Playback During Cutscenes

### DIFF
--- a/mm/2s2h/Enhancements/Songs/FasterSongPlayback.cpp
+++ b/mm/2s2h/Enhancements/Songs/FasterSongPlayback.cpp
@@ -13,7 +13,8 @@ extern u8 sPlaybackState;
 
 void RegisterFasterSongPlayback() {
     COND_ID_HOOK(OnActorUpdate, ACTOR_PLAYER, CVAR, [](Actor* actor) {
-        if (gPlayState->msgCtx.msgMode >= MSGMODE_SONG_PLAYED && gPlayState->msgCtx.msgMode <= MSGMODE_17) {
+        if (gPlayState->msgCtx.msgMode >= MSGMODE_SONG_PLAYED && gPlayState->msgCtx.msgMode <= MSGMODE_17 &&
+            !gPlayState->csCtx.state) {
             if (gPlayState->msgCtx.stateTimer > 1) {
                 gPlayState->msgCtx.stateTimer = 1;
             }

--- a/mm/2s2h/Enhancements/Songs/FasterSongPlayback.cpp
+++ b/mm/2s2h/Enhancements/Songs/FasterSongPlayback.cpp
@@ -4,17 +4,20 @@
 
 extern "C" {
 #include "variables.h"
-
 extern u8 sPlaybackState;
 }
 
 #define CVAR_NAME "gEnhancements.Songs.FasterSongPlayback"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
+#define NOT_OCARINA_ACTION_BALAD_WIND_FISH                                       \
+    (gPlayState->msgCtx.ocarinaAction < OCARINA_ACTION_PROMPT_WIND_FISH_HUMAN || \
+     gPlayState->msgCtx.ocarinaAction > OCARINA_ACTION_PROMPT_WIND_FISH_DEKU)
+
 void RegisterFasterSongPlayback() {
     COND_ID_HOOK(OnActorUpdate, ACTOR_PLAYER, CVAR, [](Actor* actor) {
         if (gPlayState->msgCtx.msgMode >= MSGMODE_SONG_PLAYED && gPlayState->msgCtx.msgMode <= MSGMODE_17 &&
-            !gPlayState->csCtx.state) {
+            !gPlayState->csCtx.state && NOT_OCARINA_ACTION_BALAD_WIND_FISH) {
             if (gPlayState->msgCtx.stateTimer > 1) {
                 gPlayState->msgCtx.stateTimer = 1;
             }


### PR DESCRIPTION
After discussing with Archez, it appears that this is a bug and not intended functionality of the enhancement.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2415697120.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2415699438.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2415710653.zip)
<!--- section:artifacts:end -->