### PR TITLE
[Rando] Fix free roam behavior with Romani reward

### DIFF
--- a/mm/2s2h/Rando/ActorBehavior/ActorBehavior.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ActorBehavior.cpp
@@ -92,6 +92,7 @@ void Rando::ActorBehavior::OnFileLoad() {
     Rando::ActorBehavior::InitEnGsBehavior();
     Rando::ActorBehavior::InitEnHgBehavior();
     Rando::ActorBehavior::InitEnInBehavior();
+    Rando::ActorBehavior::InitEnInvadepohBehavior();
     Rando::ActorBehavior::InitEnItem00Behavior();
     Rando::ActorBehavior::InitEnJgameTsnBehavior();
     Rando::ActorBehavior::InitEnJgBehavior();

--- a/mm/2s2h/Rando/ActorBehavior/ActorBehavior.h
+++ b/mm/2s2h/Rando/ActorBehavior/ActorBehavior.h
@@ -48,6 +48,7 @@ void InitEnGoBehavior();
 void InitEnGsBehavior();
 void InitEnHgBehavior();
 void InitEnInBehavior();
+void InitEnInvadepohBehavior();
 void InitEnItem00Behavior();
 void InitEnJgameTsnBehavior();
 void InitEnJgBehavior();

--- a/mm/2s2h/Rando/ActorBehavior/EnInvadepoh.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnInvadepoh.cpp
@@ -1,0 +1,18 @@
+#include "ActorBehavior.h"
+#include <libultraship/libultraship.h>
+
+void Rando::ActorBehavior::InitEnInvadepohBehavior() {
+    // This is the same block found for non-scripted actors in OfferGetItem.cpp, but without Player_TalkWithPlayer().
+    COND_VB_SHOULD(VB_GIVE_ITEM_FROM_OFFER, IS_RANDO, {
+        GetItemId* item = va_arg(args, GetItemId*);
+        Actor* actor = va_arg(args, Actor*);
+        if (actor->id == ACTOR_EN_INVADEPOH) { // Romani Ranch invasion actor
+            *should = false;
+            Player* player = GET_PLAYER(gPlayState);
+            actor->parent = &player->actor;
+            player->talkActor = actor;
+            player->talkActorDistance = actor->xzDistToPlayer;
+            player->exchangeItemAction = PLAYER_IA_MINUS1;
+        }
+    });
+}

--- a/mm/2s2h/Rando/MiscBehavior/OfferGetItem.cpp
+++ b/mm/2s2h/Rando/MiscBehavior/OfferGetItem.cpp
@@ -53,7 +53,6 @@ void Rando::MiscBehavior::InitOfferGetItemBehavior() {
                 actor->textId = 0x2AD1;
                 [[fallthrough]];
             case ACTOR_EN_DNO:
-            case ACTOR_EN_INVADEPOH:
             case ACTOR_EN_JS:
             case ACTOR_EN_KENDO_JS:
             case ACTOR_EN_GURUGURU:


### PR DESCRIPTION
The general catch-all in `OfferGetItem.cpp` doesn't play well with the Romani Ranch stop invasion reward, allowing the player to roam freely when Romani is talking. This fixes that.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2848006018.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2848010876.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2848034872.zip)
<!--- section:artifacts:end -->