### PR TITLE
Remove jitter fix slider

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -311,17 +311,6 @@ void BenMenu::AddSettings() {
         .CVar("gMatchRefreshRate")
         .PreFunc([](WidgetInfo& info) { info.isHidden = mBenMenu->disabledMap.at(DISABLE_FOR_DIRECTX).active; })
         .Options(CheckboxOptions().Tooltip("Matches interpolation value to the current game's window refresh rate."));
-    AddWidget(path, "Jitter fix : >= % d FPS", WIDGET_CVAR_SLIDER_INT)
-        .CVar("gExtraLatencyThreshold")
-        .PreFunc([](WidgetInfo& info) { info.isHidden = mBenMenu->disabledMap.at(DISABLE_FOR_NOT_DIRECTX).active; })
-        .Options(IntSliderOptions()
-                     .Tooltip("When Interpolation FPS setting is at least this threshold, add one frame of input "
-                              "lag (e.g. 16.6 ms for 60 FPS) in order to avoid jitter. This setting allows the "
-                              "CPU to work on one frame while GPU works on the previous frame.\nThis setting "
-                              "should be used when your computer is too slow to do CPU + GPU work in time.")
-                     .Min(0)
-                     .Max(360)
-                     .DefaultValue(80));
     AddWidget(path, "Renderer API (Needs reload)", WIDGET_VIDEO_BACKEND);
     AddWidget(path, "Enable Vsync", WIDGET_CVAR_CHECKBOX)
         .CVar(CVAR_VSYNC_ENABLED)

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -972,11 +972,8 @@ extern "C" void Graph_ProcessGfxCommands(Gfx* commands) {
 
     time -= fps;
 
-    int threshold = CVarGetInteger("gExtraLatencyThreshold", 80);
-
     if (wnd != nullptr) {
         wnd->SetTargetFps(fps);
-        wnd->SetMaximumFrameLatency(threshold > 0 && target_fps >= threshold ? 2 : 1);
     }
 
     // When the gfx debugger is active, only run with the final mtx


### PR DESCRIPTION
LUS defaults to always on now. And this option was confusing for most users.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2802927266.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2802927530.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2802938864.zip)
<!--- section:artifacts:end -->