### PR TITLE
Fix notebook events in Kafei's hideout

### DIFF
--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipKafeiReveal.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipKafeiReveal.cpp
@@ -28,8 +28,8 @@ void RegisterSkipKafeiReveal() {
         // Set flags that are normally set in the experience that this skips
         SET_WEEKEVENTREG(WEEKEVENTREG_RECEIVED_PENDANT_OF_MEMORIES);
         SET_WEEKEVENTREG(WEEKEVENTREG_51_08);
-        SET_WEEKEVENTREG(WEEKEVENTREG_BOMBERS_NOTEBOOK_EVENT_MET_KAFEI);
-        SET_WEEKEVENTREG(WEEKEVENTREG_BOMBERS_NOTEBOOK_EVENT_RECEIVED_PENDANT_OF_MEMORIES);
+        Message_BombersNotebookQueueEvent(gPlayState, BOMBERS_NOTEBOOK_EVENT_MET_KAFEI);
+        Message_BombersNotebookQueueEvent(gPlayState, BOMBERS_NOTEBOOK_EVENT_RECEIVED_PENDANT_OF_MEMORIES);
 
         if (GameInteractor_Should(VB_GIVE_PENDANT_OF_MEMORIES_FROM_KAFEI, true)) {
             GameInteractor::Instance->events.emplace_back(

--- a/mm/2s2h/Rando/ActorBehavior/EnFsn.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnFsn.cpp
@@ -75,6 +75,7 @@ void Rando::ActorBehavior::InitEnFsnBehavior() {
         EnFsn* enFsn = va_arg(args, EnFsn*);
         RANDO_SAVE_CHECKS[RC_KAFEIS_HIDEOUT_LETTER_TO_MAMA].eligible = true;
         enFsn->flags |= ENFSN_END_CONVERSATION;
+        enFsn->flags |= ENFSN_GAVE_LETTER_TO_MAMA;
         enFsn->textId = 0x29E4;
         enFsn->actionFunc = EnFsn_ResumeInteraction;
         SET_WEEKEVENTREG(WEEKEVENTREG_RECEIVED_PRIORITY_MAIL);


### PR DESCRIPTION
The notebook event for obtaining the priority mail check was not firing in rando. The Kafei reveal skip did set the appropriate notebook flags, but because that was done directly instead of using the notebook queue system, the messages did not display. This fixes both of those.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3110103916.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3110104751.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3110139543.zip)
<!--- section:artifacts:end -->