### PR TITLE
Port over right stick ocarina playback option from SoH

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1085,6 +1085,9 @@ void BenMenu::AddEnhancements() {
     AddWidget(path, "Dpad Ocarina", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Playback.DpadOcarina")
         .Options(CheckboxOptions().Tooltip("Enables using the Dpad for Ocarina playback."));
+    AddWidget(path, "Right Stick Ocarina", WIDGET_CVAR_CHECKBOX)
+        .CVar("gEnhancements.Playback.RightStickOcarina")
+        .Options(CheckboxOptions().Tooltip("Enables using the Right Stick for Ocarina playback."));
     AddWidget(path, "Pause Owl Warp", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Songs.PauseOwlWarp")
         .Options(CheckboxOptions().Tooltip(

--- a/mm/src/audio/code_8019AF00.c
+++ b/mm/src/audio/code_8019AF00.c
@@ -2100,6 +2100,22 @@ void AudioOcarina_ReadControllerInput(void) {
     sOcarinaInputButtonPrev = ocarinaInputButtonPrev;
     sOcarinaInputStickRel.x = input->rel.stick_x;
     sOcarinaInputStickRel.y = input->rel.stick_y;
+    if(!CVarGetInteger("gEnhancements.Playback.RightStickOcarina", 0)){
+        return;
+    }
+    s8 rstick_x = input->cur.right_stick_x;
+    s8 rstick_y = input->cur.right_stick_y;
+    const s8 sensitivity = 64;
+    if (rstick_x > sensitivity) {
+        sOcarinaInputButtonCur |= BTN_CRIGHT;
+    } else if (rstick_x < -sensitivity) {
+        sOcarinaInputButtonCur |= BTN_CLEFT;     
+    }
+    if (rstick_y > sensitivity) {
+        sOcarinaInputButtonCur |= BTN_CUP;
+    } else if (rstick_y < -sensitivity) {
+        sOcarinaInputButtonCur |= BTN_CDOWN;
+    }
 }
 
 /**

--- a/mm/src/audio/code_8019AF00.c
+++ b/mm/src/audio/code_8019AF00.c
@@ -2100,7 +2100,7 @@ void AudioOcarina_ReadControllerInput(void) {
     sOcarinaInputButtonPrev = ocarinaInputButtonPrev;
     sOcarinaInputStickRel.x = input->rel.stick_x;
     sOcarinaInputStickRel.y = input->rel.stick_y;
-    if(!CVarGetInteger("gEnhancements.Playback.RightStickOcarina", 0)){
+    if (!CVarGetInteger("gEnhancements.Playback.RightStickOcarina", 0)) {
         return;
     }
     s8 rstick_x = input->cur.right_stick_x;
@@ -2109,7 +2109,7 @@ void AudioOcarina_ReadControllerInput(void) {
     if (rstick_x > sensitivity) {
         sOcarinaInputButtonCur |= BTN_CRIGHT;
     } else if (rstick_x < -sensitivity) {
-        sOcarinaInputButtonCur |= BTN_CLEFT;     
+        sOcarinaInputButtonCur |= BTN_CLEFT;
     }
     if (rstick_y > sensitivity) {
         sOcarinaInputButtonCur |= BTN_CUP;


### PR DESCRIPTION
This PR ports a feature from SoH that allows using the right stick for ocarina playback, even when the stick is assigned to something else during normal gameplay. That way it becomes possible to e.g. use the right stick for third person camera control and still play the ocarina.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2743917172.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2743920306.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2743952676.zip)
<!--- section:artifacts:end -->