### PR TITLE
Bump LUS with GFXPC refactor

### DIFF
--- a/mm/2s2h/BenGui/BenGui.cpp
+++ b/mm/2s2h/BenGui/BenGui.cpp
@@ -3,7 +3,6 @@
 #include <spdlog/spdlog.h>
 #include <imgui.h>
 #include <imgui_internal.h>
-#include <Fast3D/gfx_pc.h>
 #include "UIWidgets.hpp"
 #include "HudEditor.h"
 #include "2s2h/Enhancements/Audio/AudioEditor.h"

--- a/mm/2s2h/BenGui/ResolutionEditor.cpp
+++ b/mm/2s2h/BenGui/ResolutionEditor.cpp
@@ -2,7 +2,8 @@
 #include <imgui.h>
 
 #include <BenGui/UIWidgets.hpp>
-#include <graphic/Fast3D/gfx_pc.h>
+#include <graphic/Fast3D/Fast3dWindow.h>
+#include <graphic/Fast3D/interpreter.h>
 #include "2s2h/BenPort.h"
 #include "2s2h/BenGui/BenMenu.h"
 
@@ -84,15 +85,30 @@ static bool disabled_pixelCount;
 
 using namespace UIWidgets;
 
+static std::weak_ptr<Fast::Interpreter> mInterpreter;
+
+std::shared_ptr<Fast::Interpreter> GetInterpreter() {
+    auto intP = mInterpreter.lock();
+    if (!intP) {
+        assert(false && "Lost reference to Fast::Interpreter");
+    }
+    return intP;
+}
+
 void RegisterResolutionWidgets() {
+    auto fastWnd = dynamic_pointer_cast<Fast::Fast3dWindow>(Ship::Context::GetInstance()->GetWindow());
+    mInterpreter = fastWnd->GetInterpreterWeak();
+
     WidgetPath path = { "Settings", "Graphics", 2 };
 
     // Resolution visualiser
     mBenMenu->AddWidget(path, "Viewport dimensions: {} x {}", WIDGET_TEXT).PreFunc([](WidgetInfo& info) {
+        auto gfx_current_game_window_viewport = GetInterpreter().get()->mGameWindowViewport;
         info.name = fmt::format("Viewport dimensions: {} x {}", gfx_current_game_window_viewport.width,
                                 gfx_current_game_window_viewport.height);
     });
     mBenMenu->AddWidget(path, "Internal resolution: {} x {}", WIDGET_TEXT).PreFunc([](WidgetInfo& info) {
+        auto gfx_current_dimensions = GetInterpreter().get()->mCurDimensions;
         info.name =
             fmt::format("Internal resolution: {} x {}", gfx_current_dimensions.width, gfx_current_dimensions.height);
     });
@@ -153,6 +169,8 @@ void RegisterResolutionWidgets() {
         })
         .Options(ComboboxOptions().ComboMap(aspectRatioPresetLabels));
     mBenMenu->AddWidget(path, "AspectRationCustom", WIDGET_CUSTOM).CustomFunction([](WidgetInfo& info) {
+        auto gfx_current_dimensions = GetInterpreter().get()->mCurDimensions;
+
         // Hide aspect ratio input fields if using one of the presets.
         if (item_aspectRatio == default_aspectRatio && !showHorizontalResField) {
             // Declare input interaction bools outside of IF statement to prevent Y field from disappearing.
@@ -451,6 +469,9 @@ void RegisterResolutionWidgets() {
 }
 
 void UpdateResolutionVars() {
+    auto gfx_current_game_window_viewport = GetInterpreter().get()->mGameWindowViewport;
+    auto gfx_current_dimensions = GetInterpreter().get()->mCurDimensions;
+
     // Clamp and update the cvars that don't use UIWidgets
     if (update[UPDATE_aspectRatioX] || update[UPDATE_aspectRatioY] || update[UPDATE_verticalPixelCount]) {
         if (update[UPDATE_aspectRatioX]) {

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -28,7 +28,7 @@
 #include <nlohmann/json.hpp>
 #include "build.h"
 
-#include <Fast3D/gfx_pc.h>
+#include <Fast3D/interpreter.h>
 #include <Fast3D/gfx_rendering_api.h>
 
 #ifdef __APPLE__
@@ -1201,7 +1201,7 @@ extern "C" char* ResourceMgr_LoadPlayerAnimByName(const char* animPath) {
 }
 
 extern "C" void ResourceMgr_PushCurrentDirectory(char* path) {
-    gfx_push_current_dir(path);
+    Fast::gfx_push_current_dir(path);
 }
 
 extern "C" Gfx* ResourceMgr_LoadGfxByName(const char* path) {
@@ -1735,26 +1735,68 @@ extern "C" void OTRControllerCallback(uint8_t rumble) {
 }
 
 extern "C" float OTRGetAspectRatio() {
-    return gfx_current_dimensions.aspect_ratio;
+    return Ship::Context::GetInstance()->GetWindow()->GetAspectRatio();
 }
 
 extern "C" float OTRGetDimensionFromLeftEdge(float v) {
+    auto fastWnd = dynamic_pointer_cast<Fast::Fast3dWindow>(Ship::Context::GetInstance()->GetWindow());
+    auto intP = fastWnd->GetInterpreterWeak().lock();
+
+    if (!intP) {
+        assert(false && "Lost reference to Fast::Interpreter");
+        return v;
+    }
+
+    auto gfx_native_dimensions = intP->mNativeDimensions;
+
     return (gfx_native_dimensions.width / 2 - gfx_native_dimensions.height / 2 * OTRGetAspectRatio() + (v));
 }
 
 extern "C" float OTRGetDimensionFromRightEdge(float v) {
+    auto fastWnd = dynamic_pointer_cast<Fast::Fast3dWindow>(Ship::Context::GetInstance()->GetWindow());
+    auto intP = fastWnd->GetInterpreterWeak().lock();
+
+    if (!intP) {
+        assert(false && "Lost reference to Fast::Interpreter");
+        return v;
+    }
+
+    auto gfx_native_dimensions = intP->mNativeDimensions;
+
     return (gfx_native_dimensions.width / 2 + gfx_native_dimensions.height / 2 * OTRGetAspectRatio() -
             (gfx_native_dimensions.width - v));
 }
 
 // Gets the width of the current render target area
 extern "C" uint32_t OTRGetGameRenderWidth() {
-    return gfx_current_dimensions.width;
+    auto fastWnd = dynamic_pointer_cast<Fast::Fast3dWindow>(Ship::Context::GetInstance()->GetWindow());
+    auto intP = fastWnd->GetInterpreterWeak().lock();
+
+    if (!intP) {
+        assert(false && "Lost reference to Fast::Interpreter");
+        return 320;
+    }
+
+    uint32_t height, width;
+    intP->GetCurDimensions(&width, &height);
+
+    return width;
 }
 
 // Gets the height of the current render target area
 extern "C" uint32_t OTRGetGameRenderHeight() {
-    return gfx_current_dimensions.height;
+    auto fastWnd = dynamic_pointer_cast<Fast::Fast3dWindow>(Ship::Context::GetInstance()->GetWindow());
+    auto intP = fastWnd->GetInterpreterWeak().lock();
+
+    if (!intP) {
+        assert(false && "Lost reference to Fast::Interpreter");
+        return 240;
+    }
+
+    uint32_t height, width;
+    intP->GetCurDimensions(&width, &height);
+
+    return height;
 }
 
 f32 floorf(f32 x);
@@ -1784,9 +1826,17 @@ Calling with Y (1,1) will return 10
 . . . _ _ _ _ _ _ _ _ . . .
 */
 extern "C" int32_t OTRConvertHUDXToScreenX(int32_t v) {
-    float gameAspectRatio = gfx_current_dimensions.aspect_ratio;
-    int32_t gameHeight = gfx_current_dimensions.height;
-    int32_t gameWidth = gfx_current_dimensions.width;
+    auto fastWnd = dynamic_pointer_cast<Fast::Fast3dWindow>(Ship::Context::GetInstance()->GetWindow());
+    auto intP = fastWnd->GetInterpreterWeak().lock();
+
+    if (!intP) {
+        assert(false && "Lost reference to Fast::Interpreter");
+        return v;
+    }
+
+    uint32_t gameHeight, gameWidth;
+    float gameAspectRatio = fastWnd->GetAspectRatio();
+    intP->GetCurDimensions(&gameWidth, &gameHeight);
     float hudAspectRatio = 4.0f / 3.0f;
     int32_t hudHeight = gameHeight;
     int32_t hudWidth = hudHeight * hudAspectRatio;
@@ -1803,11 +1853,23 @@ extern "C" int32_t OTRConvertHUDXToScreenX(int32_t v) {
 }
 
 extern "C" void Gfx_RegisterBlendedTexture(const char* name, u8* mask, u8* replacement) {
-    gfx_register_blended_texture(name, mask, replacement);
+    if (auto intP = dynamic_pointer_cast<Fast::Fast3dWindow>(Ship::Context::GetInstance()->GetWindow())
+                        ->GetInterpreterWeak()
+                        .lock()) {
+        intP->RegisterBlendedTexture(name, mask, replacement);
+    } else {
+        assert(false && "Lost reference to Fast::Interpreter");
+    }
 }
 
 extern "C" void Gfx_UnregisterBlendedTexture(const char* name) {
-    gfx_unregister_blended_texture(name);
+    if (auto intP = dynamic_pointer_cast<Fast::Fast3dWindow>(Ship::Context::GetInstance()->GetWindow())
+                        ->GetInterpreterWeak()
+                        .lock()) {
+        intP->UnregisterBlendedTexture(name);
+    } else {
+        assert(false && "Lost reference to Fast::Interpreter");
+    }
 }
 
 extern "C" void Gfx_TextureCacheDelete(const uint8_t* texAddr) {
@@ -1821,7 +1883,13 @@ extern "C" void Gfx_TextureCacheDelete(const uint8_t* texAddr) {
         texAddr = (const uint8_t*)ResourceGetDataByName(imgName);
     }
 
-    gfx_texture_cache_delete(texAddr);
+    if (auto intP = dynamic_pointer_cast<Fast::Fast3dWindow>(Ship::Context::GetInstance()->GetWindow())
+                        ->GetInterpreterWeak()
+                        .lock()) {
+        intP->TextureCacheDelete(texAddr);
+    } else {
+        assert(false && "Lost reference to Fast::Interpreter");
+    }
 }
 
 extern "C" int AudioPlayer_Buffered(void) {

--- a/mm/2s2h/resource/importer/ArrayFactory.cpp
+++ b/mm/2s2h/resource/importer/ArrayFactory.cpp
@@ -19,7 +19,7 @@ ResourceFactoryBinaryArrayV0::ReadResource(std::shared_ptr<Ship::File> file,
     for (uint32_t i = 0; i < array->ArrayCount; i++) {
         if (array->ArrayType == ArrayResourceType::Vertex) {
             // OTRTODO: Implement Vertex arrays as just a vertex resource.
-            F3DVtx data;
+            Fast::F3DVtx data;
             data.v.ob[0] = reader->ReadInt16();
             data.v.ob[1] = reader->ReadInt16();
             data.v.ob[2] = reader->ReadInt16();

--- a/mm/2s2h/resource/type/Array.cpp
+++ b/mm/2s2h/resource/type/Array.cpp
@@ -24,7 +24,7 @@ size_t Array::GetPointerSize() {
     size_t typeSize = 0;
     switch (ArrayType) {
         case ArrayResourceType::Vertex:
-            typeSize = sizeof(F3DVtx);
+            typeSize = sizeof(Fast::F3DVtx);
             break;
         case ArrayResourceType::Scalar:
         default:

--- a/mm/2s2h/resource/type/Array.h
+++ b/mm/2s2h/resource/type/Array.h
@@ -2,7 +2,10 @@
 
 #include "Resource.h"
 
+namespace Fast {
 union F3DVtx;
+}
+
 namespace SOH {
 typedef union ScalarData {
     uint8_t u8;
@@ -80,6 +83,6 @@ class Array : public Ship::Resource<void> {
     size_t ArrayCount;
     // OTRTODO: Should be a vector of resource pointers...
     std::vector<ScalarData> Scalars;
-    std::vector<F3DVtx> Vertices;
+    std::vector<Fast::F3DVtx> Vertices;
 };
 } // namespace SOH


### PR DESCRIPTION
Bumps LUS to test https://github.com/Kenix3/libultraship/pull/861

Includes the changes to deal with the new `Fast3d::Interpreter` class and redirecting old global variables to be sourced from the interpreter.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2959757214.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2959759437.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2959803575.zip)
<!--- section:artifacts:end -->