### PR TITLE
Adds ability to skip the boot logo quickly upon button press

### DIFF
--- a/mm/2s2h/Enhancements/Cutscenes/SkipToFileSelect.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/SkipToFileSelect.cpp
@@ -29,6 +29,17 @@ void RegisterSkipToFileSelect() {
             SET_NEXT_GAMESTATE(gGameState, FileSelect_Init, sizeof(FileSelectState));
         }
     });
+
+    // Allows pressing A to skip the boot logo and go to the next state (opening or file select)
+    COND_HOOK(OnConsoleLogoUpdate, true, []() {
+        ConsoleLogoState* consoleLogoState = (ConsoleLogoState*)gGameState;
+
+        if (CHECK_BTN_ANY(consoleLogoState->state.input->press.button, BTN_A | BTN_B | BTN_START)) {
+            // Force the title state to start fading to black and to last roughly 5 frames based on current fade in/out
+            consoleLogoState->visibleDuration = 0;
+            consoleLogoState->addAlpha = (255 - consoleLogoState->coverAlpha) / 5;
+        }
+    });
 }
 
 static RegisterShipInitFunc initFunc(RegisterSkipToFileSelect, { CVAR_NAME });


### PR DESCRIPTION
This adds an always-on hook to the boot logo for allowing a button press (A, B, or Start) to force the boot logo to fade out immediately and continue on to the next game state.

I think always-on makes sense and prevents us from needing to think about an additional "skip boot logo" menu option.

Stuck the changes into `SkipToFileSelect.cpp` as it mostly felt relevant there, but I can make a new file/rename this file if that is preferred.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2432954738.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2432962406.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2432963787.zip)
<!--- section:artifacts:end -->