### PR TITLE
Fix incorrect directx shader condition for texture coordinates

### DIFF
--- a/mm/assets/custom/shaders/directx/default.shader.hlsl
+++ b/mm/assets/custom/shaders/directx/default.shader.hlsl
@@ -186,7 +186,7 @@ float4 PSMain(PSInput input, float4 screenSpace : SV_Position) : SV_TARGET {
             float2 tc@{i} = input.uv@{i};
             @{s = o_clamp[i][0]}
             @{t = o_clamp[i][1]}
-            @if(s && t)
+            @if(s || t)
                 int2 texSize@{i};
                 g_texture@{i}.GetDimensions(texSize@{i}.x, texSize@{i}.y);
                 @if(s && t)


### PR DESCRIPTION
Fix incorrect directx shader condition for texture coordinates. Fixes the strange epona hair for example.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2812884100.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2812885696.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2812913290.zip)
<!--- section:artifacts:end -->