### PR TITLE
Add missing flag to keep monkeys from spawning again

### DIFF
--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipBothersomeMonkey.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipBothersomeMonkey.cpp
@@ -17,6 +17,7 @@ void RegisterSkipBothersomeMonkey() {
         EnMnk* monkey = (EnMnk*)va_arg(args, EnMnk*);
         *should = false;
         SET_EVENTINF(EVENTINF_25);
+        Flags_SetSwitch(gPlayState, 0x02);
         monkey->actionFunc = EnMnk_Monkey_WaitToRun;
     });
 }

--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipBothersomeMonkey.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipBothersomeMonkey.cpp
@@ -32,7 +32,6 @@ void RegisterSkipBothersomeMonkey() {
             }
             monkey->actionFunc = EnMnk_Monkey_SetupRunAfterTalk;
         }
-        
     });
 }
 

--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipBothersomeMonkey.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipBothersomeMonkey.cpp
@@ -7,6 +7,7 @@ extern "C" {
 #include "functions.h"
 #include "src/overlays/actors/ovl_En_Mnk/z_en_mnk.h"
 void EnMnk_Monkey_WaitToRun(EnMnk* thisx, PlayState* play);
+void EnMnk_Monkey_SetupRunAfterTalk(EnMnk* thisx, PlayState* play);
 }
 
 #define CVAR_NAME "gEnhancements.Cutscenes.SkipMiscInteractions"
@@ -15,10 +16,23 @@ void EnMnk_Monkey_WaitToRun(EnMnk* thisx, PlayState* play);
 void RegisterSkipBothersomeMonkey() {
     COND_VB_SHOULD(VB_MONKEY_WAIT_TO_TALK_AFTER_APPROACH, CVAR, {
         EnMnk* monkey = (EnMnk*)va_arg(args, EnMnk*);
-        *should = false;
-        SET_EVENTINF(EVENTINF_25);
-        Flags_SetSwitch(gPlayState, 0x02);
-        monkey->actionFunc = EnMnk_Monkey_WaitToRun;
+        if (MONKEY_GET_TYPE(&monkey->picto.actor) == MONKEY_OUTSIDEWOODS) {
+            *should = false;
+            SET_EVENTINF(EVENTINF_25);
+            SET_WEEKEVENTREG(WEEKEVENTREG_79_02);
+            if (MONKEY_GET_SWITCH_FLAG(&monkey->picto.actor) != 0x7F) {
+                Flags_SetSwitch(gPlayState, MONKEY_GET_SWITCH_FLAG(&monkey->picto.actor));
+            }
+            monkey->actionFunc = EnMnk_Monkey_WaitToRun;
+        } else if (MONKEY_GET_TYPE(&monkey->picto.actor) == MONKEY_OUTSIDECHAMBER) {
+            *should = false;
+            SET_WEEKEVENTREG(WEEKEVENTREG_08_02);
+            if (MONKEY_GET_SWITCH_FLAG(&monkey->picto.actor) != 0x7F) {
+                Flags_SetSwitch(gPlayState, MONKEY_GET_SWITCH_FLAG(&monkey->picto.actor));
+            }
+            monkey->actionFunc = EnMnk_Monkey_SetupRunAfterTalk;
+        }
+        
     });
 }
 


### PR DESCRIPTION
This skip wasn't setting a switch flag that normally gets set when the skip isn't used, causing the monkeys to keep spawning in.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2590363062.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2590364499.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2590385449.zip)
<!--- section:artifacts:end -->