### PR TITLE
Fix Persistent Mask Crash on Talking to Postman

### DIFF
--- a/mm/2s2h/Enhancements/Masks/PersistentMasks.cpp
+++ b/mm/2s2h/Enhancements/Masks/PersistentMasks.cpp
@@ -156,7 +156,7 @@ void RegisterPersistentMasks() {
 
         // But don't speed up if the player is non-human and controller input is being overriden for cutscenes/minigames
         // or if player is Kafei
-        if (STATE_CVAR && player->actor.id == ACTOR_PLAYER &&
+        if (player && STATE_CVAR && player->actor.id == ACTOR_PLAYER &&
             (GET_PLAYER_FORM == PLAYER_FORM_HUMAN || gPlayState->actorCtx.unk268 == 0)) {
             *should = true;
         }

--- a/mm/src/overlays/actors/ovl_En_Mm3/z_en_mm3.c
+++ b/mm/src/overlays/actors/ovl_En_Mm3/z_en_mm3.c
@@ -467,7 +467,8 @@ void func_80A6FEEC(EnMm3* this, PlayState* play) {
 s32 func_80A6FFAC(EnMm3* this, PlayState* play) {
     switch (GET_PLAYER_FORM) {
         case PLAYER_FORM_HUMAN:
-            if (GameInteractor_Should(VB_CONSIDER_BUNNY_HOOD_EQUIPPED, Player_GetMask(play) == PLAYER_MASK_BUNNY),
+            if (GameInteractor_Should(VB_CONSIDER_BUNNY_HOOD_EQUIPPED, Player_GetMask(play) == PLAYER_MASK_BUNNY,
+                                      GET_PLAYER(play)),
                 GET_PLAYER(play)) {
                 if (this->unk_2B2 & 0x10) {
                     return true;

--- a/mm/src/overlays/actors/ovl_En_Mm3/z_en_mm3.c
+++ b/mm/src/overlays/actors/ovl_En_Mm3/z_en_mm3.c
@@ -468,8 +468,7 @@ s32 func_80A6FFAC(EnMm3* this, PlayState* play) {
     switch (GET_PLAYER_FORM) {
         case PLAYER_FORM_HUMAN:
             if (GameInteractor_Should(VB_CONSIDER_BUNNY_HOOD_EQUIPPED, Player_GetMask(play) == PLAYER_MASK_BUNNY,
-                                      GET_PLAYER(play)),
-                GET_PLAYER(play)) {
+                                      GET_PLAYER(play))) {
                 if (this->unk_2B2 & 0x10) {
                     return true;
                 }


### PR DESCRIPTION
Persistent Masks implementer forgot to include Player pointer as argument for GI SHOULD call at `z_en_mm3.c` line 470. Also edits `PersistentMasks.cpp` to prevent null deref.

To reproduce this crash, simply turn on Persistent Bunny Hood and talk to the postman while he is on bed.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2487822166.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2487823954.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2487825571.zip)
<!--- section:artifacts:end -->