### PR TITLE
Fix sword beam collision overcorrection, convert to actor extension

### DIFF
--- a/mm/2s2h/Enhancements/Masks/FierceDeityAnywhere.cpp
+++ b/mm/2s2h/Enhancements/Masks/FierceDeityAnywhere.cpp
@@ -19,25 +19,25 @@ ActorExtensionId actorHitBySwordBeamExtId = 0;
 #define CVAR_NAME "gEnhancements.Masks.FierceDeitysAnywhere"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
-bool* GetActorHitBySwordBeam(Actor* actor) {
+bool GetActorHitBySwordBeam(Actor* actor) {
     bool* swordBeamCollisionFlag = (bool*)ActorExtension_Get(actor, actorHitBySwordBeamExtId);
     if (swordBeamCollisionFlag == NULL) {
-        return 0;
+        return false;
     }
 
-    return swordBeamCollisionFlag;
+    return *swordBeamCollisionFlag;
+}
+
+void SetActorHitBySwordBeam(Actor* actor, bool flag) {
+    bool* swordBeamCollisionFlag = (bool*)ActorExtension_Get(actor, actorHitBySwordBeamExtId);
+    if (swordBeamCollisionFlag != NULL) {
+        *swordBeamCollisionFlag = flag;
+    }
 }
 
 void RegisterFierceDeityAnywhere() {
     if (actorHitBySwordBeamExtId == 0) {
         actorHitBySwordBeamExtId = ActorExtension_CreateForAll(sizeof(bool));
-
-        GameInteractor::Instance->RegisterGameHook<GameInteractor::OnActorInit>([](Actor* actor) {
-            bool* swordBeamCollisionFlag = (bool*)ActorExtension_Get(actor, actorHitBySwordBeamExtId);
-            if (swordBeamCollisionFlag == NULL) {
-                assert(false && "Actor Extension memory not valid");
-            }
-        });
     }
 
     COND_VB_SHOULD(VB_DISABLE_FD_MASK, CVAR, { *should = false; });
@@ -66,7 +66,6 @@ void RegisterFierceDeityAnywhere() {
         DamageTable* damageTable = va_arg(args, DamageTable*);
         u32* effect = va_arg(args, u32*);
         Actor* actor = va_arg(args, Actor*);
-        bool* swordBeamCollisionFlag = GetActorHitBySwordBeam(actor);
         /*
          * 25 is the index of the sword beam damage effect.
          */
@@ -82,14 +81,14 @@ void RegisterFierceDeityAnywhere() {
             } else {
                 *effect = defaultEffect;
             }
-            *swordBeamCollisionFlag = true;
+            SetActorHitBySwordBeam(actor, true);
         } else if (index != 9) {
             /*
              * 9 is the index of the sword damage effect. With how FD plays, it is possible for the sword to connect
              * after sword beams have dealt damage. Without this check, the damage effect would revert back to the
              * light arrows effect upon sword collision.
              */
-            *swordBeamCollisionFlag = false;
+            SetActorHitBySwordBeam(actor, false);
         }
     });
 
@@ -102,7 +101,7 @@ void RegisterFierceDeityAnywhere() {
     COND_VB_SHOULD(VB_USE_NULL_FOR_DRAW_DAMAGE_EFFECTS, CVAR, {
         Actor* actor = va_arg(args, Actor*);
         // Only change the call if there is a sword beam collision
-        if (*(GetActorHitBySwordBeam(actor))) {
+        if (GetActorHitBySwordBeam(actor)) {
             *should = false;
             Vec3f* bodyPartsPos = va_arg(args, Vec3f*);
             int bodyPartsCount = va_arg(args, int);
@@ -130,7 +129,7 @@ void RegisterFierceDeityAnywhere() {
      */
     COND_VB_SHOULD(VB_DRAW_DAMAGE_EFFECT, CVAR, {
         Actor* actor = va_arg(args, Actor*);
-        if (actor != nullptr && *(GetActorHitBySwordBeam(actor))) {
+        if (actor != nullptr && GetActorHitBySwordBeam(actor)) {
             u8* type = va_arg(args, u8*);
             if (*type == ACTOR_DRAW_DMGEFF_LIGHT_ORBS) {
                 *type = ACTOR_DRAW_DMGEFF_BLUE_LIGHT_ORBS;

--- a/mm/2s2h/Enhancements/Masks/FierceDeityAnywhere.cpp
+++ b/mm/2s2h/Enhancements/Masks/FierceDeityAnywhere.cpp
@@ -1,4 +1,5 @@
 #include <libultraship/bridge.h>
+#include "2s2h/ActorExtension/ActorExtension.h"
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 
@@ -13,13 +14,32 @@ extern "C" {
 #include "overlays/actors/ovl_En_Neo_Reeba/z_en_neo_reeba.h"
 }
 
-#define HIT_BY_SWORD_BEAM 1
-#define NOT_HIT_BY_SWORD_BEAM 0
+ActorExtensionId actorHitBySwordBeamExtId = 0;
 
 #define CVAR_NAME "gEnhancements.Masks.FierceDeitysAnywhere"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
+bool* GetActorHitBySwordBeam(Actor* actor) {
+    bool* swordBeamCollisionFlag = (bool*)ActorExtension_Get(actor, actorHitBySwordBeamExtId);
+    if (swordBeamCollisionFlag == NULL) {
+        return 0;
+    }
+
+    return swordBeamCollisionFlag;
+}
+
 void RegisterFierceDeityAnywhere() {
+    if (actorHitBySwordBeamExtId == 0) {
+        actorHitBySwordBeamExtId = ActorExtension_CreateForAll(sizeof(bool));
+
+        GameInteractor::Instance->RegisterGameHook<GameInteractor::OnActorInit>([](Actor* actor) {
+            bool* swordBeamCollisionFlag = (bool*)ActorExtension_Get(actor, actorHitBySwordBeamExtId);
+            if (swordBeamCollisionFlag == NULL) {
+                assert(false && "Actor Extension memory not valid");
+            }
+        });
+    }
+
     COND_VB_SHOULD(VB_DISABLE_FD_MASK, CVAR, { *should = false; });
 
     COND_VB_SHOULD(VB_DAMAGE_MULTIPLIER, CVAR, {
@@ -46,6 +66,7 @@ void RegisterFierceDeityAnywhere() {
         DamageTable* damageTable = va_arg(args, DamageTable*);
         u32* effect = va_arg(args, u32*);
         Actor* actor = va_arg(args, Actor*);
+        bool* swordBeamCollisionFlag = GetActorHitBySwordBeam(actor);
         /*
          * 25 is the index of the sword beam damage effect.
          */
@@ -61,19 +82,14 @@ void RegisterFierceDeityAnywhere() {
             } else {
                 *effect = defaultEffect;
             }
-            /*
-             * shape.face is unused for any actor besides the player. We are hijacking this because we need to have
-             * some variable connected to the specific actor to indicate that the damage they received comes from a
-             * sword beam. Each stage of the pipeline (update, draw) goes through all actors in a batch.
-             */
-            actor->shape.face = HIT_BY_SWORD_BEAM;
+            *swordBeamCollisionFlag = true;
         } else if (index != 9) {
             /*
              * 9 is the index of the sword damage effect. With how FD plays, it is possible for the sword to connect
              * after sword beams have dealt damage. Without this check, the damage effect would revert back to the
              * light arrows effect upon sword collision.
              */
-            actor->shape.face = NOT_HIT_BY_SWORD_BEAM;
+            *swordBeamCollisionFlag = false;
         }
     });
 
@@ -86,7 +102,7 @@ void RegisterFierceDeityAnywhere() {
     COND_VB_SHOULD(VB_USE_NULL_FOR_DRAW_DAMAGE_EFFECTS, CVAR, {
         Actor* actor = va_arg(args, Actor*);
         // Only change the call if there is a sword beam collision
-        if (actor->shape.face & HIT_BY_SWORD_BEAM) {
+        if (*(GetActorHitBySwordBeam(actor))) {
             *should = false;
             Vec3f* bodyPartsPos = va_arg(args, Vec3f*);
             int bodyPartsCount = va_arg(args, int);
@@ -114,7 +130,7 @@ void RegisterFierceDeityAnywhere() {
      */
     COND_VB_SHOULD(VB_DRAW_DAMAGE_EFFECT, CVAR, {
         Actor* actor = va_arg(args, Actor*);
-        if (actor != nullptr && actor->shape.face & HIT_BY_SWORD_BEAM) {
+        if (actor != nullptr && *(GetActorHitBySwordBeam(actor))) {
             u8* type = va_arg(args, u8*);
             if (*type == ACTOR_DRAW_DMGEFF_LIGHT_ORBS) {
                 *type = ACTOR_DRAW_DMGEFF_BLUE_LIGHT_ORBS;
@@ -128,9 +144,7 @@ void RegisterFierceDeityAnywhere() {
      */
     COND_VB_SHOULD(VB_CHECK_BUMPER_COLLISION, CVAR, {
         ColliderInfo* toucher = va_arg(args, ColliderInfo*);
-        ColliderInfo* bumper = va_arg(args, ColliderInfo*);
         if (toucher->toucher.dmgFlags & DMG_SWORD_BEAM) {
-            bumper->bumper.dmgFlags |= DMG_SWORD_BEAM;
             *should = false;
         }
     });
@@ -142,12 +156,16 @@ void RegisterFierceDeityAnywhere() {
     COND_VB_SHOULD(VB_PERFORM_AC_COLLISION, CVAR, {
         Collider* at = va_arg(args, Collider*);
         Collider* ac = va_arg(args, Collider*);
+        ColliderInfo* atInfo = va_arg(args, ColliderInfo*);
+        ColliderInfo* acInfo = va_arg(args, ColliderInfo*);
         /*
          * If the AT actor is EnMThunder with a subtype > ENMTHUNDER_SUBTYPE_SPIN_REGULAR, it is a sword beam. If the AC
-         * actor is not an enemy/boss, then do not handle the sword beam collision.
+         * actor is not an enemy/boss and does not normally collide with sword beams, then do not handle the sword beam
+         * collision.
          */
         if (at->actor->id == ACTOR_EN_M_THUNDER && ((EnMThunder*)at->actor)->subtype > 1 &&
-            ac->actor->category != ACTORCAT_ENEMY && ac->actor->category != ACTORCAT_BOSS) {
+            ac->actor->category != ACTORCAT_ENEMY && ac->actor->category != ACTORCAT_BOSS &&
+            !(acInfo->bumper.dmgFlags & DMG_SWORD_BEAM)) {
             *should = false;
         }
     });

--- a/mm/src/code/z_collision_check.c
+++ b/mm/src/code/z_collision_check.c
@@ -1639,7 +1639,7 @@ void CollisionCheck_SetBounce(Collider* at, Collider* ac) {
  */
 s32 CollisionCheck_SetATvsAC(PlayState* play, Collider* at, ColliderInfo* atInfo, Vec3f* atPos, Collider* ac,
                              ColliderInfo* acInfo, Vec3f* acPos, Vec3f* hitPos) {
-    if (!GameInteractor_Should(VB_PERFORM_AC_COLLISION, true, at, ac)) {
+    if (!GameInteractor_Should(VB_PERFORM_AC_COLLISION, true, at, ac, atInfo, acInfo)) {
         return 0;
     }
 


### PR DESCRIPTION
#993 over-corrected the sword beams to *only* collide with enemies, but some non-enemy actors in the game do normally collide with sword beams (signs, Skull Kid, pirate guards to name a few). This fix pulls back the sweeping damage flag changes and instead performs the collision if the actor is an enemy or already has the `DMG_SWORD_BEAM` flag as is.

This also seemed like a good opportunity to use the new actor extension functionality in lieu of piggybacking on some unused variables, so I did that too.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2801674260.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2801683813.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2801739394.zip)
<!--- section:artifacts:end -->