### PR TITLE
Fix incorrect backend ID for OpenGL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,13 @@ Congratulations, you are now sailing with 2 Ship 2 Harkinian! Have fun!
 | Ctrl+R | Reset |
 
 ### Graphics Backends
-Currently, there are three rendering APIs supported: DirectX11 (Windows), OpenGL (all platforms), and Metal (macOS). You can change which API to use in the `Settings` menu of the menubar, which requires a restart.  If you're having an issue with crashing, you can change the API in the `2ship2harkinian.json` file by finding the line `"Backend":{`... and changing the `id` value to `3` and set the `Name` to `OpenGL`. `DirectX 11` with id `2` is the default on Windows. `Metal` with id `4` is the default on macOS.
+Currently, there are three rendering APIs supported: DirectX 11 (Windows), OpenGL (all platforms), and Metal (macOS). You can change which API to use in the `Settings` menu of the menubar, which requires a restart.
+
+If you're having an issue with crashing, you can also change the API manually in the `2ship2harkinian.json` file by finding the `"Backend": {` section and updating the backend ID and name. Be sure to use one of the valid values:
+
+- `0` = DirectX 11 (default on Windows)
+- `1` = OpenGL
+- `2` = Metal (default on macOS)
 
 # Custom Assets
 


### PR DESCRIPTION
This PR corrects the graphics backend IDs listed in the README.md file.

Previously, the README incorrectly listed:
- OpenGL as ID 3 (should be 1)
- DirectX 11 as ID 2 (should be 0)
- Metal as ID 4 (should be 2)

Also clarified behavior when setting an invalid ID, which can cause the program to silently fall back to the default backend or crash.

The updated section now provides accurate backend ID values and keeps the original guidance on changing APIs via the settings menu or the JSON file.

Fixes #1194

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3469215212.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3469215906.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3469225595.zip)
<!--- section:artifacts:end -->