### PR TITLE
Bump LUS and adjust fullscreen option

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -226,10 +226,9 @@ void BenMenu::AddSettings() {
     // Graphics Settings
     path.sidebarName = "Graphics";
     AddSidebarEntry("Settings", "Graphics", 3);
-    AddWidget(path, "Toggle Fullscreen", WIDGET_CVAR_CHECKBOX)
-        .CVar("gSettings.Fullscreen")
+    AddWidget(path, "Toggle Fullscreen", WIDGET_BUTTON)
         .Callback([](WidgetInfo& info) { Ship::Context::GetInstance()->GetWindow()->ToggleFullscreen(); })
-        .Options(CheckboxOptions().Tooltip("Toggles Fullscreen On/Off."));
+        .Options(ButtonOptions().Tooltip("Toggles Fullscreen On/Off."));
     AddWidget(path, "Internal Resolution: %.0f%%", WIDGET_CVAR_SLIDER_FLOAT)
         .CVar(CVAR_INTERNAL_RESOLUTION)
         .Callback([](WidgetInfo& info) {

--- a/mm/CMakeLists.txt
+++ b/mm/CMakeLists.txt
@@ -407,8 +407,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
             -Wno-missing-braces
             $<$<COMPILE_LANGUAGE:C>:
                 #-Werror-implicit-function-declaration
-                -Wno-discarded-array-qualifiers
-                -Wno-discarded-qualifiers
+                -Wno-ignored-qualifiers
                 -Wno-incompatible-pointer-types
                 -Wno-int-conversion
             >


### PR DESCRIPTION
Bumps LUS to latest main with its fixes
Includes the change to the menu to have fullscreen be a button instead of a cvar toggle
Also fixes an unknown compiler option for apple clang

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2853657541.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2853712574.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2853848665.zip)
<!--- section:artifacts:end -->