### PR TITLE
[Rando] Only equip sword pickups if in human form

### DIFF
--- a/mm/2s2h/Rando/MiscBehavior/MiscBehavior.cpp
+++ b/mm/2s2h/Rando/MiscBehavior/MiscBehavior.cpp
@@ -38,9 +38,11 @@ void Rando::MiscBehavior::OnFileLoad() {
     // In the case of receiving a sword, we only want to equip it to the Human's B button. Vanilla avoids this issue by
     // never letting you be other forms when you get a sword from the smithy or curiosity shop.
     COND_VB_SHOULD(VB_ITEM_GIVE_SWORD_SET_FORM_EQUIP, IS_RANDO, {
-        u8* item = va_arg(args, u8*);
         *should = false;
-        BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_B) = *item;
+        if (GET_PLAYER(gPlayState)->transformation == PLAYER_FORM_HUMAN) {
+            u8* item = va_arg(args, u8*);
+            BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_B) = *item;
+        }
     });
 
     // Fix vanilla bug where the player can often use magic before it's acquired.


### PR DESCRIPTION
Human and FD share an equip slot index of 0, meaning the `VB_ITEM_GIVE_SWORD_SET_FORM_EQUIP` hook would still equip progressive swords to the B button if acquired in FD form. This would result in FD being able to use an invisible one handed sword. This fix makes it so that this equipment change only occurs if playing in human form.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2974349315.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2974350387.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2974360464.zip)
<!--- section:artifacts:end -->