### PR TITLE
[Better Warp] Wrap entrance value for supported count on each scene

### DIFF
--- a/mm/2s2h/DeveloperTools/BetterMapSelect.c
+++ b/mm/2s2h/DeveloperTools/BetterMapSelect.c
@@ -46,6 +46,7 @@ static BetterMapSelectInfoEntry sBetterMapSelectInfo[102] = {
 #define STAGE_CURRENT_TIME 0x9000
 
 extern SceneSelectEntry sScenes[143];
+extern SceneEntranceTableEntry sSceneEntranceTable[ENTR_SCENE_MAX];
 
 static bool sIsBetterMapSelectEnabled = false;
 
@@ -273,6 +274,10 @@ void BetterMapSelect_Update(MapSelectState* mapSelectState) {
         BetterMapSelect_Init(mapSelectState);
     }
 
+    if (!sIsBetterMapSelectEnabled) {
+        return;
+    }
+
     static s32 sScene = -1;
     Input* controller1 = CONTROLLER1(&mapSelectState->state);
 
@@ -280,11 +285,33 @@ void BetterMapSelect_Update(MapSelectState* mapSelectState) {
         sScene = CVarGetInteger("gDeveloperTools.BetterMapSelect.CurrentScene", 0);
     }
 
-    mapSelectState->opt = CLAMP_MIN(mapSelectState->opt, 0);
-
     // Reset entrance value when scene changes
     if (sScene != mapSelectState->currentScene) {
         sScene = mapSelectState->currentScene;
+        mapSelectState->opt = 0;
+    }
+
+    // Clamp and wrap around the spawn value based on the supported entrances for that scene
+    if (sScene < ARRAY_COUNT(sBetterMapSelectInfo)) {
+        // Scenes from scene_table.h can be checked directly against `sSceneEntranceTable`
+        s32 entrSceneId = sBetterScenes[sScene].entrance >> 9;
+        SceneEntranceTableEntry entry = sSceneEntranceTable[entrSceneId];
+
+        if (mapSelectState->opt >= entry.tableCount) {
+            mapSelectState->opt = 0;
+        } else if (mapSelectState->opt < 0) {
+            mapSelectState->opt = entry.tableCount - 1;
+        }
+
+    } else if (sScene == 102 || sScene == 103) { // Cheset/Cow special entries
+        s32 count =
+            sScene == 102 ? ARRAY_COUNT(sBetterMapSelectChestGrottoInfo) : ARRAY_COUNT(sBetterMapSelectCowGrottoInfo);
+        if (mapSelectState->opt >= count) {
+            mapSelectState->opt = 0;
+        } else if (mapSelectState->opt < 0) {
+            mapSelectState->opt = count - 1;
+        }
+    } else { // File Select/Title Screen
         mapSelectState->opt = 0;
     }
 

--- a/mm/2s2h/DeveloperTools/BetterMapSelect.c
+++ b/mm/2s2h/DeveloperTools/BetterMapSelect.c
@@ -278,23 +278,13 @@ void BetterMapSelect_Update(MapSelectState* mapSelectState) {
         return;
     }
 
-    static s32 sScene = -1;
+    static s32 sPrevScene = -1;
     Input* controller1 = CONTROLLER1(&mapSelectState->state);
 
-    if (sScene == -1) {
-        sScene = CVarGetInteger("gDeveloperTools.BetterMapSelect.CurrentScene", 0);
-    }
-
-    // Reset entrance value when scene changes
-    if (sScene != mapSelectState->currentScene) {
-        sScene = mapSelectState->currentScene;
-        mapSelectState->opt = 0;
-    }
-
     // Clamp and wrap around the spawn value based on the supported entrances for that scene
-    if (sScene < ARRAY_COUNT(sBetterMapSelectInfo)) {
+    if (mapSelectState->currentScene < ARRAY_COUNT(sBetterMapSelectInfo)) {
         // Scenes from scene_table.h can be checked directly against `sSceneEntranceTable`
-        s32 entrSceneId = sBetterScenes[sScene].entrance >> 9;
+        s32 entrSceneId = sBetterScenes[mapSelectState->currentScene].entrance >> 9;
         SceneEntranceTableEntry entry = sSceneEntranceTable[entrSceneId];
 
         if (mapSelectState->opt >= entry.tableCount) {
@@ -302,10 +292,10 @@ void BetterMapSelect_Update(MapSelectState* mapSelectState) {
         } else if (mapSelectState->opt < 0) {
             mapSelectState->opt = entry.tableCount - 1;
         }
-
-    } else if (sScene == 102 || sScene == 103) { // Cheset/Cow special entries
-        s32 count =
-            sScene == 102 ? ARRAY_COUNT(sBetterMapSelectChestGrottoInfo) : ARRAY_COUNT(sBetterMapSelectCowGrottoInfo);
+    } else if (mapSelectState->currentScene == 102 || mapSelectState->currentScene == 103) {
+        // Cheset/Cow special entries
+        s32 count = mapSelectState->currentScene == 102 ? ARRAY_COUNT(sBetterMapSelectChestGrottoInfo)
+                                                        : ARRAY_COUNT(sBetterMapSelectCowGrottoInfo);
         if (mapSelectState->opt >= count) {
             mapSelectState->opt = 0;
         } else if (mapSelectState->opt < 0) {

--- a/mm/src/code/z_scene_table.c
+++ b/mm/src/code/z_scene_table.c
@@ -2573,10 +2573,8 @@ static EntranceTableEntry* sCutsceneEntranceTable[] = {
 #define SCENE_ENTRANCE_NONE() \
     { 0, NULL, NULL }
 
-// 2Ship [Enhancement] Hijack the static keyword so that `sSceneEntranceTable` can be externed for BetterWarp menu
-#define static
-
-static SceneEntranceTableEntry sSceneEntranceTable[] = {
+// 2Ship [Enhancement] removing the static keyword so that `sSceneEntranceTable` can be externed for BetterWarp menu
+SceneEntranceTableEntry sSceneEntranceTable[] = {
     /* 0x00 */ SCENE_ENTRANCE(sMayorsResidenceEntranceTable, "Z2_SONCHONOIE"),
     /* 0x01 */ SCENE_ENTRANCE(sMajorasLairEntranceTable, "Z2_LAST_BS"),
     /* 0x02 */ SCENE_ENTRANCE(sMagicHagsPotionShopEntranceTable, "Z2_WITCH_SHOP"),
@@ -2688,8 +2686,6 @@ static SceneEntranceTableEntry sSceneEntranceTable[] = {
     /* 0x6C */ SCENE_ENTRANCE(sSouthClockTownEntranceTable, "Z2_CLOCKTOWER"),
     /* 0x6D */ SCENE_ENTRANCE(sLaundryPoolEntranceTable, "Z2_ALLEY"),
 };
-
-#undef static // 2Ship
 
 /**
  * Returns a pointer to an entrance table from a given entrance index.

--- a/mm/src/code/z_scene_table.c
+++ b/mm/src/code/z_scene_table.c
@@ -2573,6 +2573,9 @@ static EntranceTableEntry* sCutsceneEntranceTable[] = {
 #define SCENE_ENTRANCE_NONE() \
     { 0, NULL, NULL }
 
+// 2Ship [Enhancement] Hijack the static keyword so that `sSceneEntranceTable` can be externed for BetterWarp menu
+#define static
+
 static SceneEntranceTableEntry sSceneEntranceTable[] = {
     /* 0x00 */ SCENE_ENTRANCE(sMayorsResidenceEntranceTable, "Z2_SONCHONOIE"),
     /* 0x01 */ SCENE_ENTRANCE(sMajorasLairEntranceTable, "Z2_LAST_BS"),
@@ -2685,6 +2688,8 @@ static SceneEntranceTableEntry sSceneEntranceTable[] = {
     /* 0x6C */ SCENE_ENTRANCE(sSouthClockTownEntranceTable, "Z2_CLOCKTOWER"),
     /* 0x6D */ SCENE_ENTRANCE(sLaundryPoolEntranceTable, "Z2_ALLEY"),
 };
+
+#undef static // 2Ship
 
 /**
  * Returns a pointer to an entrance table from a given entrance index.


### PR DESCRIPTION
This externs and uses `sSceneEntranceTable` with the BetterMapSelect to allow us to clamp and wrap around the entrance value for each scene based on the amount of entrances each scene supports.

I was considering doing the same for the stage value, but there isn't a variable with those counts handy like `sSceneEntranceTable`.  May revisit that later.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2971034876.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2971036784.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2971074081.zip)
<!--- section:artifacts:end -->