### PR TITLE
ZeldaArena malloc/free fix

### DIFF
--- a/mm/src/code/z_skelanime.c
+++ b/mm/src/code/z_skelanime.c
@@ -2122,6 +2122,11 @@ void SkelAnime_Free(SkelAnime* skelAnime, PlayState* play) {
     if (skelAnime->morphTable != NULL) {
         ZeldaArena_Free(skelAnime->morphTable);
     }
+
+    if (skelAnime->extraJointTable != NULL) {
+        ZeldaArena_Free(skelAnime->extraJointTable);
+    }
+
     ResourceMgr_UnregisterSkeleton(skelAnime);
 }
 


### PR DESCRIPTION
Adds a missing free for the extraJoinTable added by #1061 

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2856269903.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2856272784.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2856298584.zip)
<!--- section:artifacts:end -->