### PR TITLE
Add option to de-select XMLs and fix credits

### DIFF
--- a/mm/2s2h/Enhancements/Audio/AudioCollection.cpp
+++ b/mm/2s2h/Enhancements/Audio/AudioCollection.cpp
@@ -185,7 +185,8 @@ AudioCollection::AudioCollection() {
         SEQUENCE_MAP_ENTRY(NA_BGM_CREMIA_CARRIAGE, "Cremia Carriage", "NA_BGM_CREMIA_CARRIAGE", SEQ_BGM_WORLD, true,
                            true),
         SEQUENCE_MAP_ENTRY(NA_BGM_KEATON_QUIZ, "Keaton Quiz", "NA_BGM_KEATON_QUIZ", SEQ_BGM_WORLD, true, true),
-        SEQUENCE_MAP_ENTRY(NA_BGM_END_CREDITS, "Credits (First Half)", "NA_BGM_END_CREDITS", SEQ_BGM_WORLD, true, true),
+        // The credits cutscene uses the position in the sequence to advance. It should not be changed.
+        SEQUENCE_MAP_ENTRY(NA_BGM_END_CREDITS, "Credits (First Half)", "NA_BGM_END_CREDITS", SEQ_BGM_WORLD, false, false),
         SEQUENCE_MAP_ENTRY(NA_BGM_OPENING_LOOP, "Opening Loop", "NA_BGM_OPENING_LOOP", SEQ_BGM_WORLD, true, true),
         SEQUENCE_MAP_ENTRY(NA_BGM_TITLE_THEME, "Title Theme", "NA_BGM_TITLE_THEME", SEQ_BGM_WORLD, true, true),
         SEQUENCE_MAP_ENTRY(NA_BGM_DUNGEON_APPEAR, "Dungeon Appear", "NA_BGM_DUNGEON_APPEAR", SEQ_BGM_EVENT, true, true),
@@ -198,7 +199,7 @@ AudioCollection::AudioCollection() {
         SEQUENCE_MAP_ENTRY(NA_BGM_MOONS_DESTRUCTION, "Moon's Destruction", "NA_BGM_MOONS_DESTRUCTION", SEQ_BGM_EVENT,
                            true, true),
         SEQUENCE_MAP_ENTRY(NA_BGM_END_CREDITS_SECOND_HALF, "Credits (Second Half)", "NA_BGM_END_CREDITS_SECOND_HALF",
-                           SEQ_BGM_WORLD, true, true),
+                           SEQ_BGM_WORLD, false, false),
     };
 
     // Initialize counts for each type
@@ -366,11 +367,12 @@ size_t AudioCollection::CountSequencesByType(SeqType type) {
 }
 
 uint16_t AudioCollection::GetMaxOriginalSeqId() const {
-    uint16_t maxId = 0;
-    for (const auto& [seqId, seqInfo] : mSequenceMap) {
-        if (!(seqInfo.category & SEQ_BGM_CUSTOM) && seqId > maxId) {
-            maxId = seqId;
-        }
-    }
-    return maxId;
+    return 0x7F;
+    //uint16_t maxId = 0;
+    //for (const auto& [seqId, seqInfo] : mSequenceMap) {
+    //    if (!(seqInfo.category & SEQ_BGM_CUSTOM) && seqId > maxId) {
+    //        maxId = seqId;
+    //    }
+    //}
+    //return maxId;
 }

--- a/mm/2s2h/Enhancements/Audio/AudioCollection.cpp
+++ b/mm/2s2h/Enhancements/Audio/AudioCollection.cpp
@@ -186,7 +186,8 @@ AudioCollection::AudioCollection() {
                            true),
         SEQUENCE_MAP_ENTRY(NA_BGM_KEATON_QUIZ, "Keaton Quiz", "NA_BGM_KEATON_QUIZ", SEQ_BGM_WORLD, true, true),
         // The credits cutscene uses the position in the sequence to advance. It should not be changed.
-        SEQUENCE_MAP_ENTRY(NA_BGM_END_CREDITS, "Credits (First Half)", "NA_BGM_END_CREDITS", SEQ_BGM_WORLD, false, false),
+        SEQUENCE_MAP_ENTRY(NA_BGM_END_CREDITS, "Credits (First Half)", "NA_BGM_END_CREDITS", SEQ_BGM_WORLD, false,
+                           false),
         SEQUENCE_MAP_ENTRY(NA_BGM_OPENING_LOOP, "Opening Loop", "NA_BGM_OPENING_LOOP", SEQ_BGM_WORLD, true, true),
         SEQUENCE_MAP_ENTRY(NA_BGM_TITLE_THEME, "Title Theme", "NA_BGM_TITLE_THEME", SEQ_BGM_WORLD, true, true),
         SEQUENCE_MAP_ENTRY(NA_BGM_DUNGEON_APPEAR, "Dungeon Appear", "NA_BGM_DUNGEON_APPEAR", SEQ_BGM_EVENT, true, true),
@@ -368,11 +369,11 @@ size_t AudioCollection::CountSequencesByType(SeqType type) {
 
 uint16_t AudioCollection::GetMaxOriginalSeqId() const {
     return 0x7F;
-    //uint16_t maxId = 0;
-    //for (const auto& [seqId, seqInfo] : mSequenceMap) {
-    //    if (!(seqInfo.category & SEQ_BGM_CUSTOM) && seqId > maxId) {
-    //        maxId = seqId;
-    //    }
-    //}
-    //return maxId;
+    // uint16_t maxId = 0;
+    // for (const auto& [seqId, seqInfo] : mSequenceMap) {
+    //     if (!(seqInfo.category & SEQ_BGM_CUSTOM) && seqId > maxId) {
+    //         maxId = seqId;
+    //     }
+    // }
+    // return maxId;
 }

--- a/mm/2s2h/Extractor/Extract.cpp
+++ b/mm/2s2h/Extractor/Extract.cpp
@@ -575,7 +575,6 @@ bool Extractor::CallZapd(std::string installPath, std::string exportdir) {
     argv[18] = "-oxml";
     argv[19] = "asq,asp";
 
-
 #ifdef _WIN32
     // Grab a handle to the command window.
     HWND cmdWindow = GetConsoleWindow();

--- a/mm/2s2h/Extractor/Extract.cpp
+++ b/mm/2s2h/Extractor/Extract.cpp
@@ -527,7 +527,7 @@ std::string Extractor::Mkdtemp() {
 extern "C" int zapd_main(int argc, char** argv);
 
 bool Extractor::CallZapd(std::string installPath, std::string exportdir) {
-    constexpr int argc = 18;
+    constexpr int argc = 20;
     char xmlPath[1024];
     char confPath[1024];
     char portVersion[18]; // 5 digits for int16_max (x3) + separators + terminator
@@ -572,6 +572,9 @@ bool Extractor::CallZapd(std::string installPath, std::string exportdir) {
     argv[15] = otrFile;
     argv[16] = "--portVer";
     argv[17] = portVersion;
+    argv[18] = "-oxml";
+    argv[19] = "asq,asp";
+
 
 #ifdef _WIN32
     // Grab a handle to the command window.

--- a/mm/2s2h/Extractor/Extract.cpp
+++ b/mm/2s2h/Extractor/Extract.cpp
@@ -527,7 +527,7 @@ std::string Extractor::Mkdtemp() {
 extern "C" int zapd_main(int argc, char** argv);
 
 bool Extractor::CallZapd(std::string installPath, std::string exportdir) {
-    constexpr int argc = 20;
+    constexpr int argc = 18;
     char xmlPath[1024];
     char confPath[1024];
     char portVersion[18]; // 5 digits for int16_max (x3) + separators + terminator
@@ -572,8 +572,6 @@ bool Extractor::CallZapd(std::string installPath, std::string exportdir) {
     argv[15] = otrFile;
     argv[16] = "--portVer";
     argv[17] = portVersion;
-    argv[18] = "-oxml";
-    argv[19] = "asq,asp";
 
 #ifdef _WIN32
     // Grab a handle to the command window.


### PR DESCRIPTION
Should fix the crash in woodfall as is.
Requires https://github.com/HarbourMasters/OTRExporter/pull/32 and https://github.com/louist103/ZAPDTR/pull/21

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2760796439.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2760796522.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2760807346.zip)
<!--- section:artifacts:end -->