### PR TITLE
Fix torch lighting bug with one point skips

### DIFF
--- a/mm/2s2h/Enhancements/Cutscenes/SkipOnePointCutscenes.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/SkipOnePointCutscenes.cpp
@@ -38,6 +38,14 @@ void RegisterSkipOnePointCutscenes() {
                 }
 
                 ObjSyokudai* torch = (ObjSyokudai*)actor;
+                s32 switchFlag = OBJ_SYOKUDAI_GET_SWITCH_FLAG(actor);
+
+                // Set the flag if needed
+                if (torch->pendingAction >= OBJ_SYOKUDAI_PENDING_ACTION_CUTSCENE_AND_SWITCH) {
+                    Flags_SetSwitch(gPlayState, switchFlag);
+                }
+
+                torch->pendingAction = OBJ_SYOKUDAI_PENDING_ACTION_NONE;
                 torch->snuffTimer = OBJ_SYOKUDAI_SNUFF_NEVER;
                 *should = false;
                 break;

--- a/mm/2s2h/Enhancements/Cutscenes/SkipOnePointCutscenes.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/SkipOnePointCutscenes.cpp
@@ -32,11 +32,6 @@ void RegisterSkipOnePointCutscenes() {
 
         switch (actor->id) {
             case ACTOR_OBJ_SYOKUDAI: { // Torch
-                if (gPlayState->sceneId == SCENE_33ZORACITY) {
-                    // Currently this softlocks you, making you unable to interact with any actors
-                    break;
-                }
-
                 ObjSyokudai* torch = (ObjSyokudai*)actor;
                 s32 switchFlag = OBJ_SYOKUDAI_GET_SWITCH_FLAG(actor);
 


### PR DESCRIPTION
With onepoint skips enabled, torches where getting stuck in a update loop with playing the cutscene over and over (which got skipped over and over), we were already setting the snuff timer value, but not the pendingAction value to get the torch out of the cutscene state.

This applies the pendingAction fix, and also replicated the switch flag set in the skip as now that wont execute in vanilla.

Fixes #1016

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2842627540.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2842630670.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2842658262.zip)
<!--- section:artifacts:end -->