### PR TITLE
Add missing string format specifiers

### DIFF
--- a/mm/2s2h/BenGui/BenInputEditorWindow.cpp
+++ b/mm/2s2h/BenGui/BenInputEditorWindow.cpp
@@ -272,7 +272,7 @@ void BenInputEditorWindow::DrawButtonLineEditMappingButton(uint8_t port, CONTROL
         ImGui::OpenPopup(popupId.c_str());
     }
     if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal | ImGuiHoveredFlags_NoSharedDelay)) {
-        ImGui::SetTooltip(mapping->GetPhysicalDeviceName().c_str());
+        ImGui::SetTooltip("%s", mapping->GetPhysicalDeviceName().c_str());
     }
     ImGui::PopStyleColor();
     ImGui::PopStyleColor();
@@ -544,7 +544,7 @@ void BenInputEditorWindow::DrawStickDirectionLineEditMappingButton(uint8_t port,
         ImGui::OpenPopup(popupId.c_str());
     }
     if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal | ImGuiHoveredFlags_NoSharedDelay)) {
-        ImGui::SetTooltip(mapping->GetPhysicalDeviceName().c_str());
+        ImGui::SetTooltip("%s", mapping->GetPhysicalDeviceName().c_str());
     }
     ImGui::PopStyleColor();
     ImGui::PopStyleColor();
@@ -1112,7 +1112,7 @@ void BenInputEditorWindow::DrawGyroSection(uint8_t port) {
         auto id = mapping->GetGyroMappingId();
         ImGui::AlignTextToFramePadding();
         ImGui::SetNextItemOpen(true, ImGuiCond_Once);
-        ImGui::BulletText(mapping->GetPhysicalDeviceName().c_str());
+        ImGui::BulletText("%s", mapping->GetPhysicalDeviceName().c_str());
         DrawRemoveGyroMappingButton(port, id);
 
         static float sPitch, sYaw = 0.0f;

--- a/mm/2s2h/DeveloperTools/SaveEditor.cpp
+++ b/mm/2s2h/DeveloperTools/SaveEditor.cpp
@@ -1000,7 +1000,7 @@ void DrawSong(QuestItem slot) {
     }
     if (ImGui::IsItemHovered()) {
         ImGui::BeginTooltip();
-        ImGui::Text(songTooltip);
+        ImGui::Text("%s", songTooltip);
         ImGui::EndTooltip();
     }
     if (slot != QUEST_SONG_SUN) {
@@ -1180,7 +1180,7 @@ void DrawDungeonItemTab() {
         ImGui::BeginChild(std::to_string(i).c_str(),
                           ImVec2(INV_GRID_WIDTH * 6 + INV_GRID_PADDING * 2, INV_GRID_HEIGHT * 1.5 + INV_GRID_PADDING),
                           ImGuiChildFlags_Border);
-        ImGui::Text(dungeonNames[i]);
+        ImGui::Text("%s", dungeonNames[i]);
         if (ImGui::ImageButton(
                 stray_id.c_str(),
                 Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName(fairyIcons[dungeonId]),
@@ -1440,7 +1440,7 @@ void DrawPlayerTab() {
             ImGui::TableNextColumn();
 
             for (int i = 0; i <= 3; i++) {
-                ImGui::Text(std::to_string(states[i]).c_str());
+                ImGui::Text("%s", std::to_string(states[i]).c_str());
                 ImGui::TableNextColumn();
             }
 


### PR DESCRIPTION
2ship fails to build currently on GCC 14 for me which has `-Werror=format-security` enabled due to missing string format specifiers with the following error message. This PR fixes instances of this in 2ship. Goes along with https://github.com/louist103/OTRExporter/pull/34.
```
error: format not a string literal and no format arguments [-Werror=format-security]
```

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2487636567.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2487638822.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2487640631.zip)
<!--- section:artifacts:end -->