### PR TITLE
Fix ocarina inputs being dropped at the start of playback

### DIFF
--- a/mm/src/audio/code_8019AF00.c
+++ b/mm/src/audio/code_8019AF00.c
@@ -2197,10 +2197,6 @@ void AudioOcarina_MapSongFromPitchToButton(u8 noteSongIndex, u8 buttonSongIndex,
 void AudioOcarina_Start(u32 ocarinaFlags) {
     u8 songIndex;
 
-    if (sCurOcarinaPitch != OCARINA_PITCH_NONE && CVarGetInteger("gEnhancements.Playback.NoDropOcarinaInput", 0)) {
-        return;
-    }
-
     if ((sOcarinaSongNotes[OCARINA_SONG_SCARECROW_SPAWN][1].volume != 0xFF) &&
         ((ocarinaFlags & OCARINA_SONGS_PLAYABLE_FLAGS) == OCARINA_SONGS_PLAYABLE_FLAGS)) {
         ocarinaFlags |= (1 << OCARINA_SONG_SCARECROW_SPAWN);

--- a/mm/src/audio/code_8019AF00.c
+++ b/mm/src/audio/code_8019AF00.c
@@ -2197,6 +2197,10 @@ void AudioOcarina_MapSongFromPitchToButton(u8 noteSongIndex, u8 buttonSongIndex,
 void AudioOcarina_Start(u32 ocarinaFlags) {
     u8 songIndex;
 
+    if (sCurOcarinaPitch != OCARINA_PITCH_NONE && CVarGetInteger("gEnhancements.Playback.NoDropOcarinaInput", 0)) {
+        return;
+    }
+
     if ((sOcarinaSongNotes[OCARINA_SONG_SCARECROW_SPAWN][1].volume != 0xFF) &&
         ((ocarinaFlags & OCARINA_SONGS_PLAYABLE_FLAGS) == OCARINA_SONGS_PLAYABLE_FLAGS)) {
         ocarinaFlags |= (1 << OCARINA_SONG_SCARECROW_SPAWN);

--- a/mm/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/mm/src/overlays/actors/ovl_player_actor/z_player.c
@@ -17229,8 +17229,10 @@ void Player_Action_63(Player* this, PlayState* play) {
           (BEN_ANIM_EQUAL(this->skelAnime.animation, D_8085D17C[this->transformation]))) ||
          ((this->skelAnime.mode == 0) && (this->av2.actionVar2 == 0)))) {
         func_808525C4(play, this);
-        if (!(this->actor.flags & ACTOR_FLAG_20000000) || (this->unk_A90->id == ACTOR_EN_ZOT)) {
-            Message_DisplayOcarinaStaff(play, OCARINA_ACTION_FREE_PLAY);
+        if (!CVarGetInteger("gEnhancements.Playback.NoDropOcarinaInput", 0) || this->av2.actionVar2 == 1) {
+            if (!(this->actor.flags & ACTOR_FLAG_20000000) || (this->unk_A90->id == ACTOR_EN_ZOT)) {
+                Message_DisplayOcarinaStaff(play, OCARINA_ACTION_FREE_PLAY);
+            }
         }
     } else if (this->av2.actionVar2 != 0) {
         if (play->msgCtx.ocarinaMode == OCARINA_MODE_END) {


### PR DESCRIPTION
This was found after about a 2 hour investigation digging through this nonsense.

Within `AudioOcarina_CheckSongsWithoutMusicStaff`, the variable `sOcarinaStaffPlayingPos` is incremented to keep track of your played notes, as you play it should cycle and wrap around from 1-8. After some experimentation it was discovered that upon pulling the ocarina out and playing a note too fast, your note would be recorded at `sOcarinaStaffPlayingPos == 0`. This is because it is set to 0 from `AudioOcarina_Start`, which is (likely incorrectly) called 4 times during the z_message drawing, 2 calls of which can happen after you play your first note.

https://github.com/HarbourMasters/2ship2harkinian/blob/8b5ee5a94a8c8e081038975eee5e3553cb4b80d4/mm/src/code/z_message.c#L4492

The naive solution was to check if there is an active pitch prior to running the entire contents of `AudioOcarina_Start` over and over again.

Edit: After further investigation, it looks like Recomp also patched this issue here https://github.com/Zelda64Recomp/Zelda64Recomp/pull/428, which also prevents this code from running more than necessary, but I like their solution more than mine, opting to use it instead

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2418916878.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2418917902.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2418921766.zip)
<!--- section:artifacts:end -->