### PR TITLE
Fix Zora fin recall when carrying an item

### DIFF
--- a/mm/2s2h/Enhancements/Equipment/InstantRecall.cpp
+++ b/mm/2s2h/Enhancements/Equipment/InstantRecall.cpp
@@ -17,13 +17,16 @@ void Player_ReturnBoomerangs() {
         return;
     }
 
-    EnBoom* boomerangs = (EnBoom*)player->boomerangActor;
+    EnBoom* firstBoomerang = (EnBoom*)player->boomerangActor;
 
-    // Kill both boomerangs
-    if (boomerangs != NULL) {
-        Actor_Kill(&boomerangs->actor);
-        if (boomerangs->actor.child != NULL) {
-            Actor_Kill(boomerangs->actor.child);
+    // Kill both boomerangs as long as they are not carrying an actor
+    if (firstBoomerang != NULL) {
+        if (firstBoomerang->unk_1C8 == NULL) {
+            Actor_Kill(&firstBoomerang->actor);
+        }
+        EnBoom* secondBoomerang = (EnBoom*)firstBoomerang->actor.child;
+        if (secondBoomerang != NULL && secondBoomerang->unk_1C8 == NULL) {
+            Actor_Kill(&secondBoomerang->actor);
         }
     }
 }

--- a/mm/2s2h/Enhancements/Equipment/InstantRecall.cpp
+++ b/mm/2s2h/Enhancements/Equipment/InstantRecall.cpp
@@ -10,31 +10,19 @@ extern "C" {
 #define CVAR_NAME "gEnhancements.PlayerActions.InstantRecall"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
-void Player_ReturnBoomerangs() {
-    Player* player = GET_PLAYER(gPlayState);
+void ReturnBoomerang(Actor* actor) {
+    EnBoom* boomerang = (EnBoom*)actor;
 
-    if (player == NULL) {
-        return;
-    }
-
-    EnBoom* firstBoomerang = (EnBoom*)player->boomerangActor;
-
-    // Kill both boomerangs as long as they are not carrying an actor
-    if (firstBoomerang != NULL) {
-        if (firstBoomerang->unk_1C8 == NULL) {
-            Actor_Kill(&firstBoomerang->actor);
-        }
-        EnBoom* secondBoomerang = (EnBoom*)firstBoomerang->actor.child;
-        if (secondBoomerang != NULL && secondBoomerang->unk_1C8 == NULL) {
-            Actor_Kill(&secondBoomerang->actor);
-        }
+    // Kill the boomerang as long as it is not carrying an actor
+    if (boomerang->unk_1C8 == NULL) {
+        Actor_Kill(&boomerang->actor);
     }
 }
 
 void RegisterInstantRecall() {
     COND_ID_HOOK(OnActorUpdate, ACTOR_EN_BOOM, CVAR, [](Actor* actor) {
         if (CHECK_BTN_ALL(gPlayState->state.input->press.button, BTN_B)) {
-            Player_ReturnBoomerangs();
+            ReturnBoomerang(actor);
         }
     });
 }


### PR DESCRIPTION
Adjusts the Zora Fin Instant Recall enhancement to not kill the fin actor if it is carrying an item. This avoids items potentially falling into voids.

I've also simplified this hook to act directly on each rang actor, instead or operating off the player (which it did twice in a row because the hook is registered to the rang actor update).

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2559120588.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2559127002.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2559132822.zip)
<!--- section:artifacts:end -->