### PR TITLE
Fix Gibdo Trade crash

### DIFF
--- a/mm/2s2h/Enhancements/DifficultyOptions/GibdoTradeSequenceOptions.cpp
+++ b/mm/2s2h/Enhancements/DifficultyOptions/GibdoTradeSequenceOptions.cpp
@@ -59,7 +59,7 @@ void RegisterGibdoTradeSequenceOptions() {
         *should = false;
 
         EnTalkGibud* gibudCtx = va_arg(args, EnTalkGibud*);
-        bool doEndTradeMessage = va_arg(args, bool);
+        bool doEndTradeMessage = (bool)va_arg(args, int);
 
         if (doEndTradeMessage) {
             Message_StartTextbox(gPlayState, 0x138A, &gibudCtx->actor);


### PR DESCRIPTION
`va_arg` does not like `bool`, which made the Gibdo Trade Sequence Options enhancement crash on Linux when set to "No trade". This fix maintains the  intended behavior on Windows, but I need someone on Linux to verify that it fixes the crash.

Edit: The latest Linux build logs for the develop branch note the following:

```
/home/runner/work/2ship2harkinian/2ship2harkinian/mm/2s2h/Enhancements/DifficultyOptions/GibdoTradeSequenceOptions.cpp:62:47: note: (so you should pass ‘int’ not ‘bool’ to ‘va_arg’)
62 |         bool doEndTradeMessage = va_arg(args, bool);
```

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2775986585.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2775989869.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2776030598.zip)
<!--- section:artifacts:end -->