### PR TITLE
[Rando] Fix the two happy mask salesman checks

### DIFF
--- a/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
+++ b/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
@@ -368,7 +368,7 @@ void Rando::MiscBehavior::OnFileCreate(s16 fileNum) {
 
                 Audio_PlaySfx(NA_SE_SY_ATTENTION_SOUND);
             }
-            
+
             RANDO_SAVE_CHECKS[RC_STARTING_ITEM_DEKU_MASK].eligible = true;
             RANDO_SAVE_CHECKS[RC_STARTING_ITEM_SONG_OF_HEALING].eligible = true;
 

--- a/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
+++ b/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
@@ -346,9 +346,6 @@ void Rando::MiscBehavior::OnFileCreate(s16 fileNum) {
                                              std::to_string(RANDO_SAVE_OPTIONS[RO_LOGIC]));
                 }
 
-                RANDO_SAVE_CHECKS[RC_STARTING_ITEM_DEKU_MASK].eligible = true;
-                RANDO_SAVE_CHECKS[RC_STARTING_ITEM_SONG_OF_HEALING].eligible = true;
-
                 if (CVarGetInteger("gRando.GenerateSpoiler", 0)) {
                     nlohmann::json spoiler = Rando::Spoiler::GenerateFromSaveContext();
                     spoiler["inputSeed"] = inputSeed;
@@ -371,6 +368,10 @@ void Rando::MiscBehavior::OnFileCreate(s16 fileNum) {
 
                 Audio_PlaySfx(NA_SE_SY_ATTENTION_SOUND);
             }
+            
+            RANDO_SAVE_CHECKS[RC_STARTING_ITEM_DEKU_MASK].eligible = true;
+            RANDO_SAVE_CHECKS[RC_STARTING_ITEM_SONG_OF_HEALING].eligible = true;
+
         } catch (const std::exception& e) {
             SPDLOG_ERROR("Error with randomizer save creation: {}", e.what());
             Audio_PlaySfx(NA_SE_SY_QUIZ_INCORRECT);


### PR DESCRIPTION
Both RC_STARTING_ITEM_DEKU_MASK and RC_STARTING_ITEM_SONG_OF_HEALINGs' eligible flags were not being set upon creating a file when generating with an existing seed file. This adjusts those lines to run when either generating from scratch or generating from a file. 

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2983177277.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2983178850.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/2983202058.zip)
<!--- section:artifacts:end -->