### PR TITLE
Fix twinmold giant scale factor not clearing on reset

### DIFF
--- a/mm/src/overlays/actors/ovl_Boss_02/z_boss_02.c
+++ b/mm/src/overlays/actors/ovl_Boss_02/z_boss_02.c
@@ -2358,6 +2358,7 @@ void Boss02_Reset(void) {
     sTwinmoldStatic = NULL;
     sTwinmoldMusicStartTimer = 0;
     sBlueWarp = NULL;
+    sGiantModeScaleFactor = 1.0f;
 
     for (int i = 0; i < TWINMOLD_EFFECT_COUNT; i++) {
         sTwinmoldEffects[i].type = TWINMOLD_EFFECT_NONE;


### PR DESCRIPTION
Missed this variable needing to be reset to clear the giant mode effect in twinmold arena

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2444308528.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2444316675.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2444317749.zip)
<!--- section:artifacts:end -->