### PR TITLE
Use registration system instead of polling for dropped files

### DIFF
--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -738,7 +738,6 @@ extern "C" void InitOTR() {
     std::shared_ptr<Ship::Config> conf = OTRGlobals::Instance->context->GetConfig();
     Ship::Context::GetInstance()->GetFileDropMgr()->RegisterDropHandler(BinarySaveConverter_HandleFileDropped);
     Ship::Context::GetInstance()->GetFileDropMgr()->RegisterDropHandler(SaveManager_HandleFileDropped);
-    Ship::Context::GetInstance()->GetFileDropMgr()->RegisterDropHandler(SaveManager_HandleFileDropped);
 }
 
 extern "C" void SaveManager_ThreadPoolWait() {

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -471,33 +471,6 @@ extern "C" void OTRExtScanner() {
     }
 }
 
-void Ben_ProcessDroppedFiles(const std::string& filePath) {
-    SPDLOG_INFO("Processing dropped file: {}", filePath);
-
-    bool handled = false;
-
-    if (!handled) {
-        handled = SaveManager_HandleFileDropped(filePath);
-    }
-
-    if (!handled) {
-        handled = BinarySaveConverter_HandleFileDropped(filePath);
-    }
-
-    if (!handled) {
-        handled = Rando::Spoiler::HandleFileDropped(filePath);
-    }
-
-    if (!handled) {
-        handled = PresetManager_HandleFileDropped(filePath);
-    }
-
-    if (!handled) {
-        auto gui = Ship::Context::GetInstance()->GetWindow()->GetGui();
-        gui->GetGameOverlay()->TextDrawNotification(30.0f, true, "Unsupported file dropped, ignoring");
-    }
-}
-
 typedef struct {
     uint16_t major;
     uint16_t minor;
@@ -743,8 +716,6 @@ extern "C" void InitOTR() {
     // usually set once(?) in currently stubbed out areas of code.
     gIrqMgrRetraceTime = Ship_Random(700000, 850000);
 
-    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnFileDropped>(Ben_ProcessDroppedFiles);
-
     time_t now = time(NULL);
     tm* tm_now = localtime(&now);
     if (tm_now->tm_mon == 11 && tm_now->tm_mday >= 24 && tm_now->tm_mday <= 25) {
@@ -765,6 +736,10 @@ extern "C" void InitOTR() {
 #endif
 
     std::shared_ptr<Ship::Config> conf = OTRGlobals::Instance->context->GetConfig();
+    Ship::Context::GetInstance()->GetFileDropMgr()->RegisterDropHandler(BinarySaveConverter_HandleFileDropped);
+    Ship::Context::GetInstance()->GetFileDropMgr()->RegisterDropHandler(SaveManager_HandleFileDropped);
+
+
 }
 
 extern "C" void SaveManager_ThreadPoolWait() {
@@ -916,14 +891,6 @@ extern "C" void Graph_StartFrame() {
         }
     }
 #endif
-    auto dropMgr = Ship::Context::GetInstance()->GetFileDropMgr();
-    if (dropMgr->FileDropped()) {
-        std::string filePath = dropMgr->GetDroppedFile();
-        if (!filePath.empty()) {
-            GameInteractor::Instance->ExecuteHooks<GameInteractor::OnFileDropped>(filePath);
-        }
-        dropMgr->ClearDroppedFile();
-    }
 }
 
 void RunCommands(Gfx* Commands, const std::vector<std::unordered_map<Mtx*, MtxF>>& mtx_replacements) {

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -738,8 +738,7 @@ extern "C" void InitOTR() {
     std::shared_ptr<Ship::Config> conf = OTRGlobals::Instance->context->GetConfig();
     Ship::Context::GetInstance()->GetFileDropMgr()->RegisterDropHandler(BinarySaveConverter_HandleFileDropped);
     Ship::Context::GetInstance()->GetFileDropMgr()->RegisterDropHandler(SaveManager_HandleFileDropped);
-
-
+    Ship::Context::GetInstance()->GetFileDropMgr()->RegisterDropHandler(SaveManager_HandleFileDropped);
 }
 
 extern "C" void SaveManager_ThreadPoolWait() {

--- a/mm/2s2h/GameInteractor/GameInteractor_HookTable.h
+++ b/mm/2s2h/GameInteractor/GameInteractor_HookTable.h
@@ -1,5 +1,3 @@
-DEFINE_HOOK(OnFileDropped, (const std::string& path))
-
 DEFINE_HOOK(OnGameStateMainStart, ())
 DEFINE_HOOK(OnGameStateMainFinish, ())
 DEFINE_HOOK(OnGameStateDrawFinish, ())

--- a/mm/2s2h/PresetManager/PresetManager.cpp
+++ b/mm/2s2h/PresetManager/PresetManager.cpp
@@ -6,6 +6,7 @@
 #include "2s2h/BenPort.h"
 #include "2s2h/BenGui/UIWidgets.hpp"
 #include "2s2h/BenGui/Notification.h"
+#include "FileDropMgr.h"
 
 std::unordered_map<std::string, std::string> tagMap = {
     { "gEventLog", "Developer Tools" },
@@ -385,7 +386,7 @@ void PresetManager_CreatePreset(std::string presetName) {
     } catch (...) { Notification::Emit({ .suffix = "Failed to create preset" }); }
 }
 
-bool PresetManager_HandleFileDropped(const std::string& filePath) {
+bool PresetManager_HandleFileDropped(char* filePath) {
     try {
         std::ifstream fileStream(filePath);
 
@@ -525,7 +526,9 @@ void PresetManager_Draw() {
 }
 
 void PresetManager_RegisterHooks() {
+    Ship::Context::GetInstance()->GetFileDropMgr()->RegisterDropHandler(PresetManager_HandleFileDropped);
     PresetManager_RefreshPresets();
 }
 
-static RegisterShipInitFunc initFunc(PresetManager_RegisterHooks, {});
+static RegisterShipInitFunc initFunc(
+    PresetManager_RegisterHooks, {});

--- a/mm/2s2h/PresetManager/PresetManager.cpp
+++ b/mm/2s2h/PresetManager/PresetManager.cpp
@@ -530,5 +530,4 @@ void PresetManager_RegisterHooks() {
     PresetManager_RefreshPresets();
 }
 
-static RegisterShipInitFunc initFunc(
-    PresetManager_RegisterHooks, {});
+static RegisterShipInitFunc initFunc(PresetManager_RegisterHooks, {});

--- a/mm/2s2h/Rando/Rando.cpp
+++ b/mm/2s2h/Rando/Rando.cpp
@@ -5,6 +5,8 @@
 #include "Rando/Spoiler/Spoiler.h"
 #include "Rando/CheckTracker/CheckTracker.h"
 #include "2s2h/ShipInit.hpp"
+#include "FileDropMgr.h"
+#include "Context.h"
 
 // When a save is loaded, we want to unregister all hooks and re-register them if it's a rando save
 void OnSaveLoadHandler(s16 fileNum) {
@@ -22,6 +24,8 @@ void Rando::Init() {
     Rando::MiscBehavior::Init();
     Rando::ActorBehavior::Init();
     Rando::CheckTracker::Init();
+    Ship::Context::GetInstance()->GetFileDropMgr()->RegisterDropHandler(Rando::Spoiler::HandleFileDropped);
+
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSaveLoad>(OnSaveLoadHandler);
 }
 

--- a/mm/2s2h/Rando/Spoiler/HandleFileDropped.cpp
+++ b/mm/2s2h/Rando/Spoiler/HandleFileDropped.cpp
@@ -11,7 +11,7 @@ extern "C" {
 #include "sfx.h"
 }
 
-bool Rando::Spoiler::HandleFileDropped(const std::string& filePath) {
+bool Rando::Spoiler::HandleFileDropped(char* filePath) {
     try {
         std::ifstream fileStream(filePath);
 

--- a/mm/2s2h/Rando/Spoiler/Spoiler.h
+++ b/mm/2s2h/Rando/Spoiler/Spoiler.h
@@ -15,7 +15,7 @@ nlohmann::json GenerateFromSaveContext();
 void SaveToFile(const std::string& fileName, nlohmann::json spoiler);
 nlohmann::json LoadFromFile(const std::string& filePath);
 void ApplyToSaveContext(nlohmann::json spoiler);
-bool HandleFileDropped(const std::string& path);
+bool HandleFileDropped(char* path);
 
 } // namespace Spoiler
 

--- a/mm/2s2h/SaveManager/BinarySaveConverter.cpp
+++ b/mm/2s2h/SaveManager/BinarySaveConverter.cpp
@@ -640,7 +640,7 @@ void BinarySaveConverter_ReadBufferToSave(Legacy_SaveContext* saveContext, std::
     saveContext->save.saveInfo.checksum = 1;
 }
 
-bool BinarySaveConverter_HandleFileDropped(const std::string& filePath) {
+bool BinarySaveConverter_HandleFileDropped(char* filePath) {
     try {
         std::ifstream fileStream(filePath, std::ios::binary | std::ios::ate);
 

--- a/mm/2s2h/SaveManager/SaveManager.cpp
+++ b/mm/2s2h/SaveManager/SaveManager.cpp
@@ -242,7 +242,7 @@ std::string SaveManager_GetFileNameFromFlashSave(FlashSave flashSave) {
     return "file" + std::to_string(fileNum) + (isBackup ? "backup" : "") + ".json";
 }
 
-bool SaveManager_HandleFileDropped(const std::string& filePath) {
+bool SaveManager_HandleFileDropped(char* filePath) {
     try {
         std::ifstream fileStream(filePath);
 

--- a/mm/2s2h/SaveManager/SaveManager.h
+++ b/mm/2s2h/SaveManager/SaveManager.h
@@ -7,8 +7,8 @@
 #include <filesystem>
 #include <nlohmann/json.hpp>
 std::string SaveManager_GetFileName(int fileNum, bool isBackup = false);
-bool SaveManager_HandleFileDropped(const std::string& filePath);
-bool BinarySaveConverter_HandleFileDropped(const std::string& filePath);
+bool SaveManager_HandleFileDropped(char* filePath);
+bool BinarySaveConverter_HandleFileDropped(char* filePath);
 int SaveManager_GetOpenFileSlot();
 void SaveManager_WriteSaveFile(const std::filesystem::path& fileName, nlohmann::json j);
 #else


### PR DESCRIPTION
Moves the file drop system to a registration system handled by LUS as opposed to a polling based system handled by the port.
This PR includes commits to work with latest LUS. They can be dropped once #1179 is merged.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3838690714.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3838700939.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3838751376.zip)
<!--- section:artifacts:end -->