### PR TITLE
Fix typo in DX shader

### DIFF
--- a/mm/assets/custom/shaders/directx/default.shader.hlsl
+++ b/mm/assets/custom/shaders/directx/default.shader.hlsl
@@ -224,7 +224,7 @@ float4 PSMain(PSInput input, float4 screenSpace : SV_Position) : SV_TARGET {
                         @else
                             float4 blendVal@{i} = float4(0, 0, 0, 0);
                         @end
-                        texval@{i} = lerp(texVal@{i}, blendVal@{i}, g_textureMask@{i}.Sample(g_sampler@{i}, tc@{i}).a);
+                        texVal@{i} = lerp(texVal@{i}, blendVal@{i}, g_textureMask@{i}.Sample(g_sampler@{i}, tc@{i}).a);
                     @end
                 }
             @else


### PR DESCRIPTION
Fix typo in DX shader

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2804976228.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2804977992.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2805001474.zip)
<!--- section:artifacts:end -->