### PR TITLE
[Rando] Use cycleObtained where feasible

### DIFF
--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSongOfSoaring.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSongOfSoaring.cpp
@@ -30,7 +30,7 @@ void RegisterSkipLearningSongOfSoaring() {
     // Then, once this textId is opened for the first time, go ahead and give the player the reward.
     COND_ID_HOOK(OnOpenText, ENGRAVING_TEXT_ID, CVAR || IS_RANDO, [](u16* textId, bool* loadFromMessageTable) {
         if (IS_RANDO) {
-            if (!RANDO_SAVE_CHECKS[RC_SOUTHERN_SWAMP_SONG_OF_SOARING].obtained) {
+            if (!RANDO_SAVE_CHECKS[RC_SOUTHERN_SWAMP_SONG_OF_SOARING].cycleObtained) {
                 RANDO_SAVE_CHECKS[RC_SOUTHERN_SWAMP_SONG_OF_SOARING].eligible = true;
             }
         } else {

--- a/mm/2s2h/Rando/ActorBehavior/DmStk.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/DmStk.cpp
@@ -110,7 +110,7 @@ void Rando::ActorBehavior::InitDmStkBehavior() {
 
     COND_VB_SHOULD(VB_STK_HAVE_OCARINA, IS_RANDO, {
         auto randoSaveCheck = RANDO_SAVE_CHECKS[RC_CLOCK_TOWER_ROOF_OCARINA];
-        *should = !randoSaveCheck.obtained;
+        *should = !randoSaveCheck.cycleObtained;
     });
 
     COND_ID_HOOK(OnOpenText, 0x2013, IS_RANDO && RANDO_SAVE_OPTIONS[RO_HINTS_OATH_TO_ORDER], ApplyOathHint);

--- a/mm/2s2h/Rando/ActorBehavior/EnBaba.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnBaba.cpp
@@ -33,5 +33,5 @@ void Rando::ActorBehavior::InitEnBabaBehavior() {
     });
 
     COND_VB_SHOULD(VB_HAVE_BLAST_MASK, IS_RANDO,
-                   { *should = RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_NORTH_BOMB_LADY].obtained; });
+                   { *should = RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_NORTH_BOMB_LADY].cycleObtained; });
 }

--- a/mm/2s2h/Rando/ActorBehavior/EnCow.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnCow.cpp
@@ -75,7 +75,7 @@ void Rando::ActorBehavior::InitEnCowBehavior() {
         ((EnCow*)actor)->flags |= EN_COW_FLAG_WONT_GIVE_MILK;
 
         RandoSaveCheck& randoSaveCheck = RANDO_SAVE_CHECKS[randoCheckId];
-        if (!randoSaveCheck.shuffled || randoSaveCheck.obtained) {
+        if (!randoSaveCheck.shuffled || randoSaveCheck.cycleObtained) {
             *should = true;
             return;
         }

--- a/mm/2s2h/Rando/ActorBehavior/EnDnh.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnDnh.cpp
@@ -25,7 +25,7 @@ void Rando::ActorBehavior::InitEnDnhBehavior() {
 
         if (cmdId == MSCRIPT_CMD_BRANCH_ON_ITEM) {
             *should = false;
-            if (!RANDO_SAVE_CHECKS[RC_TOURIST_INFORMATION_PICTOBOX].obtained) {
+            if (!RANDO_SAVE_CHECKS[RC_TOURIST_INFORMATION_PICTOBOX].cycleObtained) {
                 return;
             } else {
                 skipCmds.clear();

--- a/mm/2s2h/Rando/ActorBehavior/EnFu.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnFu.cpp
@@ -17,7 +17,7 @@ void Rando::ActorBehavior::InitEnFuBehavior() {
             return;
         }
 
-        if (!RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_EAST_HONEY_DARLING_ANY_DAY].obtained) {
+        if (!RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_EAST_HONEY_DARLING_ANY_DAY].cycleObtained) {
             RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_EAST_HONEY_DARLING_ANY_DAY].eligible = true;
         }
 

--- a/mm/2s2h/Rando/ActorBehavior/EnGamelupy.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnGamelupy.cpp
@@ -82,7 +82,7 @@ void Rando::ActorBehavior::InitEnGamelupyBehavior() {
         }
 
         auto& randoSaveCheck = RANDO_SAVE_CHECKS[randoCheckId];
-        if (randoSaveCheck.obtained || !randoSaveCheck.shuffled) {
+        if (randoSaveCheck.cycleObtained || !randoSaveCheck.shuffled) {
             return;
         }
 

--- a/mm/2s2h/Rando/ActorBehavior/EnGinko.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnGinko.cpp
@@ -22,7 +22,7 @@ void Rando::ActorBehavior::InitEnGinkoBehavior() {
         if (GameInteractor_Should(VB_PASS_INTEREST_BANK_THRESHOLD,
                                   (HS_GET_BANK_RUPEES() >= 1000) && (enGinkoMan->previousBankValue < 1000),
                                   enGinkoMan) &&
-            !RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_WEST_BANK_INTEREST].obtained) {
+            !RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_WEST_BANK_INTEREST].cycleObtained) {
             RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_WEST_BANK_INTEREST].eligible = true;
         }
 

--- a/mm/2s2h/Rando/ActorBehavior/EnGk.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnGk.cpp
@@ -16,7 +16,7 @@ void Rando::ActorBehavior::InitEnGKBehavior() {
 
         switch (actor->id) {
             case ACTOR_EN_GK:
-                if (RANDO_SAVE_CHECKS[RC_GORON_RACETRACK_GOLD_DUST].obtained) {
+                if (RANDO_SAVE_CHECKS[RC_GORON_RACETRACK_GOLD_DUST].cycleObtained) {
                     return;
                 }
 
@@ -46,7 +46,7 @@ void Rando::ActorBehavior::InitEnGKBehavior() {
         *should = false;
 
         SET_WEEKEVENTREG(WEEKEVENTREG_24_80); // Ensure Goron Elder check is available
-        if (!RANDO_SAVE_CHECKS[RC_GORON_SHRINE_FULL_LULLABY].obtained) {
+        if (!RANDO_SAVE_CHECKS[RC_GORON_SHRINE_FULL_LULLABY].cycleObtained) {
             RANDO_SAVE_CHECKS[RC_GORON_SHRINE_FULL_LULLABY].eligible = true;
         }
     });

--- a/mm/2s2h/Rando/ActorBehavior/EnHg.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnHg.cpp
@@ -2,5 +2,5 @@
 
 void Rando::ActorBehavior::InitEnHgBehavior() {
     COND_VB_SHOULD(VB_HAVE_HEALED_PAMELAS_FATHER, IS_RANDO,
-                   { *should = RANDO_SAVE_CHECKS[RC_MUSIC_BOX_HOUSE_FATHER].obtained; });
+                   { *should = RANDO_SAVE_CHECKS[RC_MUSIC_BOX_HOUSE_FATHER].cycleObtained; });
 }

--- a/mm/2s2h/Rando/ActorBehavior/EnIn.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnIn.cpp
@@ -57,7 +57,8 @@ void Rando::ActorBehavior::InitEnInBehavior() {
         }
     });
 
-    COND_VB_SHOULD(VB_HAVE_GARO_MASK, IS_RANDO, { *should = RANDO_SAVE_CHECKS[RC_GORMAN_TRACK_GARO_MASK].obtained; });
+    COND_VB_SHOULD(VB_HAVE_GARO_MASK, IS_RANDO,
+                   { *should = RANDO_SAVE_CHECKS[RC_GORMAN_TRACK_GARO_MASK].cycleObtained; });
 
     // RC_GORMAN_MILK_PURCHASE
 

--- a/mm/2s2h/Rando/ActorBehavior/EnJg.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnJg.cpp
@@ -16,7 +16,7 @@ void Rando::ActorBehavior::InitEnJgBehavior() {
         // Always consider lullaby known so we don't go into the cutscene to learn it
         *should = true;
 
-        if (!RANDO_SAVE_CHECKS[RC_PATH_TO_GORON_VILLAGE_LULLABY_INTRO].obtained) {
+        if (!RANDO_SAVE_CHECKS[RC_PATH_TO_GORON_VILLAGE_LULLABY_INTRO].cycleObtained) {
             RANDO_SAVE_CHECKS[RC_PATH_TO_GORON_VILLAGE_LULLABY_INTRO].eligible = true;
         }
     });

--- a/mm/2s2h/Rando/ActorBehavior/EnJgameTsn.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnJgameTsn.cpp
@@ -12,7 +12,7 @@ void Rando::ActorBehavior::InitEnJgameTsnBehavior() {
         GetItemId* getItemId = va_arg(args, GetItemId*);
         Actor* actor = va_arg(args, Actor*);
         if (actor->id == ACTOR_EN_JGAME_TSN &&
-            *getItemId == GI_HEART_PIECE) { // Leave repeat rupee reward as-is for now
+            !RANDO_SAVE_CHECKS[RC_GREAT_BAY_COAST_FISHERMAN_MINIGAME].cycleObtained) {
             *should = false;
             Player* player = GET_PLAYER(gPlayState);
             actor->parent = &player->actor;
@@ -30,10 +30,10 @@ void Rando::ActorBehavior::InitEnJgameTsnBehavior() {
         auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
         entry.msg =
             "Want to try my %rjumping game%w for %p20 Rupees%w? Win, and I'll give you %r{{itemName}}%w!\x19\xA8";
-        // The repeat reward is a purple Rupee
-        CustomMessage::Replace(&entry.msg, "{{itemName}}",
-                               randoSaveCheck.obtained ? "50 Rupees"
-                                                       : Rando::StaticData::GetItemName(randoSaveCheck.randoItemId));
+        // The same-cycle repeat reward is a purple Rupee
+        CustomMessage::Replace(
+            &entry.msg, "{{itemName}}",
+            randoSaveCheck.cycleObtained ? "50 Rupees" : Rando::StaticData::GetItemName(randoSaveCheck.randoItemId));
 
         CustomMessage::LoadCustomMessageIntoFont(entry);
         *loadFromMessageTable = false;

--- a/mm/2s2h/Rando/ActorBehavior/EnKgy.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnKgy.cpp
@@ -13,7 +13,7 @@ void Rando::ActorBehavior::InitEnKgyBehavior() {
         RandoSaveCheck& randoGildedSwordSaveCheck = RANDO_SAVE_CHECKS[RC_MOUNTAIN_VILLAGE_SMITHY_GILDED_SWORD];
         RandoSaveCheck& randoRazorSwordSaveCheck = RANDO_SAVE_CHECKS[RC_MOUNTAIN_VILLAGE_SMITHY_RAZOR_SWORD];
 
-        if (randoRazorSwordSaveCheck.obtained) {
+        if (randoRazorSwordSaveCheck.cycleObtained) {
             randoGildedSwordSaveCheck.eligible = true;
 
             // Normally this bit is set to zero when you get your sword back. The DoNotResetRazorSword enhancement uses
@@ -30,12 +30,12 @@ void Rando::ActorBehavior::InitEnKgyBehavior() {
 
     COND_VB_SHOULD(VB_SMITHY_CHECK_FOR_RAZOR_SWORD, IS_RANDO, {
         RandoSaveCheck& randoRazorSwordSaveCheck = RANDO_SAVE_CHECKS[RC_MOUNTAIN_VILLAGE_SMITHY_RAZOR_SWORD];
-        *should = randoRazorSwordSaveCheck.obtained;
+        *should = randoRazorSwordSaveCheck.cycleObtained;
     });
 
     COND_VB_SHOULD(VB_SMITHY_CHECK_FOR_GILDED_SWORD, IS_RANDO, {
         RandoSaveCheck& randoGildedSwordSaveCheck = RANDO_SAVE_CHECKS[RC_MOUNTAIN_VILLAGE_SMITHY_GILDED_SWORD];
-        *should = randoGildedSwordSaveCheck.obtained;
+        *should = randoGildedSwordSaveCheck.cycleObtained;
     });
 
     // "If you want your sword sharpened..." (Razor Sword upgrade)
@@ -43,7 +43,7 @@ void Rando::ActorBehavior::InitEnKgyBehavior() {
         auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
 
         RandoSaveCheck& randoRazorSwordSaveCheck = RANDO_SAVE_CHECKS[RC_MOUNTAIN_VILLAGE_SMITHY_RAZOR_SWORD];
-        if (!randoRazorSwordSaveCheck.obtained) {
+        if (!randoRazorSwordSaveCheck.cycleObtained) {
             entry.msg = "\nIf you want %y{itemName}%w, it will cost you %p100 Rupees%w.\n\x10";
             entry.msg += "So, do we have a deal?\n\xC2%gI'll buy it\nNo thanks\xBF";
             CustomMessage::Replace(&entry.msg, "{itemName}",

--- a/mm/2s2h/Rando/ActorBehavior/EnKitan.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnKitan.cpp
@@ -11,7 +11,7 @@ void Rando::ActorBehavior::InitEnKitanBehavior() {
     COND_VB_SHOULD(VB_GIVE_ITEM_FROM_OFFER, IS_RANDO, {
         GetItemId* getItemId = va_arg(args, GetItemId*);
         Actor* actor = va_arg(args, Actor*);
-        if (actor->id == ACTOR_EN_KITAN && *getItemId == GI_HEART_PIECE) { // Leave repeat rupee reward as-is for now
+        if (actor->id == ACTOR_EN_KITAN && !RANDO_SAVE_CHECKS[RC_KEATON_QUIZ].cycleObtained) {
             *should = false;
             // The actor sets this flag using direct syntax, which does not trigger rando's FLAG_WEEK_EVENT_REG handling
             SET_WEEKEVENTREG(WEEKEVENTREG_79_80);

--- a/mm/2s2h/Rando/ActorBehavior/EnMaYto.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnMaYto.cpp
@@ -18,11 +18,11 @@ void Rando::ActorBehavior::InitEnMaYtoBehavior() {
         enMaYto->actionFunc = EnMaYto_PostMilkRunEnd;
     });
 
-    COND_VB_SHOULD(VB_HAVE_ROMANI_MASK, IS_RANDO, { *should = RANDO_SAVE_CHECKS[RC_CREMIA_ESCORT].obtained; });
+    COND_VB_SHOULD(VB_HAVE_ROMANI_MASK, IS_RANDO, { *should = RANDO_SAVE_CHECKS[RC_CREMIA_ESCORT].cycleObtained; });
 
     COND_VB_SHOULD(VB_PLAY_TRANSITION_CS, IS_RANDO, {
         if (gSaveContext.save.cutsceneIndex == 0x0 && gSaveContext.save.entrance == ENTRANCE(TERMINA_FIELD, 13) &&
-            !RANDO_SAVE_CHECKS[RC_CREMIA_ESCORT].obtained) {
+            !RANDO_SAVE_CHECKS[RC_CREMIA_ESCORT].cycleObtained) {
             RANDO_SAVE_CHECKS[RC_CREMIA_ESCORT].eligible = true;
             SET_WEEKEVENTREG(WEEKEVENTREG_14_01);
             Message_BombersNotebookQueueEvent(gPlayState, BOMBERS_NOTEBOOK_EVENT_RECEIVED_ROMANIS_MASK);

--- a/mm/2s2h/Rando/ActorBehavior/EnRuppecrow.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnRuppecrow.cpp
@@ -14,7 +14,7 @@ void Rando::ActorBehavior::InitEnRuppecrowBehavior() {
 
         RandoCheckId randoCheckId = (RandoCheckId)(RC_TERMINA_FIELD_GUAY_RUPEE_DROP_01 + rupeeIndex);
 
-        if (RANDO_SAVE_CHECKS[randoCheckId].obtained || !RANDO_SAVE_CHECKS[randoCheckId].shuffled) {
+        if (RANDO_SAVE_CHECKS[randoCheckId].cycleObtained || !RANDO_SAVE_CHECKS[randoCheckId].shuffled) {
             return;
         }
 


### PR DESCRIPTION
Some straggler rando behavior still used `obtained` conditionals, which precludes repeating some things on subsequent cycles. This PR changes those to use `cycleObtained` so that they can be repeated. This is not exhaustive; some rando actor behavior would have implications from being reverted each cycle (e.g. boss warps, owl statues). This PR aims only to convert the relatively safe ones.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3547684713.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3547704628.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3547878535.zip)
<!--- section:artifacts:end -->