### PR TITLE
Fix spline crash

### DIFF
--- a/mm/src/code/cutscene_camera.c
+++ b/mm/src/code/cutscene_camera.c
@@ -286,6 +286,8 @@ s32 CutsceneCamera_UpdateSplines(u8* script, CutsceneCamera* csCamera) {
             if (csCamera->splineNeedsInit == true) {
                 // Spline Header
                 spline = (CsCmdCamSpline*)&script[csCamera->cmdIndex];
+                // 2S2H [Port] This was reading OOB because `spline->numEntries` was -1. We can either set the fields to
+                // 0 and continue, or goto an existing exit.
                 if (spline->duration == -1) {
                     goto done;
                 }
@@ -336,7 +338,7 @@ s32 CutsceneCamera_UpdateSplines(u8* script, CutsceneCamera* csCamera) {
         csCamera->splineNeedsInit = true;
         spline = (CsCmdCamSpline*)&script[csCamera->cmdIndex];
         if (spline->numEntries == -1) {
-            done:
+        done:
             csCamera->state = CS_CAM_STATE_DONE;
             return 0;
         }

--- a/mm/src/code/cutscene_camera.c
+++ b/mm/src/code/cutscene_camera.c
@@ -286,6 +286,9 @@ s32 CutsceneCamera_UpdateSplines(u8* script, CutsceneCamera* csCamera) {
             if (csCamera->splineNeedsInit == true) {
                 // Spline Header
                 spline = (CsCmdCamSpline*)&script[csCamera->cmdIndex];
+                if (spline->duration == -1) {
+                    goto done;
+                }
                 csCamera->atInterp.numEntries = csCamera->eyeInterp.numEntries = spline->numEntries;
                 csCamera->duration = spline->duration;
                 csCamera->cmdIndex += sizeof(CsCmdCamSpline);
@@ -333,6 +336,7 @@ s32 CutsceneCamera_UpdateSplines(u8* script, CutsceneCamera* csCamera) {
         csCamera->splineNeedsInit = true;
         spline = (CsCmdCamSpline*)&script[csCamera->cmdIndex];
         if (spline->numEntries == -1) {
+            done:
             csCamera->state = CS_CAM_STATE_DONE;
             return 0;
         }


### PR DESCRIPTION
Fixes the crash people were seeing after finishing the song of storms cutscene with Sharp.
The crash was due to an OOB read when processing the last spline.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2981494699.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2981500448.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2981537040.zip)
<!--- section:artifacts:end -->