### PR TITLE
[Rando] Fix softlock with repeats for Anju's grandmother

### DIFF
--- a/mm/2s2h/Rando/ActorBehavior/ActorBehavior.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ActorBehavior.cpp
@@ -104,6 +104,7 @@ void Rando::ActorBehavior::OnFileLoad() {
     Rando::ActorBehavior::InitEnMa4Behavior();
     Rando::ActorBehavior::InitEnMaYtoBehavior();
     Rando::ActorBehavior::InitEnMnkBehavior();
+    Rando::ActorBehavior::InitEnNbBehavior();
     Rando::ActorBehavior::InitEnOsnBehavior();
     Rando::ActorBehavior::InitEnOwlBehavior();
     Rando::ActorBehavior::InitEnPmBehavior();

--- a/mm/2s2h/Rando/ActorBehavior/ActorBehavior.h
+++ b/mm/2s2h/Rando/ActorBehavior/ActorBehavior.h
@@ -60,6 +60,7 @@ void InitEnLiftNutsBehavior();
 void InitEnMa4Behavior();
 void InitEnMaYtoBehavior();
 void InitEnMnkBehavior();
+void InitEnNbBehavior();
 void InitEnOsnBehavior();
 void InitEnOwlBehavior();
 void InitEnPmBehavior();

--- a/mm/2s2h/Rando/ActorBehavior/EnNb.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnNb.cpp
@@ -1,0 +1,32 @@
+#include "ActorBehavior.h"
+#include <libultraship/libultraship.h>
+
+extern "C" {
+#include "variables.h"
+void func_80837B60(PlayState* play, Player* player);
+s32 func_80832558(PlayState* play, Player* player, PlayerFuncD58 arg2);
+}
+
+void Rando::ActorBehavior::InitEnNbBehavior() {
+    COND_VB_SHOULD(VB_EXEC_MSG_EVENT, IS_RANDO, {
+        u32 cmdId = va_arg(args, u32);
+        Actor* actor = va_arg(args, Actor*);
+        if (actor->id == ACTOR_EN_NB) { // Anju's Grandmother
+            MsgScript* script = va_arg(args, MsgScript*);
+            Player* player = GET_PLAYER(gPlayState);
+            switch (cmdId) {
+                case MSCRIPT_CMD_06: // MSCRIPT_OFFER_ITEM
+                    // Lock the player into conversation because a notebook message might appear
+                    func_80832558(gPlayState, player, func_80837B60);
+                    *should = false;
+                    break;
+                case MSCRIPT_CMD_16: // MSCRIPT_DONE
+                    // Prevent softlocks in case a notebook message did not appear
+                    Message_CloseTextbox(gPlayState);
+                    break;
+                default:
+                    break;
+            }
+        }
+    });
+}

--- a/mm/2s2h/Rando/MiscBehavior/OfferGetItem.cpp
+++ b/mm/2s2h/Rando/MiscBehavior/OfferGetItem.cpp
@@ -25,8 +25,6 @@ void Rando::MiscBehavior::InitOfferGetItemBehavior() {
             switch (actor->id) {
                 case ACTOR_EN_PST:
                     actor->flags |= ACTOR_FLAG_TALK_REQUESTED; // Prevent softlock
-                    [[fallthrough]];
-                case ACTOR_EN_NB:
                     func_80832558(gPlayState, player, func_80837B60);
                     *should = false;
                     return;


### PR DESCRIPTION
Like other scripted actors, Anju's grandmother doesn't play well with the generic catch-all in `OfferGetItem.cpp` and required the same fix as some other actors to prevent softlocks on repeating a check in subsequent cycles. In fact, with this change, there's only one actor case left in the general handler for scripted events. It may make more sense to just move that straggler into its own file at this point.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2718761464.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2718763442.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2718877235.zip)
<!--- section:artifacts:end -->