### PR TITLE
Adjust Temple Opening Cutscene Skips

### DIFF
--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipRaisingWoodfall.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipRaisingWoodfall.cpp
@@ -17,9 +17,6 @@ void RegisterSkipRaisingWoodfall() {
             if (*csId == 11) {
                 *should = false;
 
-                
-                Audio_PlaySequenceInCutscene(NA_BGM_DUNGEON_APPEAR);
-
                 // Need to reload the scene after WEEKEVENTREG_12_20 gets set for the temple to be up.
                 // Based on WarpPoint.cpp
                 Player* player = GET_PLAYER(gPlayState);
@@ -37,6 +34,8 @@ void RegisterSkipRaisingWoodfall() {
                 gSaveContext.respawn[RESPAWN_MODE_DOWN].playerParams = PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D);
                 gSaveContext.nextTransitionType = TRANS_TYPE_FADE_BLACK_FAST;
                 gSaveContext.respawnFlag = -8;
+
+                Audio_PlaySequenceInCutscene(NA_BGM_DUNGEON_APPEAR);
             }
         }
     });

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipRaisingWoodfall.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipRaisingWoodfall.cpp
@@ -1,8 +1,5 @@
 #include <libultraship/bridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
-#include "2s2h/CustomMessage/CustomMessage.h"
-#include "2s2h/CustomItem/CustomItem.h"
-#include "2s2h/Rando/Rando.h"
 #include "2s2h/ShipInit.hpp"
 
 extern "C" {
@@ -19,6 +16,9 @@ void RegisterSkipRaisingWoodfall() {
         if (gPlayState->sceneId == SCENE_21MITURINMAE) {
             if (*csId == 11) {
                 *should = false;
+
+                
+                Audio_PlaySequenceInCutscene(NA_BGM_DUNGEON_APPEAR);
 
                 // Need to reload the scene after WEEKEVENTREG_12_20 gets set for the temple to be up.
                 // Based on WarpPoint.cpp

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipWakingAndRidingTurtle.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipWakingAndRidingTurtle.cpp
@@ -1,8 +1,5 @@
 #include <libultraship/bridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
-#include "2s2h/CustomMessage/CustomMessage.h"
-#include "2s2h/CustomItem/CustomItem.h"
-#include "2s2h/Rando/Rando.h"
 #include "2s2h/ShipInit.hpp"
 
 extern "C" {
@@ -24,21 +21,44 @@ void RegisterSkipWakingAndRidingTurtle() {
                 // Need to reload scene. Position is where Link ends up after CS
                 // Differences from no skip: Camera ends up behind Link, Lulu is gone
                 // Based on WarpPoint.cpp
-                Player* player = GET_PLAYER(gPlayState);
+                // Player* player = GET_PLAYER(gPlayState);
 
-                gPlayState->nextEntrance = ENTRANCE(ZORA_CAPE, 2);
-                gPlayState->transitionTrigger = TRANS_TRIGGER_START;
-                gPlayState->transitionType = TRANS_TYPE_INSTANT;
+                // gPlayState->nextEntrance = ENTRANCE(ZORA_CAPE, 2);
+                // gPlayState->transitionTrigger = TRANS_TRIGGER_START;
+                // gPlayState->transitionType = TRANS_TYPE_INSTANT;
 
-                gSaveContext.respawn[RESPAWN_MODE_DOWN].entrance = ENTRANCE(ZORA_CAPE, 2);
-                gSaveContext.respawn[RESPAWN_MODE_DOWN].roomIndex = 0;
-                gSaveContext.respawn[RESPAWN_MODE_DOWN].pos.x = -5525.0f;
-                gSaveContext.respawn[RESPAWN_MODE_DOWN].pos.y = 14.0f;
-                gSaveContext.respawn[RESPAWN_MODE_DOWN].pos.z = 1548.0f;
-                gSaveContext.respawn[RESPAWN_MODE_DOWN].yaw = -16384;
-                gSaveContext.respawn[RESPAWN_MODE_DOWN].playerParams = PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D);
-                gSaveContext.nextTransitionType = TRANS_TYPE_FADE_BLACK_FAST;
-                gSaveContext.respawnFlag = -8;
+                // gSaveContext.respawn[RESPAWN_MODE_DOWN].entrance = ENTRANCE(ZORA_CAPE, 2);
+                // gSaveContext.respawn[RESPAWN_MODE_DOWN].roomIndex = 0;
+                // gSaveContext.respawn[RESPAWN_MODE_DOWN].pos.x = -5525.0f;
+                // gSaveContext.respawn[RESPAWN_MODE_DOWN].pos.y = 14.0f;
+                // gSaveContext.respawn[RESPAWN_MODE_DOWN].pos.z = 1548.0f;
+                // gSaveContext.respawn[RESPAWN_MODE_DOWN].yaw = -16384;
+                // gSaveContext.respawn[RESPAWN_MODE_DOWN].playerParams = PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D);
+                // gSaveContext.nextTransitionType = TRANS_TYPE_FADE_BLACK_FAST;
+                // gSaveContext.respawnFlag = -8;
+
+                Actor* turtle;
+                Actor* currentActor = gPlayState->actorCtx.actorLists[ACTORCAT_BG].first;
+                if (currentActor != nullptr) {
+                    while (currentActor != nullptr) {
+                        if (currentActor->id == ACTOR_DM_CHAR08) {
+                            turtle = currentActor;
+                        }
+                        currentActor = currentActor->next;
+                    }
+                }
+
+                // This gets sets a bit later after this hook executes, but needs to be set before respawning turtle
+                SET_WEEKEVENTREG(WEEKEVENTREG_53_20);
+                // probably need to kill its palm trees too
+                Actor_Kill(turtle);
+
+                // posX: -6238.000000, posY: -320.000000, posZ: 1749.000000, rotX: 0, rotY: 0, rotZ: 0, params: 0, csId: c, half: 3ff, parent: 0
+                Actor_SpawnAsChildAndCutscene(&gPlayState->actorCtx, gPlayState, ACTOR_DM_CHAR08, -6238.0, -320.0, 1749.0, 0, 0, 0, 0, 0xc, 0x3ff, NULL);
+
+                //Can't seem to get this to play after respawing
+
+                Audio_PlayFanfare(NA_BGM_DUNGEON_APPEAR);
             }
             // 13 is turtle leaving zora cape first time, 15 is subsequent times
             if (*csId == 13 || *csId == 15) {
@@ -47,7 +67,7 @@ void RegisterSkipWakingAndRidingTurtle() {
                     .entrance = ENTRANCE(GREAT_BAY_TEMPLE, 0),
                     .cutsceneIndex = 0,
                     .transitionTrigger = TRANS_TRIGGER_START,
-                    .transitionType = TRANS_TYPE_INSTANT,
+                    .transitionType = TRANS_TYPE_FADE_BLACK_FAST,
                 });
             }
         }

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipWakingAndRidingTurtle.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipWakingAndRidingTurtle.cpp
@@ -19,36 +19,35 @@ void RegisterSkipWakingAndRidingTurtle() {
         if (gPlayState->sceneId == SCENE_31MISAKI) {
             // 12 is first time waking turtle, 20 is subsequent times
             if (*csId == 12 || *csId == 20) {
-                *should = false;
-
-                Actor* turtle;
+                DmChar08* dmChar08;
                 Actor* currentActor = gPlayState->actorCtx.actorLists[ACTORCAT_BG].first;
                 if (currentActor != nullptr) {
                     while (currentActor != nullptr) {
                         if (currentActor->id == ACTOR_DM_CHAR08) {
-                            turtle = currentActor;
+                            dmChar08 = (DmChar08*)currentActor;
                         }
                         currentActor = currentActor->next;
                     }
                 }
 
-                DmChar08* dmChar08 = (DmChar08*)turtle;
+                if (dmChar08 == nullptr) {
+                    return;
+                }
 
-                Actor_Kill(dmChar08->palmTree1);
-                Actor_Kill(dmChar08->palmTree2);
+                *should = false;
 
                 // This gets sets soon after this hook executes, but needs to be set before reinitializing turtle
                 SET_WEEKEVENTREG(WEEKEVENTREG_53_20);
-                
-                turtle->init = DmChar08_Init;
-                
+
+                Actor_Kill(dmChar08->palmTree1);
+                Actor_Kill(dmChar08->palmTree2);
+                ((Actor*)dmChar08)->init = DmChar08_Init;
+
                 Audio_PlayFanfare(NA_BGM_DUNGEON_APPEAR);
             }
             // 13 is turtle leaving zora cape first time, 15 is subsequent times
             if (*csId == 13 || *csId == 15) {
                 *should = false;
-                // It would be less jarring if *should was set to true, but we still triggered the 
-                // early transition to ENTRANCE(GREAT_BAY_TEMPLE, 0)
                 GameInteractor::Instance->events.emplace_back(GIEventTransition{
                     .entrance = ENTRANCE(GREAT_BAY_TEMPLE, 0),
                     .cutsceneIndex = 0,

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipWakingAndRidingTurtle.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipWakingAndRidingTurtle.cpp
@@ -19,29 +19,20 @@ void RegisterSkipWakingAndRidingTurtle() {
         if (gPlayState->sceneId == SCENE_31MISAKI) {
             // 12 is first time waking turtle, 20 is subsequent times
             if (*csId == 12 || *csId == 20) {
-                DmChar08* dmChar08;
-                Actor* currentActor = gPlayState->actorCtx.actorLists[ACTORCAT_BG].first;
-                if (currentActor != nullptr) {
-                    while (currentActor != nullptr) {
-                        if (currentActor->id == ACTOR_DM_CHAR08) {
-                            dmChar08 = (DmChar08*)currentActor;
-                        }
-                        currentActor = currentActor->next;
-                    }
-                }
-
-                if (dmChar08 == nullptr) {
+                DmChar08* dmChar08 = (DmChar08*)Actor_FindNearby(gPlayState, &GET_PLAYER(gPlayState)->actor,
+                                                                 ACTOR_DM_CHAR08, ACTORCAT_BG, 99999.9f);
+                if (!dmChar08) {
                     return;
                 }
 
                 *should = false;
 
-                // This gets sets soon after this hook executes, but needs to be set before reinitializing turtle
+                // This gets set soon after this hook executes, but needs to be set before reinitializing turtle
                 SET_WEEKEVENTREG(WEEKEVENTREG_53_20);
 
                 Actor_Kill(dmChar08->palmTree1);
                 Actor_Kill(dmChar08->palmTree2);
-                ((Actor*)dmChar08)->init = DmChar08_Init;
+                dmChar08->dyna.actor.init = DmChar08_Init;
 
                 Audio_PlayFanfare(NA_BGM_DUNGEON_APPEAR);
             }

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipWakingAndRidingTurtle.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipWakingAndRidingTurtle.cpp
@@ -5,6 +5,9 @@
 extern "C" {
 #include "variables.h"
 #include "functions.h"
+#include "overlays/actors/ovl_Dm_Char08/z_dm_char08.h"
+
+void DmChar08_Init(Actor* thisx, PlayState* play2);
 }
 
 #define CVAR_NAME "gEnhancements.Cutscenes.SkipStoryCutscenes"
@@ -18,25 +21,6 @@ void RegisterSkipWakingAndRidingTurtle() {
             if (*csId == 12 || *csId == 20) {
                 *should = false;
 
-                // Need to reload scene. Position is where Link ends up after CS
-                // Differences from no skip: Camera ends up behind Link, Lulu is gone
-                // Based on WarpPoint.cpp
-                // Player* player = GET_PLAYER(gPlayState);
-
-                // gPlayState->nextEntrance = ENTRANCE(ZORA_CAPE, 2);
-                // gPlayState->transitionTrigger = TRANS_TRIGGER_START;
-                // gPlayState->transitionType = TRANS_TYPE_INSTANT;
-
-                // gSaveContext.respawn[RESPAWN_MODE_DOWN].entrance = ENTRANCE(ZORA_CAPE, 2);
-                // gSaveContext.respawn[RESPAWN_MODE_DOWN].roomIndex = 0;
-                // gSaveContext.respawn[RESPAWN_MODE_DOWN].pos.x = -5525.0f;
-                // gSaveContext.respawn[RESPAWN_MODE_DOWN].pos.y = 14.0f;
-                // gSaveContext.respawn[RESPAWN_MODE_DOWN].pos.z = 1548.0f;
-                // gSaveContext.respawn[RESPAWN_MODE_DOWN].yaw = -16384;
-                // gSaveContext.respawn[RESPAWN_MODE_DOWN].playerParams = PLAYER_PARAMS(0xFF, PLAYER_INITMODE_D);
-                // gSaveContext.nextTransitionType = TRANS_TYPE_FADE_BLACK_FAST;
-                // gSaveContext.respawnFlag = -8;
-
                 Actor* turtle;
                 Actor* currentActor = gPlayState->actorCtx.actorLists[ACTORCAT_BG].first;
                 if (currentActor != nullptr) {
@@ -48,21 +32,23 @@ void RegisterSkipWakingAndRidingTurtle() {
                     }
                 }
 
-                // This gets sets a bit later after this hook executes, but needs to be set before respawning turtle
+                DmChar08* dmChar08 = (DmChar08*)turtle;
+
+                Actor_Kill(dmChar08->palmTree1);
+                Actor_Kill(dmChar08->palmTree2);
+
+                // This gets sets soon after this hook executes, but needs to be set before reinitializing turtle
                 SET_WEEKEVENTREG(WEEKEVENTREG_53_20);
-                // probably need to kill its palm trees too
-                Actor_Kill(turtle);
-
-                // posX: -6238.000000, posY: -320.000000, posZ: 1749.000000, rotX: 0, rotY: 0, rotZ: 0, params: 0, csId: c, half: 3ff, parent: 0
-                Actor_SpawnAsChildAndCutscene(&gPlayState->actorCtx, gPlayState, ACTOR_DM_CHAR08, -6238.0, -320.0, 1749.0, 0, 0, 0, 0, 0xc, 0x3ff, NULL);
-
-                //Can't seem to get this to play after respawing
-
+                
+                turtle->init = DmChar08_Init;
+                
                 Audio_PlayFanfare(NA_BGM_DUNGEON_APPEAR);
             }
             // 13 is turtle leaving zora cape first time, 15 is subsequent times
             if (*csId == 13 || *csId == 15) {
                 *should = false;
+                // It would be less jarring if *should was set to true, but we still triggered the 
+                // early transition to ENTRANCE(GREAT_BAY_TEMPLE, 0)
                 GameInteractor::Instance->events.emplace_back(GIEventTransition{
                     .entrance = ENTRANCE(GREAT_BAY_TEMPLE, 0),
                     .cutsceneIndex = 0,


### PR DESCRIPTION
This accomplishes 4 things: 

1. Removes unneeded includes from copy/pasting in the changed files
2. Adds the Dungeon Appearing Fanfare to the Woodfall Temple Opening Skip
3. Adds the Dungeon Appearing Fanfare to the Waking Turtle Skip. To accomplish this, I had to rework the skip. Previously, we respawned to reload the scene after the appropriate flags were set, but I couldn't get the fanfare to play after the respawn. Now, I have the turtle actor re-initialize. 
4. Change the transition type on the Riding Turtle CS skip so it doesn't feel jarring. 

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2716380990.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2716396064.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2716431566.zip)
<!--- section:artifacts:end -->