### PR TITLE
[Rando] Fix Ghost Hut reward textbox bug

### DIFF
--- a/mm/2s2h/Rando/ActorBehavior/EnGb2.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnGb2.cpp
@@ -30,6 +30,11 @@ void Rando::ActorBehavior::InitEnGb2Behavior() {
         player->talkActorDistance = refActor->xzDistToPlayer;
         player->exchangeItemAction = PLAYER_IA_MINUS1;
         Player_TalkWithPlayer(gPlayState, refActor);
+        /*
+         * This actor sets MSGMODE_TEXT_CLOSING state and expects GI to set it back to MSGMODE_TEXT_START. Because the
+         * GI is skipped, we manually start the textbox to prevent the player from being able to move during dialog.
+         */
+        Message_StartTextbox(gPlayState, 0x14DE, refActor);
     });
 
     COND_ID_HOOK(OnOpenText, 0x14D1, IS_RANDO, [](u16* textId, bool* loadFromMessageTable) {


### PR DESCRIPTION
Similar to #1101, the player can freely move during the textboxes when rando skips the Ghost Hut reward GI. This actor seems to manually set the message state to closing and expects the GI to set it back to the start state. Since the GI gets skipped in rando, the textbox state needs reset manually.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2882518529.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2882519071.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2882561858.zip)
<!--- section:artifacts:end -->