### PR TITLE
Fast bank selection fix

### DIFF
--- a/mm/2s2h/Enhancements/Dialogue/FastBankSelection.cpp
+++ b/mm/2s2h/Enhancements/Dialogue/FastBankSelection.cpp
@@ -49,6 +49,10 @@ void OnEnGinkoManUpdate(Actor* actor) {
                     maxWallet = (99 - currentRupees);
                     break;
             }
+
+            uint32_t bankRupees = HS_GET_BANK_RUPEES();
+            maxWallet = bankRupees < maxWallet ? bankRupees : maxWallet;
+
             if (maxWallet != 0 && gPlayState->msgCtx.bankRupeesSelected != maxWallet) {
                 char firstChar = (maxWallet / 100) + '0';
                 char secondChar = ((maxWallet / 10) % 10) + '0';

--- a/mm/2s2h/Enhancements/Dialogue/FastBankSelection.cpp
+++ b/mm/2s2h/Enhancements/Dialogue/FastBankSelection.cpp
@@ -50,8 +50,7 @@ void OnEnGinkoManUpdate(Actor* actor) {
                     break;
             }
 
-            uint32_t bankRupees = HS_GET_BANK_RUPEES();
-            maxWallet = bankRupees < maxWallet ? bankRupees : maxWallet;
+            maxWallet = MIN(maxWallet, HS_GET_BANK_RUPEES());
 
             if (maxWallet != 0 && gPlayState->msgCtx.bankRupeesSelected != maxWallet) {
                 char firstChar = (maxWallet / 100) + '0';


### PR DESCRIPTION
When using fast bank selection, keeps the player from attempting to withdraw more than is in the bank.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2906408442.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2906411299.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2906470013.zip)
<!--- section:artifacts:end -->