### PR TITLE
[Rando] Fix minor issues with Ballad check

### DIFF
--- a/mm/2s2h/Rando/ActorBehavior/EnToto.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnToto.cpp
@@ -3,7 +3,8 @@
 
 extern "C" {
 #include "variables.h"
-#include "src/overlays/actors/ovl_En_Fu/z_en_fu.h"
+#include "src/overlays/actors/ovl_En_Toto/z_en_toto.h"
+extern void func_80BA36C0(EnToto* enToto, PlayState* play, s32 index);
 }
 
 void Rando::ActorBehavior::InitEnTotoBehavior() {
@@ -23,5 +24,18 @@ void Rando::ActorBehavior::InitEnTotoBehavior() {
         player->talkActor = refActor;
         player->talkActorDistance = refActor->xzDistToPlayer;
         player->exchangeItemAction = PLAYER_IA_MINUS1;
+        func_80BA36C0((EnToto*)refActor, gPlayState, 0); // Advance Toto to "Wanna play again?" state
+    });
+
+    /*
+     * "Please take my mask"
+     * Notebook events usually pop by immediately following a textbox. Since the Get Item animation is at the tail end
+     * of a cutscene, and the player may have GI animations skipped, there is no subsequent textbox to trigger notebook
+     * events. So, we queue the relevant notebook events manually with the final textbox of the cutscene.
+     */
+    COND_ID_HOOK(OnOpenText, 0x2B3B, IS_RANDO, [](u16* textId, bool* loadFromMessageTable) {
+        Message_BombersNotebookQueueEvent(gPlayState, BOMBERS_NOTEBOOK_EVENT_RECEIVED_CIRCUS_LEADERS_MASK);
+        Message_BombersNotebookQueueEvent(gPlayState, BOMBERS_NOTEBOOK_EVENT_MET_TOTO);
+        Message_BombersNotebookQueueEvent(gPlayState, BOMBERS_NOTEBOOK_EVENT_MET_GORMAN);
     });
 }


### PR DESCRIPTION
Actors would be left in a partial state with the Ballad of the Windfish check with GI animations skipped, such as Toto being unable to be interacted with. This fix advances him to his proper post-Ballad state. Additionally, notebook events would not fire with GIs skipped, so I handled that too.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2890777461.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2890777595.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2890794596.zip)
<!--- section:artifacts:end -->