### PR TITLE
[Rando] Fix typo

### DIFF
--- a/mm/2s2h/Rando/Menu.cpp
+++ b/mm/2s2h/Rando/Menu.cpp
@@ -27,7 +27,7 @@ std::unordered_map<int32_t, const char*> accessDungeonOptions = {
 std::unordered_map<int32_t, const char*> accessTrialsOptions = {
     { RO_ACCESS_TRIALS_20_MASKS, "2-6-12-20 Masks" },
     { RO_ACCESS_TRIALS_REMAINS, "Requires Associated Remains" },
-    { RO_ACCESS_TRIALS_FORMS, "Requires Assocaited Transformation" },
+    { RO_ACCESS_TRIALS_FORMS, "Requires Associated Transformation" },
     { RO_ACCESS_TRIALS_OPEN, "Open" },
 };
 


### PR DESCRIPTION
Fixes this typo
![image](https://github.com/user-attachments/assets/0e89faf1-5b6e-4355-bf4c-f81253ac1215)


<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2784457731.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2784458280.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2784487909.zip)
<!--- section:artifacts:end -->