### PR TITLE
Fix FindOpusFile for Homebrew.

### DIFF
--- a/CMake/FindOpusFile.cmake
+++ b/CMake/FindOpusFile.cmake
@@ -9,7 +9,7 @@
 # Search for the OpusFile header
 find_path(OPUSFILE_INCLUDE_DIR
     NAMES opusfile.h
-    PATHS /usr/include/opus /usr/local/include/opus /opt/local/include/opus
+    PATHS /usr/include/opus /usr/local/include/opus /opt/local/include/opus /opt/homebrew/include/opus
     DOC "Directory where opusfile.h is located"
 )
 


### PR DESCRIPTION
Adds the path to find opusfile.h on macOS when compiling using homebrew. Addresses FindOpusFile.cmake added in https://github.com/HarbourMasters/2ship2harkinian/commit/2d0942a1b187938f55d34c71e0965e37a70b1094. Thanks!

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2684377218.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2684396605.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2684592188.zip)
<!--- section:artifacts:end -->