### PR TITLE
Revert Offsets to fix GC ROM Extraction.

### DIFF
--- a/mm/assets/xml/GC_US/audio/Audio.xml
+++ b/mm/assets/xml/GC_US/audio/Audio.xml
@@ -1,6 +1,6 @@
 <Root>
     <File Name="code" OutName="audio" RangeStart="0x0">
-        <Audio Name="audio" Offset="0x00" SoundFontTableOffset="0x13B6C0" SequenceTableOffset="0x13BB70" SampleBankTableOffset="0x13C380" SequenceFontTableOffset="0x13B960">
+        <Audio Name="audio" Offset="0x00" SoundFontTableOffset="0x138F10" SequenceTableOffset="0x1393C0" SampleBankTableOffset="0x139BD0" SequenceFontTableOffset="0x1391B0">
             <Sequences>
                 <Sequence Name="Sequence_0"/>
                 <Sequence Name="Sequence_1"/>


### PR DESCRIPTION
This fixes the offsets for the GC_US ROM back to how they were before https://github.com/HarbourMasters/2ship2harkinian/commit/2d0942a1b187938f55d34c71e0965e37a70b1094, fixing extraction and use of the NTSC-U GC ROM. Thanks!

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2684976085.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2684996419.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2685144314.zip)
<!--- section:artifacts:end -->