### PR TITLE
Clear flags on boot to warp

### DIFF
--- a/mm/2s2h/DeveloperTools/BetterMapSelect.c
+++ b/mm/2s2h/DeveloperTools/BetterMapSelect.c
@@ -185,17 +185,21 @@ void BetterMapSelect_LoadGame(MapSelectState* mapSelectState, u32 entrance, s32 
             if (spawn >= 0 && spawn < ARRAY_COUNT(sBetterMapSelectGrottoInfo)) {
                 grotto = sBetterMapSelectGrottoInfo[spawn];
             }
-        } else if (entrance == ENTRANCE(GROTTOS, 4)) {
-            if (spawn >= 0 && spawn < ARRAY_COUNT(sBetterMapSelectChestGrottoInfo)) {
-                grotto = sBetterMapSelectChestGrottoInfo[spawn];
-            }
-        } else if (entrance == ENTRANCE(GROTTOS, 10)) {
-            if (spawn >= 0 && spawn < ARRAY_COUNT(sBetterMapSelectCowGrottoInfo)) {
-                grotto = sBetterMapSelectCowGrottoInfo[spawn];
+        } else {
+            // Chest/cow grotto selection uses a special list and changes the meaning of the `spawn` value,
+            // so we need to set entrance back to the value one
+            gSaveContext.save.entrance = entrance;
+
+            if (entrance == ENTRANCE(GROTTOS, 4)) { // Chests
+                if (spawn >= 0 && spawn < ARRAY_COUNT(sBetterMapSelectChestGrottoInfo)) {
+                    grotto = sBetterMapSelectChestGrottoInfo[spawn];
+                }
+            } else if (entrance == ENTRANCE(GROTTOS, 10)) { // Cows
+                if (spawn >= 0 && spawn < ARRAY_COUNT(sBetterMapSelectCowGrottoInfo)) {
+                    grotto = sBetterMapSelectCowGrottoInfo[spawn];
+                }
             }
         }
-
-        gSaveContext.save.entrance = entrance;
 
         // Set player void out location
         gSaveContext.respawn[RESPAWN_MODE_DOWN].data = grotto.downRespawn.data;

--- a/mm/2s2h/DeveloperTools/WarpPoint.cpp
+++ b/mm/2s2h/DeveloperTools/WarpPoint.cpp
@@ -46,6 +46,21 @@ void Warp() {
         gSaveContext.save.cutsceneIndex = 0;
         gSaveContext.save.playerForm = PLAYER_FORM_HUMAN;
         gSaveContext.save.linkAge = 0;
+
+        // Need to unset flag values that are outside of `.save`
+        // Normally would happened in the MapSelect_LoadGame, but is skipped because of the dummy file num below
+        // This is mostly copied from Sram_OpenSave.
+        for (size_t i = 0; i < ARRAY_COUNT(gSaveContext.eventInf); i++) {
+            gSaveContext.eventInf[i] = 0;
+        }
+        for (int i = 0; i < ARRAY_COUNT(gSaveContext.cycleSceneFlags); i++) {
+            gSaveContext.cycleSceneFlags[i].chest = gSaveContext.save.saveInfo.permanentSceneFlags[i].chest;
+            gSaveContext.cycleSceneFlags[i].switch0 = gSaveContext.save.saveInfo.permanentSceneFlags[i].switch0;
+            gSaveContext.cycleSceneFlags[i].switch1 = gSaveContext.save.saveInfo.permanentSceneFlags[i].switch1;
+            gSaveContext.cycleSceneFlags[i].clearedRoom = gSaveContext.save.saveInfo.permanentSceneFlags[i].clearedRoom;
+            gSaveContext.cycleSceneFlags[i].collectible = gSaveContext.save.saveInfo.permanentSceneFlags[i].collectible;
+        }
+
         // Using dummy file num to bypass debug save setup in map select and manually execute save init/load hooks after
         gSaveContext.fileNum = 0xFE;
         MapSelect_LoadGame((MapSelectState*)gGameState, entrance, 0);


### PR DESCRIPTION
This clears some flags that are outside of the `memset` of `.save` during boot to warp to ensure everything is cleared. This normally was happening as part of the MapSelect_LoadGame, but only when the save file is `0xFF`, which we had to hijack to a dummy value of `0xFE` for handling rando setup.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2943232402.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2943234558.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2943294682.zip)
<!--- section:artifacts:end -->