### PR TITLE
Speed up Ikana block

### DIFF
--- a/mm/2s2h/Enhancements/Cutscenes/SkipOnePointCutscenes.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/SkipOnePointCutscenes.cpp
@@ -83,6 +83,7 @@ void RegisterSkipOnePointCutscenes() {
             case ACTOR_OBJ_LIGHTBLOCK:
             case ACTOR_OBJ_LIGHTSWITCH:
             case ACTOR_BG_IKANA_BOMBWALL:
+            case ACTOR_BG_IKANA_BLOCK:
             case ACTOR_BG_HAKUGIN_BOMBWALL:
             case ACTOR_EN_SW:
             case ACTOR_OBJ_CHAN:

--- a/mm/2s2h/Enhancements/Player/FasterPushAndPull.cpp
+++ b/mm/2s2h/Enhancements/Player/FasterPushAndPull.cpp
@@ -25,24 +25,18 @@ void RegisterFasterPushAndPull() {
     });
 
     COND_VB_SHOULD(VB_PUSH_BLOCK_SET_TIMER, CVAR, {
-        ObjOshihiki* objOshihiki = va_arg(args, ObjOshihiki*);
-        objOshihiki->timer = 2;
+        Actor* actor = va_arg(args, Actor*);
+        if (actor->id == ACTOR_OBJ_OSHIHIKI) {
+            ((ObjOshihiki*)actor)->timer = 2;
+        } else if (actor->id == ACTOR_BG_IKANA_BLOCK) {
+            ((BgIkanaBlock*)actor)->unk_17B = 11;
+        }
         *should = false;
     });
 
     COND_VB_SHOULD(VB_SKATE_BLOCK_BEGIN_MOVE, CVAR, { *should = true; });
 
-    COND_VB_SHOULD(VB_BLOCK_BEGIN_MOVE, CVAR, {
-        Actor* block = va_arg(args, Actor*);
-        // Cannot always allow the Ikana block to be moved, or it will move more than one space
-        if (block->id == ACTOR_BG_IKANA_BLOCK) {
-            if (((BgIkanaBlock*)block)->unk_17B > 0) {
-                *should = true;
-            }
-        } else {
-            *should = true;
-        }
-    });
+    COND_VB_SHOULD(VB_BLOCK_BEGIN_MOVE, CVAR, { *should = true; });
 
     COND_VB_SHOULD(VB_BLOCK_BE_FINISHED_PULLING, CVAR, {
         f32* pValue = va_arg(args, f32*);

--- a/mm/2s2h/Enhancements/Player/FasterPushAndPull.cpp
+++ b/mm/2s2h/Enhancements/Player/FasterPushAndPull.cpp
@@ -4,6 +4,7 @@
 
 extern "C" {
 #include "overlays/actors/ovl_Bg_Dblue_Movebg/z_bg_dblue_movebg.h"
+#include "overlays/actors/ovl_Bg_Ikana_Block/z_bg_ikana_block.h"
 #include "overlays/actors/ovl_Obj_Oshihiki/z_obj_oshihiki.h"
 }
 
@@ -31,7 +32,17 @@ void RegisterFasterPushAndPull() {
 
     COND_VB_SHOULD(VB_SKATE_BLOCK_BEGIN_MOVE, CVAR, { *should = true; });
 
-    COND_VB_SHOULD(VB_BLOCK_BEGIN_MOVE, CVAR, { *should = true; });
+    COND_VB_SHOULD(VB_BLOCK_BEGIN_MOVE, CVAR, {
+        Actor* block = va_arg(args, Actor*);
+        // Cannot always allow the Ikana block to be moved, or it will move more than one space
+        if (block->id == ACTOR_BG_IKANA_BLOCK) {
+            if (((BgIkanaBlock*)block)->unk_17B > 0) {
+                *should = true;
+            }
+        } else {
+            *should = true;
+        }
+    });
 
     COND_VB_SHOULD(VB_BLOCK_BE_FINISHED_PULLING, CVAR, {
         f32* pValue = va_arg(args, f32*);

--- a/mm/src/overlays/actors/ovl_Bg_Ikana_Block/z_bg_ikana_block.c
+++ b/mm/src/overlays/actors/ovl_Bg_Ikana_Block/z_bg_ikana_block.c
@@ -72,8 +72,10 @@ void func_80B7EA60(BgIkanaBlock* this) {
 
 void func_80B7EB30(BgIkanaBlock* this) {
     if (this->unk_17A & (0x8 | 0x4 | 0x2 | 0x1)) {
-        if (this->unk_17B < 127) {
-            this->unk_17B++;
+        if (GameInteractor_Should(VB_PUSH_BLOCK_SET_TIMER, true, this)) {
+            if (this->unk_17B < 127) {
+                this->unk_17B++;
+            }
         }
     } else {
         this->unk_17B = 0;
@@ -132,8 +134,7 @@ s32 func_80B7EB94(BgIkanaBlock* this, PlayState* play) {
 }
 
 s32 func_80B7ECFC(BgIkanaBlock* this, PlayState* play) {
-    return func_80B7EB64(this, play) && GameInteractor_Should(VB_BLOCK_BEGIN_MOVE, func_80B7EB7C(this, play), this) &&
-           func_80B7EB94(this, play);
+    return func_80B7EB64(this, play) && func_80B7EB7C(this, play) && func_80B7EB94(this, play);
 }
 
 void func_80B7ED54(BgIkanaBlock* this) {

--- a/mm/src/overlays/actors/ovl_Bg_Ikana_Block/z_bg_ikana_block.c
+++ b/mm/src/overlays/actors/ovl_Bg_Ikana_Block/z_bg_ikana_block.c
@@ -7,6 +7,8 @@
 #include "z_bg_ikana_block.h"
 #include "objects/gameplay_dangeon_keep/gameplay_dangeon_keep.h"
 
+#include "2s2h/GameInteractor/GameInteractor.h"
+
 #define FLAGS (ACTOR_FLAG_10)
 
 #define THIS ((BgIkanaBlock*)thisx)
@@ -130,7 +132,8 @@ s32 func_80B7EB94(BgIkanaBlock* this, PlayState* play) {
 }
 
 s32 func_80B7ECFC(BgIkanaBlock* this, PlayState* play) {
-    return func_80B7EB64(this, play) && func_80B7EB7C(this, play) && func_80B7EB94(this, play);
+    return func_80B7EB64(this, play) && GameInteractor_Should(VB_BLOCK_BEGIN_MOVE, func_80B7EB7C(this, play), this) &&
+           func_80B7EB94(this, play);
 }
 
 void func_80B7ED54(BgIkanaBlock* this) {
@@ -290,7 +293,8 @@ void func_80B7F290(BgIkanaBlock* this, PlayState* play) {
 
     Math_StepToF(&this->unk_16C, 2.0f, 0.4f);
 
-    if (Math_StepToF(this->unk_164, this->unk_168, this->unk_16C)) {
+    if (GameInteractor_Should(VB_BLOCK_BE_FINISHED_PULLING, Math_StepToF(this->unk_164, this->unk_168, this->unk_16C),
+                              this->unk_164, this->unk_168, this->unk_16C, this->unk_16C)) {
         Player* player = GET_PLAYER(play);
 
         if (!func_80B7EB94(this, play)) {


### PR DESCRIPTION
The fast push/pull enhancement didn't account for `ACTOR_BG_IKANA_BLOCK`. This adds it to the mix, and also throws in a one point skip since the actor normally has a tiny cutscene when the puzzle is solved.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2972521235.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2972521628.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2972533802.zip)
<!--- section:artifacts:end -->