### PR TITLE
Fix FD Bomb Shop softlock, allow FD to open more doors

### DIFF
--- a/mm/2s2h/Enhancements/Masks/FierceDeityAnywhere.cpp
+++ b/mm/2s2h/Enhancements/Masks/FierceDeityAnywhere.cpp
@@ -197,6 +197,15 @@ void RegisterFierceDeityAnywhere() {
             actor->world.rot.z = 3;
         }
     });
+
+    // Allow FD to open doors
+    COND_VB_SHOULD(VB_BE_NEAR_DOOR, CVAR, {
+        f32 playerZPosRelToDoor = *va_arg(args, f32*);
+        // Vanilla proximity is 50.0f, but FD cannot get that close to some doors
+        if (GET_PLAYER_FORM == PLAYER_FORM_FIERCE_DEITY && fabsf(playerZPosRelToDoor) < 60.0f) {
+            *should = true;
+        }
+    });
 }
 
 static RegisterShipInitFunc initFunc(RegisterFierceDeityAnywhere, { CVAR_NAME });

--- a/mm/2s2h/GameInteractor/GameInteractor.h
+++ b/mm/2s2h/GameInteractor/GameInteractor.h
@@ -237,6 +237,7 @@ typedef enum {
     VB_SNOWBALL_SET_FLAG,
     VB_START_JUMPSLASH,
     VB_SETUP_TRANSITION,
+    VB_BE_NEAR_DOOR,
 } GIVanillaBehavior;
 
 typedef enum {

--- a/mm/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.c
+++ b/mm/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.c
@@ -296,7 +296,7 @@ s32 func_808A0E28(DoorShutter* this, PlayState* play) {
         ShutterInfo* shutterInfo = &D_808A21B0[this->unk_164];
         f32 temp_f0 = func_808A0D90(play, this, 0.0f, shutterInfo->unk_0A, shutterInfo->unk_0B);
 
-        if (fabsf(temp_f0) < 50.0f) {
+        if (GameInteractor_Should(VB_BE_NEAR_DOOR, fabsf(temp_f0) < 50.0f, &temp_f0)) {
             s16 temp_v0_2 = BINANG_SUB(player->actor.shape.rot.y, this->slidingDoor.dyna.actor.shape.rot.y);
 
             if (temp_f0 > 0.0f) {

--- a/mm/src/overlays/actors/ovl_En_Door/z_en_door.c
+++ b/mm/src/overlays/actors/ovl_En_Door/z_en_door.c
@@ -19,6 +19,8 @@
 #include "objects/object_kaizoku_obj/object_kaizoku_obj.h"
 #include "objects/gameplay_field_keep/gameplay_field_keep.h"
 
+#include "2s2h/GameInteractor/GameInteractor.h"
+
 #define FLAGS (ACTOR_FLAG_10)
 
 #define THIS ((EnDoor*)thisx)
@@ -525,8 +527,9 @@ void func_80866B20(EnDoor* this, PlayState* play) {
         Vec3f playerPosRelToDoor;
 
         Actor_OffsetOfPointInActorCoords(&this->knobDoor.dyna.actor, &playerPosRelToDoor, &player->actor.world.pos);
-        if (D_80867BC0 || ((fabsf(playerPosRelToDoor.y) < 20.0f) && (fabsf(playerPosRelToDoor.x) < 20.0f) &&
-                           (fabsf(playerPosRelToDoor.z) < 50.0f))) {
+        if (D_80867BC0 ||
+            ((fabsf(playerPosRelToDoor.y) < 20.0f) && (fabsf(playerPosRelToDoor.x) < 20.0f) &&
+             GameInteractor_Should(VB_BE_NEAR_DOOR, fabsf(playerPosRelToDoor.z) < 50.0f, &playerPosRelToDoor.z))) {
             s16 yawDiff = player->actor.shape.rot.y - this->knobDoor.dyna.actor.shape.rot.y;
 
             if (playerPosRelToDoor.z > 0.0f) {

--- a/mm/src/overlays/actors/ovl_En_Sob1/z_en_sob1.c
+++ b/mm/src/overlays/actors/ovl_En_Sob1/z_en_sob1.c
@@ -237,6 +237,8 @@ u16 EnSob1_GetWelcome(EnSob1* this, PlayState* play) {
             case PLAYER_MASK_POSTMAN:
                 return 0x644;
 
+            // 2SH2 [FD Enhancement] - Treat FD as any other non-human form
+            case PLAYER_MASK_FIERCE_DEITY:
             case PLAYER_MASK_GORON:
             case PLAYER_MASK_ZORA:
             case PLAYER_MASK_DEKU:


### PR DESCRIPTION
These two things are separate, but they have the same goal of preventing FD softlocks. This addresses the remaining item listed in #647.

- The Bomb Shop owner softlock and the associated fix are similar to #674 and #730.
- FD cannot get close enough to some doors to use them. `VB_BE_NEAR_DOOR` was added to extend the Z proximity a little bit when FDA is enabled.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2969916147.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2969939224.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2970005390.zip)
<!--- section:artifacts:end -->