### PR TITLE
Adjust file select options texture fixe

### DIFF
--- a/mm/src/overlays/gamestates/ovl_file_choose/z_file_nameset_NES.c
+++ b/mm/src/overlays/gamestates/ovl_file_choose/z_file_nameset_NES.c
@@ -1266,16 +1266,9 @@ void FileSelect_DrawOptionsImpl(GameState* thisx) {
 
         //! @bug the gOptionsMenuHeaders usage here will produce an OoB read for i == 5. It reads the first element of
         //! `gOptionsMenuSettings`
-        // 2S2H [Port] - directly use first element of gOptionsMenuSettings when i == 5, note this is fixed in the GC-US
-        // version
-        u16 height;
-        if (i == 5) {
-            height = gOptionsMenuSettings[0].height;
-        } else {
-            height = gOptionsMenuHeaders[i].height;
-        }
+        // 2S2H [Port] Use `gOptionsMenuSettings` instead for correct height values matching textures
         gDPLoadTextureBlock(POLY_OPA_DISP++, gOptionsMenuSettings[i].texture, G_IM_FMT_IA, G_IM_SIZ_8b,
-                            gOptionsMenuSettings[i].width, height, 0, G_TX_NOMIRROR | G_TX_WRAP,
+                            gOptionsMenuSettings[i].width, gOptionsMenuSettings[i].height, 0, G_TX_NOMIRROR | G_TX_WRAP,
                             G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
         gSP1Quadrangle(POLY_OPA_DISP++, vtx, vtx + 2, vtx + 3, vtx + 1, 0);
     }


### PR DESCRIPTION
Previously we addressed a vanilla OoB bug with rendering the file select options textures for Z-Targetting, but there is still an issue where the code was using `gOptionsMenuHeaders` and getting a height value of `17` instead of the textures matching `16` height, which leads to garbage pixel data rendering on the bottom.

![image](https://github.com/user-attachments/assets/a69aa3d1-6654-4c35-8f8f-8c997b385aaf)

This adjust the fix to instead just directly use `gOptionsMenuSettings` to ensure the proper height values are used for both textures.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2685160887.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2685176683.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2685339894.zip)
<!--- section:artifacts:end -->