### PR TITLE
Add crash protection for action swap

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1077,6 +1077,17 @@ void BenMenu::AddEnhancements() {
     path = { "Enhancements", "Fixes", 1 };
     AddSidebarEntry("Enhancements", "Fixes", 3);
     AddWidget(path, "Fixes", WIDGET_SEPARATOR_TEXT);
+    AddWidget(path, "Fix Console Crashes", WIDGET_CVAR_CHECKBOX)
+        .CVar("gEnhancements.Fixes.ConsoleCrashes")
+        .Options(CheckboxOptions()
+                     .Tooltip("Fixes crashes that would typically happen on Console. "
+                              "Disabling this option will simply soft reset 2Ship when encountering these "
+                              "crashes instead of actually crashing the program.\n\n"
+                              "Includes the following:\n"
+                              "- HESS/Weirdshot crashes\n"
+                              "- Action Swap crash without arrow ammo\n"
+                              "- Owl Warp menu crash when moving the cursor with Index-Warp active")
+                     .DefaultValue(true));
     AddWidget(path, "Fix Ammo Count Color", WIDGET_CVAR_CHECKBOX)
         .CVar("gFixes.FixAmmoCountEnvColor")
         .Options(CheckboxOptions().Tooltip("Fixes a missing gDPSetEnvColor, which causes the ammo count to be "
@@ -1084,9 +1095,6 @@ void BenMenu::AddEnhancements() {
     AddWidget(path, "Fix Fierce Deity Z-Target movement", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Fixes.FierceDeityZTargetMovement")
         .Options(CheckboxOptions().Tooltip("Fixes Fierce Deity movement being choppy when Z-targeting"));
-    AddWidget(path, "Fix Hess and Weirdshot Crash", WIDGET_CVAR_CHECKBOX)
-        .CVar("gEnhancements.Fixes.HessCrash")
-        .Options(CheckboxOptions().Tooltip("Fixes a crash that can occur when performing a HESS or Weirdshot."));
     AddWidget(path, "Fix Text Control Characters", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Fixes.ControlCharacters")
         .Options(CheckboxOptions().Tooltip("Fixes certain control characters not functioning properly "

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -1766,7 +1766,12 @@ extern "C" int Controller_ShouldRumble(size_t slot) {
 }
 
 // Helper to redirect the user to the boot screen in place of known console crash scenarios, and emits a notification
-extern "C" void Ship_HandleConsoleCrashAsReset() {
+extern "C" bool Ship_HandleConsoleCrashAsReset() {
+    // If fix crashes is on, return false and let fallback handling process in source
+    if (CVarGetInteger("gEnhancements.Fixes.ConsoleCrashes", 1)) {
+        return false;
+    }
+
     std::reinterpret_pointer_cast<Ship::ConsoleWindow>(
         Ship::Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Console"))
         ->Dispatch("reset");
@@ -1776,4 +1781,6 @@ extern "C" void Ship_HandleConsoleCrashAsReset() {
         .message = "Crash prevented!",
         .remainingTime = 10.0f,
     });
+
+    return true;
 }

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -55,6 +55,7 @@ CrowdControl* CrowdControl::Instance;
 #include "2s2h/DeveloperTools/DebugConsole.h"
 #include "2s2h/DeveloperTools/DeveloperTools.h"
 #include "2s2h/SaveManager/SaveManager.h"
+#include "2s2h/BenGui/Notification.h"
 #include "2s2h/ShipUtils.h"
 #include "2s2h/ShipInit.hpp"
 
@@ -1762,4 +1763,17 @@ extern "C" int Controller_ShouldRumble(size_t slot) {
     }
 
     return 0;
+}
+
+// Helper to redirect the user to the boot screen in place of known console crash scenarios, and emits a notification
+extern "C" void Ship_HandleConsoleCrashAsReset() {
+    std::reinterpret_pointer_cast<Ship::ConsoleWindow>(
+        Ship::Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Console"))
+        ->Dispatch("reset");
+
+    Notification::Emit({
+        .itemIcon = "__OTR__icon_item_24_static_yar/gQuestIconGoldSkulltulaTex",
+        .message = "Crash prevented!",
+        .remainingTime = 10.0f,
+    });
 }

--- a/mm/2s2h/BenPort.h
+++ b/mm/2s2h/BenPort.h
@@ -143,6 +143,8 @@ void Gfx_UnregisterBlendedTexture(const char* name);
 void Gfx_TextureCacheDelete(const uint8_t* texAddr);
 void CheckTracker_OnMessageClose();
 
+void Ship_HandleConsoleCrashAsReset();
+
 int32_t GetGIID(uint32_t itemID);
 #endif
 

--- a/mm/2s2h/BenPort.h
+++ b/mm/2s2h/BenPort.h
@@ -143,7 +143,7 @@ void Gfx_UnregisterBlendedTexture(const char* name);
 void Gfx_TextureCacheDelete(const uint8_t* texAddr);
 void CheckTracker_OnMessageClose();
 
-void Ship_HandleConsoleCrashAsReset();
+bool Ship_HandleConsoleCrashAsReset();
 
 int32_t GetGIID(uint32_t itemID);
 #endif

--- a/mm/src/code/z_player_lib.c
+++ b/mm/src/code/z_player_lib.c
@@ -1811,10 +1811,10 @@ void Player_DrawImpl(PlayState* play, void** skeleton, Vec3s* jointTable, s32 dL
 
     gfx = POLY_OPA_DISP;
 
-    if (CVarGetInteger("gEnhancements.Fixes.HessCrash", 1)) {
-        if (eyeIndex >= PLAYER_EYES_MAX) {
-            eyeIndex = 0;
-        }
+    // 2S2H [Port] Hess crash fix
+    if (eyeIndex >= PLAYER_EYES_MAX) {
+        Ship_HandleConsoleCrashAsReset();
+        eyeIndex = 0;
     }
 
     if (eyeIndex < 0) {
@@ -1831,10 +1831,10 @@ void Player_DrawImpl(PlayState* play, void** skeleton, Vec3s* jointTable, s32 dL
 
     gSPSegment(&gfx[0], 0x08, Lib_SegmentedToVirtual(sPlayerEyesTextures[playerForm][eyeIndex]));
 
-    if (CVarGetInteger("gEnhancements.Fixes.HessCrash", 1)) {
-        if (mouthIndex >= PLAYER_MOUTH_MAX) {
-            mouthIndex = 0;
-        }
+    // 2S2H [Port] Hess crash fix
+    if (mouthIndex >= PLAYER_MOUTH_MAX) {
+        Ship_HandleConsoleCrashAsReset();
+        mouthIndex = 0;
     }
 
     if (mouthIndex < 0) {
@@ -2422,10 +2422,10 @@ s32 Player_OverrideLimbDrawGameplayDefault(PlayState* play, s32 limbIndex, Gfx**
 
                     if (handIndex != 0) {
                         handIndex = (handIndex >> 8) - 1;
-                        if (CVarGetInteger("gEnhancements.Fixes.HessCrash", 1)) {
-                            if (handIndex >= 2) {
-                                handIndex = 0;
-                            }
+                        // 2S2H [Port] Hess crash fix
+                        if (handIndex >= 2) {
+                            Ship_HandleConsoleCrashAsReset();
+                            handIndex = 0;
                         }
                         rightHandDLists = &D_801C0964[handIndex][D_801F59E0];
                     }

--- a/mm/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/mm/src/overlays/actors/ovl_player_actor/z_player.c
@@ -13794,7 +13794,7 @@ s32 Player_UpperAction_7(Player* this, PlayState* play) {
                     // For the port hard crashing is not desirable, so we are opting to clear the game state
                     if (this->unk_B28 - 1 < 0) {
                         Ship_HandleConsoleCrashAsReset();
-                        return 0;
+                        Player_PlaySfx(this, NA_SE_NONE);
                     } else {
                         Player_PlaySfx(this, D_8085D5FC[this->unk_B28 - 1]);
                     }

--- a/mm/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/mm/src/overlays/actors/ovl_player_actor/z_player.c
@@ -45,6 +45,7 @@
 #include "objects/object_link_nuts/object_link_nuts.h"
 #include "objects/object_link_child/object_link_child.h"
 
+#include "2s2h/BenPort.h"
 #include "2s2h/GameInteractor/GameInteractor.h"
 
 #define THIS ((Player*)thisx)
@@ -3968,7 +3969,14 @@ s32 func_808306F8(Player* this, PlayState* play) {
             ArrowMagic magicArrowType;
 
             if (var_v1 != 2) {
-                Player_PlaySfx(this, D_8085CFB0[var_v1 - 1]);
+                // 2S2H [Port] When using action swap, D_8085CFB0 is indexed with -1 leading
+                // to UB sent into Player_PlaySfx. On console this resolves as 1 and nothing noticable happens.
+                // For the port, sometimes this UB would crash so we are opting to just request NA_SE_NONE instead.
+                if (var_v1 - 1 < 0) {
+                    Player_PlaySfx(this, NA_SE_NONE);
+                } else {
+                    Player_PlaySfx(this, D_8085CFB0[var_v1 - 1]);
+                }
             }
 
             if (!Player_IsHoldingHookshot(this) && (func_808305BC(play, this, &item, &arrowType) > 0)) {
@@ -13781,7 +13789,15 @@ s32 Player_UpperAction_7(Player* this, PlayState* play) {
         if (this->unk_B28 >= 0) {
             if (index != 0) {
                 if (!func_80831194(play, this)) {
-                    Player_PlaySfx(this, D_8085D5FC[this->unk_B28 - 1]);
+                    // 2S2H [Port] When using action swap without arrows, D_8085D5FC is indexed with -1 leading
+                    // to UB sent into Player_PlaySfx. On console this resolves as 58104 and causes a crash.
+                    // For the port hard crashing is not desirable, so we are opting to clear the game state
+                    if (this->unk_B28 - 1 < 0) {
+                        Ship_HandleConsoleCrashAsReset();
+                        return 0;
+                    } else {
+                        Player_PlaySfx(this, D_8085D5FC[this->unk_B28 - 1]);
+                    }
                 }
 
                 if (this->transformation == PLAYER_FORM_DEKU) {

--- a/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_map.c
+++ b/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_map.c
@@ -18,6 +18,26 @@
 // 2S2H [Port] (and line 26) don't do pointer math and access the list of digits directly.
 extern const char* sCounterTextures[];
 
+// 2S2H [Port] The cursor updating logic for owl warping can get stuck in an infinite loop
+// when there are no world map points registered. This can happen when using index warping and moving the cursor
+// on the menu. We want to completely avoid an infinite loop on the port, so we check to see that there are no points
+// and break out of the loop or soft reset as needed.
+// Defined as a macro for re-use and to be able to "break" out of the parent while loop.
+#define SHIP_HANDLE_OWL_CURSOR_INF_LOOP()                 \
+    {                                                     \
+        bool hasPoint = false;                            \
+        for (int i = 0; i <= OWL_WARP_STONE_TOWER; i++) { \
+            if (pauseCtx->worldMapPoints[i]) {            \
+                hasPoint = true;                          \
+                break;                                    \
+            }                                             \
+        }                                                 \
+        if (!hasPoint) {                                  \
+            Ship_HandleConsoleCrashAsReset();             \
+            break;                                        \
+        }                                                 \
+    }
+
 void KaleidoScope_DrawDungeonStrayFairyCount(PlayState* play) {
     s16 counterDigits[2];
     s16 rectLeft;
@@ -978,6 +998,7 @@ void Ship_UpdateWorldMapCursorMirrorWorld(PlayState* play) {
 
         if (goingRight) {
             do {
+                SHIP_HANDLE_OWL_CURSOR_INF_LOOP();
                 pauseCtx->cursorPoint[PAUSE_WORLD_MAP]++;
                 if (pauseCtx->cursorPoint[PAUSE_WORLD_MAP] > OWL_WARP_STONE_TOWER) {
                     pauseCtx->cursorPoint[PAUSE_WORLD_MAP] = OWL_WARP_GREAT_BAY_COAST;
@@ -985,6 +1006,7 @@ void Ship_UpdateWorldMapCursorMirrorWorld(PlayState* play) {
             } while (!pauseCtx->worldMapPoints[pauseCtx->cursorPoint[PAUSE_WORLD_MAP]]);
         } else if (goingLeft) {
             do {
+                SHIP_HANDLE_OWL_CURSOR_INF_LOOP();
                 pauseCtx->cursorPoint[PAUSE_WORLD_MAP]--;
                 if (pauseCtx->cursorPoint[PAUSE_WORLD_MAP] < OWL_WARP_GREAT_BAY_COAST) {
                     pauseCtx->cursorPoint[PAUSE_WORLD_MAP] = OWL_WARP_STONE_TOWER;
@@ -1134,6 +1156,7 @@ void KaleidoScope_UpdateWorldMapCursor(PlayState* play) {
             pauseCtx->cursorShrinkRate = 4.0f;
             sStickAdjTimer = 0;
             do {
+                SHIP_HANDLE_OWL_CURSOR_INF_LOOP();
                 pauseCtx->cursorPoint[PAUSE_WORLD_MAP]++;
                 if (pauseCtx->cursorPoint[PAUSE_WORLD_MAP] > OWL_WARP_STONE_TOWER) {
                     pauseCtx->cursorPoint[PAUSE_WORLD_MAP] = OWL_WARP_GREAT_BAY_COAST;
@@ -1143,6 +1166,7 @@ void KaleidoScope_UpdateWorldMapCursor(PlayState* play) {
             pauseCtx->cursorShrinkRate = 4.0f;
             sStickAdjTimer = 0;
             do {
+                SHIP_HANDLE_OWL_CURSOR_INF_LOOP();
                 pauseCtx->cursorPoint[PAUSE_WORLD_MAP]--;
                 if (pauseCtx->cursorPoint[PAUSE_WORLD_MAP] < OWL_WARP_GREAT_BAY_COAST) {
                     pauseCtx->cursorPoint[PAUSE_WORLD_MAP] = OWL_WARP_STONE_TOWER;


### PR DESCRIPTION
This adds some crash prevention around the behavior of action swap. Specifically there are two instances of OOB/UB access that both regard playing SFX.

The first instance happens when drawing an arrow with action swap. This OOB access on console leads to a value of `1` which isn't a valid SFX entry, but seems to be gracefully handled. For some windows users however, a different value is read from memory and could cause a hard crash in 2ship. Since this console behavior is that nothing happens, I've opted to address this situation by playing `NA_SE_NONE`.

The second instance happens when releasing the bow without having any bow ammo. This OOB access on console leads to a value of `58104`, which is not a valid SFX entry either, however this causes a crash on console. In this case I've opted to create a new handler `Ship_HandleConsoleCrashAsReset` which does as it suggests, which is to soft reset 2ship to avoid hard crashing. A notification is emitted to let the user know that the crash was prevented.

This handler can be placed in other places of known crashes from glitches, like index warping. In a follow up PR I might explore a "safer glitches" toggle that can be set by players to skip the soft reset and just keep the game playing like normal.

I'm not sure yet if I like this handler being placed in `BenPort` but I also don't know where else it makes sense (maybe ShipUtils?)

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2489257243.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2489264547.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2489269304.zip)
<!--- section:artifacts:end -->