### PR TITLE
Fix percentage sliders behaviour

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -593,7 +593,7 @@ void BenMenu::AddEnhancements() {
             }
         })
         .Options(CheckboxOptions().Tooltip("Inverts the Camera Y Axis").DefaultValue(true));
-    AddWidget(path, "Third-Person Horizontal Sensitivity: %.0f", WIDGET_CVAR_SLIDER_FLOAT)
+    AddWidget(path, "Third-Person Camera\nHorizontal Sensitivity: %.0f%%", WIDGET_CVAR_SLIDER_FLOAT)
         .CVar("gEnhancements.Camera.RightStick.CameraSensitivity.X")
         .PreFunc([](WidgetInfo& info) {
             if (mBenMenu->disabledMap.at(DISABLE_FOR_CAMERAS_OFF).active) {
@@ -607,7 +607,7 @@ void BenMenu::AddEnhancements() {
                      .Max(5.0f)
                      .DefaultValue(1.0f)
                      .IsPercentage());
-    AddWidget(path, "Third-Person Vertical Sensitivity: %.0f", WIDGET_CVAR_SLIDER_FLOAT)
+    AddWidget(path, "Third-Person Camera\nVertical Sensitivity: %.0f%%", WIDGET_CVAR_SLIDER_FLOAT)
         .CVar("gEnhancements.Camera.RightStick.CameraSensitivity.Y")
         .PreFunc([](WidgetInfo& info) {
             if (mBenMenu->disabledMap.at(DISABLE_FOR_CAMERAS_OFF).active) {

--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -449,18 +449,18 @@ void BenMenu::AddEnhancements() {
         .CVar("gEnhancements.Camera.FirstPerson.SensitivityX")
         .Options(FloatSliderOptions()
                      .Tooltip("Adjusts the Sensitivity of the X Axis in First Person Mode.")
-                     .Min(0.01f)
-                     .Max(2.0f)
                      .DefaultValue(1.0f)
-                     .IsPercentage());
+                     .IsPercentage()
+                     .Min(0.01f)
+                     .Max(2.0f));
     AddWidget(path, "Y Axis Sensitivity: %.0f%%", WIDGET_CVAR_SLIDER_FLOAT)
         .CVar("gEnhancements.Camera.FirstPerson.SensitivityY")
         .Options(FloatSliderOptions()
                      .Tooltip("Adjusts the Sensitivity of the Y Axis in First Person Mode.")
-                     .Min(0.01f)
-                     .Max(2.0f)
                      .DefaultValue(1.0f)
-                     .IsPercentage());
+                     .IsPercentage()
+                     .Min(0.01f)
+                     .Max(2.0f));
     AddWidget(path, "Gyro Aiming", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Camera.FirstPerson.GyroEnabled")
         .Options(CheckboxOptions().Tooltip("Enables Gyro Aiming in First Person Mode."));
@@ -476,19 +476,19 @@ void BenMenu::AddEnhancements() {
         .CVar("gEnhancements.Camera.FirstPerson.GyroSensitivityX")
         .Options(FloatSliderOptions()
                      .Tooltip("Adjusts the Sensitivity of the X Axis of the Gyro in First Person Mode.")
-                     .Min(0.01f)
-                     .Max(2.0f)
                      .DefaultValue(1.0f)
-                     .IsPercentage())
+                     .IsPercentage()
+                     .Min(0.01f)
+                     .Max(2.0f))
         .PreFunc([](WidgetInfo& info) { info.isHidden = mBenMenu->disabledMap.at(DISABLE_FOR_GYRO_OFF).active; });
     AddWidget(path, "Gyro Y Axis Sensitivity: %.0f%%", WIDGET_CVAR_SLIDER_FLOAT)
         .CVar("gEnhancements.Camera.FirstPerson.GyroSensitivityY")
         .Options(FloatSliderOptions()
                      .Tooltip("Adjusts the Sensitivity of the Y Axis of the Gyro in First Person Mode.")
-                     .Min(0.01f)
-                     .Max(2.0f)
                      .DefaultValue(1.0f)
-                     .IsPercentage())
+                     .IsPercentage()
+                     .Min(0.01f)
+                     .Max(2.0f))
         .PreFunc([](WidgetInfo& info) { info.isHidden = mBenMenu->disabledMap.at(DISABLE_FOR_GYRO_OFF).active; });
     AddWidget(path, "Right Stick Aiming", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Camera.FirstPerson.RightStickEnabled")
@@ -515,19 +515,19 @@ void BenMenu::AddEnhancements() {
         .PreFunc([](WidgetInfo& info) { info.isHidden = mBenMenu->disabledMap.at(DISABLE_FOR_RIGHT_STICK_OFF).active; })
         .Options(FloatSliderOptions()
                      .Tooltip("Adjusts the Sensitivity of the X Axis of the Right Stick in First Person Mode.")
-                     .Min(0.01f)
-                     .Max(2.0f)
                      .DefaultValue(1.0f)
-                     .IsPercentage());
+                     .IsPercentage()
+                     .Min(0.01f)
+                     .Max(2.0f));
     AddWidget(path, "Right Stick Y Axis Sensitivity: %.0f%%", WIDGET_CVAR_SLIDER_FLOAT)
         .CVar("gEnhancements.Camera.FirstPerson.RightStickSensitivityY")
         .PreFunc([](WidgetInfo& info) { info.isHidden = mBenMenu->disabledMap.at(DISABLE_FOR_RIGHT_STICK_OFF).active; })
         .Options(FloatSliderOptions()
                      .Tooltip("Adjusts the Sensitivity of the Y Axis of the Right Stick in First Person Mode.")
-                     .Min(0.01f)
-                     .Max(2.0f)
                      .DefaultValue(1.0f)
-                     .IsPercentage());
+                     .IsPercentage()
+                     .Min(0.01f)
+                     .Max(2.0f));
 
     path.column = 2;
     AddWidget(path, "Cameras", WIDGET_SEPARATOR_TEXT);
@@ -603,10 +603,10 @@ void BenMenu::AddEnhancements() {
         .Options(FloatSliderOptions()
                      .Tooltip("Adjust the Sensitivity of the x axis when in Third Person.")
                      .Format("%.0f%%")
-                     .Min(0.01f)
-                     .Max(5.0f)
                      .DefaultValue(1.0f)
-                     .IsPercentage());
+                     .IsPercentage()
+                     .Min(0.01f)
+                     .Max(5.0f));
     AddWidget(path, "Third-Person Camera\nVertical Sensitivity: %.0f%%", WIDGET_CVAR_SLIDER_FLOAT)
         .CVar("gEnhancements.Camera.RightStick.CameraSensitivity.Y")
         .PreFunc([](WidgetInfo& info) {
@@ -617,10 +617,10 @@ void BenMenu::AddEnhancements() {
         .Options(FloatSliderOptions()
                      .Tooltip("Adjust the Sensitivity of the x axis when in Third Person.")
                      .Format("%.0f%%")
-                     .Min(0.01f)
-                     .Max(5.0f)
                      .DefaultValue(1.0f)
-                     .IsPercentage());
+                     .IsPercentage()
+                     .Min(0.01f)
+                     .Max(5.0f));
     AddWidget(path, "Enable Roll (6\xC2\xB0 of Freedom)", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Camera.DebugCam.6DOF")
         .PreFunc([](WidgetInfo& info) { info.isHidden = mBenMenu->disabledMap.at(DISABLE_FOR_DEBUG_CAM_OFF).active; })
@@ -633,10 +633,10 @@ void BenMenu::AddEnhancements() {
         .Options(FloatSliderOptions()
                      .Tooltip("Adjusts the speed of the Camera.")
                      .Format("%.0f%%")
-                     .Min(0.1f)
-                     .Max(3.0f)
                      .DefaultValue(0.5f)
-                     .IsPercentage());
+                     .IsPercentage()
+                     .Min(0.1f)
+                     .Max(3.0f));
 
     path = { "Enhancements", "Cheats", 1 };
     AddSidebarEntry("Enhancements", "Cheats", 3);

--- a/mm/2s2h/BenGui/UIWidgets.hpp
+++ b/mm/2s2h/BenGui/UIWidgets.hpp
@@ -305,9 +305,7 @@ namespace UIWidgets {
         }
         FloatSliderOptions& IsPercentage(bool isPercentage_ = true) {
             isPercentage = isPercentage_;
-            format = "%.0f";
-            min = 0.0f;
-            max = 1.0f;
+            format = "%.0f%%";
             return *this;
         }
         FloatSliderOptions& Tooltip(const char* tooltip_) {

--- a/mm/2s2h/BenGui/UIWidgets.hpp
+++ b/mm/2s2h/BenGui/UIWidgets.hpp
@@ -306,6 +306,8 @@ namespace UIWidgets {
         FloatSliderOptions& IsPercentage(bool isPercentage_ = true) {
             isPercentage = isPercentage_;
             format = "%.0f%%";
+            min = 0.0f;
+            max = 1.0f;
             return *this;
         }
         FloatSliderOptions& Tooltip(const char* tooltip_) {


### PR DESCRIPTION
Several sliders in the menu are broken because IsPercentage() overwrites their min/max inputs. This for example prevents increasing any stick axis sensitivity beyond 1.0, making e.g. third person camera velocity quite slow even at the max setting. But the menu widgets clearly intend for values greater than 1.0 (and this is also possible in SOH).  Overwriting min to 0.0 also allows setting the sensitivity to 0, which doesn't make any sense.
The description string for the third person camera sensitivity was also cut off.

## Current state:
![current](https://github.com/user-attachments/assets/1f531dd4-8f4d-49af-88a2-2c01496ae96f)

## Fix:
![fix](https://github.com/user-attachments/assets/47c1f0f2-86bd-4c0a-935d-fe4e86b35498)


<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2713029691.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2713032787.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2713157106.zip)
<!--- section:artifacts:end -->