### PR TITLE
[Rando] Fix snowball drops when not shuffled

### DIFF
--- a/mm/2s2h/Rando/ActorBehavior/ObjSnowball.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ObjSnowball.cpp
@@ -139,18 +139,23 @@ std::map<std::pair<float, float>, RandoCheckId> snowballCoordsMap = {
 // snowballs is inconsistent based on the day, so we fallback to the coords which are consistent
 void IdentifySnowball(Actor* actor, bool* should) {
     s16 actorListIndex = GetActorListIndex(actor);
+    RandoCheckId randoCheckId = RC_UNKNOWN;
 
     auto it = snowballActorIdMap.find({ gPlayState->sceneId, gPlayState->roomCtx.curRoom.num, actorListIndex });
     if (it != snowballActorIdMap.end()) {
-        Rando::ActorBehavior::SetActorRandoCheckId(actor, it->second);
+        randoCheckId = it->second;
+    } else {
+        auto it2 = snowballCoordsMap.find({ actor->home.pos.x, actor->home.pos.z });
+        if (it2 != snowballCoordsMap.end()) {
+            randoCheckId = it2->second;
+        }
+    }
+
+    if (!RANDO_SAVE_CHECKS[randoCheckId].shuffled || RANDO_SAVE_CHECKS[randoCheckId].cycleObtained) {
         return;
     }
 
-    auto it2 = snowballCoordsMap.find({ actor->home.pos.x, actor->home.pos.z });
-    if (it2 != snowballCoordsMap.end()) {
-        Rando::ActorBehavior::SetActorRandoCheckId(actor, it2->second);
-        return;
-    }
+    Rando::ActorBehavior::SetActorRandoCheckId(actor, randoCheckId);
 }
 
 void SpawnSnowballDrop(Vec3f pos, RandoCheckId randoCheckId) {


### PR DESCRIPTION
Snowballs weren't checking the `shuffled` flag like other mundane drops do when identifying the particular check, leading them to drop RI junk when not shuffled instead of regular items.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2891283230.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2891285556.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2891305201.zip)
<!--- section:artifacts:end -->