### PR TITLE
Fix array access related to bombers code cutscene

### DIFF
--- a/mm/src/overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.c
+++ b/mm/src/overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.c
@@ -261,9 +261,9 @@ void func_809C4BC4(EnBomBowlMan* this, PlayState* play) {
 
     if (CutsceneManager_GetCurrentCsId() == CS_ID_GLOBAL_TALK) {
         CutsceneManager_Stop(CS_ID_GLOBAL_TALK);
-        CutsceneManager_Queue(this->csId1);
-    } else if (!CutsceneManager_IsNext(this->csId1)) {
-        CutsceneManager_Queue(this->csId1);
+        CutsceneManager_Queue(this->csIdList[2]);
+    } else if (!CutsceneManager_IsNext(this->csIdList[2])) {
+        CutsceneManager_Queue(this->csIdList[2]);
     }
 
     EnBomBowlMan_ChangeAnim(this, ENBOMBOWLMAN_ANIM_3, 1.0f);
@@ -283,16 +283,16 @@ void func_809C4DA4(EnBomBowlMan* this, PlayState* play) {
 
         if (CutsceneManager_GetCurrentCsId() == CS_ID_GLOBAL_TALK) {
             CutsceneManager_Stop(CS_ID_GLOBAL_TALK);
-            CutsceneManager_Queue(this->csId1);
+            CutsceneManager_Queue(this->csIdList[2]);
             return;
         }
 
-        if (!CutsceneManager_IsNext(this->csId1)) {
-            CutsceneManager_Queue(this->csId1);
+        if (!CutsceneManager_IsNext(this->csIdList[2])) {
+            CutsceneManager_Queue(this->csIdList[2]);
             return;
         }
 
-        CutsceneManager_StartWithPlayerCs(this->csId1, &this->actor);
+        CutsceneManager_StartWithPlayerCs(this->csIdList[2], &this->actor);
         this->unk_2B8 = 1;
         this->unk_2C0 = 0;
         this->unk_2D4 = this->actor.yawTowardsPlayer;
@@ -315,7 +315,7 @@ void func_809C4DA4(EnBomBowlMan* this, PlayState* play) {
             case 0:
                 this->unk_2C0 = 1;
                 D_809C6104 = 1;
-                Camera_SetTargetActor(Play_GetCamera(play, CutsceneManager_GetCurrentSubCamId(this->csId1)),
+                Camera_SetTargetActor(Play_GetCamera(play, CutsceneManager_GetCurrentSubCamId(this->csIdList[2])),
                                       &this->unk_2D8->actor);
                 this->unk_2D4 = 0;
                 this->unk_2BC = 10;
@@ -336,7 +336,7 @@ void func_809C4DA4(EnBomBowlMan* this, PlayState* play) {
                 if (player->transformation == PLAYER_FORM_HUMAN) {
                     if (GameInteractor_Should(VB_BOM_BOWL_MAN_GIVE_ITEM, true, this)) {
                         this->unk_2B8 = 2;
-                        CutsceneManager_Stop(this->csId1);
+                        CutsceneManager_Stop(this->csIdList[2]);
                         func_809C59A4(this, play);
                         sp28 = true;
                     }
@@ -347,11 +347,11 @@ void func_809C4DA4(EnBomBowlMan* this, PlayState* play) {
                     D_809C6100 = 1;
                     if (CutsceneManager_GetCurrentCsId() == CS_ID_GLOBAL_TALK) {
                         CutsceneManager_Stop(CS_ID_GLOBAL_TALK);
-                        CutsceneManager_Queue(this->csId2);
-                    } else if (!CutsceneManager_IsNext(this->csId2)) {
-                        CutsceneManager_Queue(this->csId2);
+                        CutsceneManager_Queue(this->csIdList[3]);
+                    } else if (!CutsceneManager_IsNext(this->csIdList[3])) {
+                        CutsceneManager_Queue(this->csIdList[3]);
                     }
-                    CutsceneManager_Stop(this->csId1);
+                    CutsceneManager_Stop(this->csIdList[2]);
                     this->actionFunc = func_809C5B1C;
                     sp28 = true;
                 }
@@ -368,7 +368,7 @@ void func_809C4DA4(EnBomBowlMan* this, PlayState* play) {
 
             case 4:
                 if (this->unk_2B8 != 2) {
-                    CutsceneManager_Stop(this->csId1);
+                    CutsceneManager_Stop(this->csIdList[2]);
                 }
                 play->msgCtx.msgLength = 0;
                 EnBomBowlMan_ChangeAnim(this, ENBOMBOWLMAN_ANIM_1, 1.0f);
@@ -604,11 +604,11 @@ void func_809C5AA4(EnBomBowlMan* this, PlayState* play) {
 void func_809C5B1C(EnBomBowlMan* this, PlayState* play) {
     if (CutsceneManager_GetCurrentCsId() == CS_ID_GLOBAL_TALK) {
         CutsceneManager_Stop(CS_ID_GLOBAL_TALK);
-        CutsceneManager_Queue(this->csId2);
-    } else if (!CutsceneManager_IsNext(this->csId2)) {
-        CutsceneManager_Queue(this->csId2);
+        CutsceneManager_Queue(this->csIdList[3]);
+    } else if (!CutsceneManager_IsNext(this->csIdList[3])) {
+        CutsceneManager_Queue(this->csIdList[3]);
     } else {
-        CutsceneManager_StartWithPlayerCs(this->csId2, &this->actor);
+        CutsceneManager_StartWithPlayerCs(this->csIdList[3], &this->actor);
         func_809C5BA0(this);
     }
 }
@@ -646,7 +646,7 @@ void func_809C5BF4(EnBomBowlMan* this, PlayState* play) {
         }
 
         if (this->unk_2F4 == 0) {
-            subCam = Play_GetCamera(play, CutsceneManager_GetCurrentSubCamId(this->csId2));
+            subCam = Play_GetCamera(play, CutsceneManager_GetCurrentSubCamId(this->csIdList[3]));
 
             if (D_809C6100 > 5) {
                 Player* player = GET_PLAYER(play);

--- a/mm/src/overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.h
+++ b/mm/src/overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.h
@@ -44,9 +44,9 @@ typedef struct EnBomBowlMan {
     /* 0x2C2 */ s16 unk_2C2;
     /* 0x2C4 */ f32 animEndFrame;
     /* 0x2C8 */ f32 unk_2C8;
-    /* 0x2CC */ s16 csIdList[2];
-    /* 0x2D0 */ s16 csId1;
-    /* 0x2D2 */ s16 csId2;
+    /* 0x2CC */ s16 csIdList[4];
+    ///* 0x2D0 */ s16 csId1;
+    ///* 0x2D2 */ s16 csId2;
     /* 0x2D4 */ s16 unk_2D4;
     /* 0x2D6 */ s16 csId3;
     /* 0x2D8 */ struct EnBomBowlMan* unk_2D8;

--- a/mm/src/overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.h
+++ b/mm/src/overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.h
@@ -45,8 +45,6 @@ typedef struct EnBomBowlMan {
     /* 0x2C4 */ f32 animEndFrame;
     /* 0x2C8 */ f32 unk_2C8;
     /* 0x2CC */ s16 csIdList[4];
-    ///* 0x2D0 */ s16 csId1;
-    ///* 0x2D2 */ s16 csId2;
     /* 0x2D4 */ s16 unk_2D4;
     /* 0x2D6 */ s16 csId3;
     /* 0x2D8 */ struct EnBomBowlMan* unk_2D8;

--- a/mm/src/overlays/actors/ovl_En_Bomjima/z_en_bomjima.h
+++ b/mm/src/overlays/actors/ovl_En_Bomjima/z_en_bomjima.h
@@ -41,8 +41,8 @@ typedef struct EnBomjima {
     /* 0x2CA */ s16 unk_2CA;
     /* 0x2CC */ f32 animEndFrame;
     /* 0x2D0 */ f32 unk_2D0;
-    /* 0x2D4 */ s16 csIdList[2];
-    /* 0x2D8 */ UNK_TYPE1 unk2D8[4]; // maybe a part of the above?
+    /* 0x2D4 */ s16 csIdList[3];
+    /* 0x2D8 */ UNK_TYPE1 unk2D8[3]; // maybe a part of the above?
     /* 0x2DC */ s16 unk_2DC;
     /* 0x2DE */ s16 cutsceneEnded;
     /* 0x2E0 */ s16 unk_2E0;

--- a/mm/src/overlays/actors/ovl_En_Bomjima/z_en_bomjima.h
+++ b/mm/src/overlays/actors/ovl_En_Bomjima/z_en_bomjima.h
@@ -41,8 +41,7 @@ typedef struct EnBomjima {
     /* 0x2CA */ s16 unk_2CA;
     /* 0x2CC */ f32 animEndFrame;
     /* 0x2D0 */ f32 unk_2D0;
-    /* 0x2D4 */ s16 csIdList[3];
-    /* 0x2D8 */ UNK_TYPE1 unk2D8[2]; // maybe a part of the above?
+    /* 0x2D4 */ s16 csIdList[4];
     /* 0x2DC */ s16 unk_2DC;
     /* 0x2DE */ s16 cutsceneEnded;
     /* 0x2E0 */ s16 unk_2E0;

--- a/mm/src/overlays/actors/ovl_En_Bomjima/z_en_bomjima.h
+++ b/mm/src/overlays/actors/ovl_En_Bomjima/z_en_bomjima.h
@@ -42,7 +42,7 @@ typedef struct EnBomjima {
     /* 0x2CC */ f32 animEndFrame;
     /* 0x2D0 */ f32 unk_2D0;
     /* 0x2D4 */ s16 csIdList[3];
-    /* 0x2D8 */ UNK_TYPE1 unk2D8[3]; // maybe a part of the above?
+    /* 0x2D8 */ UNK_TYPE1 unk2D8[2]; // maybe a part of the above?
     /* 0x2DC */ s16 unk_2DC;
     /* 0x2DE */ s16 cutsceneEnded;
     /* 0x2E0 */ s16 unk_2E0;


### PR DESCRIPTION
Thanks to the UB sanitizer for finding this. The array was originally too small so the CSIDs were being written OOB.
Fixes #330 

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2973957937.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2973958318.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2973970569.zip)
<!--- section:artifacts:end -->