### PR TITLE
Menu fixes and some cleanup

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -224,11 +224,6 @@ void BenMenu::AddSettings() {
     AddWidget(path, "Audio API", WIDGET_AUDIO_BACKEND);
 
     // Graphics Settings
-    static int32_t maxFps = 360;
-    static const char* tooltip =
-        "Uses Matrix Interpolation to create extra frames, resulting in smoother graphics. This is "
-        "purely visual and does not impact game logic, execution of glitches etc.\n\nA higher target "
-        "FPS than your monitor's refresh rate will waste resources, and might give a worse result.";
     path.sidebarName = "Graphics";
     AddSidebarEntry("Settings", "Graphics", 3);
     AddWidget(path, "Toggle Fullscreen", WIDGET_CVAR_CHECKBOX)
@@ -289,7 +284,11 @@ void BenMenu::AddSettings() {
             if (mBenMenu->disabledMap.at(DISABLE_FOR_MATCH_REFRESH_RATE_ON).active)
                 info.activeDisables.push_back(DISABLE_FOR_MATCH_REFRESH_RATE_ON);
         })
-        .Options(IntSliderOptions().Tooltip(tooltip).Min(20).Max(maxFps).DefaultValue(20));
+        .Options(IntSliderOptions().Min(20).Max(360).DefaultValue(20).Tooltip(
+            "Uses Matrix Interpolation to create extra frames, resulting in smoother graphics. "
+            "This is purely visual and does not impact game logic, execution of glitches etc.\n\n"
+            "A higher target FPS than your monitor's refresh rate will waste resources, and might give a worse "
+            "result."));
     AddWidget(path, "Match Refresh Rate", WIDGET_CVAR_CHECKBOX)
         .CVar("gMatchRefreshRate")
         .Options(CheckboxOptions().Tooltip("Matches interpolation value to the refresh rate of your display."));

--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1117,7 +1117,11 @@ void BenMenu::AddEnhancements() {
             "When starting a game you will be taken straight to South Clock Town as Deku Link."));
     AddWidget(path, "Skip First Cycle", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Cutscenes.SkipFirstCycle")
-        .PreFunc([](WidgetInfo& info) { info.isHidden = mBenMenu->disabledMap.at(DISABLE_FOR_INTRO_SKIP_OFF).active; })
+        .PreFunc([](WidgetInfo& info) {
+            if (mBenMenu->disabledMap.at(DISABLE_FOR_INTRO_SKIP_OFF).active) {
+                info.activeDisables.push_back(DISABLE_FOR_INTRO_SKIP_OFF);
+            }
+        })
         .Options(CheckboxOptions().Tooltip(
             "When starting a game you will be taken straight to South Clock Town as Human Link "
             "with Deku Mask, Ocarina, Song of Time, and Song of Healing."));

--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -951,8 +951,9 @@ void BenMenu::AddEnhancements() {
                      .ComboMap(motionBlurOptions));
     AddWidget(path, "Interpolate", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Graphics.MotionBlur.Interpolate")
-        .PreFunc(
-            [](WidgetInfo& info) { info.isHidden = mBenMenu->disabledMap.at(DISABLE_FOR_MOTION_BLUR_MODE).value == 1; })
+        .PreFunc([](WidgetInfo& info) {
+            info.isHidden = mBenMenu->disabledMap.at(DISABLE_FOR_MOTION_BLUR_MODE).value == MOTION_BLUR_ALWAYS_OFF;
+        })
         .Options(CheckboxOptions().Tooltip(
             "Change motion blur capture to also happen on interpolated frames instead of only on game frames.\n"
             "This notably reduces the overall motion blur strength but smooths out the trails."));
@@ -960,13 +961,13 @@ void BenMenu::AddEnhancements() {
         .ValuePointer((bool*)&R_MOTION_BLUR_ENABLED)
         .PreFunc([](WidgetInfo& info) {
             info.valuePointer = (bool*)&R_MOTION_BLUR_ENABLED;
-            info.isHidden = mBenMenu->disabledMap.at(DISABLE_FOR_MOTION_BLUR_MODE).value != 0;
+            info.isHidden = mBenMenu->disabledMap.at(DISABLE_FOR_MOTION_BLUR_MODE).value != MOTION_BLUR_DYNAMIC;
         });
     AddWidget(path, "Strength", WIDGET_CVAR_SLIDER_INT)
         .CVar("gEnhancements.Graphics.MotionBlur.Strength")
         .Options(IntSliderOptions().Tooltip("Motion Blur strength.").Min(0).Max(255).DefaultValue(180))
         .PreFunc([](WidgetInfo& info) {
-            info.isHidden = mBenMenu->disabledMap.at(DISABLE_FOR_MOTION_BLUR_MODE).value != 2;
+            info.isHidden = mBenMenu->disabledMap.at(DISABLE_FOR_MOTION_BLUR_MODE).value != MOTION_BLUR_ALWAYS_ON;
         });
     AddWidget(path, "Strength", WIDGET_SLIDER_INT)
         .Options(IntSliderOptions().Tooltip("Motion Blur strength.").Min(0).Max(255).DefaultValue(180))
@@ -974,7 +975,7 @@ void BenMenu::AddEnhancements() {
         .Callback([](WidgetInfo& info) { R_MOTION_BLUR_ALPHA = motionBlurStrength; })
         .PreFunc([](WidgetInfo& info) {
             motionBlurStrength = R_MOTION_BLUR_ALPHA;
-            info.isHidden = mBenMenu->disabledMap.at(DISABLE_FOR_MOTION_BLUR_MODE).value != 0 ||
+            info.isHidden = mBenMenu->disabledMap.at(DISABLE_FOR_MOTION_BLUR_MODE).value != MOTION_BLUR_DYNAMIC ||
                             mBenMenu->disabledMap.at(DISABLE_FOR_MOTION_BLUR_OFF).active;
         });
 

--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1637,7 +1637,7 @@ void BenMenu::InitElement() {
           { [](disabledInfo& info) -> bool { return !CVarGetInteger("gEnhancements.Saving.Autosave", 0); },
             "AutoSave is Disabled" } },
         { DISABLE_FOR_NULL_PLAY_STATE,
-          { [](disabledInfo& info) -> bool { return gPlayState == NULL; }, "Save Not Loaded" } },
+          { [](disabledInfo& info) -> bool { return gPlayState == NULL; }, "Not in game" } },
         { DISABLE_FOR_DEBUG_MODE_OFF,
           { [](disabledInfo& info) -> bool { return !CVarGetInteger("gDeveloperTools.DebugEnabled", 0); },
             "Debug Mode is Disabled" } },

--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -714,7 +714,7 @@ void BenMenu::AddEnhancements() {
     AddWidget(path, "Arrow Type Cycling", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.PlayerActions.ArrowCycle")
         .Options(CheckboxOptions().Tooltip(
-            "While aiming the bow, use L to cycle between Normal, Fire, Ice and Light arrows."));
+            "While aiming the bow, use R to cycle between Normal, Fire, Ice and Light arrows."));
     AddWidget(path, "Bombchu Drops", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Equipment.ChuDrops")
         .Options(

--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -296,7 +296,9 @@ void BenMenu::AddSettings() {
     AddWidget(path, "Enable Vsync", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_VSYNC_ENABLED)
         .PreFunc([](WidgetInfo& info) { info.isHidden = mBenMenu->disabledMap.at(DISABLE_FOR_NO_VSYNC).active; })
-        .Options(CheckboxOptions().Tooltip("Removes tearing, but clamps your max FPS to your displays refresh rate."));
+        .Options(CheckboxOptions()
+                     .Tooltip("Removes tearing, but clamps your max FPS to your displays refresh rate.")
+                     .DefaultValue(true));
     AddWidget(path, "Windowed Fullscreen", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_SDL_WINDOWED_FULLSCREEN)
         .PreFunc([](WidgetInfo& info) {

--- a/mm/2s2h/BenGui/BenMenu.h
+++ b/mm/2s2h/BenGui/BenMenu.h
@@ -5,8 +5,8 @@
 #include "UIWidgets.hpp"
 #include "Menu.h"
 #include "2s2h/Enhancements/Enhancements.h"
-#include "graphic/Fast3D/gfx_rendering_api.h"
 #include "2s2h/DeveloperTools/DeveloperTools.h"
+#include "graphic/Fast3D/gfx_rendering_api.h"
 
 namespace BenGui {
 

--- a/mm/2s2h/BenGui/Menu.h
+++ b/mm/2s2h/BenGui/Menu.h
@@ -3,9 +3,6 @@
 
 #include <libultraship/libultraship.h>
 #include "UIWidgets.hpp"
-#include "2s2h/Enhancements/Enhancements.h"
-#include "graphic/Fast3D/gfx_rendering_api.h"
-#include "2s2h/DeveloperTools/DeveloperTools.h"
 #include "MenuTypes.h"
 
 namespace Ship {

--- a/mm/2s2h/Enhancements/Cutscenes/SkipToFileSelect.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/SkipToFileSelect.cpp
@@ -23,7 +23,13 @@ void RegisterSkipToFileSelect() {
             // Normally called on console logo screen
             gSaveContext.seqId = NA_BGM_DISABLED;
             gSaveContext.ambienceId = AMBIENCE_ID_DISABLED;
-            gSaveContext.gameMode = GAMEMODE_TITLE_SCREEN;
+
+            // Normally the following is called by the opening cutscene
+            Sram_InitNewSave();
+            gSaveContext.save.time = CLOCK_TIME(8, 0);
+            gSaveContext.save.day = 1;
+            gSaveContext.save.playerForm = PLAYER_FORM_HUMAN;
+            gSaveContext.gameMode = GAMEMODE_FILE_SELECT;
 
             STOP_GAMESTATE(gGameState);
             SET_NEXT_GAMESTATE(gGameState, FileSelect_Init, sizeof(FileSelectState));
@@ -37,7 +43,7 @@ void RegisterSkipToFileSelect() {
         if (CHECK_BTN_ANY(consoleLogoState->state.input->press.button, BTN_A | BTN_B | BTN_START)) {
             // Force the title state to start fading to black and to last roughly 5 frames based on current fade in/out
             consoleLogoState->visibleDuration = 0;
-            consoleLogoState->addAlpha = (255 - consoleLogoState->coverAlpha) / 5;
+            consoleLogoState->addAlpha = std::max<int16_t>((255 - consoleLogoState->coverAlpha) / 5, 1);
         }
     });
 }

--- a/mm/2s2h/Enhancements/Graphics/EnemyHealthBars.cpp
+++ b/mm/2s2h/Enhancements/Graphics/EnemyHealthBars.cpp
@@ -191,6 +191,7 @@ static RegisterShipInitFunc initFunc(
                 u8* maxHealth = (u8*)ActorExtension_Get(actor, actorEnemyHealthExtId);
                 if (maxHealth == NULL) {
                     assert(false && "Actor Extension memory not valid");
+                    return;
                 }
 
                 *maxHealth = actor->colChkInfo.health;

--- a/mm/2s2h/NameTag/NameTag.cpp
+++ b/mm/2s2h/NameTag/NameTag.cpp
@@ -7,7 +7,7 @@
 #include "2s2h/ShipUtils.h"
 
 extern "C" {
-#include "z64.h"
+#include "z64actor.h"
 #include "macros.h"
 #include "functions.h"
 #include "variables.h"
@@ -129,18 +129,16 @@ void DrawNameTag(PlayState* play, const NameTag* nameTag) {
             vtxGroup++;
         }
 
-        if (nameTag->processedText[i] != '\n') {
-            TexturePtr texture = Ship_GetCharFontTextureNES(nameTag->processedText[i]);
-            int16_t vertexStart = 4 * (i % 16);
+        TexturePtr texture = Ship_GetCharFontTextureNES(nameTag->processedText[i]);
+        int16_t vertexStart = 4 * (i % 16);
 
-            // Multi-instruction macro, need to insert all to the dl buffer
-            Gfx charTexture[] = { gsDPLoadTextureBlock_4b(
-                texture, G_IM_FMT_I, FONT_CHAR_TEX_WIDTH, FONT_CHAR_TEX_HEIGHT, 0, G_TX_NOMIRROR | G_TX_CLAMP,
-                G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD) };
-            nameTagDl.insert(nameTagDl.end(), std::begin(charTexture), std::end(charTexture));
+        // Multi-instruction macro, need to insert all to the dl buffer
+        Gfx charTexture[] = { gsDPLoadTextureBlock_4b(texture, G_IM_FMT_I, FONT_CHAR_TEX_WIDTH, FONT_CHAR_TEX_HEIGHT, 0,
+                                                      G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP,
+                                                      G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD) };
+        nameTagDl.insert(nameTagDl.end(), std::begin(charTexture), std::end(charTexture));
 
-            nameTagDl.push_back(gsSP1Quadrangle(vertexStart, vertexStart + 2, vertexStart + 3, vertexStart + 1, 0));
-        }
+        nameTagDl.push_back(gsSP1Quadrangle(vertexStart, vertexStart + 2, vertexStart + 3, vertexStart + 1, 0));
     }
 
     nameTagDl.push_back(gsSPPopMatrix(G_MTX_MODELVIEW));

--- a/mm/2s2h/NameTag/NameTag.h
+++ b/mm/2s2h/NameTag/NameTag.h
@@ -4,7 +4,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-#include "z64actor.h"
+#include "color.h"
 #ifdef __cplusplus
 }
 #endif
@@ -22,6 +22,8 @@ void NameTag_RegisterHooks();
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+struct Actor;
 
 // Registers a name tag to an actor with additional options applied
 void NameTag_RegisterForActorWithOptions(Actor* actor, const char* text, NameTagOptions options);


### PR DESCRIPTION
A couple menu fixes and a some random cleanups that I had from SoH

* Add missing early return after assert for enemy health bars
* Cleanup nametag headers and remove unneeded newline check (the texture func returns the empty texture just fine)
* Cleanup unneeded headers from menu headers
* Fix possible skip boot fade out glitch and ensure some save context values are set to match what is being skipped
* Update Arrow Cycle tooltip to mention R button instead of L
* Use motion blur enums in menu instead of magic nums
* Switch "Skip First Cycle" to disable itself instead of hiding when "Skip Intro" is not enabled (we should try not to hide toggles if we don't need to)
* Tweaks the "no playstate" disabled menu entry to not mention "loaded saves" as that is not true
* Default VSync to on

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2847833159.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2847835168.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2847847954.zip)
<!--- section:artifacts:end -->