### PR TITLE
[Rando] Fix snowball checks' item drop location

### DIFF
--- a/mm/2s2h/Rando/ActorBehavior/ObjSnowball.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ObjSnowball.cpp
@@ -182,7 +182,7 @@ void Rando::ActorBehavior::InitObjSnowballBehavior() {
         }
 
         if (!RANDO_SAVE_CHECKS[randoCheckId].cycleObtained) {
-            SpawnSnowballDrop(actor->home.pos, randoCheckId);
+            SpawnSnowballDrop(actor->world.pos, randoCheckId);
             *should = false;
         }
     });
@@ -204,7 +204,7 @@ void Rando::ActorBehavior::InitObjSnowballBehavior() {
         }
 
         if (!RANDO_SAVE_CHECKS[randoCheckId].cycleObtained) {
-            SpawnSnowballDrop(actor->home.pos, randoCheckId);
+            SpawnSnowballDrop(actor->world.pos, randoCheckId);
         }
     });
 }


### PR DESCRIPTION
Currently, throwing snowballs makes the randomized item drop in the spawn location of the snowball rather then where it landed. This PR fixes that so the item spawns where the snowball breaks.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2716451430.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2716451649.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2716495654.zip)
<!--- section:artifacts:end -->