### PR TITLE
Change vector to array for some GUI textures

### DIFF
--- a/mm/2s2h/ShipUtils.cpp
+++ b/mm/2s2h/ShipUtils.cpp
@@ -45,7 +45,7 @@ std::unordered_map<s16, const char*> sceneNames = {
 #undef DEFINE_SCENE_UNSET
 
 // These textures are not in existing lists that we iterate over.
-std::vector<const char*> miscellaneousTextures = {
+std::array<const char*, 18> miscellaneousTextures = {
     gArcheryScoreIconTex,
     gBarrelTrackerIcon,
     gChestTrackerIcon,
@@ -66,9 +66,9 @@ std::vector<const char*> miscellaneousTextures = {
     gWorldMapOwlFaceTex,
 };
 
-std::vector<const char*> digitList = { gCounterDigit0Tex, gCounterDigit1Tex, gCounterDigit2Tex, gCounterDigit3Tex,
-                                       gCounterDigit4Tex, gCounterDigit5Tex, gCounterDigit6Tex, gCounterDigit7Tex,
-                                       gCounterDigit8Tex, gCounterDigit9Tex, gCounterColonTex };
+std::array<const char*, 11> digitList = { gCounterDigit0Tex, gCounterDigit1Tex, gCounterDigit2Tex, gCounterDigit3Tex,
+                                          gCounterDigit4Tex, gCounterDigit5Tex, gCounterDigit6Tex, gCounterDigit7Tex,
+                                          gCounterDigit8Tex, gCounterDigit9Tex, gCounterColonTex };
 
 extern "C" const char* Ship_GetSceneName(s16 sceneId) {
     if (sceneNames.contains(sceneId)) {
@@ -180,25 +180,23 @@ extern "C" s32 Ship_Random(s32 min, s32 max) {
 }
 
 void LoadGuiTextures() {
-    for (TexturePtr entry : gItemIcons) {
-        const char* path = static_cast<const char*>(entry);
+    for (const TexturePtr entry : gItemIcons) {
+        auto path = static_cast<const char*>(entry);
         Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadGuiTexture(path, path, ImVec4(1, 1, 1, 1));
     }
-    for (TexturePtr entry : gQuestIcons) {
-        const char* path = static_cast<const char*>(entry);
+    for (const TexturePtr entry : gQuestIcons) {
+        auto path = static_cast<const char*>(entry);
         Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadGuiTexture(path, path, ImVec4(1, 1, 1, 1));
     }
-    for (TexturePtr entry : gBombersNotebookPhotos) {
-        const char* path = static_cast<const char*>(entry);
+    for (const TexturePtr entry : gBombersNotebookPhotos) {
+        auto path = static_cast<const char*>(entry);
         Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadGuiTexture(path, path, ImVec4(1, 1, 1, 1));
     }
-    for (auto& entry : miscellaneousTextures) {
-        const char* path = static_cast<const char*>(entry);
-        Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadGuiTexture(path, path, ImVec4(1, 1, 1, 1));
+    for (const auto entry : miscellaneousTextures) {
+        Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadGuiTexture(entry, entry, ImVec4(1, 1, 1, 1));
     }
-    for (auto& entry : digitList) {
-        const char* path = static_cast<const char*>(entry);
-        Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadGuiTexture(path, path, ImVec4(1, 1, 1, 1));
+    for (const auto entry : digitList) {
+        Ship::Context::GetInstance()->GetWindow()->GetGui()->LoadGuiTexture(entry, entry, ImVec4(1, 1, 1, 1));
     }
 }
 

--- a/mm/2s2h/ShipUtils.h
+++ b/mm/2s2h/ShipUtils.h
@@ -8,7 +8,7 @@
 
 void LoadGuiTextures();
 std::string convertEnumToReadableName(const std::string& input);
-extern std::vector<const char*> digitList;
+extern std::array<const char*, 11> digitList;
 
 extern "C" {
 #endif


### PR DESCRIPTION
Since its known what size these are at compile time there is no reason to use a vector.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2802007535.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2802016392.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2802056374.zip)
<!--- section:artifacts:end -->