### PR TITLE
Restore ability to spam B to swim faster from OoT

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1120,6 +1120,9 @@ void BenMenu::AddEnhancements() {
     AddWidget(path, "Side Rolls", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Restorations.SideRoll")
         .Options(CheckboxOptions().Tooltip("Restores side rolling from OoT."));
+    AddWidget(path, "Faster Swim", WIDGET_CVAR_CHECKBOX)
+        .CVar("gEnhancements.Restorations.OoTFasterSwim")
+        .Options(CheckboxOptions().Tooltip("Restores the ability to swim faster by spamming the B button, as in OoT."));
     AddWidget(path, "Tatl ISG", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Restorations.TatlISG")
         .Options(CheckboxOptions().Tooltip("Restores Navi ISG from OoT, but now with Tatl."));

--- a/mm/2s2h/Enhancements/Restorations/OoTFasterSwim.cpp
+++ b/mm/2s2h/Enhancements/Restorations/OoTFasterSwim.cpp
@@ -1,0 +1,27 @@
+#include <libultraship/bridge.h>
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/ShipInit.hpp"
+
+extern "C" {
+#include "variables.h"
+void Player_Action_57(Player* player, PlayState* play);
+}
+
+#define CVAR_NAME "gEnhancements.Restorations.OoTFasterSwim"
+#define CVAR CVarGetInteger(CVAR_NAME, 0)
+
+void RegisterOoTFasterSwim() {
+    COND_VB_SHOULD(VB_CLAMP_ANIMATION_SPEED, CVAR, {
+        Player* player = GET_PLAYER(gPlayState);
+        f32* animationSpeed = va_arg(args, f32*);
+
+        if (player->actionFunc == Player_Action_57 && player->transformation == PLAYER_FORM_HUMAN) {
+            *should = false;
+            if (*animationSpeed < 1.0f) {
+                *animationSpeed = 1.0f;
+            }
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterOoTFasterSwim, { CVAR_NAME });

--- a/mm/2s2h/GameInteractor/GameInteractor.h
+++ b/mm/2s2h/GameInteractor/GameInteractor.h
@@ -93,6 +93,7 @@ typedef enum {
     VB_GORON_ROLL_INCREASE_SPIKE_LEVEL,
     VB_GORON_ROLL_DISABLE_SPIKE_MODE,
     VB_DEKU_LINK_SPIN_ON_LAST_HOP,
+    VB_CLAMP_ANIMATION_SPEED,
 } GIVanillaBehavior;
 
 typedef enum {

--- a/mm/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/mm/src/overlays/actors/ovl_player_actor/z_player.c
@@ -13240,7 +13240,9 @@ void func_808477D0(PlayState* play, Player* this, Input* input, f32 arg3) {
     }
 
     var_fv0 = var_fv0 * arg3;
-    var_fv0 = CLAMP(var_fv0, 1.0f, 2.5f);
+    if (GameInteractor_Should(VB_CLAMP_ANIMATION_SPEED, true, &var_fv0)) {
+        var_fv0 = CLAMP(var_fv0, 1.0f, 2.5f);
+    }
     this->skelAnime.playSpeed = var_fv0;
 
     PlayerAnimation_Update(play, &this->skelAnime);


### PR DESCRIPTION
~~I didn't feel like this called for a hook/VB. Willing to convert it if people feel otherwise.~~
Changed my mind, converted to a hook and checking explicitly for human transform and the correct player action for swimming, as this is used in a few spots

Reference:
https://github.com/HarbourMasters/Shipwright/blob/47fdaabd1bc47ec11e8be1e98ab512980c3ef9cc/soh/src/overlays/actors/ovl_player_actor/z_player.c#L12964-L12966

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2485250136.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2485251188.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2485252314.zip)
<!--- section:artifacts:end -->