### PR TITLE
Fix Right Stick Invert Y missing default value

### DIFF
--- a/mm/2s2h/BenGui/SearchableMenuItems.h
+++ b/mm/2s2h/BenGui/SearchableMenuItems.h
@@ -989,7 +989,7 @@ void AddEnhancements() {
                 "gEnhancements.Camera.RightStick.InvertYAxis",
                 "Inverts the Camera Y Axis",
                 WIDGET_CVAR_CHECKBOX,
-                {},
+                { .defaultVariant = true },
                 nullptr,
                 [](widgetInfo& info) {
                     if (disabledMap.at(DISABLE_FOR_CAMERAS_OFF).active) {


### PR DESCRIPTION
Resolves dissonance between `SearchableMenuItems` and `GameInteractor` in which the former has no default value specified yet the latter assumes it to be default true. This fixes a bug in which in the event the CVar is not set (such as new config generation), the enhancement will appear deselected yet the game acts as though it were set to true.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2419611155.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2419611551.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2419615230.zip)
<!--- section:artifacts:end -->