### PR TITLE
Document and fix vanilla bug with smoke rendering

### DIFF
--- a/mm/src/overlays/actors/ovl_Obj_Entotu/z_obj_entotu.c
+++ b/mm/src/overlays/actors/ovl_Obj_Entotu/z_obj_entotu.c
@@ -140,7 +140,9 @@ void func_80A34B28(ObjEntotu* this, PlayState* play) {
 
         OPEN_DISPS(play->state.gfxCtx);
 
-        Gfx_SetupDL25_Opa(play->state.gfxCtx);
+        //! @bug Uses Gfx_SetupDL25_Opa instead of Gfx_SetupDL25_Xlu. Gfx setup from previous actor is inherited.
+        // 2S2H [Port] Opting to use correct XLU setup for proper rendering
+        Gfx_SetupDL25_Xlu(play->state.gfxCtx);
 
         gSPSegment(POLY_XLU_DISP++, 0x08,
                    Gfx_TwoTexScroll(play->state.gfxCtx, 0, 0, sp57, 0x20, 0x20, 1, 0, sp56, 0x20, 0x20));

--- a/mm/src/overlays/actors/ovl_Obj_Smork/z_obj_smork.c
+++ b/mm/src/overlays/actors/ovl_Obj_Smork/z_obj_smork.c
@@ -119,7 +119,9 @@ void func_80A3D9C4(ObjSmork* this, PlayState* play) {
 
         OPEN_DISPS(play->state.gfxCtx);
 
-        Gfx_SetupDL25_Opa(play->state.gfxCtx);
+        //! @bug Uses Gfx_SetupDL25_Opa instead of Gfx_SetupDL25_Xlu. Gfx setup from previous actor is inherited.
+        // 2S2H [Port] Opting to use correct XLU setup for proper rendering
+        Gfx_SetupDL25_Xlu(play->state.gfxCtx);
 
         gSPSegment(POLY_XLU_DISP++, 0x08,
                    Gfx_TwoTexScroll(play->state.gfxCtx, 0, 0, sp57, 0x20, 0x20, 1, 0, sp56, 0x20, 0x20));


### PR DESCRIPTION
Documents and fixes an incorrect gfx setup call used for the chimney smoke effects. The setup was run on OPA when the actor is actually rendered on XLU. This means the gfx would inherit setup from the previous XLU actor.

In the case of Romani Ranch at night during the Aliens attack start cutscene, the UFO lens flare renders right before the smoke and causes it to appear in bright white when its alpha should be close to 0. Most likely there is floating point precision differences that prevents this from occurring on console (the smoke effect has a check for > 0.0f to even render in the first place).

I've opted to fix the gfx setup to address the smoke effect in the Aliens cutscene.

The Stock Pot Inn had the same bug, so I opted to fixed that too.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2600129327.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2600131049.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2600131369.zip)
<!--- section:artifacts:end -->