### PR TITLE
Adjust CVar names for difficulty options

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1177,12 +1177,12 @@ void BenMenu::AddEnhancements() {
     path = { "Enhancements", "Difficulty Options", 1 };
     AddSidebarEntry("Enhancements", "Difficulty Options", 3);
     AddWidget(path, "Disable Takkuri Steal", WIDGET_CVAR_CHECKBOX)
-        .CVar("gEnhancements.Cheats.DisableTakkuriSteal")
+        .CVar("gEnhancements.DifficultyOptions.DisableTakkuriSteal")
         .Options(CheckboxOptions().Tooltip(
             "Prevents the Takkuri from stealing key items like bottles and swords. It may still steal "
             "other items."));
     AddWidget(path, "Deku Guard Search Balls", WIDGET_CVAR_COMBOBOX)
-        .CVar("gEnhancements.Cheats.DekuGuardSearchBalls")
+        .CVar("gEnhancements.DifficultyOptions.DekuGuardSearchBalls")
         .Options(
             ComboboxOptions()
                 .Tooltip("Choose when to show the Deku Palace Guards' search balls\n"
@@ -1192,7 +1192,7 @@ void BenMenu::AddEnhancements() {
                 .DefaultIndex(DekuGuardSearchBallsOptions::DEKU_GUARD_SEARCH_BALLS_NIGHT_ONLY)
                 .ComboMap(dekuGuardSearchBallsOptions));
     AddWidget(path, "Gibdo Trade Sequence Options", WIDGET_CVAR_COMBOBOX)
-        .CVar("gEnhancements.Cheats.GibdoTradeSequence")
+        .CVar("gEnhancements.DifficultyOptions.GibdoTradeSequence")
         .Options(
             ComboboxOptions()
                 .Tooltip(

--- a/mm/2s2h/Enhancements/DifficultyOptions/DekuGuardSearchBalls.cpp
+++ b/mm/2s2h/Enhancements/DifficultyOptions/DekuGuardSearchBalls.cpp
@@ -3,7 +3,7 @@
 #include "Enhancements/Enhancements.h"
 #include "2s2h/ShipInit.hpp"
 
-#define CVAR_NAME "gEnhancements.Cheats.DekuGuardSearchBalls"
+#define CVAR_NAME "gEnhancements.DifficultyOptions.DekuGuardSearchBalls"
 #define CVAR CVarGetInteger(CVAR_NAME, DEKU_GUARD_SEARCH_BALLS_NIGHT_ONLY)
 
 void RegisterShowDekuGuardSearchBalls() {

--- a/mm/2s2h/Enhancements/DifficultyOptions/DisableTakkuriSteal.cpp
+++ b/mm/2s2h/Enhancements/DifficultyOptions/DisableTakkuriSteal.cpp
@@ -2,7 +2,7 @@
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 
-#define CVAR_NAME "gEnhancements.Cheats.DisableTakkuriSteal"
+#define CVAR_NAME "gEnhancements.DifficultyOptions.DisableTakkuriSteal"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 void RegisterDisableTakkuriSteal() {

--- a/mm/2s2h/Enhancements/DifficultyOptions/GibdoTradeSequenceOptions.cpp
+++ b/mm/2s2h/Enhancements/DifficultyOptions/GibdoTradeSequenceOptions.cpp
@@ -4,7 +4,7 @@
 #include "2s2h/ShipInit.hpp"
 #include <stdarg.h>
 
-#define CVAR_NAME "gEnhancements.Cheats.GibdoTradeSequence"
+#define CVAR_NAME "gEnhancements.DifficultyOptions.GibdoTradeSequence"
 #define CVAR CVarGetInteger(CVAR_NAME, GIBDO_TRADE_SEQUENCE_VANILLA)
 
 extern "C" {


### PR DESCRIPTION
Rename some difficulty option CVar names to no longer be called "Cheats"

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2518717738.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2518722449.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2518726145.zip)
<!--- section:artifacts:end -->