### PR TITLE
Skip Intro Persistence Fix

### DIFF
--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipTatlInterrupts.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipTatlInterrupts.cpp
@@ -19,6 +19,7 @@ void RegisterSkipTatlInterrupts() {
         if (gSaveContext.save.entrance == ENTRANCE(SOUTH_CLOCK_TOWN, 0) && gSaveContext.save.cutsceneIndex == 0 &&
             !CHECK_WEEKEVENTREG(WEEKEVENTREG_59_04)) {
             Flags_SetWeekEventReg(WEEKEVENTREG_59_04);
+            Sram_SaveSpecialEnterClockTown(gPlayState);
         }
     });
 

--- a/mm/2s2h/Enhancements/Cutscenes/SkipIntroSequence.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/SkipIntroSequence.cpp
@@ -60,6 +60,8 @@ void RegisterSkipIntroSequence() {
             SET_WEEKEVENTREG(WEEKEVENTREG_ENTERED_WEST_CLOCK_TOWN);
             SET_WEEKEVENTREG(WEEKEVENTREG_ENTERED_NORTH_CLOCK_TOWN);
         }
+        // Persist this modified state so moon crashes without saving keep it
+        Sram_SaveSpecialEnterClockTown(gPlayState);
     });
 }
 


### PR DESCRIPTION
Pre-fix:
https://imgur.com/a/dzjs19O

Post Fix:
https://imgur.com/a/Iosjvsk

I was not able to reproduce all the issues reported in #970 & #1140 but this could potentially fix those as well.

Added persistence to SkipTatlInterrupt, I didn't test it, but Balloondude confirmed it fixed it as well.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3568832926.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3568836726.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3568879099.zip)
<!--- section:artifacts:end -->