### PR TITLE
Add restoration for pause buffer input window

### DIFF
--- a/mm/2s2h/BenGui/SearchableMenuItems.h
+++ b/mm/2s2h/BenGui/SearchableMenuItems.h
@@ -1466,21 +1466,31 @@ void AddEnhancements() {
         { "Restorations",
           3,
           { // Restorations
-            { { .widgetName = "Restorations", .widgetType = WIDGET_SEPARATOR_TEXT },
-              { "Constant Distance Backflips and Sidehops", "gEnhancements.Restorations.ConstantFlipsHops",
-                "Backflips and Sidehops travel a constant distance as they did in OoT.", WIDGET_CVAR_CHECKBOX },
-              { "Power Crouch Stab", "gEnhancements.Restorations.PowerCrouchStab",
-                "Crouch stabs will use the power of Link's previous melee attack, as is in MM JP 1.0 and OoT.",
-                WIDGET_CVAR_CHECKBOX },
-              { "Side Rolls", "gEnhancements.Restorations.SideRoll", "Restores side rolling from OoT.",
-                WIDGET_CVAR_CHECKBOX },
-              { "Tatl ISG", "gEnhancements.Restorations.TatlISG", "Restores Navi ISG from OoT, but now with Tatl.",
-                WIDGET_CVAR_CHECKBOX },
-              { "Woodfall Mountain Appearance", "gEnhancements.Restorations.WoodfallMountainAppearance",
-                "Restores the appearance of Woodfall mountain to not look poisoned "
-                "when viewed from Termina Field after clearing Woodfall Temple\n\n"
-                "Requires a scene reload to take effect",
-                WIDGET_CVAR_CHECKBOX } } } });
+            {
+                { .widgetName = "Restorations", .widgetType = WIDGET_SEPARATOR_TEXT },
+                { "Constant Distance Backflips and Sidehops", "gEnhancements.Restorations.ConstantFlipsHops",
+                  "Backflips and Sidehops travel a constant distance as they did in OoT.", WIDGET_CVAR_CHECKBOX },
+                { "Power Crouch Stab", "gEnhancements.Restorations.PowerCrouchStab",
+                  "Crouch stabs will use the power of Link's previous melee attack, as is in MM JP 1.0 and OoT.",
+                  WIDGET_CVAR_CHECKBOX },
+                { "Side Rolls", "gEnhancements.Restorations.SideRoll", "Restores side rolling from OoT.",
+                  WIDGET_CVAR_CHECKBOX },
+                { "Tatl ISG", "gEnhancements.Restorations.TatlISG", "Restores Navi ISG from OoT, but now with Tatl.",
+                  WIDGET_CVAR_CHECKBOX },
+                { "Woodfall Mountain Appearance", "gEnhancements.Restorations.WoodfallMountainAppearance",
+                  "Restores the appearance of Woodfall mountain to not look poisoned "
+                  "when viewed from Termina Field after clearing Woodfall Temple\n\n"
+                  "Requires a scene reload to take effect",
+                  WIDGET_CVAR_CHECKBOX },
+                {
+                    "Pause Buffer Input Window",
+                    "gEnhancements.Restorations.PauseBufferWindow",
+                    "Amount of time in frames you have to buffer an input while unpausing the game. Original hardware "
+                    "is around 20",
+                    WIDGET_CVAR_SLIDER_INT,
+                    { 0, 40, 0 },
+                },
+            } } });
 
     enhancementsSidebar.push_back(
         { "Difficulty Options",

--- a/mm/2s2h/Enhancements/Restorations/PauseBufferInputs.cpp
+++ b/mm/2s2h/Enhancements/Restorations/PauseBufferInputs.cpp
@@ -1,0 +1,54 @@
+#include <libultraship/libultraship.h>
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/ShipInit.hpp"
+
+extern "C" {
+#include "variables.h"
+#include "overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_scope.h"
+}
+
+#define CVAR_NAME "gEnhancements.Restorations.PauseBufferWindow"
+#define CVAR CVarGetInteger(CVAR_NAME, 0)
+
+static u16 inputBufferTimer = 0;
+static u16 pauseInputs = 0;
+
+void RegisterPauseBufferInputs() {
+    COND_VB_SHOULD(VB_KALEIDO_UNPAUSE_CLOSE, CVAR, {
+        Input* input = CONTROLLER1(&gPlayState->state);
+
+        // Store all inputs that were pressed during the buffer window
+        pauseInputs |= input->press.button;
+
+        // Wait a specified number of frames before continuing the unpause
+        inputBufferTimer++;
+        if (inputBufferTimer < CVAR) {
+            *should = false;
+        }
+    });
+
+    COND_HOOK(OnGameStateMainStart, CVAR, []() {
+        if (gPlayState == NULL) {
+            return;
+        }
+
+        Input* input = CONTROLLER1(&gPlayState->state);
+        PauseContext* pauseCtx = &gPlayState->pauseCtx;
+
+        // if the input buffer timer is not 0 and the pause state is off, then the player just unpaused
+        if (inputBufferTimer != 0 && pauseCtx->state == PAUSE_STATE_OFF) {
+            inputBufferTimer = 0;
+
+            // So we need to re-apply the inputs that were pressed during the buffer window
+            input->press.button |= pauseInputs;
+        }
+
+        // Reset the timer and stored inputs at the beginning of the unpause process
+        if (pauseCtx->state == PAUSE_STATE_UNPAUSE_SETUP && pauseCtx->itemPageRoll != 160.0f) {
+            inputBufferTimer = 0;
+            pauseInputs = 0;
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterPauseBufferInputs, { CVAR_NAME });

--- a/mm/2s2h/GameInteractor/GameInteractor.h
+++ b/mm/2s2h/GameInteractor/GameInteractor.h
@@ -34,6 +34,7 @@ typedef enum {
     // Vanilla condition: gSaveContext.showTitleCard
     VB_SHOW_TITLE_CARD,
     VB_PLAY_ENTRANCE_CS,
+    VB_KALEIDO_UNPAUSE_CLOSE,
     VB_DISABLE_FD_MASK,
     VB_DOGGY_RACE_SET_MAX_SPEED,
     VB_LOWER_RAZOR_SWORD_DURABILITY,

--- a/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_scope_NES.c
+++ b/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_scope_NES.c
@@ -4119,6 +4119,9 @@ void KaleidoScope_Update(PlayState* play) {
             break;
 
         case PAUSE_STATE_UNPAUSE_CLOSE:
+            if (!GameInteractor_Should(VB_KALEIDO_UNPAUSE_CLOSE, true)) {
+                break;
+            }
             pauseCtx->state = PAUSE_STATE_OFF;
             GameState_SetFramerateDivisor(&play->state, 3);
             R_PAUSE_BG_PRERENDER_STATE = PAUSE_BG_PRERENDER_UNK4;


### PR DESCRIPTION
Would love to get some playtesting on this from people who are used to pause buffering on hardware. From my naive testing this seems to be consistent with it.

The placement & tooltip may need a bit of iteration? not sure

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2442430501.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2442431631.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2442448294.zip)
<!--- section:artifacts:end -->