### PR TITLE
Add safe crash handling for hookslide in GBT

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1102,7 +1102,8 @@ void BenMenu::AddEnhancements() {
                               "Includes the following:\n"
                               "- HESS/Weirdshot crashes\n"
                               "- Action Swap crash without arrow ammo\n"
-                              "- Owl Warp menu crash when moving the cursor with Index-Warp active")
+                              "- Owl Warp menu crash when moving the cursor with Index-Warp active\n"
+                              "- Remote Hookshot Hookslide crashes when over voids in Great Bay Temple")
                      .DefaultValue(true));
     AddWidget(path, "Fix Ammo Count Color", WIDGET_CVAR_CHECKBOX)
         .CVar("gFixes.FixAmmoCountEnvColor")


### PR DESCRIPTION
Adds safe crash handling for using RHS hookslide and traveling over voids in Great Bay Temple.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2519001548.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2519008168.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2519014296.zip)
<!--- section:artifacts:end -->