### PR TITLE
Improve better warp menu behavior and better grotto support

### DIFF
--- a/mm/2s2h/DeveloperTools/BetterMapSelect.c
+++ b/mm/2s2h/DeveloperTools/BetterMapSelect.c
@@ -5,24 +5,8 @@
 #include "overlays/gamestates/ovl_select/z_select.h"
 #include <libultraship/bridge.h>
 
-extern SceneSelectEntry sScenes[143];
-
-void BetterMapSelect_LoadGame(MapSelectState* mapSelectState, u32 entrance, s32 spawn) {
-    CVarSetInteger("gDeveloperTools.BetterMapSelect.CurrentScene", mapSelectState->currentScene);
-    CVarSetInteger("gDeveloperTools.BetterMapSelect.TopDisplayedScene", mapSelectState->topDisplayedScene);
-    CVarSetInteger("gDeveloperTools.BetterMapSelect.PageDownIndex", mapSelectState->pageDownIndex);
-    CVarSave();
-    MapSelect_LoadGame(mapSelectState, entrance, spawn);
-}
-
-void BetterMapSelect_LoadFileSelect(MapSelectState* mapSelectState) {
-    CVarSetInteger("gDeveloperTools.BetterMapSelect.CurrentScene", mapSelectState->currentScene);
-    CVarSetInteger("gDeveloperTools.BetterMapSelect.TopDisplayedScene", mapSelectState->topDisplayedScene);
-    CVarSetInteger("gDeveloperTools.BetterMapSelect.PageDownIndex", mapSelectState->pageDownIndex);
-    CVarSave();
-    STOP_GAMESTATE(&mapSelectState->state);
-    SET_NEXT_GAMESTATE(&mapSelectState->state, FileSelect_Init, sizeof(FileSelectState));
-}
+void BetterMapSelect_LoadGame(MapSelectState* mapSelectState, u32 entrance, s32 spawn);
+void BetterMapSelect_LoadFileSelect(MapSelectState* mapSelectState);
 
 // 2S2H Added columns to scene table: entranceSceneId, betterMapSelectIndex, humanName
 #define DEFINE_SCENE(_name, _enumValue, _textId, _drawConfig, _restrictionFlags, _persistentCycleFlags, \
@@ -58,38 +42,236 @@ static BetterMapSelectInfoEntry sBetterMapSelectInfo[102] = {
 #undef DEFINE_SCENE
 #undef DEFINE_SCENE_UNSET
 
-static bool isBetterMapSelect = false;
-static bool isInitialized = false;
+#define STAGE_CURRENT_TIME 0x9000
+
+extern SceneSelectEntry sScenes[143];
+
+static bool sIsBetterMapSelectEnabled = false;
+
+typedef struct {
+    u16 entrance;
+    s16 roomIndex;
+    s16 data;
+    s16 yaw;
+    s16 playerParams;
+    Vec3f pos;
+} BetterMapSelectRespawnInfo;
+
+typedef struct {
+    BetterMapSelectRespawnInfo grottoRespawn;
+    BetterMapSelectRespawnInfo downRespawn;
+} BetterMapSelectGrottoRespawnInfo;
+
+#define UNUSED_GROTTO_RESPAWN                                    \
+    {                                                            \
+        0, 0, 0xFF, 0, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_4), { \
+            0, 0, 0                                              \
+        }                                                        \
+    }
+
+// clang-format off
+BetterMapSelectGrottoRespawnInfo sBetterMapSelectGrottoInfo[] = {
+    /*  0 */ { { ENTRANCE(TERMINA_FIELD, 0), 0, 0x1F, -5644, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_4), { -2782, 48, -1654 } },
+               { ENTRANCE(TERMINA_FIELD, 0), 0, 0x01, -16384, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D), { -2400, 68, -400 } } },
+    /*  1 */ { { ENTRANCE(TERMINA_FIELD, 0), 0, 0x1F, -21118, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_4), { -1592, -222, 4622 } },
+               { ENTRANCE(TERMINA_FIELD, 6), 0, 0x01, 0, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D), { -412, -77, 1681 } } },
+    /*  2 */ { { ENTRANCE(TERMINA_FIELD, 0), 0, 0x1F, -27125, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_4), { 4450, 254, 925 } },
+               { ENTRANCE(TERMINA_FIELD, 7), 0, 0x01, 16384, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D), { 1672, 68, -394 } } },
+    /*  3 */ { { ENTRANCE(TERMINA_FIELD, 0), 0, 0x1F, -11287, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_4), { 192, 48, -3138 } },
+               { ENTRANCE(TERMINA_FIELD, 8), 0, 0x01, -32768, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D), { -400, 48, -2520 } } },
+    /*  4 */ { { ENTRANCE(TERMINA_FIELD, 0), 0, 0x3F, -22028, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_4), { 1012, -221, 3642 } }, // Reused chest
+               { ENTRANCE(TERMINA_FIELD, 6), 0, 0x01, 0, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D), { -412, -77, 1681 } } },
+    /*  5 */ { { ENTRANCE(PATH_TO_GORON_VILLAGE_WINTER, 0), 0, 0xFF, -21846, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_4), { 589, 195, 53 } },
+               { ENTRANCE(PATH_TO_GORON_VILLAGE_WINTER, 0), 0, 0x01, 20024, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D), { -2044, 200, 1288 } } },
+    /*  6 */ { UNUSED_GROTTO_RESPAWN,
+               { ENTRANCE(DEKU_PALACE, 2), 0, 0x01, 0, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D), { 5, 0, 1433 } } },
+    /*  7 */ { { ENTRANCE(TERMINA_FIELD, 0), 0, 0x1F, 10558, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_4), { -2425, -281, -3291 } },
+               { ENTRANCE(TERMINA_FIELD, 8), 0, 0x01, -32768, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D), { -400, 48, -2520 } } },
+    /*  8 */ { UNUSED_GROTTO_RESPAWN,
+               { ENTRANCE(DEKU_PALACE, 2), 0, 0x01, 0, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D), { 5, 0, 1433 } } },
+    /*  9 */ { { ENTRANCE(TERMINA_FIELD, 0), 0, 0x1F, -19479, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_4), { 3223, 219, 1417 } },
+               { ENTRANCE(TERMINA_FIELD, 7), 0, 0x01, 16384, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D), { 1672, 68, -394 } } },
+    /* 10 */ { { ENTRANCE(TERMINA_FIELD, 0), 0, 0x1F, -32768, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_4), { -375, -222, 3976 } }, // Reused cow
+               { ENTRANCE(TERMINA_FIELD, 6), 0, 0x01, 0, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D), { -412, -77, 1681 } } },
+    /* 11 */ { { ENTRANCE(TERMINA_FIELD, 0), 0, 0x1F, 0, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_4), { -5159, -281, -571 } },
+               { ENTRANCE(TERMINA_FIELD, 0), 0, 0x01, -16384, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D), { -2400, 68, -400 } } },
+    /* 12 */ { UNUSED_GROTTO_RESPAWN,
+               { ENTRANCE(DEKU_PALACE, 2), 0, 0x01, 0, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D), { 5, 0, 1433 } } },
+    /* 13 */ { { ENTRANCE(TERMINA_FIELD, 0), 0, 0x1F, 21663, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_4), { -2317, -221, 3418 } },
+               { ENTRANCE(TERMINA_FIELD, 6), 0, 0x01, 0, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D), { -412, -77, 1681 } } },
+    /* 14 */ { UNUSED_GROTTO_RESPAWN,
+               { ENTRANCE(DEKU_PALACE, 2), 0, 0x01, 0, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D), { 5, 0, 1433 } } },
+    /* 15 */ { UNUSED_GROTTO_RESPAWN,
+               { ENTRANCE(DEKU_PALACE, 2), 0, 0x01, 0, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D), { 5, 0, 1433 } } },
+    /* 16 */ { UNUSED_GROTTO_RESPAWN,
+               { ENTRANCE(GORON_VILLAGE_WINTER, 3), 0, 0x01, -12015, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D), { 2621, -200, -1389 } } },
+};
+
+// TODO: Figure out how to deal with re-used grottos
+
+// Grotto 4 re-use
+// Termina Field near Ikana pillar grotto
+// { { ENTRANCE(TERMINA_FIELD, 0), 0, 0x9A, 0, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_4), { 2367, 315, -192 } },
+// { ENTRANCE(TERMINA_FIELD, 7), 0, 0x01, 16384, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D), { 1672, 68, -394 } } },
+// Termina Field near swamp grass grotto
+// { { ENTRANCE(TERMINA_FIELD, 0), 0, 0x3F, -22028, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_4), { 1012, -221, 3642 } },
+// { ENTRANCE(TERMINA_FIELD, 6), 0, 0x01, 0, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D), { -412, -77, 1681 } } },
+// Road to Southern Swamp near heart piece tree grotto
+// { { ENTRANCE(ROAD_TO_SOUTHERN_SWAMP, 0), 0, 0x3E, 4187, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_4), { 104, -182, 2202 } },
+// { ENTRANCE(ROAD_TO_SOUTHERN_SWAMP, 0), 0, 0x01, -3641, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D), { 331, -143, 245 } } },
+// Woods of Mystery Day 2 path grotto
+// { { ENTRANCE(WOODS_OF_MYSTERY, 0), 2, 0x5C, 0, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_4), { 2, 0, -889 } },
+// { ENTRANCE(WOODS_OF_MYSTERY, 0), 1, 0x01, -16384, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D), { 274, 0, 0 } } },
+// Southern Swamp behind spider house grotto
+// { { ENTRANCE(SOUTHERN_SWAMP_POISONED, 0), 1, 0x3D, -5462, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_4), { -1700, 38, 1800 } },
+// { ENTRANCE(SOUTHERN_SWAMP_POISONED, 8), 1, 0x01, -2731, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D), { -1049, 12, 2042 } } },
+// Mountain Village Spring ramps near Darmani grave grotto
+// { { ENTRANCE(MOUNTAIN_VILLAGE_SPRING, 0), 1, 0x3B, -10377, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_4), { 2406, 1168, -1197 } },
+// { ENTRANCE(MOUNTAIN_VILLAGE_SPRING, 2), 0, 0x01, -22210, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D), { 2089, 15, 939 } } },
+// Path to Goron Village ramp hidden grotto
+// { { ENTRANCE(PATH_TO_GORON_VILLAGE_WINTER, 0), 0, 0x99, 12379, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_4), { -1309, 320, 143 } },
+// { ENTRANCE(PATH_TO_GORON_VILLAGE_WINTER, 0), 0, 0x01, 20024, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D), { -2044, 200, 1288 } } },
+// Path to Snowhead snow triangle hidden grotto
+// { { ENTRANCE(PATH_TO_SNOWHEAD, 0), 0, 0x33, -19479, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_4), { -987, 360, -2339 } },
+// { ENTRANCE(PATH_TO_SNOWHEAD, 1), 0, 0x01, 8192, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D), { -2518, 550, -3441 } } },
+// Great Bay behind Fisherman hut grotto
+// { { ENTRANCE(GREAT_BAY_COAST, 0), 0, 0x37, -11287, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_4), { 1359, 80, 5018 } },
+// { ENTRANCE(GREAT_BAY_COAST, 4), 0, 0x01, -28217, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D), { 1137, 92, 4635 } } },
+// Zora Cape under rock grotto
+// { { ENTRANCE(ZORA_CAPE, 0), 0, 0x95, -14018, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_4), { -562, 80, 2707 } },
+// { ENTRANCE(ZORA_CAPE, 0), 0, 0x01, 3583, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D), { 92, 12, 333 } } },
+// Road to Ikana under rock grotto
+// { { ENTRANCE(ROAD_TO_IKANA, 0), 0, 0x96, -19479, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_4), { -428, 200, -335 } },
+// { ENTRANCE(ROAD_TO_IKANA, 0), 0, 0x01, 14563, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D), { -3006, 0, -305 } } },
+// Ikana Graveyard rock circle hidden grotto
+// { { ENTRANCE(IKANA_GRAVEYARD, 0), 0, 0xB8, -28217, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_4), { 106, 314, -1777 } },
+// { ENTRANCE(IKANA_GRAVEYARD, 0), 0, 0x01, -32768, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D), { -45, -49, 864 } } },
+// Ikana Canyon near Secret Shrine grotto
+// { { ENTRANCE(IKANA_CANYON, 0), 2, 0xB4, -28217, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_4), { -2475, -505, 2475 } },
+// { ENTRANCE(IKANA_CANYON, 12), 2, 0x01, 13653, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D), { -3068, -505, 2690 } } },
+
+// Grotto 10 re-use
+// Termina Field Hollow Log hidden grotto
+// { { ENTRANCE(TERMINA_FIELD, 0), 0, 0x1F, -32768, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_4), { -375, -222, 3976 } },
+// { ENTRANCE(TERMINA_FIELD, 6), 0, 0x01, 0, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D), { -412, -77, 1681 } } },
+// Great Bay Cliffs near Gerudo Fortress grotto
+// { { ENTRANCE(GREAT_BAY_COAST, 0), 0, 0xFF, -13654, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_4), { 2077, 333, -215 } },
+// { ENTRANCE(GREAT_BAY_COAST, 6), 0, 0x01, 16019, PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D), { 1321, -16, -1029 } } },
+
+// clang-format on
+
+void BetterMapSelect_LoadGame(MapSelectState* mapSelectState, u32 entrance, s32 spawn) {
+    CVarSetInteger("gDeveloperTools.BetterMapSelect.CurrentScene", mapSelectState->currentScene);
+    CVarSetInteger("gDeveloperTools.BetterMapSelect.Opt", mapSelectState->opt);
+    CVarSetInteger("gDeveloperTools.BetterMapSelect.TopDisplayedScene", mapSelectState->topDisplayedScene);
+    CVarSetInteger("gDeveloperTools.BetterMapSelect.PageDownIndex", mapSelectState->pageDownIndex);
+    CVarSave();
+    MapSelect_LoadGame(mapSelectState, entrance, spawn);
+
+    // Remove dummy cutscene index for retaining current time
+    if (gSaveContext.save.cutsceneIndex == STAGE_CURRENT_TIME) {
+        gSaveContext.save.cutsceneIndex = 0;
+    }
+
+    // Handle Grotto return locations
+    if (Entrance_GetSceneIdAbsolute(entrance) == SCENE_KAKUSIANA) {
+        if (spawn >= 0 && spawn < ARRAY_COUNT(sBetterMapSelectGrottoInfo)) {
+            // Set player void out location
+            gSaveContext.respawn[RESPAWN_MODE_DOWN].data = sBetterMapSelectGrottoInfo[spawn].downRespawn.data;
+            gSaveContext.respawn[RESPAWN_MODE_DOWN].roomIndex = sBetterMapSelectGrottoInfo[spawn].downRespawn.roomIndex;
+            gSaveContext.respawn[RESPAWN_MODE_DOWN].entrance = sBetterMapSelectGrottoInfo[spawn].downRespawn.entrance;
+            gSaveContext.respawn[RESPAWN_MODE_DOWN].pos = sBetterMapSelectGrottoInfo[spawn].downRespawn.pos;
+            gSaveContext.respawn[RESPAWN_MODE_DOWN].yaw = sBetterMapSelectGrottoInfo[spawn].downRespawn.yaw;
+            gSaveContext.respawn[RESPAWN_MODE_DOWN].playerParams =
+                sBetterMapSelectGrottoInfo[spawn].downRespawn.playerParams;
+
+            // Copy void out to top
+            gSaveContext.respawn[RESPAWN_MODE_TOP] = gSaveContext.respawn[RESPAWN_MODE_DOWN];
+
+            // Set grotto respawn info
+            gSaveContext.respawn[RESPAWN_MODE_UNK_3].data = sBetterMapSelectGrottoInfo[spawn].grottoRespawn.data;
+            gSaveContext.respawn[RESPAWN_MODE_UNK_3].roomIndex =
+                sBetterMapSelectGrottoInfo[spawn].grottoRespawn.roomIndex;
+            gSaveContext.respawn[RESPAWN_MODE_UNK_3].entrance =
+                sBetterMapSelectGrottoInfo[spawn].grottoRespawn.entrance;
+            gSaveContext.respawn[RESPAWN_MODE_UNK_3].pos = sBetterMapSelectGrottoInfo[spawn].grottoRespawn.pos;
+            gSaveContext.respawn[RESPAWN_MODE_UNK_3].yaw = sBetterMapSelectGrottoInfo[spawn].grottoRespawn.yaw;
+            gSaveContext.respawn[RESPAWN_MODE_UNK_3].playerParams =
+                sBetterMapSelectGrottoInfo[spawn].grottoRespawn.playerParams;
+        }
+    }
+}
+
+void BetterMapSelect_LoadFileSelect(MapSelectState* mapSelectState) {
+    CVarSetInteger("gDeveloperTools.BetterMapSelect.CurrentScene", mapSelectState->currentScene);
+    CVarSetInteger("gDeveloperTools.BetterMapSelect.Opt", mapSelectState->opt);
+    CVarSetInteger("gDeveloperTools.BetterMapSelect.TopDisplayedScene", mapSelectState->topDisplayedScene);
+    CVarSetInteger("gDeveloperTools.BetterMapSelect.PageDownIndex", mapSelectState->pageDownIndex);
+    CVarSave();
+    gSaveContext.gameMode = GAMEMODE_FILE_SELECT;
+    STOP_GAMESTATE(&mapSelectState->state);
+    SET_NEXT_GAMESTATE(&mapSelectState->state, FileSelect_Init, sizeof(FileSelectState));
+}
 
 void BetterMapSelect_Init(MapSelectState* mapSelectState) {
-    isBetterMapSelect = CVarGetInteger("gDeveloperTools.BetterMapSelect.Enabled", 0);
-    if (CVarGetInteger("gDeveloperTools.BetterMapSelect.Enabled", 0)) {
-        if (!isInitialized) {
-            s32 i;
-            for (i = 0; i < ARRAY_COUNT(sBetterMapSelectInfo); i++) {
+    static bool sIsInitialized = false;
+    sIsBetterMapSelectEnabled = CVarGetInteger("gDeveloperTools.BetterMapSelect.Enabled", 0);
+
+    if (sIsBetterMapSelectEnabled) {
+        if (!sIsInitialized) {
+            for (s32 i = 0; i < ARRAY_COUNT(sBetterMapSelectInfo); i++) {
                 sBetterScenes[sBetterMapSelectInfo[i].index].name = sBetterMapSelectInfo[i].name;
                 sBetterScenes[sBetterMapSelectInfo[i].index].entrance = sBetterMapSelectInfo[i].entrance;
             }
-            isInitialized = true;
+            sIsInitialized = true;
         }
 
         mapSelectState->scenes = sBetterScenes;
         mapSelectState->count = ARRAY_COUNT(sBetterScenes);
         mapSelectState->currentScene = CVarGetInteger("gDeveloperTools.BetterMapSelect.CurrentScene", 0);
+        mapSelectState->opt = CVarGetInteger("gDeveloperTools.BetterMapSelect.Opt", 0);
         mapSelectState->topDisplayedScene = CVarGetInteger("gDeveloperTools.BetterMapSelect.TopDisplayedScene", 0);
         mapSelectState->pageDownIndex = CVarGetInteger("gDeveloperTools.BetterMapSelect.PageDownIndex", 0);
+
+        gSaveContext.save.cutsceneIndex = STAGE_CURRENT_TIME;
     } else {
         mapSelectState->scenes = sScenes;
         mapSelectState->count = ARRAY_COUNT(sScenes);
         mapSelectState->currentScene = 0;
+        mapSelectState->opt = 0;
         mapSelectState->topDisplayedScene = 0;
         mapSelectState->pageDownIndex = 0;
+
+        if (gSaveContext.save.cutsceneIndex == STAGE_CURRENT_TIME) {
+            gSaveContext.save.cutsceneIndex = 0;
+        }
     }
 }
 
 void BetterMapSelect_Update(MapSelectState* mapSelectState) {
-    if (isBetterMapSelect != CVarGetInteger("gDeveloperTools.BetterMapSelect.Enabled", 0)) {
+    if (sIsBetterMapSelectEnabled != CVarGetInteger("gDeveloperTools.BetterMapSelect.Enabled", 0)) {
         BetterMapSelect_Init(mapSelectState);
+    }
+
+    static s32 sScene = -1;
+    Input* controller1 = CONTROLLER1(&mapSelectState->state);
+
+    if (sScene == -1) {
+        sScene = CVarGetInteger("gDeveloperTools.BetterMapSelect.CurrentScene", 0);
+    }
+
+    mapSelectState->opt = CLAMP_MIN(mapSelectState->opt, 0);
+
+    // Reset entrance value when scene changes
+    if (sScene != mapSelectState->currentScene) {
+        sScene = mapSelectState->currentScene;
+        mapSelectState->opt = 0;
+    }
+
+    // Update to a normal stage value, then standard MapSelect_Update handles the rest
+    if (gSaveContext.save.cutsceneIndex == STAGE_CURRENT_TIME &&
+        CHECK_BTN_ANY(controller1->press.button, BTN_R | BTN_Z)) {
+        gSaveContext.save.cutsceneIndex = 0;
     }
 }
 
@@ -220,5 +402,26 @@ void BetterMapSelect_PrintMenu(MapSelectState* mapSelectState, GfxPrint* printer
             stageName = "???";
             break;
     }
-    GfxPrint_Printf(printer, "%s", stageName);
+
+    if (gSaveContext.save.cutsceneIndex != STAGE_CURRENT_TIME) {
+        GfxPrint_Printf(printer, "%s", stageName);
+    } else {
+        u16 curMinutes = (s32)TIME_TO_MINUTES_F(gSaveContext.save.time) % 60;
+        u16 curHours = (s32)TIME_TO_MINUTES_F(gSaveContext.save.time) / 60;
+        char* ampm = "";
+        char* hourPrefix = "";
+        char* minutePrefix = curMinutes < 10 ? "0" : "";
+
+        // Handle 24 or 12 hour time
+        if (CVarGetInteger("gEnhancements.Graphics.24HoursClock", 0)) {
+            if (curHours < 10) {
+                hourPrefix = "0";
+            }
+        } else {
+            ampm = curHours >= 12 ? "pm" : "am";
+            curHours = curHours % 12 ? curHours % 12 : 12;
+        }
+
+        GfxPrint_Printf(printer, "%s%d:%s%d %s", hourPrefix, curHours, minutePrefix, curMinutes, ampm);
+    }
 };

--- a/mm/include/tables/scene_table.h
+++ b/mm/include/tables/scene_table.h
@@ -34,7 +34,7 @@
 // Majora's Lair
 /* 0x0B */ DEFINE_SCENE(Z2_LAST_BS,           SCENE_LAST_BS,           0,     SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_MOON,                                    PERSISTENT_CYCLE_FLAGS_SET(0, 0, 0, (1 << 31)),                                                             MAJORAS_LAIR,                  96, "Majora's Lair")
 // Beneath the Graveyard
-/* 0x0C */ DEFINE_SCENE(Z2_HAKASHITA,         SCENE_HAKASHITA,         0x113, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET(0, 0, 0, (1 << 31)),                                                             BENEATH_THE_GRAVERYARD,        60, "Beneath the Graveyard")
+/* 0x0C */ DEFINE_SCENE(Z2_HAKASHITA,         SCENE_HAKASHITA,         0x113, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET(0, 0, 0, (1 << 31)),                                                             BENEATH_THE_GRAVERYARD,        75, "Beneath the Graveyard")
 // Curiosity Shop
 /* 0x0D */ DEFINE_SCENE(Z2_AYASHIISHOP,       SCENE_AYASHIISHOP,       0x10E, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_INDOORS,                                 PERSISTENT_CYCLE_FLAGS_NONE,                                                                                CURIOSITY_SHOP,                11, "Curiosity Shop")
 /* 0x0E */ DEFINE_SCENE_UNSET(SCENE_UNSET_0E)
@@ -46,17 +46,17 @@
 // The Mayor's Residence
 /* 0x12 */ DEFINE_SCENE(Z2_SONCHONOIE,        SCENE_SONCHONOIE,        0x10B, SCENE_DRAW_CFG_DEFAULT,              RESTRICTIONS_INDOORS,                                 PERSISTENT_CYCLE_FLAGS_NONE,                                                                                MAYORS_RESIDENCE,               5, "The Mayor's Residence")
 // Ikana Canyon
-/* 0x13 */ DEFINE_SCENE(Z2_IKANA,             SCENE_IKANA,             0x141, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET((1 << 20), 0, 0, (1 << 1) | (1 << 30)),                                          IKANA_CANYON,                  62, "Ikana Canyon")
+/* 0x13 */ DEFINE_SCENE(Z2_IKANA,             SCENE_IKANA,             0x141, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET((1 << 20), 0, 0, (1 << 1) | (1 << 30)),                                          IKANA_CANYON,                  77, "Ikana Canyon")
 // Pirates' Fortress
-/* 0x14 */ DEFINE_SCENE(Z2_KAIZOKU,           SCENE_KAIZOKU,           0,     SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_NONE,                                                                                PIRATES_FORTRESS,              87, "Pirates' Fortress")
+/* 0x14 */ DEFINE_SCENE(Z2_KAIZOKU,           SCENE_KAIZOKU,           0,     SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_NONE,                                                                                PIRATES_FORTRESS,              69, "Pirates' Fortress")
 // Milk Bar
 /* 0x15 */ DEFINE_SCENE(Z2_MILK_BAR,          SCENE_MILK_BAR,          0x10C, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_INDOORS,                                 PERSISTENT_CYCLE_FLAGS_NONE,                                                                                MILK_BAR,                      10, "Milk Bar")
 // Stone Tower Temple
-/* 0x16 */ DEFINE_SCENE(Z2_INISIE_N,          SCENE_INISIE_N,          0x144, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET((1 << 26), 0, 0, 0),                                                             STONE_TOWER_TEMPLE,            72, "Stone Tower Temple")
+/* 0x16 */ DEFINE_SCENE(Z2_INISIE_N,          SCENE_INISIE_N,          0x144, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET((1 << 26), 0, 0, 0),                                                             STONE_TOWER_TEMPLE,            87, "Stone Tower Temple")
 // Treasure Chest Shop
 /* 0x17 */ DEFINE_SCENE(Z2_TAKARAYA,          SCENE_TAKARAYA,          0x109, SCENE_DRAW_CFG_DEFAULT,              RESTRICTIONS_INDOORS,                                 PERSISTENT_CYCLE_FLAGS_SET(2, 0, 0, 0),                                                                     TREASURE_CHEST_SHOP,           14, "Treasure Chest Shop")
 // Inverted Stone Tower Temple
-/* 0x18 */ DEFINE_SCENE(Z2_INISIE_R,          SCENE_INISIE_R,          0x144, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET((1 << 26), 0, 0, 0),                                                             STONE_TOWER_TEMPLE_INVERTED,   73, "Inverted Stone Tower Temple")
+/* 0x18 */ DEFINE_SCENE(Z2_INISIE_R,          SCENE_INISIE_R,          0x144, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET((1 << 26), 0, 0, 0),                                                             STONE_TOWER_TEMPLE_INVERTED,   88, "Inverted Stone Tower Temple")
 // Clock Tower Rooftop
 /* 0x19 */ DEFINE_SCENE(Z2_OKUJOU,            SCENE_OKUJOU,            0,     SCENE_DRAW_CFG_DEFAULT,              RESTRICTIONS_SET(0, 0, 0, 0, 0, 3, 3, 3, 3, 3, 0, 0), PERSISTENT_CYCLE_FLAGS_NONE,                                                                                CLOCK_TOWER_ROOFTOP,           20, "Clock Tower Rooftop")
 // Before Clock Town
@@ -66,7 +66,7 @@
 // Path to Mountain Village
 /* 0x1C */ DEFINE_SCENE(Z2_13HUBUKINOMITI,    SCENE_13HUBUKINOMITI,    0,     SCENE_DRAW_CFG_DEFAULT,              RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_NONE,                                                                                PATH_TO_MOUNTAIN_VILLAGE,      42, "Path to Mountain Village")
 // Ancient Castle of Ikana
-/* 0x1D */ DEFINE_SCENE(Z2_CASTLE,            SCENE_CASTLE,            0x142, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET(0, (1 << 31), 0, (1 << 10)),                                                     IKANA_CASTLE,                  68, "Ancient Castle of Ikana")
+/* 0x1D */ DEFINE_SCENE(Z2_CASTLE,            SCENE_CASTLE,            0x142, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET(0, (1 << 31), 0, (1 << 10)),                                                     IKANA_CASTLE,                  83, "Ancient Castle of Ikana")
 // Deku Scrub Playground
 /* 0x1E */ DEFINE_SCENE(Z2_DEKUTES,           SCENE_DEKUTES,           0,     SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_SET(0, 1, 0, 0, 0, 3, 0, 0, 0, 0, 0, 1), PERSISTENT_CYCLE_FLAGS_NONE,                                                                                DEKU_SCRUB_PLAYGROUND,         99, "Deku Scrub Playground")
 // Odolwa's Lair
@@ -78,17 +78,17 @@
 // Milk Road
 /* 0x22 */ DEFINE_SCENE(Z2_ROMANYMAE,         SCENE_ROMANYMAE,         0x149, SCENE_DRAW_CFG_DEFAULT,              RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET((1 << 10), 0, 0, 0),                                                             MILK_ROAD,                     22, "Milk Road")
 // Pirates' Fortress Interior
-/* 0x23 */ DEFINE_SCENE(Z2_PIRATE,            SCENE_PIRATE,            0,     SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET(0, 0, 0, (1 << 12)),                                                             PIRATES_FORTRESS_INTERIOR,     88, "Pirates' Fortress Interior")
+/* 0x23 */ DEFINE_SCENE(Z2_PIRATE,            SCENE_PIRATE,            0,     SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET(0, 0, 0, (1 << 12)),                                                             PIRATES_FORTRESS_INTERIOR,     70, "Pirates' Fortress Interior")
 // Swamp Shooting Gallery
 /* 0x24 */ DEFINE_SCENE(Z2_SYATEKI_MORI,      SCENE_SYATEKI_MORI,      0x11B, SCENE_DRAW_CFG_DEFAULT,              RESTRICTIONS_INDOORS,                                 PERSISTENT_CYCLE_FLAGS_NONE,                                                                                SWAMP_SHOOTING_GALLERY,        29, "Swamp Shooting Gallery")
 // Pinnacle Rock
-/* 0x25 */ DEFINE_SCENE(Z2_SINKAI,            SCENE_SINKAI,            0x135, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET(0, 0, 0, 2),                                                                     PINNACLE_ROCK,                 79, "Pinnacle Rock")
+/* 0x25 */ DEFINE_SCENE(Z2_SINKAI,            SCENE_SINKAI,            0x135, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET(0, 0, 0, 2),                                                                     PINNACLE_ROCK,                 66, "Pinnacle Rock")
 // Fairy's Fountain
 /* 0x26 */ DEFINE_SCENE(Z2_YOUSEI_IZUMI,      SCENE_YOUSEI_IZUMI,      0x13E, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET((1 << 10), 0, 0, 0),                                                             FAIRY_FOUNTAIN,                97, "Fairy's Fountain")
 // Swamp Spider House
 /* 0x27 */ DEFINE_SCENE(Z2_KINSTA1,           SCENE_KINSTA1,           0x11E, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NO_DOUBLE_TIME,                          PERSISTENT_CYCLE_FLAGS_NONE,                                                                                SWAMP_SPIDER_HOUSE,            34, "Swamp Spider House")
 // Oceanside Spider House
-/* 0x28 */ DEFINE_SCENE(Z2_KINDAN2,           SCENE_KINDAN2,           0x13F, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NO_DOUBLE_TIME,                          PERSISTENT_CYCLE_FLAGS_SET(0, 0, 0, (1 << 31)),                                                             OCEANSIDE_SPIDER_HOUSE,        85, "Oceanside Spider House")
+/* 0x28 */ DEFINE_SCENE(Z2_KINDAN2,           SCENE_KINDAN2,           0x13F, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NO_DOUBLE_TIME,                          PERSISTENT_CYCLE_FLAGS_SET(0, 0, 0, (1 << 31)),                                                             OCEANSIDE_SPIDER_HOUSE,        62, "Oceanside Spider House")
 // Astral Observatory
 /* 0x29 */ DEFINE_SCENE(Z2_TENMON_DAI,        SCENE_TENMON_DAI,        0x114, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_SET(0, 0, 0, 0, 0, 0, 0, 3, 3, 0, 0, 0), PERSISTENT_CYCLE_FLAGS_NONE,                                                                                ASTRAL_OBSERVATORY,             6, "Astral Observatory")
 // Moon Deku Trial
@@ -102,31 +102,31 @@
 // Post Office
 /* 0x2E */ DEFINE_SCENE(Z2_POSTHOUSE,         SCENE_POSTHOUSE,         0x111, SCENE_DRAW_CFG_DEFAULT,              RESTRICTIONS_SET(0, 0, 0, 0, 0, 3, 0, 0, 3, 0, 0, 1), PERSISTENT_CYCLE_FLAGS_SET(3, 0, 0, 0),                                                                     POST_OFFICE,                    8, "Post Office")
 // Marine Research Lab
-/* 0x2F */ DEFINE_SCENE(Z2_LABO,              SCENE_LABO,              0x13A, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_SET(0, 0, 0, 0, 0, 3, 0, 0, 3, 0, 0, 1), PERSISTENT_CYCLE_FLAGS_NONE,                                                                                MARINE_RESEARCH_LAB,           78, "Marine Research Lab")
+/* 0x2F */ DEFINE_SCENE(Z2_LABO,              SCENE_LABO,              0x13A, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_SET(0, 0, 0, 0, 0, 3, 0, 0, 3, 0, 0, 1), PERSISTENT_CYCLE_FLAGS_NONE,                                                                                MARINE_RESEARCH_LAB,           60, "Marine Research Lab")
 // Beneath the Graveyard (Day 3) and Dampe's House
-/* 0x30 */ DEFINE_SCENE(Z2_DANPEI2TEST,       SCENE_DANPEI2TEST,       0x113, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NO_DOUBLE_TIME,                          PERSISTENT_CYCLE_FLAGS_SET(0, 0, 0, (1 << 31)),                                                             DAMPES_HOUSE,                  61, "Beneath Graveyard and Dampe's House")
+/* 0x30 */ DEFINE_SCENE(Z2_DANPEI2TEST,       SCENE_DANPEI2TEST,       0x113, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NO_DOUBLE_TIME,                          PERSISTENT_CYCLE_FLAGS_SET(0, 0, 0, (1 << 31)),                                                             DAMPES_HOUSE,                  76, "Beneath Graveyard and Dampe's House")
 /* 0x31 */ DEFINE_SCENE_UNSET(SCENE_UNSET_31)
 // Goron Shrine
 /* 0x32 */ DEFINE_SCENE(Z2_16GORON_HOUSE,     SCENE_16GORON_HOUSE,     0x124, SCENE_DRAW_CFG_DEFAULT,              RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_NONE,                                                                                GORON_SHRINE,                  52, "Goron Shrine")
 // Zora Hall
-/* 0x33 */ DEFINE_SCENE(Z2_33ZORACITY,        SCENE_33ZORACITY,        0x136, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_SET(0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0), PERSISTENT_CYCLE_FLAGS_NONE,                                                                                ZORA_HALL,                     80, "Zora Hall")
+/* 0x33 */ DEFINE_SCENE(Z2_33ZORACITY,        SCENE_33ZORACITY,        0x136, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_SET(0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0), PERSISTENT_CYCLE_FLAGS_NONE,                                                                                ZORA_HALL,                     64, "Zora Hall")
 // Trading Post
 /* 0x34 */ DEFINE_SCENE(Z2_8ITEMSHOP,         SCENE_8ITEMSHOP,         0x10F, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_SET(0, 0, 0, 0, 0, 3, 0, 0, 3, 0, 0, 1), PERSISTENT_CYCLE_FLAGS_NONE,                                                                                TRADING_POST,                  13, "Trading Post")
 // Romani Ranch
 /* 0x35 */ DEFINE_SCENE(Z2_F01,               SCENE_F01,               0x12E, SCENE_DRAW_CFG_DEFAULT,              RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_NONE,                                                                                ROMANI_RANCH,                  24, "Romani Ranch")
 // Twinmold's Lair
-/* 0x36 */ DEFINE_SCENE(Z2_INISIE_BS,         SCENE_INISIE_BS,         0,     SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET(0, 0, 0, (1 << 31)),                                                             TWINMOLDS_LAIR,                74, "Twinmold's Lair")
+/* 0x36 */ DEFINE_SCENE(Z2_INISIE_BS,         SCENE_INISIE_BS,         0,     SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET(0, 0, 0, (1 << 31)),                                                             TWINMOLDS_LAIR,                89, "Twinmold's Lair")
 // Great Bay Coast
-/* 0x37 */ DEFINE_SCENE(Z2_30GYOSON,          SCENE_30GYOSON,          0x134, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET((1 << 10) | (1 << 20), 0, 0, (1 << 1) | (1 << 5)),                               GREAT_BAY_COAST,               76, "Great Bay Coast")
+/* 0x37 */ DEFINE_SCENE(Z2_30GYOSON,          SCENE_30GYOSON,          0x134, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET((1 << 10) | (1 << 20), 0, 0, (1 << 1) | (1 << 5)),                               GREAT_BAY_COAST,               58, "Great Bay Coast")
 // Zora Cape
-/* 0x38 */ DEFINE_SCENE(Z2_31MISAKI,          SCENE_31MISAKI,          0x134, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET((1 << 10), 0, 0, (1 << 7)),                                                      ZORA_CAPE,                     82, "Zora Cape")
+/* 0x38 */ DEFINE_SCENE(Z2_31MISAKI,          SCENE_31MISAKI,          0x134, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET((1 << 10), 0, 0, (1 << 7)),                                                      ZORA_CAPE,                     63, "Zora Cape")
 // Lottery Shop
 /* 0x39 */ DEFINE_SCENE(Z2_TAKARAKUJI,        SCENE_TAKARAKUJI,        0x112, SCENE_DRAW_CFG_DEFAULT,              RESTRICTIONS_SET(0, 0, 0, 0, 0, 3, 0, 0, 3, 0, 0, 1), PERSISTENT_CYCLE_FLAGS_NONE,                                                                                LOTTERY_SHOP,                  17, "Lottery Shop")
 /* 0x3A */ DEFINE_SCENE_UNSET(SCENE_UNSET_3A)
 // Pirates' Fortress Moat
-/* 0x3B */ DEFINE_SCENE(Z2_TORIDE,            SCENE_TORIDE,            0x138, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET((1 << 10), 0, 0, 0),                                                             PIRATES_FORTRESS_EXTERIOR,     86, "Pirates' Fortress Moat")
+/* 0x3B */ DEFINE_SCENE(Z2_TORIDE,            SCENE_TORIDE,            0x138, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET((1 << 10), 0, 0, 0),                                                             PIRATES_FORTRESS_EXTERIOR,     68, "Pirates' Fortress Moat")
 // Fisherman's Hut
-/* 0x3C */ DEFINE_SCENE(Z2_FISHERMAN,         SCENE_FISHERMAN,         0x13B, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_SET(0, 0, 0, 0, 0, 3, 0, 0, 3, 0, 0, 1), PERSISTENT_CYCLE_FLAGS_NONE,                                                                                FISHERMANS_HUT,                83, "Fisherman's Hut")
+/* 0x3C */ DEFINE_SCENE(Z2_FISHERMAN,         SCENE_FISHERMAN,         0x13B, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_SET(0, 0, 0, 0, 0, 3, 0, 0, 3, 0, 0, 1), PERSISTENT_CYCLE_FLAGS_NONE,                                                                                FISHERMANS_HUT,                61, "Fisherman's Hut")
 // Goron Shop
 /* 0x3D */ DEFINE_SCENE(Z2_GORONSHOP,         SCENE_GORONSHOP,         0x129, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_INDOORS,                                 PERSISTENT_CYCLE_FLAGS_NONE,                                                                                GORON_SHOP,                    53, "Goron Shop")
 // Deku King's Chamber
@@ -140,7 +140,7 @@
 // Cucco Shack
 /* 0x42 */ DEFINE_SCENE(Z2_F01C,              SCENE_F01C,              0x12F, SCENE_DRAW_CFG_DEFAULT,              RESTRICTIONS_NO_DOUBLE_TIME,                          PERSISTENT_CYCLE_FLAGS_NONE,                                                                                CUCCO_SHACK,                   26, "Cucco Shack")
 // Ikana Graveyard
-/* 0x43 */ DEFINE_SCENE(Z2_BOTI,              SCENE_BOTI,              0x106, SCENE_DRAW_CFG_DEFAULT,              RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_NONE,                                                                                IKANA_GRAVEYARD,               59, "Ikana Graveyard")
+/* 0x43 */ DEFINE_SCENE(Z2_BOTI,              SCENE_BOTI,              0x106, SCENE_DRAW_CFG_DEFAULT,              RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_NONE,                                                                                IKANA_GRAVEYARD,               74, "Ikana Graveyard")
 // Goht's Lair
 /* 0x44 */ DEFINE_SCENE(Z2_HAKUGIN_BS,        SCENE_HAKUGIN_BS,        0,     SCENE_DRAW_CFG_DEFAULT,              RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET(0, 0, 0, (1 << 31)),                                                             GOHTS_LAIR,                    57, "Goht's Lair")
 // Southern Swamp (poison)
@@ -152,39 +152,39 @@
 // Goron Village (spring)
 /* 0x48 */ DEFINE_SCENE(Z2_11GORONNOSATO2,    SCENE_11GORONNOSATO2,    0x123, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET(0, 0, 0, (1 << 30)),                                                             GORON_VILLAGE_SPRING,          51, "Goron Village (spring)")
 // Great Bay Temple
-/* 0x49 */ DEFINE_SCENE(Z2_SEA,               SCENE_SEA,               0x13D, SCENE_DRAW_CFG_GREAT_BAY_TEMPLE,     RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET((1 << 4) | (1 << 5) | (1 << 6), 0, 0, 0),                                        GREAT_BAY_TEMPLE,              89, "Great Bay Temple")
+/* 0x49 */ DEFINE_SCENE(Z2_SEA,               SCENE_SEA,               0x13D, SCENE_DRAW_CFG_GREAT_BAY_TEMPLE,     RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET((1 << 4) | (1 << 5) | (1 << 6), 0, 0, 0),                                        GREAT_BAY_TEMPLE,              71, "Great Bay Temple")
 // Waterfall Rapids
-/* 0x4A */ DEFINE_SCENE(Z2_35TAKI,            SCENE_35TAKI,            0x137, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_NONE,                                                                                WATERFALL_RAPIDS,              84, "Waterfall Rapids")
+/* 0x4A */ DEFINE_SCENE(Z2_35TAKI,            SCENE_35TAKI,            0x137, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_NONE,                                                                                WATERFALL_RAPIDS,              67, "Waterfall Rapids")
 // Beneath the Well
-/* 0x4B */ DEFINE_SCENE(Z2_REDEAD,            SCENE_REDEAD,            0x145, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_NONE,                                                                                BENEATH_THE_WELL,              65, "Beneath the Well")
+/* 0x4B */ DEFINE_SCENE(Z2_REDEAD,            SCENE_REDEAD,            0x145, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_NONE,                                                                                BENEATH_THE_WELL,              80, "Beneath the Well")
 // Zora Hall Rooms
-/* 0x4C */ DEFINE_SCENE(Z2_BANDROOM,          SCENE_BANDROOM,          0,     SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_SET(0, 0, 0, 0, 0, 3, 0, 0, 3, 0, 0, 0), PERSISTENT_CYCLE_FLAGS_SET(0, 0, 0, (1 << 30)),                                                             ZORA_HALL_ROOMS,               81, "Zora Hall Rooms")
+/* 0x4C */ DEFINE_SCENE(Z2_BANDROOM,          SCENE_BANDROOM,          0,     SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_SET(0, 0, 0, 0, 0, 3, 0, 0, 3, 0, 0, 0), PERSISTENT_CYCLE_FLAGS_SET(0, 0, 0, (1 << 30)),                                                             ZORA_HALL_ROOMS,               65, "Zora Hall Rooms")
 // Goron Village (winter)
 /* 0x4D */ DEFINE_SCENE(Z2_11GORONNOSATO,     SCENE_11GORONNOSATO,     0x123, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET(0, 0, 0, (1 << 30)),                                                             GORON_VILLAGE_WINTER,          50, "Goron Village (winter)")
 // Goron Graveyard
 /* 0x4E */ DEFINE_SCENE(Z2_GORON_HAKA,        SCENE_GORON_HAKA,        0x12A, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_NONE,                                                                                GORON_GRAVERYARD,              46, "Goron Graveyard")
 // Sakon's Hideout
-/* 0x4F */ DEFINE_SCENE(Z2_SECOM,             SCENE_SECOM,             0x143, SCENE_DRAW_CFG_MAT_ANIM_MANUAL_STEP, RESTRICTIONS_SET(0, 0, 0, 0, 0, 3, 3, 0, 3, 0, 0, 0), PERSISTENT_CYCLE_FLAGS_NONE,                                                                                SAKONS_HIDEOUT,                63, "Sakon's Hideout")
+/* 0x4F */ DEFINE_SCENE(Z2_SECOM,             SCENE_SECOM,             0x143, SCENE_DRAW_CFG_MAT_ANIM_MANUAL_STEP, RESTRICTIONS_SET(0, 0, 0, 0, 0, 3, 3, 0, 3, 0, 0, 0), PERSISTENT_CYCLE_FLAGS_NONE,                                                                                SAKONS_HIDEOUT,                78, "Sakon's Hideout")
 // Mountain Village (winter)
 /* 0x50 */ DEFINE_SCENE(Z2_10YUKIYAMANOMURA,  SCENE_10YUKIYAMANOMURA,  0x122, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET((1 << 20), 0, 0, (1 << 31)),                                                     MOUNTAIN_VILLAGE_WINTER,       43, "Mountain Village (winter)")
 // Ghost Hut
-/* 0x51 */ DEFINE_SCENE(Z2_TOUGITES,          SCENE_TOUGITES,          0x146, SCENE_DRAW_CFG_DEFAULT,              RESTRICTIONS_SET(0, 0, 0, 0, 0, 3, 3, 3, 3, 3, 0, 0), PERSISTENT_CYCLE_FLAGS_NONE,                                                                                GHOST_HUT,                     66, "Ghost Hut")
+/* 0x51 */ DEFINE_SCENE(Z2_TOUGITES,          SCENE_TOUGITES,          0x146, SCENE_DRAW_CFG_DEFAULT,              RESTRICTIONS_SET(0, 0, 0, 0, 0, 3, 3, 3, 3, 3, 0, 0), PERSISTENT_CYCLE_FLAGS_NONE,                                                                                GHOST_HUT,                     81, "Ghost Hut")
 // Deku Shrine
 /* 0x52 */ DEFINE_SCENE(Z2_DANPEI,            SCENE_DANPEI,            0x120, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NO_DOUBLE_TIME,                          PERSISTENT_CYCLE_FLAGS_NONE,                                                                                DEKU_SHRINE,                   36, "Deku Shrine")
 // Road to Ikana
-/* 0x53 */ DEFINE_SCENE(Z2_IKANAMAE,          SCENE_IKANAMAE,          0,     SCENE_DRAW_CFG_DEFAULT,              RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_NONE,                                                                                ROAD_TO_IKANA,                 58, "Road to Ikana")
+/* 0x53 */ DEFINE_SCENE(Z2_IKANAMAE,          SCENE_IKANAMAE,          0,     SCENE_DRAW_CFG_DEFAULT,              RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_NONE,                                                                                ROAD_TO_IKANA,                 73, "Road to Ikana")
 // Swordsman's School
 /* 0x54 */ DEFINE_SCENE(Z2_DOUJOU,            SCENE_DOUJOU,            0x110, SCENE_DRAW_CFG_DEFAULT,              RESTRICTIONS_SET(0, 0, 0, 0, 0, 3, 0, 0, 3, 0, 0, 1), PERSISTENT_CYCLE_FLAGS_NONE,                                                                                SWORDMANS_SCHOOL,               7, "Swordsman's School")
 // Music Box House
-/* 0x55 */ DEFINE_SCENE(Z2_MUSICHOUSE,        SCENE_MUSICHOUSE,        0x147, SCENE_DRAW_CFG_MAT_ANIM_MANUAL_STEP, RESTRICTIONS_SET(0, 0, 0, 0, 0, 3, 0, 0, 3, 0, 0, 0), PERSISTENT_CYCLE_FLAGS_NONE,                                                                                MUSIC_BOX_HOUSE,               64, "Music Box House")
+/* 0x55 */ DEFINE_SCENE(Z2_MUSICHOUSE,        SCENE_MUSICHOUSE,        0x147, SCENE_DRAW_CFG_MAT_ANIM_MANUAL_STEP, RESTRICTIONS_SET(0, 0, 0, 0, 0, 3, 0, 0, 3, 0, 0, 0), PERSISTENT_CYCLE_FLAGS_NONE,                                                                                MUSIC_BOX_HOUSE,               79, "Music Box House")
 // Igos du Ikana's Lair
-/* 0x56 */ DEFINE_SCENE(Z2_IKNINSIDE,         SCENE_IKNINSIDE,         0x142, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_SET(0, 0, 0, 0, 0, 3, 3, 3, 3, 0, 0, 0), PERSISTENT_CYCLE_FLAGS_NONE,                                                                                IGOS_DU_IKANAS_LAIR,           69, "Igos du Ikana's Lair")
+/* 0x56 */ DEFINE_SCENE(Z2_IKNINSIDE,         SCENE_IKNINSIDE,         0x142, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_SET(0, 0, 0, 0, 0, 3, 3, 3, 3, 0, 0, 0), PERSISTENT_CYCLE_FLAGS_NONE,                                                                                IGOS_DU_IKANAS_LAIR,           84, "Igos du Ikana's Lair")
 // Tourist Information
 /* 0x57 */ DEFINE_SCENE(Z2_MAP_SHOP,          SCENE_MAP_SHOP,          0x119, SCENE_DRAW_CFG_DEFAULT,              RESTRICTIONS_INDOORS,                                 PERSISTENT_CYCLE_FLAGS_NONE,                                                                                TOURIST_INFORMATION,           32, "Tourist Information")
 // Stone Tower
-/* 0x58 */ DEFINE_SCENE(Z2_F40,               SCENE_F40,               0x140, SCENE_DRAW_CFG_DEFAULT,              RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET((1 << 10), 0, 0, 0),                                                             STONE_TOWER,                   70, "Stone Tower")
+/* 0x58 */ DEFINE_SCENE(Z2_F40,               SCENE_F40,               0x140, SCENE_DRAW_CFG_DEFAULT,              RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET((1 << 10), 0, 0, 0),                                                             STONE_TOWER,                   85, "Stone Tower")
 // Inverted Stone Tower
-/* 0x59 */ DEFINE_SCENE(Z2_F41,               SCENE_F41,               0,     SCENE_DRAW_CFG_DEFAULT,              RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET((1 << 10), 0, 0, 0),                                                             STONE_TOWER_INVERTED,          71, "Inverted Stone Tower")
+/* 0x59 */ DEFINE_SCENE(Z2_F41,               SCENE_F41,               0,     SCENE_DRAW_CFG_DEFAULT,              RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET((1 << 10), 0, 0, 0),                                                             STONE_TOWER_INVERTED,          86, "Inverted Stone Tower")
 // Mountain Village (spring)
 /* 0x5A */ DEFINE_SCENE(Z2_10YUKIYAMANOMURA2, SCENE_10YUKIYAMANOMURA2, 0x122, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET((1 << 20), 0, 0, (1 << 31)),                                                     MOUNTAIN_VILLAGE_SPRING,       44, "Mountain Village (spring)")
 // Path to Snowhead
@@ -196,13 +196,13 @@
 // Path to Goron Village (spring)
 /* 0x5E */ DEFINE_SCENE(Z2_17SETUGEN2,        SCENE_17SETUGEN2,        0,     SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET(0, 0, 0, (1 << 7)),                                                              PATH_TO_GORON_VILLAGE_SPRING,  48, "Path to Goron Village (spring)")
 // Gyorg's Lair
-/* 0x5F */ DEFINE_SCENE(Z2_SEA_BS,            SCENE_SEA_BS,            0,     SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET(0, 0, 0, (1 << 31)),                                                             GYORGS_LAIR,                   90, "Gyorg's Lair")
+/* 0x5F */ DEFINE_SCENE(Z2_SEA_BS,            SCENE_SEA_BS,            0,     SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET(0, 0, 0, (1 << 31)),                                                             GYORGS_LAIR,                   72, "Gyorg's Lair")
 // Secret Shrine
-/* 0x60 */ DEFINE_SCENE(Z2_RANDOM,            SCENE_RANDOM,            0x12C, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET(0, 0, 0, (1 << 10)),                                                             SECRET_SHRINE,                 67, "Secret Shrine")
+/* 0x60 */ DEFINE_SCENE(Z2_RANDOM,            SCENE_RANDOM,            0x12C, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_SET(0, 0, 0, (1 << 10)),                                                             SECRET_SHRINE,                 82, "Secret Shrine")
 // Stock Pot Inn
 /* 0x61 */ DEFINE_SCENE(Z2_YADOYA,            SCENE_YADOYA,            0x10A, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_INDOORS,                                 PERSISTENT_CYCLE_FLAGS_NONE,                                                                                STOCK_POT_INN,                  9, "Stock Pot Inn")
 // Great Bay Cutscene
-/* 0x62 */ DEFINE_SCENE(Z2_KONPEKI_ENT,       SCENE_KONPEKI_ENT,       0x139, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_NONE,                                                                                GREAT_BAY_CUTSCENE,            77, "Great Bay Cutscene")
+/* 0x62 */ DEFINE_SCENE(Z2_KONPEKI_ENT,       SCENE_KONPEKI_ENT,       0x139, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_NONE,                                                                                GREAT_BAY_CUTSCENE,            59, "Great Bay Cutscene")
 // Clock Tower Interior
 /* 0x63 */ DEFINE_SCENE(Z2_INSIDETOWER,       SCENE_INSIDETOWER,       0,     SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_SET(0, 0, 0, 0, 3, 3, 3, 3, 3, 0, 0, 0), PERSISTENT_CYCLE_FLAGS_SET(1 << 0, 0, 0, 0),                                                                CLOCK_TOWER_INTERIOR,          19, "Clock Tower Interior")
 // Woods of Mystery
@@ -216,7 +216,7 @@
 // Bomb Shop
 /* 0x68 */ DEFINE_SCENE(Z2_BOMYA,             SCENE_BOMYA,             0x10D, SCENE_DRAW_CFG_DEFAULT,              RESTRICTIONS_INDOORS,                                 PERSISTENT_CYCLE_FLAGS_NONE,                                                                                BOMB_SHOP,                     12, "Bomb Shop")
 // Giants' Chamber
-/* 0x69 */ DEFINE_SCENE(Z2_KYOJINNOMA,        SCENE_KYOJINNOMA,        0,     SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_NONE,                                                                                GIANTS_CHAMBER,                75, "Giants' Chamber")
+/* 0x69 */ DEFINE_SCENE(Z2_KYOJINNOMA,        SCENE_KYOJINNOMA,        0,     SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NONE,                                    PERSISTENT_CYCLE_FLAGS_NONE,                                                                                GIANTS_CHAMBER,                90, "Giants' Chamber")
 // Gorman Track
 /* 0x6A */ DEFINE_SCENE(Z2_KOEPONARACE,       SCENE_KOEPONARACE,       0x131, SCENE_DRAW_CFG_MAT_ANIM,             RESTRICTIONS_NO_DOUBLE_TIME,                          PERSISTENT_CYCLE_FLAGS_NONE,                                                                                GORMAN_TRACK,                  23, "Gorman Track")
 // Goron Racetrack

--- a/mm/src/overlays/gamestates/ovl_select/z_select.c
+++ b/mm/src/overlays/gamestates/ovl_select/z_select.c
@@ -1124,8 +1124,14 @@ void MapSelect_Init(GameState* thisx) {
     }
 
     GameState_SetFramerateDivisor(&this->state, 1);
+
+    // 2S2H [Enhancement] Init better menu and abort early to retain player form
+    BetterMapSelect_Init(this);
+    if (CVarGetInteger("gDeveloperTools.BetterMapSelect.Enabled", 0)) {
+        return;
+    }
+
     gSaveContext.save.cutsceneIndex = 0;
     gSaveContext.save.playerForm = PLAYER_FORM_HUMAN;
     gSaveContext.save.linkAge = 0;
-    BetterMapSelect_Init(this);
 }


### PR DESCRIPTION
This adds the following improvements to better warp menu:

* Menu reordered to have Great Bay related areas show before Ikana, and Giants cutscene to be after Ikana
* Entrance value (opt) is now persisted to CVar like the other values
* Entrance value can no longer be negative (no real use case for that)
* Entrance value will reset to 0 when changing scenes
* Player form will default to the current save's form
* Stage value will now default to the current save's time (with print out), pressing Z/R will change stage value like before
* Grotto respawn info added. This enables leaving grottos to take the player out to the proper overworld location, as well as setting the player void/death respawn info as well to prevent crashing.

Whats not handled by this PR is access to the re-used chest and cow grottos. I've included the respawn info data in a TODO comment and will revisit after I think through a nice way to incorporate them into the warp menu.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2638433251.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2638438282.zip)
<!--- section:artifacts:end -->