### PR TITLE
Fix goron dust particles not spawning by seeding gIrqMgrRetraceTime & gRDPTimeTotal

### DIFF
--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -732,6 +732,10 @@ extern "C" void InitOTR() {
     OTRAudio_Init();
     OTRExtScanner();
 
+    // Just came up with arbitrary numbers that seemed to work, this is
+    // usually set once(?) in currently stubbed out areas of code.
+    gIrqMgrRetraceTime = Ship_Random(700000, 850000);
+
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnFileDropped>(Ben_ProcessDroppedFiles);
 
     time_t now = time(NULL);

--- a/mm/src/code/graph.c
+++ b/mm/src/code/graph.c
@@ -336,10 +336,15 @@ void Graph_ExecuteAndDraw(GraphicsContext* gfxCtx, GameState* gameState) {
 
         gRSPGfxTimeTotal = gRSPGfxTimeAcc;
         gRSPAudioTimeTotal = gRSPAudioTimeAcc;
-        gRDPTimeTotal = gRDPTimeAcc;
+        // #region @2S2H [Port] gRDPTimeAcc is usually set in Sched_HandleRDPDone, which
+        // is currently never called and stubbed out in the port. For now we're
+        // just opting to set this to the time per frame / 10 instead, no idea
+        // how bad of an idea this is. :)
+        gRDPTimeTotal = (time - gRDPTimeAcc) / 10;
         gRSPGfxTimeAcc = 0;
         gRSPAudioTimeAcc = 0;
-        gRDPTimeAcc = 0;
+        gRDPTimeAcc = time;
+        // #endregion
 
         if (sGraphPrevUpdateEndTime != 0) {
             gGraphUpdatePeriod = time - sGraphPrevUpdateEndTime;


### PR DESCRIPTION
Not gonna lie, I don't really understand what's going on or what's _supposed_ to go on here.

The problem stems from the Goron dust particles(and a few other visual things?) call `func_80173B48` to get what I'm assuming is just a pseudo random number. The source of that function is
```cpp
s32 func_80173B48(GameState* gameState) {
    s32 result = OS_CYCLES_TO_NSEC(gameState->framerateDivisor * gIrqMgrRetraceTime) - OS_CYCLES_TO_NSEC(gRDPTimeTotal);

    return result;
}
```

`gIrqMgrRetraceTime` and `gRDPTimeTotal` are both always 0 in 2ship, because they are usually set in now-stubbed out code. From what I could tell using recomp to test, `gIrqMgrRetraceTime` is just a giant number that's set once on boot, so I just gave it an arbitrary random number that seems to work, and `gRDPTimeTotal` is more aptly named time spent in RDP, we don't have a good way of capturing this so I'm just using time since this block last ran which seems to work.

This is unlikely to be the correct solution to this bug, but it fixes the visible issue. I'm open to better solutions or someone with better understanding.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3148175532.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3148179437.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3148196110.zip)
<!--- section:artifacts:end -->