### PR TITLE
[Rando] Add damage requirements to Ghost Hut logic

### DIFF
--- a/mm/2s2h/Rando/Logic/Regions/East.cpp
+++ b/mm/2s2h/Rando/Logic/Regions/East.cpp
@@ -95,7 +95,9 @@ static RegisterShipInitFunc initFunc([]() {
     };
     Regions[RR_GHOST_HUT] = RandoRegion{ .sceneId = SCENE_TOUGITES,
         .checks = {
-            CHECK(RC_IKANA_CANYON_GHOST_HUT_PIECE_OF_HEART, CHECK_MAX_HP(4)),
+            // The first three sisters can be damaged with almost anything, but Meg requires ranged attacks.
+            // Not using CAN_USE_EXPLOSIVE here, as the Blast Mask cannot reach, and the Powder Keg can only be used once.
+            CHECK(RC_IKANA_CANYON_GHOST_HUT_PIECE_OF_HEART, CHECK_MAX_HP(4) && (CAN_USE_PROJECTILE || HAS_ITEM(ITEM_BOMB) || HAS_ITEM(ITEM_BOMBCHU))),
         },
         .exits = { //     TO                                         FROM
             EXIT(ENTRANCE(IKANA_CANYON, 1),                 ENTRANCE(GHOST_HUT, 0), true),


### PR DESCRIPTION
The last Poe sister can only be damaged from afar, which was not reflected in logic.

- Projectiles work (arrows, hookshot, Deku bubbles, Zora boomerangs)
- Bombs and bombchus can work with timing and/or luring Meg within range
- The Blast Mask does not have the necessary range
- The Powder Keg can damage her once, but since you can only hold one at a time, it's not enough to finish the job

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2816590667.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2816604620.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2816674346.zip)
<!--- section:artifacts:end -->