### PR TITLE
Fix and improve hook unregister cleanup

### DIFF
--- a/mm/2s2h/GameInteractor/GameInteractor.cpp
+++ b/mm/2s2h/GameInteractor/GameInteractor.cpp
@@ -8,6 +8,9 @@ extern "C" {
 #include <libultraship/bridge.h>
 
 void GameInteractor_ExecuteOnGameStateMainStart() {
+    // Cleanup all hooks at the start of each frame
+    GameInteractor::Instance->RemoveAllQueuedHooks();
+
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnGameStateMainStart>();
 }
 


### PR DESCRIPTION
* (Depends on #1001)

This aims to fix and improve some of the hook cleanup process when unregistering. On hook unregister, we were queuing up the hook to be removed upon next hook execution. There was two issues with this:

* Because the unregister isn't processed until that specific hook + ID/Ptr combo is executed, this means the hook could linger for a long time (or potentially forever in the case of Ptr)
* The looping in the execute for ID/Ptr hooks was using a range-based loop for the outer loop, but also modifying the underlying structure in place, which messes up the range loop and leading to some hooks not unregistering at the right time.

To address this, I've updated the ID/Ptr executes to now use iterator begin/end loops and proper erase on both loops/structures.

I also created a method for each hook type to process all unregisters for their type, and then one top method that executes all of those methods for all hook types. This gives us a way to effectively process the entire queue. For right now, I'm calling this as part of `OnGameStateMainStart` (so once at the beginning of each frame).

This means that no hooks should linger between frames, and additional unregistering will still happen like before mid-frame.
(I'll move the `RemoveAllQueuedHooks` to the `GameInteractor::RegisterOwnHooks` pattern that is on the rando branch after merge)

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2633190471.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2633200871.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2633205273.zip)
<!--- section:artifacts:end -->