### PR TITLE
Add Hook Debugger Window

### DIFF
--- a/mm/2s2h/BenGui/BenGui.cpp
+++ b/mm/2s2h/BenGui/BenGui.cpp
@@ -35,6 +35,7 @@ std::shared_ptr<Ship::GuiWindow> mStatsWindow;
 std::shared_ptr<Ship::GuiWindow> mGfxDebuggerWindow;
 std::shared_ptr<Ship::GuiWindow> mInputEditorWindow;
 
+std::shared_ptr<HookDebuggerWindow> mHookDebuggerWindow;
 std::shared_ptr<SaveEditorWindow> mSaveEditorWindow;
 std::shared_ptr<HudEditorWindow> mHudEditorWindow;
 std::shared_ptr<CosmeticEditorWindow> mCosmeticEditorWindow;
@@ -88,6 +89,10 @@ void SetupGuiElements() {
         SPDLOG_ERROR("Could not find input editor window");
     }
 
+    mHookDebuggerWindow =
+        std::make_shared<HookDebuggerWindow>("gWindows.HookDebugger", "Hook Debugger", ImVec2(480, 600));
+    gui->AddGuiWindow(mHookDebuggerWindow);
+
     mSaveEditorWindow = std::make_shared<SaveEditorWindow>("gWindows.SaveEditor", "Save Editor", ImVec2(480, 600));
     gui->AddGuiWindow(mSaveEditorWindow);
 
@@ -133,6 +138,7 @@ void Destroy() {
     mCollisionViewerWindow = nullptr;
     mEventLogWindow = nullptr;
     mNotificationWindow = nullptr;
+    mHookDebuggerWindow = nullptr;
     mSaveEditorWindow = nullptr;
     mHudEditorWindow = nullptr;
     mCosmeticEditorWindow = nullptr;

--- a/mm/2s2h/BenGui/BenGui.hpp
+++ b/mm/2s2h/BenGui/BenGui.hpp
@@ -7,6 +7,7 @@
 #include "DeveloperTools/ActorViewer.h"
 #include "DeveloperTools/CollisionViewer.h"
 #include "DeveloperTools/EventLog.h"
+#include "DeveloperTools/HookDebugger.h"
 #include "BenInputEditorWindow.h"
 
 namespace BenGui {

--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1427,6 +1427,13 @@ void BenMenu::AddDevTools() {
             "Enables the Gfx Debugger window, allowing you to input commands, type help for some examples"))
         .WindowName("GfxDebuggerWindow");
 
+    path = { "Dev Tools", "Hook Debugger", 1 };
+    AddSidebarEntry("Dev Tools", "Hook Debugger", 1);
+    AddWidget(path, "Popout Hook Debugger", WIDGET_WINDOW_BUTTON)
+        .CVar("gWindows.HookDebugger")
+        .Options(ButtonOptions().Tooltip("Enables the Hook Debugger window, for viewing info about registered hooks"))
+        .WindowName("Hook Debugger");
+
     path = { "Dev Tools", "Save Editor", 1 };
     AddSidebarEntry("Dev Tools", "Save Editor", 1);
     AddWidget(path, "Popout Save Editor", WIDGET_WINDOW_BUTTON)

--- a/mm/2s2h/DeveloperTools/HookDebugger.cpp
+++ b/mm/2s2h/DeveloperTools/HookDebugger.cpp
@@ -1,0 +1,99 @@
+#include "HookDebugger.h"
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/BenGui/UIWidgets.hpp"
+#include <string>
+#include <version>
+
+static std::map<const char*, std::map<HOOK_ID, HookInfo>*> hookData;
+
+const ImVec4 grey = ImVec4(0.75, 0.75, 0.75, 1);
+const ImVec4 yellow = ImVec4(1, 1, 0, 1);
+const ImVec4 red = ImVec4(1, 0, 0, 1);
+
+void DrawHookRegisteringInfos(const char* hookName) {
+    size_t numHooks = (*hookData[hookName]).size();
+
+    if (numHooks == 0) {
+        ImGui::TextColored(grey, "No hooks found");
+        return;
+    }
+
+    ImGui::Text("Total Registered: %d", numHooks);
+
+    if (ImGui::BeginTable(("Table##" + std::string(hookName)).c_str(), 4,
+                          ImGuiTableFlags_Resizable | ImGuiTableFlags_Reorderable | ImGuiTableFlags_Hideable |
+                              ImGuiTableFlags_Borders | ImGuiTableFlags_SizingFixedFit)) {
+        ImGui::TableSetupColumn("ID", ImGuiTableColumnFlags_WidthFixed);
+        ImGui::TableSetupColumn("Type", ImGuiTableColumnFlags_WidthFixed);
+        ImGui::TableSetupColumn("Registration Info", ImGuiTableColumnFlags_WidthStretch);
+        ImGui::TableSetupColumn("# Calls", ImGuiTableColumnFlags_WidthFixed);
+        ImGui::TableHeadersRow();
+        for (auto& [id, hookInfo] : (*hookData[hookName])) {
+            ImGui::TableNextRow();
+
+            ImGui::TableNextColumn();
+            ImGui::Text("%d", id);
+
+            ImGui::TableNextColumn();
+            switch (hookInfo.registering.type) {
+                case HOOK_TYPE_NORMAL:
+                    ImGui::Text("Normal");
+                    break;
+                case HOOK_TYPE_ID:
+                    ImGui::Text("ID");
+                    break;
+                case HOOK_TYPE_PTR:
+                    ImGui::Text("Ptr");
+                    break;
+                case HOOK_TYPE_FILTER:
+                    ImGui::Text("Filter");
+                    break;
+                default:
+                    ImGui::TextColored(red, "[UNKNOWN]");
+                    break;
+            }
+
+            ImGui::TableNextColumn();
+            if (hookInfo.registering.valid) {
+                // Replace the space after the return type of the parent function with a non-breaking space
+                std::string parentFunction = std::string(hookInfo.registering.function);
+                size_t pos = parentFunction.find_first_of(" ");
+                if (pos != std::string::npos) {
+                    parentFunction.replace(pos, 1, "\u00A0");
+                }
+                // Non breaking space to keep the arrow with the parent function
+                ImGui::TextWrapped("%s(%d:%d) <-\u00A0%s", hookInfo.registering.file, hookInfo.registering.line,
+                                   hookInfo.registering.column, parentFunction.c_str());
+            } else {
+                ImGui::TextColored(yellow, "[Unavailable]");
+            }
+
+            ImGui::TableNextColumn();
+            ImGui::Text("%d", hookInfo.calls);
+        }
+        ImGui::EndTable();
+    }
+}
+
+void HookDebuggerWindow::DrawElement() {
+#ifndef __cpp_lib_source_location
+    ImGui::TextColored(yellow, "Some features of the Hook Debugger are unavailable because SoH was compiled "
+                               "without \"<source_location>\" support "
+                               "(\"__cpp_lib_source_location\" not defined in \"<version>\").");
+#endif
+
+    for (auto& [hookName, _] : hookData) {
+        if (ImGui::TreeNode(hookName)) {
+            DrawHookRegisteringInfos(hookName);
+            ImGui::TreePop();
+        }
+    }
+}
+
+void HookDebuggerWindow::InitElement() {
+#define DEFINE_HOOK(name, _) hookData.insert({ #name, GameInteractor::Instance->GetHookData<GameInteractor::name>() });
+
+#include "2s2h/GameInteractor/GameInteractor_HookTable.h"
+
+#undef DEFINE_HOOK
+}

--- a/mm/2s2h/DeveloperTools/HookDebugger.h
+++ b/mm/2s2h/DeveloperTools/HookDebugger.h
@@ -1,0 +1,15 @@
+#ifndef HOOK_DEBUGGER_H
+#define HOOK_DEBUGGER_H
+
+#include <libultraship/libultraship.h>
+
+class HookDebuggerWindow : public Ship::GuiWindow {
+  public:
+    using GuiWindow::GuiWindow;
+
+    void InitElement() override;
+    void DrawElement() override;
+    void UpdateElement() override{};
+};
+
+#endif // HOOK_DEBUGGER_H

--- a/mm/2s2h/GameInteractor/GameInteractor.h
+++ b/mm/2s2h/GameInteractor/GameInteractor.h
@@ -178,11 +178,6 @@ struct HookRegisteringInfo {
 struct HookInfo {
     uint32_t calls;
     HookRegisteringInfo registering;
-
-    HookInfo() : calls(0), registering(HookRegisteringInfo{}) {
-    }
-    HookInfo(HookRegisteringInfo _registering) : calls(0), registering(_registering) {
-    }
 };
 
 #ifdef __cpp_lib_source_location
@@ -236,7 +231,8 @@ class GameInteractor {
         }
 
         RegisteredGameHooks<H>::functions[this->nextHookId] = h;
-        RegisteredGameHooks<H>::hookData[this->nextHookId] = HookInfo{ GET_CURRENT_REGISTERING_INFO(HOOK_TYPE_NORMAL) };
+        RegisteredGameHooks<H>::hookData[this->nextHookId] =
+            HookInfo{ 0, GET_CURRENT_REGISTERING_INFO(HOOK_TYPE_NORMAL) };
         return this->nextHookId++;
     }
     template <typename H> void UnregisterGameHook(HOOK_ID hookId) {
@@ -272,7 +268,7 @@ class GameInteractor {
         }
 
         RegisteredGameHooks<H>::functionsForID[id][this->nextHookId] = h;
-        RegisteredGameHooks<H>::hookData[this->nextHookId] = HookInfo{ GET_CURRENT_REGISTERING_INFO(HOOK_TYPE_ID) };
+        RegisteredGameHooks<H>::hookData[this->nextHookId] = HookInfo{ 0, GET_CURRENT_REGISTERING_INFO(HOOK_TYPE_ID) };
         return this->nextHookId++;
     }
     template <typename H> void UnregisterGameHookForID(HOOK_ID hookId) {
@@ -317,7 +313,7 @@ class GameInteractor {
         }
 
         RegisteredGameHooks<H>::functionsForPtr[ptr][this->nextHookId] = h;
-        RegisteredGameHooks<H>::hookData[this->nextHookId] = HookInfo{ GET_CURRENT_REGISTERING_INFO(HOOK_TYPE_PTR) };
+        RegisteredGameHooks<H>::hookData[this->nextHookId] = HookInfo{ 0, GET_CURRENT_REGISTERING_INFO(HOOK_TYPE_PTR) };
         return this->nextHookId++;
     }
     template <typename H> void UnregisterGameHookForPtr(HOOK_ID hookId) {
@@ -363,7 +359,8 @@ class GameInteractor {
         }
 
         RegisteredGameHooks<H>::functionsForFilter[this->nextHookId] = std::make_pair(f, h);
-        RegisteredGameHooks<H>::hookData[this->nextHookId] = HookInfo{ GET_CURRENT_REGISTERING_INFO(HOOK_TYPE_FILTER) };
+        RegisteredGameHooks<H>::hookData[this->nextHookId] =
+            HookInfo{ 0, GET_CURRENT_REGISTERING_INFO(HOOK_TYPE_FILTER) };
         return this->nextHookId++;
     }
     template <typename H> void UnregisterGameHookForFilter(HOOK_ID hookId) {

--- a/mm/2s2h/GameInteractor/GameInteractor.h
+++ b/mm/2s2h/GameInteractor/GameInteractor.h
@@ -131,17 +131,66 @@ typedef enum {
 
 #include <vector>
 #include <functional>
+#include <map>
 #include <unordered_map>
 #include <cstdint>
 #include <algorithm>
 
+#include <version>
+#ifdef __cpp_lib_source_location
+#include <source_location>
+#else
+#pragma message("Compiling without <source_location> support, the Hook Debugger will not be available")
+#endif
+
 typedef uint32_t HOOK_ID;
 
-#define DEFINE_HOOK(name, args)                  \
-    struct name {                                \
-        typedef std::function<void args> fn;     \
-        typedef std::function<bool args> filter; \
+enum HookType {
+    HOOK_TYPE_NORMAL,
+    HOOK_TYPE_ID,
+    HOOK_TYPE_PTR,
+    HOOK_TYPE_FILTER,
+};
+
+struct HookRegisteringInfo {
+    bool valid;
+    const char* file;
+    std::uint_least32_t line;
+    std::uint_least32_t column;
+    const char* function;
+    HookType type;
+
+    HookRegisteringInfo()
+        : valid(false), file("unknown file"), line(0), column(0), function("unknown function"), type(HOOK_TYPE_NORMAL) {
     }
+
+    HookRegisteringInfo(const char* _file, std::uint_least32_t _line, std::uint_least32_t _column,
+                        const char* _function, HookType _type)
+        : valid(true), file(_file), line(_line), column(_column), function(_function), type(_type) {
+        // Trim off user parent directories
+        const char* trimmed = strstr(_file, "mm/2s2h/");
+        if (trimmed != nullptr) {
+            file = trimmed;
+        }
+    }
+};
+
+struct HookInfo {
+    uint32_t calls;
+    HookRegisteringInfo registering;
+
+    HookInfo() : calls(0), registering(HookRegisteringInfo{}) {
+    }
+    HookInfo(HookRegisteringInfo _registering) : calls(0), registering(_registering) {
+    }
+};
+
+#ifdef __cpp_lib_source_location
+#define GET_CURRENT_REGISTERING_INFO(type) \
+    (HookRegisteringInfo{ location.file_name(), location.line(), location.column(), location.function_name(), type })
+#else
+#define GET_CURRENT_REGISTERING_INFO(type) (HookRegisteringInfo{})
+#endif
 
 class GameInteractor {
   public:
@@ -158,6 +207,9 @@ class GameInteractor {
         inline static std::unordered_map<int32_t, std::unordered_map<HOOK_ID, typename H::fn>> functionsForID;
         inline static std::unordered_map<uintptr_t, std::unordered_map<HOOK_ID, typename H::fn>> functionsForPtr;
         inline static std::unordered_map<HOOK_ID, std::pair<typename H::filter, typename H::fn>> functionsForFilter;
+
+        // Used for the hook debugger
+        inline static std::map<HOOK_ID, HookInfo> hookData;
     };
     template <typename H> struct HooksToUnregister {
         inline static std::vector<HOOK_ID> hooks;
@@ -166,8 +218,17 @@ class GameInteractor {
         inline static std::vector<HOOK_ID> hooksForFilter;
     };
 
+    template <typename H> std::map<uint32_t, HookInfo>* GetHookData() {
+        return &RegisteredGameHooks<H>::hookData;
+    }
+
     // General Hooks
-    template <typename H> HOOK_ID RegisterGameHook(typename H::fn h) {
+    template <typename H>
+#ifdef __cpp_lib_source_location
+    HOOK_ID RegisterGameHook(typename H::fn h, const std::source_location location = std::source_location::current()) {
+#else
+    HOOK_ID RegisterGameHook(typename H::fn h) {
+#endif
         if (this->nextHookId == 0 || this->nextHookId >= UINT32_MAX)
             this->nextHookId = 1;
         while (RegisteredGameHooks<H>::functions.find(this->nextHookId) != RegisteredGameHooks<H>::functions.end()) {
@@ -175,6 +236,7 @@ class GameInteractor {
         }
 
         RegisteredGameHooks<H>::functions[this->nextHookId] = h;
+        RegisteredGameHooks<H>::hookData[this->nextHookId] = HookInfo{ GET_CURRENT_REGISTERING_INFO(HOOK_TYPE_NORMAL) };
         return this->nextHookId++;
     }
     template <typename H> void UnregisterGameHook(HOOK_ID hookId) {
@@ -185,15 +247,23 @@ class GameInteractor {
     template <typename H, typename... Args> void ExecuteHooks(Args&&... args) {
         for (auto& hookId : HooksToUnregister<H>::hooks) {
             RegisteredGameHooks<H>::functions.erase(hookId);
+            RegisteredGameHooks<H>::hookData.erase(hookId);
         }
         HooksToUnregister<H>::hooks.clear();
         for (auto& hook : RegisteredGameHooks<H>::functions) {
             hook.second(std::forward<Args>(args)...);
+            RegisteredGameHooks<H>::hookData[hook.first].calls += 1;
         }
     }
 
     // ID based Hooks
-    template <typename H> HOOK_ID RegisterGameHookForID(int32_t id, typename H::fn h) {
+    template <typename H>
+#ifdef __cpp_lib_source_location
+    HOOK_ID RegisterGameHookForID(int32_t id, typename H::fn h,
+                                  std::source_location location = std::source_location::current()) {
+#else
+    HOOK_ID RegisterGameHookForID(int32_t id, typename H::fn h) {
+#endif
         if (this->nextHookId == 0 || this->nextHookId >= UINT32_MAX)
             this->nextHookId = 1;
         while (RegisteredGameHooks<H>::functionsForID[id].find(this->nextHookId) !=
@@ -202,6 +272,7 @@ class GameInteractor {
         }
 
         RegisteredGameHooks<H>::functionsForID[id][this->nextHookId] = h;
+        RegisteredGameHooks<H>::hookData[this->nextHookId] = HookInfo{ GET_CURRENT_REGISTERING_INFO(HOOK_TYPE_ID) };
         return this->nextHookId++;
     }
     template <typename H> void UnregisterGameHookForID(HOOK_ID hookId) {
@@ -218,6 +289,7 @@ class GameInteractor {
                     HooksToUnregister<H>::hooksForID.erase(std::remove(HooksToUnregister<H>::hooksForID.begin(),
                                                                        HooksToUnregister<H>::hooksForID.end(), hookId),
                                                            HooksToUnregister<H>::hooksForID.end());
+                    RegisteredGameHooks<H>::hookData.erase(hookId);
                 } else {
                     ++it;
                 }
@@ -225,11 +297,18 @@ class GameInteractor {
         }
         for (auto& hook : RegisteredGameHooks<H>::functionsForID[id]) {
             hook.second(std::forward<Args>(args)...);
+            RegisteredGameHooks<H>::hookData[hook.first].calls += 1;
         }
     }
 
     // PTR based Hooks
-    template <typename H> HOOK_ID RegisterGameHookForPtr(uintptr_t ptr, typename H::fn h) {
+    template <typename H>
+#ifdef __cpp_lib_source_location
+    HOOK_ID RegisterGameHookForPtr(uintptr_t ptr, typename H::fn h,
+                                   const std::source_location location = std::source_location::current()) {
+#else
+    HOOK_ID RegisterGameHookForPtr(uintptr_t ptr, typename H::fn h) {
+#endif
         if (this->nextHookId == 0 || this->nextHookId >= UINT32_MAX)
             this->nextHookId = 1;
         while (RegisteredGameHooks<H>::functionsForPtr[ptr].find(this->nextHookId) !=
@@ -238,6 +317,7 @@ class GameInteractor {
         }
 
         RegisteredGameHooks<H>::functionsForPtr[ptr][this->nextHookId] = h;
+        RegisteredGameHooks<H>::hookData[this->nextHookId] = HookInfo{ GET_CURRENT_REGISTERING_INFO(HOOK_TYPE_PTR) };
         return this->nextHookId++;
     }
     template <typename H> void UnregisterGameHookForPtr(HOOK_ID hookId) {
@@ -255,6 +335,7 @@ class GameInteractor {
                                                                         HooksToUnregister<H>::hooksForPtr.end(),
                                                                         hookId),
                                                             HooksToUnregister<H>::hooksForPtr.end());
+                    RegisteredGameHooks<H>::hookData.erase(hookId);
                 } else {
                     ++it;
                 }
@@ -262,11 +343,18 @@ class GameInteractor {
         }
         for (auto& hook : RegisteredGameHooks<H>::functionsForPtr[ptr]) {
             hook.second(std::forward<Args>(args)...);
+            RegisteredGameHooks<H>::hookData[hook.first].calls += 1;
         }
     }
 
     // Filter based Hooks
-    template <typename H> HOOK_ID RegisterGameHookForFilter(typename H::filter f, typename H::fn h) {
+    template <typename H>
+#ifdef __cpp_lib_source_location
+    HOOK_ID RegisterGameHookForFilter(typename H::filter f, typename H::fn h,
+                                      const std::source_location location = std::source_location::current()) {
+#else
+    HOOK_ID RegisterGameHookForFilter(typename H::filter f, typename H::fn h) {
+#endif
         if (this->nextHookId == 0 || this->nextHookId >= UINT32_MAX)
             this->nextHookId = 1;
         while (RegisteredGameHooks<H>::functionsForFilter.find(this->nextHookId) !=
@@ -275,6 +363,7 @@ class GameInteractor {
         }
 
         RegisteredGameHooks<H>::functionsForFilter[this->nextHookId] = std::make_pair(f, h);
+        RegisteredGameHooks<H>::hookData[this->nextHookId] = HookInfo{ GET_CURRENT_REGISTERING_INFO(HOOK_TYPE_FILTER) };
         return this->nextHookId++;
     }
     template <typename H> void UnregisterGameHookForFilter(HOOK_ID hookId) {
@@ -285,11 +374,13 @@ class GameInteractor {
     template <typename H, typename... Args> void ExecuteHooksForFilter(Args&&... args) {
         for (auto& hookId : HooksToUnregister<H>::hooksForFilter) {
             RegisteredGameHooks<H>::functionsForFilter.erase(hookId);
+            RegisteredGameHooks<H>::hookData.erase(hookId);
         }
         HooksToUnregister<H>::hooksForFilter.clear();
         for (auto& hook : RegisteredGameHooks<H>::functionsForFilter) {
             if (hook.second.first(std::forward<Args>(args)...)) {
                 hook.second.second(std::forward<Args>(args)...);
+                RegisteredGameHooks<H>::hookData[hook.first].calls += 1;
             }
         }
     }
@@ -312,56 +403,15 @@ class GameInteractor {
         }
     };
 
-    DEFINE_HOOK(OnFileDropped, (std::string path));
+#define DEFINE_HOOK(name, args)                  \
+    struct name {                                \
+        typedef std::function<void args> fn;     \
+        typedef std::function<bool args> filter; \
+    };
 
-    DEFINE_HOOK(OnGameStateMainStart, ());
-    DEFINE_HOOK(OnGameStateMainFinish, ());
-    DEFINE_HOOK(OnGameStateDrawFinish, ());
-    DEFINE_HOOK(OnGameStateUpdate, ());
-    DEFINE_HOOK(OnConsoleLogoUpdate, ());
-    DEFINE_HOOK(OnKaleidoUpdate, (PauseContext * pauseCtx));
-    DEFINE_HOOK(BeforeKaleidoDrawPage, (PauseContext * pauseCtx, u16 pauseIndex));
-    DEFINE_HOOK(AfterKaleidoDrawPage, (PauseContext * pauseCtx, u16 pauseIndex));
-    DEFINE_HOOK(OnSaveInit, (s16 fileNum));
-    DEFINE_HOOK(BeforeEndOfCycleSave, ());
-    DEFINE_HOOK(AfterEndOfCycleSave, ());
-    DEFINE_HOOK(BeforeMoonCrashSaveReset, ());
-    DEFINE_HOOK(AfterInterfaceClockDraw, ());
-    DEFINE_HOOK(BeforeInterfaceClockDraw, ());
+#include "GameInteractor_HookTable.h"
 
-    DEFINE_HOOK(OnSceneInit, (s8 sceneId, s8 spawnNum));
-    DEFINE_HOOK(OnRoomInit, (s8 sceneId, s8 roomNum));
-    DEFINE_HOOK(AfterRoomSceneCommands, (s8 sceneId, s8 roomNum));
-    DEFINE_HOOK(OnPlayDrawWorldEnd, ());
-    DEFINE_HOOK(OnPlayDestroy, ());
-
-    DEFINE_HOOK(ShouldActorInit, (Actor * actor, bool* should));
-    DEFINE_HOOK(OnActorInit, (Actor * actor));
-    DEFINE_HOOK(ShouldActorUpdate, (Actor * actor, bool* should));
-    DEFINE_HOOK(OnActorUpdate, (Actor * actor));
-    DEFINE_HOOK(ShouldActorDraw, (Actor * actor, bool* should));
-    DEFINE_HOOK(OnActorDraw, (Actor * actor));
-    DEFINE_HOOK(OnActorKill, (Actor * actor));
-    DEFINE_HOOK(OnActorDestroy, (Actor * actor));
-    DEFINE_HOOK(OnPlayerPostLimbDraw, (Player * player, s32 limbIndex));
-
-    DEFINE_HOOK(OnSceneFlagSet, (s16 sceneId, FlagType flagType, u32 flag));
-    DEFINE_HOOK(OnSceneFlagUnset, (s16 sceneId, FlagType flagType, u32 flag));
-    DEFINE_HOOK(OnFlagSet, (FlagType flagType, u32 flag));
-    DEFINE_HOOK(OnFlagUnset, (FlagType flagType, u32 flag));
-
-    DEFINE_HOOK(AfterCameraUpdate, (Camera * camera));
-    DEFINE_HOOK(OnCameraChangeModeFlags, (Camera * camera));
-    DEFINE_HOOK(OnCameraChangeSettingsFlags, (Camera * camera));
-
-    DEFINE_HOOK(OnPassPlayerInputs, (Input * input));
-
-    DEFINE_HOOK(OnOpenText, (u16 textId));
-
-    DEFINE_HOOK(ShouldItemGive, (u8 item, bool* should));
-    DEFINE_HOOK(OnItemGive, (u8 item));
-
-    DEFINE_HOOK(ShouldVanillaBehavior, (GIVanillaBehavior flag, bool* should, va_list originalArgs));
+#undef DEFINE_HOOK
 };
 
 extern "C" {

--- a/mm/2s2h/GameInteractor/GameInteractor_HookTable.h
+++ b/mm/2s2h/GameInteractor/GameInteractor_HookTable.h
@@ -1,0 +1,50 @@
+DEFINE_HOOK(OnFileDropped, (std::string path))
+
+DEFINE_HOOK(OnGameStateMainStart, ())
+DEFINE_HOOK(OnGameStateMainFinish, ())
+DEFINE_HOOK(OnGameStateDrawFinish, ())
+DEFINE_HOOK(OnGameStateUpdate, ())
+DEFINE_HOOK(OnConsoleLogoUpdate, ())
+DEFINE_HOOK(OnKaleidoUpdate, (PauseContext * pauseCtx))
+DEFINE_HOOK(BeforeKaleidoDrawPage, (PauseContext * pauseCtx, u16 pauseIndex))
+DEFINE_HOOK(AfterKaleidoDrawPage, (PauseContext * pauseCtx, u16 pauseIndex))
+DEFINE_HOOK(OnSaveInit, (s16 fileNum))
+DEFINE_HOOK(BeforeEndOfCycleSave, ())
+DEFINE_HOOK(AfterEndOfCycleSave, ())
+DEFINE_HOOK(BeforeMoonCrashSaveReset, ())
+DEFINE_HOOK(AfterInterfaceClockDraw, ())
+DEFINE_HOOK(BeforeInterfaceClockDraw, ())
+
+DEFINE_HOOK(OnSceneInit, (s8 sceneId, s8 spawnNum))
+DEFINE_HOOK(OnRoomInit, (s8 sceneId, s8 roomNum))
+DEFINE_HOOK(AfterRoomSceneCommands, (s8 sceneId, s8 roomNum))
+DEFINE_HOOK(OnPlayDrawWorldEnd, ())
+DEFINE_HOOK(OnPlayDestroy, ())
+
+DEFINE_HOOK(ShouldActorInit, (Actor * actor, bool* should))
+DEFINE_HOOK(OnActorInit, (Actor * actor))
+DEFINE_HOOK(ShouldActorUpdate, (Actor * actor, bool* should))
+DEFINE_HOOK(OnActorUpdate, (Actor * actor))
+DEFINE_HOOK(ShouldActorDraw, (Actor * actor, bool* should))
+DEFINE_HOOK(OnActorDraw, (Actor * actor))
+DEFINE_HOOK(OnActorKill, (Actor * actor))
+DEFINE_HOOK(OnActorDestroy, (Actor * actor))
+DEFINE_HOOK(OnPlayerPostLimbDraw, (Player * player, s32 limbIndex))
+
+DEFINE_HOOK(OnSceneFlagSet, (s16 sceneId, FlagType flagType, u32 flag))
+DEFINE_HOOK(OnSceneFlagUnset, (s16 sceneId, FlagType flagType, u32 flag))
+DEFINE_HOOK(OnFlagSet, (FlagType flagType, u32 flag))
+DEFINE_HOOK(OnFlagUnset, (FlagType flagType, u32 flag))
+
+DEFINE_HOOK(AfterCameraUpdate, (Camera * camera))
+DEFINE_HOOK(OnCameraChangeModeFlags, (Camera * camera))
+DEFINE_HOOK(OnCameraChangeSettingsFlags, (Camera * camera))
+
+DEFINE_HOOK(OnPassPlayerInputs, (Input * input))
+
+DEFINE_HOOK(OnOpenText, (u16 textId))
+
+DEFINE_HOOK(ShouldItemGive, (u8 item, bool* should))
+DEFINE_HOOK(OnItemGive, (u8 item))
+
+DEFINE_HOOK(ShouldVanillaBehavior, (GIVanillaBehavior flag, bool* should, va_list originalArgs))


### PR DESCRIPTION
Ports over https://github.com/HarbourMasters/Shipwright/pull/4323 from SoH, with some slight tweaks

Tweaks include:
* Removing user parent directories from hook info
* Better default table formatting/sizing to work out of the box with the modern menu
* Using `map` for the hook info so that the debugger has a stable order

![image](https://github.com/user-attachments/assets/d6efaf35-fb96-4a29-8fe8-c7e8a6bf4090)

I haven't measure this, so I don't know if this introduces any significant performance impacts, but if it did I could see argument about putting the debugging structs behind a compile time variable so devs would have to explicitly enable it.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2633099140.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2633103053.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2633114521.zip)
<!--- section:artifacts:end -->