### PR TITLE
Clear gHorseIsMounted on reset

### DIFF
--- a/mm/src/overlays/gamestates/ovl_title/z_title.c
+++ b/mm/src/overlays/gamestates/ovl_title/z_title.c
@@ -10,6 +10,7 @@
 #include "CIC6105.h"
 #include "overlays/gamestates/ovl_opening/z_opening.h"
 #include "misc/nintendo_rogo_static/nintendo_rogo_static.h"
+#include "z64horse.h"
 
 #include "build.h"
 #include "BenPort.h"
@@ -255,6 +256,9 @@ void ConsoleLogo_Init(GameState* thisx) {
     // } else {
     gSaveContext.fileNum = 0xFF;
     // }
+    // If the player triggered a reset command while on Epona, then Link will be riding Epona upon loading a save in
+    // the same play session. This ensures that the Epona state is cleared before that.
+    gHorseIsMounted = false;
     // #endregion
 
     gSaveContext.flashSaveAvailable = true;


### PR DESCRIPTION
If the player resets 2ship while riding Epona and then loads a save, Link will be riding Epona upon load. This can result in having Epona in unintended locations or in non-human forms. `gHorseIsMounted` controls this behavior and must be reset.

I'm not sure what the best location for this is, but it needs to happen somewhere in the pipeline for a reset. I tossed it into `ConsoleLogo_Init` since there's a 2S2H region there, but I'm open to suggestions on other locations.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3437287237.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3437288439.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3437316048.zip)
<!--- section:artifacts:end -->