### PR TITLE
[SFX] Mute Low HP Alarm, Carpenters Sounds, and Crying Goron Child

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -737,6 +737,9 @@ void BenMenu::AddEnhancements() {
         .CVar("gEnhancements.Sfx.MuteCarpenterSfx")
         .Options(CheckboxOptions().Tooltip("Requires scene reload to take effect. Mutes the carpenter sounds coming "
                                            "from the tower in South Clock Town."));
+    AddWidget(path, "Mute Crying Goron Child", WIDGET_CVAR_CHECKBOX)
+        .CVar("gEnhancements.Sfx.ChildGoronCry")
+        .Options(CheckboxOptions().Tooltip("Mutes crying Goron Child inside of Goron Shrine."));
     AddWidget(path, "Minigames", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Always Win Doggy Race", WIDGET_CVAR_COMBOBOX)
         .CVar("gEnhancements.Minigames.AlwaysWinDoggyRace")

--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -729,6 +729,14 @@ void BenMenu::AddEnhancements() {
             }
         })
         .Options(CheckboxOptions().Tooltip("Mirrors the world horizontally."));
+    AddWidget(path, "SFX", WIDGET_SEPARATOR_TEXT);
+    AddWidget(path, "Mute Low HP Alarm", WIDGET_CVAR_CHECKBOX)
+        .CVar("gEnhancements.Sfx.LowHpAlarm")
+        .Options(CheckboxOptions().Tooltip("Mutes the beeping alarm when you are critically low on health."));
+    AddWidget(path, "Mute Carpenter Sounds", WIDGET_CVAR_CHECKBOX)
+        .CVar("gEnhancements.Sfx.MuteCarpenterSfx")
+        .Options(CheckboxOptions().Tooltip("Requires scene reload to take effect. Mutes the carpenter sounds coming "
+                                           "from the tower in South Clocktown."));
     AddWidget(path, "Minigames", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Always Win Doggy Race", WIDGET_CVAR_COMBOBOX)
         .CVar("gEnhancements.Minigames.AlwaysWinDoggyRace")

--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -736,7 +736,7 @@ void BenMenu::AddEnhancements() {
     AddWidget(path, "Mute Carpenter Sounds", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Sfx.MuteCarpenterSfx")
         .Options(CheckboxOptions().Tooltip("Requires scene reload to take effect. Mutes the carpenter sounds coming "
-                                           "from the tower in South Clocktown."));
+                                           "from the tower in South Clock Town."));
     AddWidget(path, "Minigames", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Always Win Doggy Race", WIDGET_CVAR_COMBOBOX)
         .CVar("gEnhancements.Minigames.AlwaysWinDoggyRace")

--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -739,7 +739,7 @@ void BenMenu::AddEnhancements() {
                                            "from the tower in South Clock Town."));
     AddWidget(path, "Mute Crying Goron Child", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Sfx.ChildGoronCry")
-        .Options(CheckboxOptions().Tooltip("Mutes crying Goron Child inside of Goron Shrine."));
+        .Options(CheckboxOptions().Tooltip("Mutes the crying Goron child inside Goron Shrine."));
     AddWidget(path, "Minigames", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Always Win Doggy Race", WIDGET_CVAR_COMBOBOX)
         .CVar("gEnhancements.Minigames.AlwaysWinDoggyRace")

--- a/mm/2s2h/Enhancements/Sfx/MuteCarpenterSfx.cpp
+++ b/mm/2s2h/Enhancements/Sfx/MuteCarpenterSfx.cpp
@@ -1,0 +1,28 @@
+#include <libultraship/bridge.h>
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/ShipInit.hpp"
+
+extern "C" {
+#include "overlays/actors/ovl_Obj_Sound/z_obj_sound.h"
+}
+
+#define CVAR_NAME "gEnhancements.Sfx.MuteCarpenterSfx"
+#define CVAR CVarGetInteger(CVAR_NAME, 0)
+
+void RegisterMuteCarpenterSfx() {
+    COND_ID_HOOK(ShouldActorInit, ACTOR_OBJ_SOUND, CVAR, [](Actor* actor, bool* should) {
+        ObjSound* objSound = (ObjSound*)actor;
+
+        // Returning if not in South or East Clocktown just as a safety precaution, incase these actor params are used
+        // elsewhere
+        if (gPlayState->sceneId != SCENE_CLOCKTOWER && gPlayState->sceneId != SCENE_TOWN) {
+            return;
+        }
+
+        if ((objSound->actor.params & OBJ_SOUND_ID_MASK) == 16) {
+            Actor_Kill(&objSound->actor);
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterMuteCarpenterSfx, { CVAR_NAME });

--- a/mm/2s2h/Enhancements/Sfx/MuteCarpenterSfx.cpp
+++ b/mm/2s2h/Enhancements/Sfx/MuteCarpenterSfx.cpp
@@ -20,7 +20,7 @@ void RegisterMuteCarpenterSfx() {
         }
 
         if ((objSound->actor.params & OBJ_SOUND_ID_MASK) == 16) {
-            Actor_Kill(&objSound->actor);
+            *should = false;
         }
     });
 }

--- a/mm/2s2h/Enhancements/Sfx/MuteCryingGoronChild.cpp
+++ b/mm/2s2h/Enhancements/Sfx/MuteCryingGoronChild.cpp
@@ -1,0 +1,12 @@
+#include <libultraship/bridge.h>
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/ShipInit.hpp"
+
+#define CVAR_NAME "gEnhancements.Sfx.ChildGoronCry"
+#define CVAR CVarGetInteger(CVAR_NAME, 0)
+
+void RegisterMuteCryingGoronChild() {
+    COND_VB_SHOULD(VB_PLAY_GORON_CHILD_CRY, CVAR, { *should = false; });
+}
+
+static RegisterShipInitFunc initFunc(RegisterMuteCryingGoronChild, { CVAR_NAME });

--- a/mm/2s2h/Enhancements/Sfx/MuteLowHpAlarm.cpp
+++ b/mm/2s2h/Enhancements/Sfx/MuteLowHpAlarm.cpp
@@ -1,0 +1,12 @@
+#include <libultraship/bridge.h>
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/ShipInit.hpp"
+
+#define CVAR_NAME "gEnhancements.Sfx.LowHpAlarm"
+#define CVAR CVarGetInteger(CVAR_NAME, 0)
+
+void RegisterMuteLowHpAlarm() {
+    COND_VB_SHOULD(VB_PLAY_LOW_HP_ALARM, CVAR, { *should = false; });
+}
+
+static RegisterShipInitFunc initFunc(RegisterMuteLowHpAlarm, { CVAR_NAME });

--- a/mm/2s2h/GameInteractor/GameInteractor.h
+++ b/mm/2s2h/GameInteractor/GameInteractor.h
@@ -101,6 +101,7 @@ typedef enum {
     VB_GIBDO_TRADE_SEQUENCE_DO_TRADE,
     VB_GET_ITEM_ACTION_FROM_MASK,
     VB_PERFORM_AC_COLLISION,
+    VB_PLAY_LOW_HP_ALARM,
 } GIVanillaBehavior;
 
 typedef enum {

--- a/mm/2s2h/GameInteractor/GameInteractor.h
+++ b/mm/2s2h/GameInteractor/GameInteractor.h
@@ -102,6 +102,7 @@ typedef enum {
     VB_GET_ITEM_ACTION_FROM_MASK,
     VB_PERFORM_AC_COLLISION,
     VB_PLAY_LOW_HP_ALARM,
+    VB_PLAY_GORON_CHILD_CRY,
 } GIVanillaBehavior;
 
 typedef enum {

--- a/mm/src/code/z_lifemeter.c
+++ b/mm/src/code/z_lifemeter.c
@@ -6,6 +6,7 @@
 #include "BenPort.h"
 #include "2s2h/BenGui/HudEditor.h"
 #include "2s2h/BenGui/CosmeticEditor.h"
+#include "2s2h/GameInteractor/GameInteractor.h"
 
 s16 sHeartsPrimColors[3][3] = { { 255, 70, 50 }, { 255, 190, 0 }, { 100, 100, 255 } };
 s16 sHeartsEnvColors[3][3] = { { 50, 40, 60 }, { 255, 0, 0 }, { 0, 0, 255 } };
@@ -478,7 +479,9 @@ void LifeMeter_UpdateSizeAndBeep(PlayState* play) {
             interfaceCtx->lifeSizeChangeDirection = 0;
             if (!Player_InCsMode(play) && (play->pauseCtx.state == PAUSE_STATE_OFF) &&
                 (play->pauseCtx.debugEditor == DEBUG_EDITOR_NONE) && LifeMeter_IsCritical() && !Play_InCsMode(play)) {
-                Audio_PlaySfx(NA_SE_SY_HITPOINT_ALARM);
+                if (GameInteractor_Should(VB_PLAY_LOW_HP_ALARM, true)) {
+                    Audio_PlaySfx(NA_SE_SY_HITPOINT_ALARM);
+                }
             }
         }
     } else {

--- a/mm/src/overlays/actors/ovl_En_Gk/z_en_gk.c
+++ b/mm/src/overlays/actors/ovl_En_Gk/z_en_gk.c
@@ -6,6 +6,8 @@
 
 #include "z_en_gk.h"
 
+#include "2s2h/GameInteractor/GameInteractor.h"
+
 #define FLAGS (ACTOR_FLAG_TARGETABLE | ACTOR_FLAG_FRIENDLY)
 
 #define THIS ((EnGk*)thisx)
@@ -878,7 +880,9 @@ void func_80B51EA4(EnGk* this, PlayState* play) {
 void func_80B51FD0(EnGk* this, PlayState* play) {
     if (!CHECK_WEEKEVENTREG(WEEKEVENTREG_CALMED_GORON_ELDERS_SON)) {
         if (this->unk_1E4 & 2) {
-            Audio_PlaySfx_AtFixedPos(&this->actor.projectedPos, NA_SE_EN_GOLON_KID_CRY - SFX_FLAG);
+            if (GameInteractor_Should(VB_PLAY_GORON_CHILD_CRY, true)) {
+                Audio_PlaySfx_AtFixedPos(&this->actor.projectedPos, NA_SE_EN_GOLON_KID_CRY - SFX_FLAG);
+            }
         } else {
             this->unk_1E4 |= 2;
         }
@@ -908,7 +912,9 @@ void func_80B5202C(EnGk* this, PlayState* play) {
         if (this->unk_1E4 & 2) {
             if ((play->msgCtx.ocarinaMode != OCARINA_MODE_ACTIVE) && (play->msgCtx.ocarinaMode != OCARINA_MODE_EVENT) &&
                 (play->csCtx.state == CS_STATE_IDLE)) {
-                Audio_PlaySfx_AtFixedPos(&this->actor.projectedPos, NA_SE_EN_GOLON_KID_CRY - SFX_FLAG);
+                if (GameInteractor_Should(VB_PLAY_GORON_CHILD_CRY, true)) {
+                    Audio_PlaySfx_AtFixedPos(&this->actor.projectedPos, NA_SE_EN_GOLON_KID_CRY - SFX_FLAG);
+                }
             }
         } else {
             this->unk_1E4 |= 2;


### PR DESCRIPTION
Adds SFX options to mute Low HP Alarm, the carpenter sounds heard in South and East Clock Town from the tower being built, and the crying Goron Child inside the Goron Shrine. He will still cry during certain text when outside and inside the Goron Racetrack, as these are easily skippable and don't last long.

Added an SFX section in Gameplay below modes, until #778 is merged in and can be relocated.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2633850052.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2633857051.zip)
<!--- section:artifacts:end -->