### PR TITLE
Fix missing 2ship.o2r when debugging

### DIFF
--- a/CMake/copy-existing-otrs.cmake
+++ b/CMake/copy-existing-otrs.cmake
@@ -12,15 +12,7 @@ if(EXISTS ${SOURCE_DIR}/mm/2ship.o2r)
     message(STATUS "Copied 2ship.o2r")
 endif()
 
-# Additionally for Windows, copy the otrs to the target dir, side by side with 2ship.exe
-if(SYSTEM_NAME MATCHES "Windows")
-    if(NOT ONLY2SHIPOTR AND EXISTS ${SOURCE_DIR}/mm/mm.o2r)
-        execute_process(COMMAND ${CMAKE_COMMAND} -E copy mm.o2r ${TARGET_DIR}/mm.o2r)
-    endif()
-    if(EXISTS ${SOURCE_DIR}/OTRExporter/2ship.o2r)
-        execute_process(COMMAND ${CMAKE_COMMAND} -E copy 2ship.o2r ${TARGET_DIR})
-    endif()
-endif()
+
 
 if(NOT ONLY2SHIPOTR AND (NOT EXISTS ${SOURCE_DIR}/mm.o2r))
     message(FATAL_ERROR "Failed to copy. No O2R files found.")

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -136,7 +136,7 @@ OTRGlobals::OTRGlobals() {
         }
     }
 
-    std::string shipOtrPath = Ship::Context::GetPathRelativeToAppBundle("2ship.o2r");
+    std::string shipOtrPath = Ship::Context::LocateFileAcrossAppDirs("2ship.o2r");
     if (std::filesystem::exists(shipOtrPath)) {
         archiveFiles.push_back(shipOtrPath);
     }


### PR DESCRIPTION
Fixes an issue where 2ship.o2r isn't detected in the expected directory by using the same directory as mm.o2r.
Also removed the copy into `$TargetDir` on windows since its not set as the working directory and was pointless.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3099344894.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3099345807.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3099358753.zip)
<!--- section:artifacts:end -->