### PR TITLE
Fix Persistent Bunny Hood losing color with other masks

### DIFF
--- a/mm/2s2h/Enhancements/Masks/PersistentMasks.cpp
+++ b/mm/2s2h/Enhancements/Masks/PersistentMasks.cpp
@@ -65,11 +65,17 @@ void UpdatePersistentMasksState() {
             }
 
             OPEN_DISPS(gPlayState->state.gfxCtx);
+
+            // Set back geometry modes left over from player head DL, incase another mask changed the values
+            gSPLoadGeometryMode(POLY_OPA_DISP++,
+                                G_ZBUFFER | G_SHADE | G_CULL_BACK | G_FOG | G_LIGHTING | G_SHADING_SMOOTH);
+
             Matrix_Push();
             Player_DrawBunnyHood(gPlayState);
             gSPDisplayList(POLY_OPA_DISP++,
                            (Gfx*)D_801C0B20[PLAYER_MASK_BUNNY - 1]); // D_801C0B20 is an array of mask DLs
             Matrix_Pop();
+
             CLOSE_DISPS(gPlayState->state.gfxCtx);
         });
 

--- a/mm/2s2h/Enhancements/Masks/PersistentMasks.cpp
+++ b/mm/2s2h/Enhancements/Masks/PersistentMasks.cpp
@@ -152,8 +152,12 @@ void RegisterPersistentMasks() {
 
     // Speed the player up when the bunny hood state is active
     COND_VB_SHOULD(VB_CONSIDER_BUNNY_HOOD_EQUIPPED, CVAR, {
+        Player* player = va_arg(args, Player*);
+
         // But don't speed up if the player is non-human and controller input is being overriden for cutscenes/minigames
-        if (STATE_CVAR && (GET_PLAYER_FORM == PLAYER_FORM_HUMAN || gPlayState->actorCtx.unk268 == 0)) {
+        // or if player is Kafei
+        if (STATE_CVAR && player->actor.id == ACTOR_PLAYER &&
+            (GET_PLAYER_FORM == PLAYER_FORM_HUMAN || gPlayState->actorCtx.unk268 == 0)) {
             *should = true;
         }
     });

--- a/mm/src/overlays/actors/ovl_En_Mm3/z_en_mm3.c
+++ b/mm/src/overlays/actors/ovl_En_Mm3/z_en_mm3.c
@@ -209,7 +209,8 @@ void func_80A6F5E4(EnMm3* this, PlayState* play) {
                 } else {
                     func_80A70084(this, play);
                     if (GameInteractor_Should(VB_CONSIDER_BUNNY_HOOD_EQUIPPED,
-                                              Player_GetMask(play) == PLAYER_MASK_BUNNY)) {
+                                              Player_GetMask(play) == PLAYER_MASK_BUNNY),
+                        GET_PLAYER(play)) {
                         Message_StartTextbox(play, 0x27A0, &this->actor);
                         this->unk_2B4 = 0x27A0;
                     } else {
@@ -347,7 +348,8 @@ void func_80A6F9DC(EnMm3* this, PlayState* play) {
 
                     player->stateFlags1 |= PLAYER_STATE1_20;
                     if (GameInteractor_Should(VB_CONSIDER_BUNNY_HOOD_EQUIPPED,
-                                              Player_GetMask(play) == PLAYER_MASK_BUNNY)) {
+                                              Player_GetMask(play) == PLAYER_MASK_BUNNY),
+                        player) {
                         Interface_StartPostmanTimer(0, POSTMAN_MINIGAME_BUNNY_HOOD_ON);
                     } else {
                         Interface_StartPostmanTimer(0, POSTMAN_MINIGAME_BUNNY_HOOD_OFF);
@@ -416,7 +418,7 @@ void func_80A6FBFC(EnMm3* this, PlayState* play) {
     } else {
         Actor_OfferTalk(&this->actor, play, this->actor.xzDistToPlayer + 10.0f);
         func_80123E90(play, &this->actor);
-        if (GameInteractor_Should(VB_CONSIDER_BUNNY_HOOD_EQUIPPED, Player_GetMask(play) == PLAYER_MASK_BUNNY)) {
+        if (GameInteractor_Should(VB_CONSIDER_BUNNY_HOOD_EQUIPPED, Player_GetMask(play) == PLAYER_MASK_BUNNY), player) {
             Audio_PlaySfx(NA_SE_SY_STOPWATCH_TIMER_INF - SFX_FLAG);
         } else {
             Audio_PlaySfx(NA_SE_SY_STOPWATCH_TIMER_3 - SFX_FLAG);
@@ -465,7 +467,8 @@ void func_80A6FEEC(EnMm3* this, PlayState* play) {
 s32 func_80A6FFAC(EnMm3* this, PlayState* play) {
     switch (GET_PLAYER_FORM) {
         case PLAYER_FORM_HUMAN:
-            if (GameInteractor_Should(VB_CONSIDER_BUNNY_HOOD_EQUIPPED, Player_GetMask(play) == PLAYER_MASK_BUNNY)) {
+            if (GameInteractor_Should(VB_CONSIDER_BUNNY_HOOD_EQUIPPED, Player_GetMask(play) == PLAYER_MASK_BUNNY),
+                GET_PLAYER(play)) {
                 if (this->unk_2B2 & 0x10) {
                     return true;
                 }
@@ -502,7 +505,8 @@ s32 func_80A6FFAC(EnMm3* this, PlayState* play) {
 void func_80A70084(EnMm3* this, PlayState* play) {
     switch (GET_PLAYER_FORM) {
         case PLAYER_FORM_HUMAN:
-            if (GameInteractor_Should(VB_CONSIDER_BUNNY_HOOD_EQUIPPED, Player_GetMask(play) == PLAYER_MASK_BUNNY)) {
+            if (GameInteractor_Should(VB_CONSIDER_BUNNY_HOOD_EQUIPPED, Player_GetMask(play) == PLAYER_MASK_BUNNY),
+                GET_PLAYER(play)) {
                 this->unk_2B2 |= 0x10;
                 this->unk_2B2 |= 1;
             } else {

--- a/mm/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/mm/src/overlays/actors/ovl_player_actor/z_player.c
@@ -12210,7 +12210,7 @@ void Player_UpdateCommon(Player* this, PlayState* play, Input* input) {
 
         this->actor.shape.face = ((play->gameplayFrames & 0x20) ? 0 : 3) + this->blinkInfo.eyeTexIndex;
 
-        if (GameInteractor_Should(VB_CONSIDER_BUNNY_HOOD_EQUIPPED, this->currentMask == PLAYER_MASK_BUNNY)) {
+        if (GameInteractor_Should(VB_CONSIDER_BUNNY_HOOD_EQUIPPED, this->currentMask == PLAYER_MASK_BUNNY, this)) {
             Player_UpdateBunnyEars(this);
         }
 
@@ -13095,7 +13095,7 @@ s32 Ship_HandleFirstPersonAiming(PlayState* play, Player* this, s32 arg2) {
     if (!playerMovementLocked && CVarGetInteger("gEnhancements.Camera.FirstPerson.MoveInFirstPerson", 0) &&
         CVarGetInteger("gEnhancements.Camera.FirstPerson.RightStickEnabled", 0)) {
         f32 movementSpeed = 8.25f; // account for form
-        if (GameInteractor_Should(VB_CONSIDER_BUNNY_HOOD_EQUIPPED, this->currentMask == PLAYER_MASK_BUNNY)) {
+        if (GameInteractor_Should(VB_CONSIDER_BUNNY_HOOD_EQUIPPED, this->currentMask == PLAYER_MASK_BUNNY, this)) {
             movementSpeed *= 1.5f;
         }
 
@@ -14597,7 +14597,7 @@ void Player_Action_13(Player* this, PlayState* play) {
 
     Player_GetMovementSpeedAndYaw(this, &speedTarget, &yawTarget, SPEED_MODE_CURVED, play);
 
-    if (GameInteractor_Should(VB_CONSIDER_BUNNY_HOOD_EQUIPPED, this->currentMask == PLAYER_MASK_BUNNY)) {
+    if (GameInteractor_Should(VB_CONSIDER_BUNNY_HOOD_EQUIPPED, this->currentMask == PLAYER_MASK_BUNNY, this)) {
         speedTarget *= 1.5f;
     }
 


### PR DESCRIPTION
The bunny hood DL does not set the required GeometryMode values, instead it works by inheriting the previous values from links head limb.

The persistent bunny hood draw behavior runs after the currently equipped mask is drawn, and in some cases those masks change the GeometryMode values which lead to the bunny hood textures just rendering the env fog color instead.

This adds a `gSPLoadGeometryMode` before the persistent bunny hood draw so reset the values back.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2458573914.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2458576776.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2458583657.zip)
<!--- section:artifacts:end -->