### PR TITLE
Item Tracker: Gold Skulltulas

### DIFF
--- a/mm/2s2h/Enhancements/Trackers/ItemTracker.cpp
+++ b/mm/2s2h/Enhancements/Trackers/ItemTracker.cpp
@@ -377,28 +377,26 @@ ItemTrackerWindow::CountInfo ItemTrackerWindow::GetItemCountInfo(int itemId) {
                 .maxCap = 15,
             };
             break;
-        case TRACKER_ITEM_GOLD_SKULLTULA_TOKEN_SWAMP:
-            {
-                u32 swampTokenCount = (gSaveContext.save.saveInfo.skullTokenCount >> 16) & 0xFFFF;
-            
-                info = {
-                    .cur = (uint16_t) swampTokenCount,
-                    .curCap = 30,
-                    .maxCap = 30,
-                };
-                break;
-            }
-        case TRACKER_ITEM_GOLD_SKULLTULA_TOKEN_OCEAN:
-            {
-                u32 oceanTokenCount = gSaveContext.save.saveInfo.skullTokenCount & 0xFFFF;
+        case TRACKER_ITEM_GOLD_SKULLTULA_TOKEN_SWAMP: {
+            u32 swampTokenCount = (gSaveContext.save.saveInfo.skullTokenCount >> 16) & 0xFFFF;
 
-                info = {
-                    .cur = (uint16_t) oceanTokenCount,
-                    .curCap = 30,
-                    .maxCap = 30,
-                };
-                break;
-            }
+            info = {
+                .cur = (uint16_t)swampTokenCount,
+                .curCap = 30,
+                .maxCap = 30,
+            };
+            break;
+        }
+        case TRACKER_ITEM_GOLD_SKULLTULA_TOKEN_OCEAN: {
+            u32 oceanTokenCount = gSaveContext.save.saveInfo.skullTokenCount & 0xFFFF;
+
+            info = {
+                .cur = (uint16_t)oceanTokenCount,
+                .curCap = 30,
+                .maxCap = 30,
+            };
+            break;
+        }
         case TRACKER_ITEM_KEY_WOODFALL:
         case TRACKER_ITEM_KEY_SNOWHEAD:
         case TRACKER_ITEM_KEY_GREAT_BAY:
@@ -647,8 +645,7 @@ int ItemTrackerWindow::DrawGoldSkulltulas(int columns, int prevDrawnColumns) {
         ImGui::SetCursorPos(pos);
         ImGui::BeginGroup();
 
-        DrawItem((char*)sGoldSkulltulaTextures[i], i == 0 ? swampTokenCount == 0: oceanTokenCount == 0,
-                    mIconSize);
+        DrawItem((char*)sGoldSkulltulaTextures[i], i == 0 ? swampTokenCount == 0 : oceanTokenCount == 0, mIconSize);
         DrawItemCount(i + TRACKER_ITEM_GOLD_SKULLTULA_TOKEN_SWAMP, pos);
 
         ImGui::EndGroup();

--- a/mm/2s2h/Enhancements/Trackers/ItemTracker.cpp
+++ b/mm/2s2h/Enhancements/Trackers/ItemTracker.cpp
@@ -44,8 +44,6 @@ ItemTrackerWindow::~ItemTrackerWindow() {
     config->SetFloat(CFG_TRACKER_ITEM("IconSpacing"), mIconSpacing);
     config->SetFloat(CFG_TRACKER_ITEM("TextSize"), mTextSize);
     config->SetFloat(CFG_TRACKER_ITEM("TextOffset"), mTextOffset);
-    config->SetColor(CFG_TRACKER_ITEM("SwampSkulltulaTint"), Color_RGBA8(256, 256, 256, 256));
-    config->SetColor(CFG_TRACKER_ITEM("OceanSkulltulaTint"), Color_RGBA8(256, 256, 256, 256));
     config->SetInteger(CFG_TRACKER_ITEM("WindowType"), (int8_t)mWindowType);
     config->SetInteger(CFG_TRACKER_ITEM("IsDraggable"), mIsDraggable);
     config->SetInteger(CFG_TRACKER_ITEM("OnlyDrawPaused"), mOnlyDrawPaused);
@@ -78,10 +76,6 @@ void ItemTrackerWindow::LoadSettings() {
     mIconSpacing = config->GetFloat(CFG_TRACKER_ITEM("IconSpacing"), 12.0f);
     mTextSize = config->GetFloat(CFG_TRACKER_ITEM("TextSize"), 10.0f);
     mTextOffset = config->GetFloat(CFG_TRACKER_ITEM("TextOffset"), 11.0f);
-    CVarSetColor(CFG_TRACKER_ITEM("SwampSkulltulaTint"),
-                 config->GetColor(CFG_TRACKER_ITEM("SwampSkulltulaTint"), Color_RGBA8(256, 256, 256, 256)));
-    CVarSetColor(CFG_TRACKER_ITEM("OceanSkulltulaTint"),
-                 config->GetColor(CFG_TRACKER_ITEM("OceanSkulltulaTint"), Color_RGBA8(256, 256, 256, 256)));
     mWindowType =
         (TrackerWindowType)config->GetInteger(CFG_TRACKER_ITEM("WindowType"), (int8_t)TrackerWindowType::Floating);
     mIsDraggable = config->GetInteger(CFG_TRACKER_ITEM("IsDraggable"), true);
@@ -660,17 +654,14 @@ int ItemTrackerWindow::DrawGoldSkulltulas(int columns, int prevDrawnColumns) {
 
         // Determine tint color based on whether drawing Skulltula for Swamp or Ocean House
         // Colors are not exactly their tints to account for Skulltula texture base colors
-        float r, g, b, a;
+        ImVec4 defaultSwampTint = ImVec4(25.0f / 255.0f, 251.0f / 255.0f, 0.0f, 1.0f);
+        ImVec4 defaultOceanTint = ImVec4(0.0f, 209.0f / 256.0f, 231.0f / 256.0f, 1.0f);
+
+        ImVec4 tintColor;
         if (i == 0) {
-            r = static_cast<float>(CVarGetColor(CFG_TRACKER_ITEM("SwampSkulltulaTint"), Color_RGBA8()).r) / 255.0f;
-            g = static_cast<float>(CVarGetColor(CFG_TRACKER_ITEM("SwampSkulltulaTint"), Color_RGBA8()).g) / 255.0f;
-            b = static_cast<float>(CVarGetColor(CFG_TRACKER_ITEM("SwampSkulltulaTint"), Color_RGBA8()).b) / 255.0f;
-            a = 1.0f;
+            tintColor = defaultSwampTint;
         } else {
-            r = static_cast<float>(CVarGetColor(CFG_TRACKER_ITEM("OceanSkulltulaTint"), Color_RGBA8()).r) / 255.0f;
-            g = static_cast<float>(CVarGetColor(CFG_TRACKER_ITEM("OceanSkulltulaTint"), Color_RGBA8()).g) / 255.0f;
-            b = static_cast<float>(CVarGetColor(CFG_TRACKER_ITEM("OceanSkulltulaTint"), Color_RGBA8()).b) / 255.0f;
-            a = 1.0f;
+            tintColor = defaultOceanTint;
         }
 
         ImVec4 tintColor = ImVec4(r, g, b, a);

--- a/mm/2s2h/Enhancements/Trackers/ItemTracker.cpp
+++ b/mm/2s2h/Enhancements/Trackers/ItemTracker.cpp
@@ -44,6 +44,8 @@ ItemTrackerWindow::~ItemTrackerWindow() {
     config->SetFloat(CFG_TRACKER_ITEM("IconSpacing"), mIconSpacing);
     config->SetFloat(CFG_TRACKER_ITEM("TextSize"), mTextSize);
     config->SetFloat(CFG_TRACKER_ITEM("TextOffset"), mTextOffset);
+    config->SetColor(CFG_TRACKER_ITEM("SwampSkulltulaTint"), Color_RGBA8(256, 256, 256, 256));
+    config->SetColor(CFG_TRACKER_ITEM("OceanSkulltulaTint"), Color_RGBA8(256, 256, 256, 256));
     config->SetInteger(CFG_TRACKER_ITEM("WindowType"), (int8_t)mWindowType);
     config->SetInteger(CFG_TRACKER_ITEM("IsDraggable"), mIsDraggable);
     config->SetInteger(CFG_TRACKER_ITEM("OnlyDrawPaused"), mOnlyDrawPaused);
@@ -76,6 +78,10 @@ void ItemTrackerWindow::LoadSettings() {
     mIconSpacing = config->GetFloat(CFG_TRACKER_ITEM("IconSpacing"), 12.0f);
     mTextSize = config->GetFloat(CFG_TRACKER_ITEM("TextSize"), 10.0f);
     mTextOffset = config->GetFloat(CFG_TRACKER_ITEM("TextOffset"), 11.0f);
+    CVarSetColor(CFG_TRACKER_ITEM("SwampSkulltulaTint"),
+                 config->GetColor(CFG_TRACKER_ITEM("SwampSkulltulaTint"), Color_RGBA8(256, 256, 256, 256)));
+    CVarSetColor(CFG_TRACKER_ITEM("OceanSkulltulaTint"),
+                 config->GetColor(CFG_TRACKER_ITEM("OceanSkulltulaTint"), Color_RGBA8(256, 256, 256, 256)));
     mWindowType =
         (TrackerWindowType)config->GetInteger(CFG_TRACKER_ITEM("WindowType"), (int8_t)TrackerWindowType::Floating);
     mIsDraggable = config->GetInteger(CFG_TRACKER_ITEM("IsDraggable"), true);
@@ -146,6 +152,18 @@ void DrawItem(char* tex, bool drawFaded, float itemSize) {
 
     ImGui::Image(gui->GetTextureByName(tex), ImVec2(itemSize, itemSize), ImVec2(0, 0), ImVec2(1, 1),
                  drawFaded ? fadedTex : opaqueTex);
+}
+
+void DrawItemTinted(char* tex, bool drawFaded, float itemSize, ImVec4 tintColor) {
+    auto gui = Ship::Context::GetInstance()->GetWindow()->GetGui();
+    if (!gui->HasTextureByName(tex)) {
+        return;
+    }
+
+    ImVec4 opacityMix = drawFaded ? fadedTex : opaqueTex;
+    ImVec4 color = ImVec4(opacityMix.x * tintColor.x, opacityMix.y * tintColor.y, opacityMix.z * tintColor.z,
+                          opacityMix.w * tintColor.w);
+    ImGui::Image(gui->GetTextureByName(tex), ImVec2(itemSize, itemSize), ImVec2(0, 0), ImVec2(1, 1), color);
 }
 
 static constexpr std::array<ImVec4, 5> songInfo = {
@@ -235,11 +253,6 @@ static constexpr std::array<const char*, 4> sStrayFairyTextures = {
     gDungeonStrayFairySnowheadIconTex,
     gDungeonStrayFairyGreatBayIconTex,
     gDungeonStrayFairyStoneTowerIconTex,
-};
-
-static constexpr std::array<const char*, 4> sGoldSkulltulaTextures = {
-    gQuestIconGoldSkulltulaTex,
-    gQuestIconGoldSkulltula2Tex,
 };
 
 static constexpr uint16_t sSmallKeyCounts[4] = { 1, 3, 1, 4 };
@@ -645,7 +658,25 @@ int ItemTrackerWindow::DrawGoldSkulltulas(int columns, int prevDrawnColumns) {
         ImGui::SetCursorPos(pos);
         ImGui::BeginGroup();
 
-        DrawItem((char*)sGoldSkulltulaTextures[i], i == 0 ? swampTokenCount == 0 : oceanTokenCount == 0, mIconSize);
+        // Determine tint color based on whether drawing Skulltula for Swamp or Ocean House
+        // Colors are not exactly their tints to account for Skulltula texture base colors
+        float r, g, b, a;
+        if (i == 0) {
+            r = static_cast<float>(CVarGetColor(CFG_TRACKER_ITEM("SwampSkulltulaTint"), Color_RGBA8()).r) / 255.0f;
+            g = static_cast<float>(CVarGetColor(CFG_TRACKER_ITEM("SwampSkulltulaTint"), Color_RGBA8()).g) / 255.0f;
+            b = static_cast<float>(CVarGetColor(CFG_TRACKER_ITEM("SwampSkulltulaTint"), Color_RGBA8()).b) / 255.0f;
+            a = 1.0f;
+        } else {
+            r = static_cast<float>(CVarGetColor(CFG_TRACKER_ITEM("OceanSkulltulaTint"), Color_RGBA8()).r) / 255.0f;
+            g = static_cast<float>(CVarGetColor(CFG_TRACKER_ITEM("OceanSkulltulaTint"), Color_RGBA8()).g) / 255.0f;
+            b = static_cast<float>(CVarGetColor(CFG_TRACKER_ITEM("OceanSkulltulaTint"), Color_RGBA8()).b) / 255.0f;
+            a = 1.0f;
+        }
+
+        ImVec4 tintColor = ImVec4(r, g, b, a);
+        bool drawFaded = i == 0 ? swampTokenCount == 0 : oceanTokenCount == 0;
+        DrawItem((char*)gQuestIconGoldSkulltulaTex, drawFaded, mIconSize);
+        DrawItemTinted((char*)gMagicArrowEquipEffectTex, drawFaded, mIconSize, tintColor);
         DrawItemCount(i + TRACKER_ITEM_GOLD_SKULLTULA_TOKEN_SWAMP, pos);
 
         ImGui::EndGroup();

--- a/mm/2s2h/Enhancements/Trackers/ItemTracker.cpp
+++ b/mm/2s2h/Enhancements/Trackers/ItemTracker.cpp
@@ -664,10 +664,32 @@ int ItemTrackerWindow::DrawGoldSkulltulas(int columns, int prevDrawnColumns) {
             tintColor = defaultOceanTint;
         }
 
-        ImVec4 tintColor = ImVec4(r, g, b, a);
         bool drawFaded = i == 0 ? swampTokenCount == 0 : oceanTokenCount == 0;
+        const float arrowTexScalingFactor = 1.5f;
+        float posOffset = (mIconSize * arrowTexScalingFactor - mIconSize) / 2;
+
+        // Draw glowing background for skulltula
+        ImGui::SetNextItemAllowOverlap();
+        ImGui::SetCursorPos(ImVec2(pos.x - posOffset, pos.y - posOffset));
+        DrawItemTinted((char*)gMagicArrowEquipEffectTex, drawFaded, mIconSize * arrowTexScalingFactor, tintColor);
+
+        // Draw Skulltula icon
+        ImGui::SetCursorPos(pos);
         DrawItem((char*)gQuestIconGoldSkulltulaTex, drawFaded, mIconSize);
-        DrawItemTinted((char*)gMagicArrowEquipEffectTex, drawFaded, mIconSize, tintColor);
+        ImVec2 finalPos = ImGui::GetCursorPos();
+
+        // Draw Ocean/Swamp accessibility text
+        const char* skulltulaHouseText = i == 0 ? "Swamp" : "Ocean";
+        ImGui::SetWindowFontScale(mTextSize / 13.0f);
+
+        float x = finalPos.x + (mIconSize / 2.0f) - (ImGui::CalcTextSize(skulltulaHouseText).x / 2.0f);
+        float y = finalPos.y - (mTextOffset / 36.0f) * mIconSize - 16 * (mTextSize / 13.0f);
+
+        // Normalize the offset based on the icon being 36x36 to account for larger icons.
+        ImGui::SetCursorPos({ x, y });
+        ImGui::Text("%s", skulltulaHouseText);
+
+        ImGui::SetCursorPos(finalPos);
         DrawItemCount(i + TRACKER_ITEM_GOLD_SKULLTULA_TOKEN_SWAMP, pos);
 
         ImGui::EndGroup();

--- a/mm/2s2h/Enhancements/Trackers/ItemTracker.cpp
+++ b/mm/2s2h/Enhancements/Trackers/ItemTracker.cpp
@@ -23,6 +23,8 @@ typedef enum {
     TRACKER_ITEM_STRAY_FAIRY_SNOWHEAD,
     TRACKER_ITEM_STRAY_FAIRY_GREAT_BAY,
     TRACKER_ITEM_STRAY_FAIRY_STONE_TOWER,
+    TRACKER_ITEM_GOLD_SKULLTULA_TOKEN_SWAMP,
+    TRACKER_ITEM_GOLD_SKULLTULA_TOKEN_OCEAN,
     TRACKER_ITEM_KEY_WOODFALL,
     TRACKER_ITEM_KEY_SNOWHEAD,
     TRACKER_ITEM_KEY_GREAT_BAY,
@@ -55,6 +57,7 @@ ItemTrackerWindow::~ItemTrackerWindow() {
     config->SetInteger(CFG_TRACKER_ITEM("MiscDrawMode"), (int8_t)mItemDrawModes[SECTION_MISC]);
     config->SetInteger(CFG_TRACKER_ITEM("SongsDrawMode"), (int8_t)mItemDrawModes[SECTION_SONGS]);
     config->SetInteger(CFG_TRACKER_ITEM("StrayFairiesDrawMode"), (int8_t)mItemDrawModes[SECTION_STRAY_FAIRIES]);
+    config->SetInteger(CFG_TRACKER_ITEM("GoldSkulltulasDrawMode"), (int8_t)mItemDrawModes[SECTION_GOLD_SKULLTULAS]);
     config->SetInteger(CFG_TRACKER_ITEM("DungeonDrawMode"), (int8_t)mItemDrawModes[SECTION_DUNGEON]);
 
     config->Save();
@@ -96,6 +99,8 @@ void ItemTrackerWindow::LoadSettings() {
         CFG_TRACKER_ITEM("SongsDrawMode"), (int32_t)ItemTrackerDisplayType::MainWindow);
     mItemDrawModes[SECTION_STRAY_FAIRIES] = (ItemTrackerDisplayType)config->GetInteger(
         CFG_TRACKER_ITEM("StrayFairiesDrawMode"), (int32_t)ItemTrackerDisplayType::MainWindow);
+    mItemDrawModes[SECTION_GOLD_SKULLTULAS] = (ItemTrackerDisplayType)config->GetInteger(
+        CFG_TRACKER_ITEM("GoldSkulltulasDrawMode"), (int32_t)ItemTrackerDisplayType::MainWindow);
     mItemDrawModes[SECTION_DUNGEON] = (ItemTrackerDisplayType)config->GetInteger(
         CFG_TRACKER_ITEM("DungeonDrawMode"), (int32_t)ItemTrackerDisplayType::MainWindow);
 }
@@ -232,6 +237,11 @@ static constexpr std::array<const char*, 4> sStrayFairyTextures = {
     gDungeonStrayFairyStoneTowerIconTex,
 };
 
+static constexpr std::array<const char*, 4> sGoldSkulltulaTextures = {
+    gQuestIconGoldSkulltulaTex,
+    gQuestIconGoldSkulltula2Tex,
+};
+
 static constexpr uint16_t sSmallKeyCounts[4] = { 1, 3, 1, 4 };
 
 bool ItemTrackerWindow::HasAmmoCount(int itemId) {
@@ -328,6 +338,8 @@ bool ItemTrackerWindow::HasItemCount(int itemId) {
         case TRACKER_ITEM_STRAY_FAIRY_SNOWHEAD:
         case TRACKER_ITEM_STRAY_FAIRY_GREAT_BAY:
         case TRACKER_ITEM_STRAY_FAIRY_STONE_TOWER:
+        case TRACKER_ITEM_GOLD_SKULLTULA_TOKEN_SWAMP:
+        case TRACKER_ITEM_GOLD_SKULLTULA_TOKEN_OCEAN:
         case TRACKER_ITEM_KEY_WOODFALL:
         case TRACKER_ITEM_KEY_SNOWHEAD:
         case TRACKER_ITEM_KEY_GREAT_BAY:
@@ -365,6 +377,28 @@ ItemTrackerWindow::CountInfo ItemTrackerWindow::GetItemCountInfo(int itemId) {
                 .maxCap = 15,
             };
             break;
+        case TRACKER_ITEM_GOLD_SKULLTULA_TOKEN_SWAMP:
+            {
+                u32 swampTokenCount = (gSaveContext.save.saveInfo.skullTokenCount >> 16) & 0xFFFF;
+            
+                info = {
+                    .cur = (uint16_t) swampTokenCount,
+                    .curCap = 30,
+                    .maxCap = 30,
+                };
+                break;
+            }
+        case TRACKER_ITEM_GOLD_SKULLTULA_TOKEN_OCEAN:
+            {
+                u32 oceanTokenCount = gSaveContext.save.saveInfo.skullTokenCount & 0xFFFF;
+
+                info = {
+                    .cur = (uint16_t) oceanTokenCount,
+                    .curCap = 30,
+                    .maxCap = 30,
+                };
+                break;
+            }
         case TRACKER_ITEM_KEY_WOODFALL:
         case TRACKER_ITEM_KEY_SNOWHEAD:
         case TRACKER_ITEM_KEY_GREAT_BAY:
@@ -597,6 +631,31 @@ int ItemTrackerWindow::DrawStrayFairies(int columns, int prevDrawnColumns) {
     return 1;
 }
 
+int ItemTrackerWindow::DrawGoldSkulltulas(int columns, int prevDrawnColumns) {
+    int topPadding = 0;
+
+    // upper 16 bits store Swamp skulls, lower 16 bits store Ocean skulls
+    u32 swampTokenCount = (gSaveContext.save.saveInfo.skullTokenCount >> 16) & 0xFFFF;
+    u32 oceanTokenCount = gSaveContext.save.saveInfo.skullTokenCount & 0xFFFF;
+
+    for (size_t i = 0; i < 2; i++) {
+        int row = prevDrawnColumns + (i / columns);
+        int column = i % columns;
+        ImVec2 pos = ImVec2((column * (mIconSize + mIconSpacing) + 8.0f),
+                            (row * (mIconSize + mIconSpacing)) + 8.0f + topPadding);
+
+        ImGui::SetCursorPos(pos);
+        ImGui::BeginGroup();
+
+        DrawItem((char*)sGoldSkulltulaTextures[i], i == 0 ? swampTokenCount == 0: oceanTokenCount == 0,
+                    mIconSize);
+        DrawItemCount(i + TRACKER_ITEM_GOLD_SKULLTULA_TOKEN_SWAMP, pos);
+
+        ImGui::EndGroup();
+    }
+    return 1;
+}
+
 int ItemTrackerWindow::DrawSongs(int columns, int prevDrawnColumns) {
     int topPadding = 0;
 
@@ -770,6 +829,20 @@ void ItemTrackerWindow::DrawItemsInRows(int columns) {
         }
         advancedBy = DrawStrayFairies(5, drawPos);
         if (mItemDrawModes[SECTION_STRAY_FAIRIES] == ItemTrackerDisplayType::Separate) {
+            EndFloatingWindows();
+        } else {
+            mainWindowPos += advancedBy;
+        }
+    }
+
+    if (mItemDrawModes[SECTION_GOLD_SKULLTULAS] != ItemTrackerDisplayType::Hidden) {
+        int drawPos = mainWindowPos;
+        if (mItemDrawModes[SECTION_GOLD_SKULLTULAS] == ItemTrackerDisplayType::Separate) {
+            drawPos = 0;
+            BeginFloatingWindows("Gold Skulltulas");
+        }
+        advancedBy = DrawGoldSkulltulas(2, drawPos);
+        if (mItemDrawModes[SECTION_GOLD_SKULLTULAS] == ItemTrackerDisplayType::Separate) {
             EndFloatingWindows();
         } else {
             mainWindowPos += advancedBy;

--- a/mm/2s2h/Enhancements/Trackers/ItemTracker.h
+++ b/mm/2s2h/Enhancements/Trackers/ItemTracker.h
@@ -20,6 +20,7 @@ typedef enum {
     SECTION_MISC,
     SECTION_SONGS,
     SECTION_STRAY_FAIRIES,
+    SECTION_GOLD_SKULLTULAS,
     SECTION_DUNGEON,
     SECTION_MAX,
 } ItemTrackerSection;
@@ -76,6 +77,7 @@ class ItemTrackerWindow : public Ship::GuiWindow {
     int DrawMisc(int columns, int startAt);
     int DrawSongs(int columns, int startAt);
     int DrawStrayFairies(int columns, int startAt);
+    int DrawGoldSkulltulas(int columsn, int startAt);
     void DrawNote(size_t songIndex, bool drawFaded);
     void DrawOwlFace(bool drawFaded);
     int DrawDungeonItemsVert(int columns, int startAt);

--- a/mm/2s2h/Enhancements/Trackers/ItemTrackerSettings.cpp
+++ b/mm/2s2h/Enhancements/Trackers/ItemTrackerSettings.cpp
@@ -70,6 +70,7 @@ void ItemTrackerSettingsWindow::DrawElement() {
     UIWidgets::Combobox("Miscellaneous", mItemTrackerWindow->GetDrawModePtr(SECTION_MISC), displayTypes);
     UIWidgets::Combobox("Songs", mItemTrackerWindow->GetDrawModePtr(SECTION_SONGS), displayTypes);
     UIWidgets::Combobox("Stray Fairies", mItemTrackerWindow->GetDrawModePtr(SECTION_STRAY_FAIRIES), displayTypes);
+    UIWidgets::Combobox("Gold Skulltulas", mItemTrackerWindow->GetDrawModePtr(SECTION_GOLD_SKULLTULAS), displayTypes);
     UIWidgets::Combobox("Dungeon Items", mItemTrackerWindow->GetDrawModePtr(SECTION_DUNGEON), displayTypes);
 
     UIWidgets::Checkbox(

--- a/mm/2s2h/Enhancements/Trackers/ItemTrackerSettings.cpp
+++ b/mm/2s2h/Enhancements/Trackers/ItemTrackerSettings.cpp
@@ -71,10 +71,6 @@ void ItemTrackerSettingsWindow::DrawElement() {
     UIWidgets::Combobox("Songs", mItemTrackerWindow->GetDrawModePtr(SECTION_SONGS), displayTypes);
     UIWidgets::Combobox("Stray Fairies", mItemTrackerWindow->GetDrawModePtr(SECTION_STRAY_FAIRIES), displayTypes);
     UIWidgets::Combobox("Gold Skulltulas", mItemTrackerWindow->GetDrawModePtr(SECTION_GOLD_SKULLTULAS), displayTypes);
-    UIWidgets::CVarColorPicker("Swamp Skulltula Tint", "ItemTracker.SwampSkulltulaTint",
-                               Color_RGBA8(256, 256, 256, 256));
-    UIWidgets::CVarColorPicker("Ocean Skulltula Tint", "ItemTracker.OceanSkulltulaTint",
-                               Color_RGBA8(256, 256, 256, 256));
     UIWidgets::Combobox("Dungeon Items", mItemTrackerWindow->GetDrawModePtr(SECTION_DUNGEON), displayTypes);
 
     UIWidgets::Checkbox(

--- a/mm/2s2h/Enhancements/Trackers/ItemTrackerSettings.cpp
+++ b/mm/2s2h/Enhancements/Trackers/ItemTrackerSettings.cpp
@@ -71,6 +71,10 @@ void ItemTrackerSettingsWindow::DrawElement() {
     UIWidgets::Combobox("Songs", mItemTrackerWindow->GetDrawModePtr(SECTION_SONGS), displayTypes);
     UIWidgets::Combobox("Stray Fairies", mItemTrackerWindow->GetDrawModePtr(SECTION_STRAY_FAIRIES), displayTypes);
     UIWidgets::Combobox("Gold Skulltulas", mItemTrackerWindow->GetDrawModePtr(SECTION_GOLD_SKULLTULAS), displayTypes);
+    UIWidgets::CVarColorPicker("Swamp Skulltula Tint", "ItemTracker.SwampSkulltulaTint",
+                               Color_RGBA8(256, 256, 256, 256));
+    UIWidgets::CVarColorPicker("Ocean Skulltula Tint", "ItemTracker.OceanSkulltulaTint",
+                               Color_RGBA8(256, 256, 256, 256));
     UIWidgets::Combobox("Dungeon Items", mItemTrackerWindow->GetDrawModePtr(SECTION_DUNGEON), displayTypes);
 
     UIWidgets::Checkbox(

--- a/mm/2s2h/ShipUtils.cpp
+++ b/mm/2s2h/ShipUtils.cpp
@@ -14,6 +14,7 @@
 #include "assets/archives/schedule_dma_static/schedule_dma_static_yar.h"
 #include "assets/interface/icon_item_dungeon_static/icon_item_dungeon_static.h"
 #include "assets/interface/icon_item_field_static/icon_item_field_static.h"
+#include "assets/archives/icon_item_static/icon_item_static_yar.h"
 
 extern "C" {
 #include "z64.h"
@@ -54,6 +55,7 @@ std::vector<const char*> miscellaneousTextures = {
     gDungeonStrayFairyWoodfallIconTex,
     gPotTrackerIcon,
     gQuestIconGoldSkulltulaTex,
+    gMagicArrowEquipEffectTex,
     gRupeeCounterIconTex,
     gStrayFairyGreatBayIconTex,
     gStrayFairySnowheadIconTex,


### PR DESCRIPTION
Adds Gold Skulltulas to the Item Tracker as their own section, so as to allow users to separate it out for rando vs vanilla item tracker configurations.

![415933874-bfe5e2e4-95a3-4f0e-9be0-764131520cb2](https://github.com/user-attachments/assets/03d8157f-4dad-4c08-8802-f200bc9fd513)


<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2714250899.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2714256061.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2714336266.zip)
<!--- section:artifacts:end -->