### PR TITLE
Fix BGM replay bug caused by enhancements that bypass normal scene transitions

### DIFF
--- a/mm/2s2h/Enhancements/Fixes/BgmReplay.cpp
+++ b/mm/2s2h/Enhancements/Fixes/BgmReplay.cpp
@@ -7,9 +7,13 @@ extern "C" {
 #include "functions.h"
 }
 
-#define CVAR_FASTER_SCENE_TRANSITIONS CVarGetInteger("gEnhancements.Timesavers.FasterSceneTransitions", 0)
-#define CVAR_PAUSE_SAVE CVarGetInteger("gEnhancements.Saving.PauseSave", 0)
-#define CVAR_DEBUG_MODE CVarGetInteger("gDeveloperTools.DebugEnabled", 0)
+#define CVAR_NAME_FASTER_SCENE_TRANSITIONS "gEnhancements.Timesavers.FasterSceneTransitions"
+#define CVAR_NAME_PAUSE_SAVE "gEnhancements.Saving.PauseSave"
+#define CVAR_NAME_DEBUG_MODE "gDeveloperTools.DebugEnabled"
+
+#define CVAR_FASTER_SCENE_TRANSITIONS CVarGetInteger(CVAR_NAME_FASTER_SCENE_TRANSITIONS, 0)
+#define CVAR_PAUSE_SAVE CVarGetInteger(CVAR_NAME_PAUSE_SAVE, 0)
+#define CVAR_DEBUG_MODE CVarGetInteger(CVAR_NAME_DEBUG_MODE, 0)
 
 /*
  * Certain 2ship features circumvent sequence player state manipulation: debug warping, loading into a dungeon via
@@ -31,4 +35,5 @@ void RegisterFixBgmReplay() {
         [](s8 sceneId, s8 spawnNum) { AudioScript_SequencePlayerDisable(&gAudioCtx.seqPlayers[SEQ_PLAYER_BGM_MAIN]); });
 }
 
-static RegisterShipInitFunc initFunc(RegisterFixBgmReplay, {});
+static RegisterShipInitFunc initFunc(RegisterFixBgmReplay, { CVAR_NAME_FASTER_SCENE_TRANSITIONS, CVAR_NAME_PAUSE_SAVE,
+                                                             CVAR_NAME_DEBUG_MODE });

--- a/mm/2s2h/Enhancements/Fixes/BgmReplay.cpp
+++ b/mm/2s2h/Enhancements/Fixes/BgmReplay.cpp
@@ -16,23 +16,28 @@ extern "C" {
 #define CVAR_DEBUG_MODE CVarGetInteger(CVAR_NAME_DEBUG_MODE, 0)
 
 /*
- * Certain 2ship features circumvent sequence player state manipulation: debug warping, loading into a dungeon via
- * pause save, and faster scene transitions for example. Something about these different features causes
- * SEQ_PLAYER_BGM_MAIN to have the wrong isSeqPlayerInit and enabled flags. A result of this is that the active main BGM
- * sequence is seen as NA_BGM_DISABLED even if BGM is playing. Attempts to store and restore BGM from this point will
- * play silence, as seen with mini-boss battles.
+ * When the player transitions from one scene to another, the main BGM sequence may fade out the volume, disable the
+ * player when the fadeTimer hits 0, then play a new BGM in the next scene. However, certain 2ship features prevent that
+ * fadeTimer from decrementing all the way to 0. This prevents the main BGM sequence player from being disabled in
+ * AudioScript_SequencePlayerProcessSound. The next sequence will play fine, but gActiveSeqs[SEQ_PLAYER_BGM_MAIN] will
+ * be in an invalid state. The result is that attempts to store and then replay the main BGM will play silence, as seen
+ * with mini-boss battles.
  *
- * Rather than get in the weeds of tracking audio state information between different enhancements, a simple workaround
- * is to call AudioScript_SequencePlayerDisable in an OnSceneInit hook. This forces SEQ_PLAYER_BGM_MAIN to reset its
- * state information.
- *
- * Enabled when any of the enhancements in question are enabled.
+ * This fix intercepts the point where the a scene BGM change plays and calls AudioScript_SequencePlayerDisable if any
+ * of the enhancements in question are enabled and this is a transition where a different BGM will play.
  */
 
 void RegisterFixBgmReplay() {
-    COND_HOOK(
-        OnSceneInit, CVAR_FASTER_SCENE_TRANSITIONS || CVAR_PAUSE_SAVE || CVAR_DEBUG_MODE,
-        [](s8 sceneId, s8 spawnNum) { AudioScript_SequencePlayerDisable(&gAudioCtx.seqPlayers[SEQ_PLAYER_BGM_MAIN]); });
+    COND_VB_SHOULD(VB_PLAY_SCENE_SEQUENCE, CVAR_FASTER_SCENE_TRANSITIONS || CVAR_PAUSE_SAVE || CVAR_DEBUG_MODE, {
+        u16 sRequestedSceneSeqId = *va_arg(args, u16*);
+        u16 sPrevMainBgmSeqId = *va_arg(args, u16*);
+        u16 seqId = *va_arg(args, u16*);
+        // Entering new scene that has different BGM to play. This is the same condition in Audio_PlaySceneSequence.
+        if (sRequestedSceneSeqId != seqId &&
+            ((seqId != NA_BGM_FINAL_HOURS) || (sPrevMainBgmSeqId == NA_BGM_DISABLED))) {
+            AudioScript_SequencePlayerDisable(&gAudioCtx.seqPlayers[SEQ_PLAYER_BGM_MAIN]);
+        }
+    });
 }
 
 static RegisterShipInitFunc initFunc(RegisterFixBgmReplay, { CVAR_NAME_FASTER_SCENE_TRANSITIONS, CVAR_NAME_PAUSE_SAVE,

--- a/mm/2s2h/Enhancements/Fixes/BgmReplay.cpp
+++ b/mm/2s2h/Enhancements/Fixes/BgmReplay.cpp
@@ -1,0 +1,29 @@
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/ShipInit.hpp"
+
+extern "C" {
+#include "variables.h"
+#include "functions.h"
+}
+
+/*
+ * Certain 2ship features circumvent sequence player state manipulation: debug warping, loading into a dungeon via
+ * pause save, and faster scene transitions for example. Something about these different features causes
+ * SEQ_PLAYER_BGM_MAIN to have the wrong isSeqPlayerInit and enabled flags. A result of this is that the active main BGM
+ * sequence is seen as NA_BGM_DISABLED even if BGM is playing. Attempts to store and restore BGM from this point will
+ * play silence, as seen with mini-boss battles.
+ *
+ * Rather than get in the weeds of tracking audio state information between different enhancements, a simple workaround
+ * is to call AudioScript_SequencePlayerDisable in an OnSceneInit hook. This forces SEQ_PLAYER_BGM_MAIN to reset its
+ * state information.
+ *
+ * Enabled by default, as different enhancements result in the same bug. This shouldn't hurt any vanilla behavior.
+ */
+
+void RegisterFixBgmReplay() {
+    COND_HOOK(OnSceneInit, true, [](s8 sceneId, s8 spawnNum) {
+        AudioScript_SequencePlayerDisable(&gAudioCtx.seqPlayers[SEQ_PLAYER_BGM_MAIN]);
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterFixBgmReplay, {});

--- a/mm/2s2h/Enhancements/Fixes/BgmReplay.cpp
+++ b/mm/2s2h/Enhancements/Fixes/BgmReplay.cpp
@@ -1,3 +1,4 @@
+#include "public/bridge/consolevariablebridge.h"
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 
@@ -5,6 +6,10 @@ extern "C" {
 #include "variables.h"
 #include "functions.h"
 }
+
+#define CVAR_FASTER_SCENE_TRANSITIONS CVarGetInteger("gEnhancements.Timesavers.FasterSceneTransitions", 0)
+#define CVAR_PAUSE_SAVE CVarGetInteger("gEnhancements.Saving.PauseSave", 0)
+#define CVAR_DEBUG_MODE CVarGetInteger("gDeveloperTools.DebugEnabled", 0)
 
 /*
  * Certain 2ship features circumvent sequence player state manipulation: debug warping, loading into a dungeon via
@@ -17,13 +22,13 @@ extern "C" {
  * is to call AudioScript_SequencePlayerDisable in an OnSceneInit hook. This forces SEQ_PLAYER_BGM_MAIN to reset its
  * state information.
  *
- * Enabled by default, as different enhancements result in the same bug. This shouldn't hurt any vanilla behavior.
+ * Enabled when any of the enhancements in question are enabled.
  */
 
 void RegisterFixBgmReplay() {
-    COND_HOOK(OnSceneInit, true, [](s8 sceneId, s8 spawnNum) {
-        AudioScript_SequencePlayerDisable(&gAudioCtx.seqPlayers[SEQ_PLAYER_BGM_MAIN]);
-    });
+    COND_HOOK(
+        OnSceneInit, CVAR_FASTER_SCENE_TRANSITIONS || CVAR_PAUSE_SAVE || CVAR_DEBUG_MODE,
+        [](s8 sceneId, s8 spawnNum) { AudioScript_SequencePlayerDisable(&gAudioCtx.seqPlayers[SEQ_PLAYER_BGM_MAIN]); });
 }
 
 static RegisterShipInitFunc initFunc(RegisterFixBgmReplay, {});

--- a/mm/2s2h/GameInteractor/GameInteractor.h
+++ b/mm/2s2h/GameInteractor/GameInteractor.h
@@ -240,6 +240,7 @@ typedef enum {
     VB_SETUP_TRANSITION,
     VB_BE_NEAR_DOOR,
     VB_LOAD_PLAYER_ANIMATION_FRAME,
+    VB_PLAY_SCENE_SEQUENCE,
 } GIVanillaBehavior;
 
 typedef enum {

--- a/mm/src/audio/code_8019AF00.c
+++ b/mm/src/audio/code_8019AF00.c
@@ -5478,6 +5478,11 @@ void Audio_StartMorningSceneSequence(u16 seqId) {
 }
 
 void Audio_PlaySceneSequence(u16 seqId, u8 dayMinusOne) {
+    if (!GameInteractor_Should(VB_PLAY_SCENE_SEQUENCE, true, &sRequestedSceneSeqId, &sPrevMainBgmSeqId, &seqId,
+                               &dayMinusOne)) {
+        return;
+    }
+
     if (sRequestedSceneSeqId != seqId) {
         if (seqId == NA_BGM_AMBIENCE) {
             Audio_PlayAmbience(AMBIENCE_ID_08);

--- a/mm/src/audio/code_8019AF00.c
+++ b/mm/src/audio/code_8019AF00.c
@@ -5478,8 +5478,7 @@ void Audio_StartMorningSceneSequence(u16 seqId) {
 }
 
 void Audio_PlaySceneSequence(u16 seqId, u8 dayMinusOne) {
-    if (!GameInteractor_Should(VB_PLAY_SCENE_SEQUENCE, true, &sRequestedSceneSeqId, &sPrevMainBgmSeqId, &seqId,
-                               &dayMinusOne)) {
+    if (GameInteractor_Should(VB_PLAY_SCENE_SEQUENCE, false, &sRequestedSceneSeqId, &sPrevMainBgmSeqId, &seqId)) {
         return;
     }
 


### PR DESCRIPTION
Note: This is separate albeit symptomatically similar to the Great Bay Coast cutscene music bug.

Some of 2ship's enhancements give rise to a bug where the main BGM sequence is seen as `NA_BGM_DISABLED` even if music is playing. This breaks the behavior of `Audio_PlayBgm_StorePrevBgm` and causes `Audio_RestorePrevBgm` to play silence. So far, it seems like debug warping, faster scene transitions, and loading into a pause save result in this bug for the immediate subsequent scene, until the player transfers to another scene in a vanilla way.

In a normal transition, the main BGM sequence player is supposed to be disabled when the fadeTimer is exactly 0. The enhancements in question bypass this in one way or another, causing the bug. This fix is enabled when any of those three enhancements is enabled.


<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3348903759.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3348975350.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3349251125.zip)
<!--- section:artifacts:end -->