### PR TITLE
Add interpolation fixes to console logo and file chose skybox

### DIFF
--- a/mm/src/code/z_view.c
+++ b/mm/src/code/z_view.c
@@ -444,7 +444,8 @@ s32 View_ApplyPerspective(View* view) {
         }
     }
 
-    if (dont_interpolate) {
+    // Ignore camera heuristics when not in the PlayState or the game is paused as the camera moves a lot in Kaleido
+    if (dont_interpolate && gPlayState != NULL && R_PAUSE_BG_PRERENDER_STATE == PRERENDER_FILTER_STATE_NONE) {
         FrameInterpolation_DontInterpolateCamera();
     }
 

--- a/mm/src/overlays/gamestates/ovl_file_choose/z_file_choose_NES.c
+++ b/mm/src/overlays/gamestates/ovl_file_choose/z_file_choose_NES.c
@@ -2414,9 +2414,9 @@ void FileSelect_Main(GameState* thisx) {
 
     FileSelect_PulsateCursor(&this->state);
     gFileSelectUpdateFuncs[this->menuMode](&this->state);
-    FileSelect_UpdateAndDrawSkybox(this);
 
     FrameInterpolation_StartRecord();
+    FileSelect_UpdateAndDrawSkybox(this);
     gFileSelectDrawFuncs[this->menuMode](&this->state);
     FrameInterpolation_StopRecord();
 

--- a/mm/src/overlays/gamestates/ovl_title/z_title.c
+++ b/mm/src/overlays/gamestates/ovl_title/z_title.c
@@ -13,6 +13,7 @@
 
 #include "build.h"
 #include "BenPort.h"
+#include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include <stdlib.h>
 
@@ -193,7 +194,10 @@ void ConsoleLogo_Main(GameState* thisx) {
     gSPSegment(POLY_OPA_DISP++, 0x01, this->staticSegment);
 
     ConsoleLogo_UpdateCounters(this);
+    FrameInterpolation_StartRecord();
     ConsoleLogo_Draw(&this->state);
+    FrameInterpolation_StopRecord();
+
     if (this->exit) {
         gSaveContext.seqId = (u8)NA_BGM_DISABLED;
         gSaveContext.ambienceId = AMBIENCE_ID_DISABLED;


### PR DESCRIPTION
This adds interpolation handling around the console logo and the file choose skybox rotation.

Fixes an issue where reseting would show the console logo flash in a sporadic way, as it was applying old recorded matrix info.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2569437201.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2569437950.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2569445901.zip)
<!--- section:artifacts:end -->