### PR TITLE
[Rando] Separate CAN_PLAY_SONG from MeetsMoonRequirements

### DIFF
--- a/mm/2s2h/Rando/Logic/Logic.h
+++ b/mm/2s2h/Rando/Logic/Logic.h
@@ -180,7 +180,7 @@ inline uint32_t RemainsCount() {
 }
 
 inline bool MeetsMoonRequirements() {
-    return CAN_PLAY_SONG(OATH) && RemainsCount() >= RANDO_SAVE_OPTIONS[RO_ACCESS_MOON_REMAINS_COUNT];
+    return RemainsCount() >= RANDO_SAVE_OPTIONS[RO_ACCESS_MOON_REMAINS_COUNT];
 }
 
 inline bool CanKillEnemy(ActorId EnemyId) {

--- a/mm/2s2h/Rando/Logic/Regions/Central.cpp
+++ b/mm/2s2h/Rando/Logic/Regions/Central.cpp
@@ -79,7 +79,7 @@ static RegisterShipInitFunc initFunc([]() {
             CHECK(RC_CLOCK_TOWER_ROOF_POT_04, true),
         },
         .exits = { //     TO                                         FROM
-            EXIT(ENTRANCE(THE_MOON, 0),                              ONE_WAY_EXIT, MeetsMoonRequirements()),
+            EXIT(ENTRANCE(THE_MOON, 0),                              ONE_WAY_EXIT, CAN_PLAY_SONG(OATH) && MeetsMoonRequirements()),
         },
         .oneWayEntrances = {
             ENTRANCE(CLOCK_TOWER_ROOFTOP, 0), // From clock tower platform


### PR DESCRIPTION
The Boss Remains requirement setting has `CAN_PLAY_SONG` coupled with the condition, which inadvertently prevents going to the moon if the player used Ocarina Items in lieu of the actual Ocarina. This PR moves the `CAN_PLAY_SONG` condition from the shared boolean to the logic file so that only logic cares about the Ocarina, not the warp itself.

Fixes #1150

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3111191819.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3111221948.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3111237612.zip)
<!--- section:artifacts:end -->