### PR TITLE
[Rando] Fix Dungeon Access Logic

### DIFF
--- a/mm/2s2h/Rando/Logic/Logic.h
+++ b/mm/2s2h/Rando/Logic/Logic.h
@@ -153,8 +153,9 @@ inline bool CanAccessDungeon(DungeonIndex dungeonIndex) {
         case RO_ACCESS_DUNGEONS_SONG_ONLY:
             return hasSongAccess;
         case RO_ACCESS_DUNGEONS_OPEN:
-        default:
             return true;
+        default:
+            return hasSongAccess && hasFormAccess;
     }
 }
 

--- a/mm/2s2h/Rando/Logic/Logic.h
+++ b/mm/2s2h/Rando/Logic/Logic.h
@@ -154,6 +154,7 @@ inline bool CanAccessDungeon(DungeonIndex dungeonIndex) {
             return hasSongAccess;
         case RO_ACCESS_DUNGEONS_OPEN:
             return true;
+        case RO_ACCESS_DUNGEONS_FORM_AND_SONG:
         default:
             return hasSongAccess && hasFormAccess;
     }


### PR DESCRIPTION
Didn't handle the default logic correctly when adding the new dungeon access options. This should fix that.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2700909450.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2700993789.zip)
<!--- section:artifacts:end -->