### PR TITLE
 Settings: Basic Speedrun Cutscene Behavior Customization

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -423,7 +423,9 @@ void BenMenu::AddSettings() {
     path.column = 1;
     path.sidebarName = "Speedrunning";
     AddSidebarEntry("Settings", "Speedrunning", 1);
-    AddWidget(path, "Speedrunning", WIDGET_CUSTOM).CustomFunction([](WidgetInfo& info) { SpeedrunCustomization_Draw(); });
+    AddWidget(path, "Speedrunning", WIDGET_CUSTOM).CustomFunction([](WidgetInfo& info) {
+        SpeedrunCustomization_Draw();
+    });
 }
 int32_t motionBlurStrength;
 

--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -10,6 +10,7 @@
 #include "DeveloperTools/EventLog.h"
 #include "2s2h/Enhancements/GfxPatcher/AuthenticGfxPatches.h"
 #include "2s2h/PresetManager/PresetManager.h"
+#include "2s2h/SpeedrunCustomization/SpeedrunCustomization.h"
 #include "HudEditor.h"
 #include "Notification.h"
 #include <variant>
@@ -418,6 +419,11 @@ void BenMenu::AddSettings() {
     path.sidebarName = "Presets";
     AddSidebarEntry("Settings", "Presets", 1);
     AddWidget(path, "Presets", WIDGET_CUSTOM).CustomFunction([](WidgetInfo& info) { PresetManager_Draw(); });
+
+    path.column = 1;
+    path.sidebarName = "Speedrunning";
+    AddSidebarEntry("Settings", "Speedrunning", 1);
+    AddWidget(path, "Speedrunning", WIDGET_CUSTOM).CustomFunction([](WidgetInfo& info) { SpeedrunCustomization_Draw(); });
 }
 int32_t motionBlurStrength;
 

--- a/mm/2s2h/Enhancements/Cutscenes/SkipIntroSequence.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/SkipIntroSequence.cpp
@@ -12,6 +12,11 @@ void Flags_SetWeekEventReg(s32 flag);
 #define FIRST_CYCLE_CVAR_NAME "gEnhancements.Cutscenes.SkipFirstCycle"
 #define FIRST_CYCLE_CVAR CVarGetInteger(FIRST_CYCLE_CVAR_NAME, 0)
 
+#define INTRO_GIVE_NUTS_CVAR_NAME "gSpeedrun.CutsceneSkipBehavior.Intro.GrantDekuNuts"
+#define INTRO_GIVE_NUTS_CVAR CVarGetInteger(INTRO_GIVE_NUTS_CVAR_NAME, 1)
+#define FIRST_CYCLE_GIVE_BOMB_BAG_CVAR_NAME "gSpeedrun.CutsceneSkipBehavior.FirstCycle.GrantBombBag"
+#define FIRST_CYCLE_GIVE_BOMB_BAG_CVAR CVarGetInteger(FIRST_CYCLE_GIVE_BOMB_BAG_CVAR_NAME, 0)
+
 void RegisterSkipIntroSequence() {
     COND_VB_SHOULD(VB_PLAY_TRANSITION_CS, INTRO_CVAR, {
         // Intro cutscene
@@ -32,8 +37,10 @@ void RegisterSkipIntroSequence() {
         gSaveContext.save.isFirstCycle = true;
 
         // Mark chest as opened and give the player the Deku Nuts
-        gSaveContext.cycleSceneFlags[SCENE_OPENINGDAN].chest |= (1 << 0);
-        Item_Give(gPlayState, ITEM_DEKU_NUTS_10);
+        if (INTRO_GIVE_NUTS_CVAR) {
+            gSaveContext.cycleSceneFlags[SCENE_OPENINGDAN].chest |= (1 << 0);
+            Item_Give(gPlayState, ITEM_DEKU_NUTS_10);
+        }
 
         if (FIRST_CYCLE_CVAR) {
             gSaveContext.save.playerForm = PLAYER_FORM_HUMAN;
@@ -43,8 +50,13 @@ void RegisterSkipIntroSequence() {
             gSaveContext.save.saveInfo.inventory.questItems |= (1 << QUEST_SONG_TIME) | (1 << QUEST_SONG_HEALING);
             gSaveContext.save.saveInfo.playerData.threeDayResetCount = 1;
 
-            // Lose nuts
+            // Lose any nuts that may have been given
             AMMO(ITEM_DEKU_NUT) = 0;
+
+            if (FIRST_CYCLE_GIVE_BOMB_BAG_CVAR) {
+                Item_Give(gPlayState, ITEM_BOMB_BAG_20);
+                AMMO(ITEM_BOMB) = 0;
+            }
 
             // Tatl's text at seeing the broken great fairy
             gSaveContext.cycleSceneFlags[SCENE_YOUSEI_IZUMI].switch0 |= (1 << 10);

--- a/mm/2s2h/SpeedrunCustomization/SpeedrunCustomization.cpp
+++ b/mm/2s2h/SpeedrunCustomization/SpeedrunCustomization.cpp
@@ -1,0 +1,57 @@
+#include "2s2h/BenGui/UIWidgets.hpp"
+
+extern "C" {
+#include "z64item.h"
+#include "variables.h"
+}
+
+#define INTRO_GIVE_NUTS_CVAR_NAME "gSpeedrun.CutsceneSkipBehavior.Intro.GrantDekuNuts"
+#define FIRST_CYCLE_GIVE_BOMB_BAG_CVAR_NAME "gSpeedrun.CutsceneSkipBehavior.FirstCycle.GrantBombBag"
+
+struct SkippableItem {
+    ItemId itemId;
+    const char* tooltip;
+    const char* cvarName;
+    char defaultValue;
+};
+
+std::vector<SkippableItem> SkippableItems = {
+    { ITEM_BOMB_BAG_20, "Bomb Bag (20)", FIRST_CYCLE_GIVE_BOMB_BAG_CVAR_NAME, 0 },
+    { ITEM_DEKU_NUT, "Deku Nuts (10)", INTRO_GIVE_NUTS_CVAR_NAME, 1 },
+};
+
+const TexturePtr GetIconTexturePath(ItemId itemId) {
+    return gItemIcons[itemId];
+}
+
+void SpeedrunCustomization_Draw() {
+    f32 columnWidth = ImGui::GetContentRegionAvail().x / 3 - (ImGui::GetStyle().ItemSpacing.x * 2);
+
+    ImGui::BeginChild("speedrunItemSkips", ImVec2(columnWidth, 0));
+    ImGui::SeparatorText("Toggle Starting Item Skips");
+    for (size_t i = 0; i < SkippableItems.size(); i++) {
+        SkippableItem skippableItem = SkippableItems[i];
+
+        const char* texturePath = (const char*)GetIconTexturePath(skippableItem.itemId);
+        ImTextureID textureId = Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName(texturePath);
+        ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
+        ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0, 0));
+        ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.0f, 1.0f, 1.0f, 0.0f));
+        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(1.0f, 1.0f, 1.0f, 0.2f));
+        ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(1.0f, 1.0f, 1.0f, 0.1f));
+        int32_t itemSkipFlag = CVarGetInteger(skippableItem.cvarName, skippableItem.defaultValue);
+        float alpha = itemSkipFlag ? 1.0f : 0.4f;
+
+        if (ImGui::ImageButton(std::to_string(i).c_str(), textureId, ImVec2(columnWidth / 8, columnWidth / 8),
+                               ImVec2(0, 0), ImVec2(1, 1), ImVec4(0, 0, 0, 0), ImVec4(1, 1, 1, alpha))) {
+            CVarSetInteger(skippableItem.cvarName, !itemSkipFlag);
+            Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
+        }
+        ImGui::SameLine();
+        ImGui::PopStyleColor(3);
+        ImGui::PopStyleVar(2);
+        UIWidgets::Tooltip(skippableItem.tooltip);
+    }
+    ImGui::EndChild();
+    ImGui::SameLine();
+}

--- a/mm/2s2h/SpeedrunCustomization/SpeedrunCustomization.h
+++ b/mm/2s2h/SpeedrunCustomization/SpeedrunCustomization.h
@@ -1,0 +1,7 @@
+
+#ifndef SPEEDRUN_CUSTOMIZATION_H
+#define SPEEDRUN_CUSTOMIZATION_H
+
+void SpeedrunCustomization_Draw();
+
+#endif // SPEEDRUN_CUSTOMIZATION_H


### PR DESCRIPTION
Adds a basic sidebar menu and CVar conventions for configuring cutscene customizations requested by speedrunners.

Namely, this PR allows speedrunners to customize what items are granted by the Skip Intro Sequence/Skip First Cycle Time Saver enhancements.

![420559570-2820f114-7bf2-4fa9-abc4-878fc9cb6092](https://github.com/user-attachments/assets/a820847a-f4dc-4af0-a776-64c420b6d431)



<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2715239399.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2715241228.zip)
<!--- section:artifacts:end -->