### PR TITLE
[Rando] Change rando sword pickup fix to check if not FD

### DIFF
--- a/mm/2s2h/Rando/MiscBehavior/MiscBehavior.cpp
+++ b/mm/2s2h/Rando/MiscBehavior/MiscBehavior.cpp
@@ -39,7 +39,8 @@ void Rando::MiscBehavior::OnFileLoad() {
     // never letting you be other forms when you get a sword from the smithy or curiosity shop.
     COND_VB_SHOULD(VB_ITEM_GIVE_SWORD_SET_FORM_EQUIP, IS_RANDO, {
         *should = false;
-        if (GET_PLAYER_FORM == PLAYER_FORM_HUMAN) {
+        // FD and human share equip slots, so do not change the equip slot if the player is FD.
+        if (GET_PLAYER_FORM != PLAYER_FORM_FIERCE_DEITY) {
             u8* item = va_arg(args, u8*);
             BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_B) = *item;
         }


### PR DESCRIPTION
#1131 fixed a bug where picking up swords as FD erroneously equipped that sword immediately. This fix only changed the sword equip if the player is in human form. However, this inadvertently caused sword upgrades to only cosmetically change if picked up in any of the three other forms. The HUD icon and damage output would still match whichever sword the player had before.

This fix tweaks it to instead check if the player is not FD. FD is the only affected form by the original bug, as FD and human share equip slots. Other forms have their own equip slots, thus it is safe to acquire sword upgrades in those forms.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3395356859.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3395375711.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3395533585.zip)
<!--- section:artifacts:end -->