### PR TITLE
Fix build on ubuntu 20.04 arm64

### DIFF
--- a/mm/2s2h/Rando/ActorBehavior/ActorBehavior.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ActorBehavior.cpp
@@ -7,7 +7,7 @@ extern "C" {
 }
 
 // This is kind of a catch-all for things that are simple enough to not need their own file.
-void MiscVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, void* optionalArg) {
+void MiscVanillaBehaviorHandler(GIVanillaBehavior id, bool* should, va_list optionalArg) {
     switch (id) {
         case VB_MADAME_AROMA_ASK_FOR_HELP:
             *should = !CHECK_WEEKEVENTREG(WEEKEVENTREG_BOMBERS_NOTEBOOK_EVENT_RECEIVED_KAFEIS_MASK);


### PR DESCRIPTION
Fixes build on Ubuntu 20.04 arm64, by making the signature of MiscVanillaBehaviorHandler match ShouldVanillaBehavior. Fixes #1063

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2758132188.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2758132955.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2758143849.zip)
<!--- section:artifacts:end -->