### PR TITLE
[Enhancement] Hidden grottos visibility marker

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1295,6 +1295,18 @@ void BenMenu::AddEnhancements() {
                          "- No trade: Gibdos will vanish without taking items.")
                 .DefaultIndex(GibdoTradeSequenceOptions::GIBDO_TRADE_SEQUENCE_VANILLA)
                 .ComboMap(gibdoTradeSequenceOptions));
+    AddWidget(path, "Hidden Grottos Visibility", WIDGET_CVAR_COMBOBOX)
+        .CVar("gEnhancements.DifficultyOptions.HiddenGrottosVisibility")
+        .Options(
+            ComboboxOptions()
+                .Tooltip(
+                    "Enable visual markers for hidden grottos:\n"
+                    "- Off: No visual markers for hidden grottos. Vanilla behavior.\n"
+                    "- Wear Mask of Truth: Hidden grottos are visible when wearing the Mask of Truth. MM3D behavior.\n"
+                    "- Have Mask of Truth: Hidden grottos are visible once the Mask of Truth is obtained.\n"
+                    "- Always: Hidden grottos always have a visual marker.\n")
+                .DefaultIndex(HiddenGrottosVisibilityOptions::HIDDEN_GROTTOS_VISIBLITY_OFF)
+                .ComboMap(maskOfTruthGrottoOptions));
 
     path.column = SECTION_COLUMN_2;
     AddWidget(path, "Hyper Enemies", WIDGET_CVAR_CHECKBOX)

--- a/mm/2s2h/BenGui/BenMenu.h
+++ b/mm/2s2h/BenGui/BenMenu.h
@@ -103,6 +103,13 @@ static const std::unordered_map<int32_t, const char*> powerCrouchStabOptions = {
     { 2, "Unpatched (OoT)" },
 };
 
+static const std::unordered_map<int32_t, const char*> maskOfTruthGrottoOptions = {
+    { HIDDEN_GROTTOS_VISIBLITY_OFF, "Off" },
+    { HIDDEN_GROTTOS_VISIBLITY_WEAR_MASK_OF_TRUTH, "Wear Mask of Truth" },
+    { HIDDEN_GROTTOS_VISIBLITY_HAVE_MASK_OF_TRUTH, "Have Mask of Truth" },
+    { HIDDEN_GROTTOS_VISIBLITY_ALWAYS, "Always" },
+};
+
 static const std::unordered_map<int32_t, const char*> damageMultiplierOptions = {
     { 0, "1x" }, { 1, "2x" }, { 2, "4x" }, { 3, "8x" }, { 4, "16x" }, { 10, "1 Hit KO" },
 };

--- a/mm/2s2h/Enhancements/DifficultyOptions/HiddenGrottosVisibility.cpp
+++ b/mm/2s2h/Enhancements/DifficultyOptions/HiddenGrottosVisibility.cpp
@@ -1,0 +1,51 @@
+#include "public/bridge/consolevariablebridge.h"
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/ShipInit.hpp"
+#include "2s2h/Enhancements/Enhancements.h"
+
+extern "C" {
+#include "overlays/actors/ovl_Door_Ana/z_door_ana.h"
+}
+
+#define CVAR_NAME "gEnhancements.DifficultyOptions.HiddenGrottosVisibility"
+#define CVAR CVarGetInteger(CVAR_NAME, 0)
+
+void drawHiddenGrottoMarker(Actor* actor) {
+    s32 grottoType = DOORANA_GET_TYPE(actor);
+    if (grottoType == DOORANA_TYPE_HIDDEN_STORMS || grottoType == DOORANA_TYPE_HIDDEN_BOMB) {
+        if (gGameState->frames % 4) {
+            return;
+        }
+
+        static Vec3f sVelocity = { 0.0f, 3.0f, 0.0f };
+        static Vec3f sAccel = { 0.0f, 0.0f, 0.0f };
+        static Color_RGBA8 sPrimColor = { 255, 255, 255, 255 };
+        static Color_RGBA8 sEnvColor = { 0, 255, 64, 255 };
+        Vec3f newPos;
+
+        newPos.x = Rand_CenteredFloat(10.0f) + actor->world.pos.x;
+        newPos.y = (Rand_ZeroOne() * 10.0f) + actor->world.pos.y;
+        newPos.z = Rand_CenteredFloat(10.0f) + actor->world.pos.z;
+
+        EffectSsKirakira_SpawnDispersed(gPlayState, &newPos, &sVelocity, &sAccel, &sPrimColor, &sEnvColor, 5000, 16);
+    }
+}
+
+void RegisterHiddenGrottosVisibility() {
+    COND_ID_HOOK(OnActorDraw, ACTOR_DOOR_ANA, CVAR == HIDDEN_GROTTOS_VISIBLITY_HAVE_MASK_OF_TRUTH, [](Actor* actor) {
+        if (INV_CONTENT(ITEM_MASK_TRUTH) == ITEM_MASK_TRUTH) {
+            drawHiddenGrottoMarker(actor);
+        }
+    });
+
+    COND_ID_HOOK(OnActorDraw, ACTOR_DOOR_ANA, CVAR == HIDDEN_GROTTOS_VISIBLITY_WEAR_MASK_OF_TRUTH, [](Actor* actor) {
+        if (Player_GetMask(gPlayState) == PLAYER_MASK_TRUTH) {
+            drawHiddenGrottoMarker(actor);
+        }
+    });
+
+    COND_ID_HOOK(OnActorDraw, ACTOR_DOOR_ANA, CVAR == HIDDEN_GROTTOS_VISIBLITY_ALWAYS,
+                 [](Actor* actor) { drawHiddenGrottoMarker(actor); });
+}
+
+static RegisterShipInitFunc initFunc(RegisterHiddenGrottosVisibility, { CVAR_NAME });

--- a/mm/2s2h/Enhancements/Enhancements.h
+++ b/mm/2s2h/Enhancements/Enhancements.h
@@ -39,6 +39,13 @@ enum DekuGuardSearchBallsOptions {
     DEKU_GUARD_SEARCH_BALLS_ALWAYS,
 };
 
+enum HiddenGrottosVisibilityOptions {
+    HIDDEN_GROTTOS_VISIBLITY_OFF,
+    HIDDEN_GROTTOS_VISIBLITY_WEAR_MASK_OF_TRUTH,
+    HIDDEN_GROTTOS_VISIBLITY_HAVE_MASK_OF_TRUTH,
+    HIDDEN_GROTTOS_VISIBLITY_ALWAYS,
+};
+
 // Old Entry Point
 void InitEnhancements();
 


### PR DESCRIPTION
Adds the MM equivalent to SoH's Shard of Agony feature. The visual effect and "Wear Mask of Truth" option are inspired by MM3D.

- **Off**: No visual marker, vanilla behavior
- **Wear Mask of Truth**: Hidden grottos are marked when the Mask of Truth is equipped. This is how it works in MM3D.
- **Have Mask of Truth**: Hidden grottos are marked once the Mask of Truth is obtained, but it does not need to be worn. For convenience's sake, making it similar to the Stone of Agony in SoH.
- **Always**: Hidden grottos are always marked, regardless of the Mask of Truth.

![image](https://github.com/user-attachments/assets/0036ca98-7697-477e-8d83-839c36bdcb64)

The enhancement accounts for Song of Storms hidden grottos just because they are defined in the code, but I don't think any actually exist in MM.


<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3147813322.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3147813965.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3147825008.zip)
<!--- section:artifacts:end -->