### PR TITLE
Fix left stick being locked when `Right Stick Aiming` disabled

### DIFF
--- a/mm/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/mm/src/overlays/actors/ovl_player_actor/z_player.c
@@ -13019,7 +13019,8 @@ s32 Ship_HandleFirstPersonAiming(PlayState* play, Player* this, s32 arg2) {
     float gyroX = 0.0f;
     float gyroY = 0.0f;
 
-    if (!CVarGetInteger("gEnhancements.Camera.FirstPerson.MoveInFirstPerson", 0)) {
+    if (!(CVarGetInteger("gEnhancements.Camera.FirstPerson.MoveInFirstPerson", 0) &&
+          CVarGetInteger("gEnhancements.Camera.FirstPerson.RightStickEnabled", 0))) {
         s32 leftStickX = sPlayerControlInput->rel.stick_x; // -60 to 60
         s32 leftStickY = sPlayerControlInput->rel.stick_y; // -60 to 60
 


### PR DESCRIPTION
Simple fix which allows usage of left stick in first person when `Move while aiming` enabled but `Right Stick Aiming` disabled.
![image](https://github.com/user-attachments/assets/cf0c1713-39fe-4fa9-a07b-db0920219e1d)



<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2536688254.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2536696694.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2536700846.zip)
<!--- section:artifacts:end -->