### PR TITLE
Fix snowhead snowball being placed out of bounds

### DIFF
--- a/mm/src/overlays/actors/ovl_En_Goroiwa/z_en_goroiwa.c
+++ b/mm/src/overlays/actors/ovl_En_Goroiwa/z_en_goroiwa.c
@@ -976,7 +976,9 @@ void EnGoroiwa_Init(Actor* thisx, PlayState* play) {
         return;
     }
 
-    if ((this->actor.home.rot.y >= (sp2C->count - 1)) && (this->actor.home.rot.y < 0)) {
+    //! @bug: Impossible to reach, && should be an ||
+    // 2S2H [Port] Opting to fix this to address a rolling snowball in snowhead being placed with garbage values
+    if ((this->actor.home.rot.y >= (sp2C->count - 1)) || (this->actor.home.rot.y < 0)) {
         this->actor.home.rot.y = 0;
     }
 


### PR DESCRIPTION
One of the snowhead rolling snowballs had a spawn rotation value that would cause it to index out of range on its path list and getting garbage values assigned to its starting position. It would roll somewhere out of bounds for a long time until something would cause it to "break" and then fall again normally.

Presumably on console this out of bounds read would be the next point of the next path, but I also noticed a check for rotation values bounds checking had a vanilla bug causing the condition to be impossible to reach.

Fixing this condition fixes the snow balls first position.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2439149673.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2439154506.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2439159866.zip)
<!--- section:artifacts:end -->