### PR TITLE
Tweaks to TimeMovesWhenYouMove

### DIFF
--- a/mm/2s2h/Enhancements/Modes/TimeMovesWhenYouMove.cpp
+++ b/mm/2s2h/Enhancements/Modes/TimeMovesWhenYouMove.cpp
@@ -9,15 +9,70 @@ extern "C" {
 #define CVAR_NAME "gModes.TimeMovesWhenYouMove"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
+// Arbitrary speed to determine the offset is unset
+#define DEFAULT_TIME_OFFSET -12345
+static s32 sStoredTimeOffset = DEFAULT_TIME_OFFSET;
+
 void RegisterTimeMovesWhenYouMove() {
-    gSaveContext.save.timeSpeedOffset = 0;
+    if (!CVAR && sStoredTimeOffset != DEFAULT_TIME_OFFSET) {
+        gSaveContext.save.timeSpeedOffset = sStoredTimeOffset;
+        sStoredTimeOffset = DEFAULT_TIME_OFFSET;
+    }
+
+    // This is WIP code, sort of turns this enhancement into a "Super Hot" mode where
+    // actors update functions are also halted when not moving. The problem is this breaks
+    // many situations, like opening a chest or talking to actors. So it needs more time in the oven
+
+    // COND_HOOK(ShouldActorUpdate, CVAR, [](Actor* actor, bool* should) {
+    //     static bool hookIsFiring = false;
+    //     if (actor->id == ACTOR_ARMS_HOOK) {
+    //         ArmsHook* hook = (ArmsHook*)actor;
+    //         if (hook->actionFunc == ArmsHook_Shoot) {
+    //             hookIsFiring = true;
+    //         } else {
+    //             hookIsFiring = false;
+    //         }
+    //     }
+
+    //     if (actor->id != ACTOR_EN_ARROW &&
+    //         (actor->id == ACTOR_PLAYER || actor->category == ACTORCAT_BG || actor->category == ACTORCAT_DOOR ||
+    //          actor->category == ACTORCAT_SWITCH || actor->category == ACTORCAT_ITEMACTION)) {
+    //         return;
+    //     }
+
+    //     Player* player = GET_PLAYER(gPlayState);
+
+    //     static Actor* lastTalkActor = NULL;
+    //     if (player->talkActor != NULL && player->talkActor != lastTalkActor) {
+    //         lastTalkActor = player->talkActor;
+    //     }
+
+    //     if (player->linearVelocity == 0 &&
+    //         lastTalkActor != actor && !(player->stateFlags1 & PLAYER_STATE1_1) &&
+    //         !(player->stateFlags1 & PLAYER_STATE1_2) && !(player->stateFlags1 & PLAYER_STATE1_20) &&
+    //         !(player->stateFlags1 & PLAYER_STATE1_40) && !(player->stateFlags1 & PLAYER_STATE1_80) &&
+    //         !(player->stateFlags1 & PLAYER_STATE1_100) && !(player->stateFlags1 & PLAYER_STATE1_400) &&
+    //         !(player->stateFlags1 & PLAYER_STATE1_1000) && !(player->stateFlags1 & PLAYER_STATE1_2000000) &&
+    //         !(player->stateFlags1 & PLAYER_STATE1_10000000) && !(player->stateFlags1 & PLAYER_STATE1_20000000) &&
+    //         !(player->stateFlags2 & PLAYER_STATE2_8) && !(player->stateFlags3 & PLAYER_STATE3_8) &&
+    //         !(player->stateFlags3 & PLAYER_STATE3_2000000) && (!hookIsFiring)) {
+    //         *should = false;
+    //     }
+    // });
 
     COND_ID_HOOK(OnActorUpdate, ACTOR_PLAYER, CVAR, [](Actor* actor) {
         Player* player = GET_PLAYER(gPlayState);
+        bool timeShouldMove = (player->stateFlags2 & PLAYER_STATE2_8000000) || player->linearVelocity != 0.0f;
 
-        gSaveContext.save.timeSpeedOffset = -R_TIME_SPEED;
-        if (player->linearVelocity != 0) {
-            gSaveContext.save.timeSpeedOffset = CLAMP(player->linearVelocity / 2 - R_TIME_SPEED, -R_TIME_SPEED, 10);
+        if (timeShouldMove && sStoredTimeOffset != DEFAULT_TIME_OFFSET) {
+            gSaveContext.save.timeSpeedOffset = sStoredTimeOffset;
+            sStoredTimeOffset = DEFAULT_TIME_OFFSET;
+
+            // This is for the section above, lets arrows continue flying after they were fired with time frozen
+            // player->unk_D57 = 4;
+        } else if (!timeShouldMove && sStoredTimeOffset == DEFAULT_TIME_OFFSET) {
+            sStoredTimeOffset = gSaveContext.save.timeSpeedOffset;
+            gSaveContext.save.timeSpeedOffset = -R_TIME_SPEED;
         }
     });
 }


### PR DESCRIPTION
This tweaks how the TimeMovesWhenYouMove mode works, making it compatible with the inverted song of time slowdown, and it no longer is based on velocity.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2716681475.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2716682468.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2716713731.zip)
<!--- section:artifacts:end -->