### PR TITLE
Slider upgrades

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -364,12 +364,13 @@ void BenMenu::AddSettings() {
 
     // Audio Settings
     path.sidebarName = "Audio";
+    path.column = SECTION_COLUMN_1;
     AddSidebarEntry("Settings", "Audio", 3);
     AddWidget(path, "Master Volume: %.0f%%", WIDGET_CVAR_SLIDER_FLOAT)
         .CVar("gSettings.Audio.MasterVolume")
         .Options(FloatSliderOptions()
                      .Tooltip("Adjust the overall sound volume.")
-                     .ShowButtons(false)
+                     .ShowAdjustmentButtons(false)
                      .Format("")
                      .IsPercentage());
     AddWidget(path, "Main Music Volume: %.0f%%", WIDGET_CVAR_SLIDER_FLOAT)
@@ -379,7 +380,7 @@ void BenMenu::AddSettings() {
         })
         .Options(FloatSliderOptions()
                      .Tooltip("Adjust the background music volume.")
-                     .ShowButtons(false)
+                     .ShowAdjustmentButtons(false)
                      .Format("")
                      .IsPercentage());
     AddWidget(path, "Sub Music Volume: %.0f%%", WIDGET_CVAR_SLIDER_FLOAT)
@@ -387,8 +388,11 @@ void BenMenu::AddSettings() {
         .Callback([](WidgetInfo& info) {
             AudioSeq_SetPortVolumeScale(SEQ_PLAYER_BGM_SUB, CVarGetFloat("gSettings.Audio.SubMusicVolume", 1.0f));
         })
-        .Options(
-            FloatSliderOptions().Tooltip("Adjust the sub music volume.").ShowButtons(false).Format("").IsPercentage());
+        .Options(FloatSliderOptions()
+                     .Tooltip("Adjust the sub music volume.")
+                     .ShowAdjustmentButtons(false)
+                     .Format("")
+                     .IsPercentage());
     AddWidget(path, "Sound Effects Volume: %.0f%%", WIDGET_CVAR_SLIDER_FLOAT)
         .CVar("gSettings.Audio.SoundEffectsVolume")
         .Callback([](WidgetInfo& info) {
@@ -396,7 +400,7 @@ void BenMenu::AddSettings() {
         })
         .Options(FloatSliderOptions()
                      .Tooltip("Adjust the sound effects volume.")
-                     .ShowButtons(false)
+                     .ShowAdjustmentButtons(false)
                      .Format("")
                      .IsPercentage());
     AddWidget(path, "Fanfare Volume: %.0f%%", WIDGET_CVAR_SLIDER_FLOAT)
@@ -404,8 +408,11 @@ void BenMenu::AddSettings() {
         .Callback([](WidgetInfo& info) {
             AudioSeq_SetPortVolumeScale(SEQ_PLAYER_FANFARE, CVarGetFloat("gSettings.Audio.FanfareVolume", 1.0f));
         })
-        .Options(
-            FloatSliderOptions().Tooltip("Adjust the fanfare volume.").ShowButtons(false).Format("").IsPercentage());
+        .Options(FloatSliderOptions()
+                     .Tooltip("Adjust the fanfare volume.")
+                     .ShowAdjustmentButtons(false)
+                     .Format("")
+                     .IsPercentage());
     AddWidget(path, "Ambience Volume: %.0f%%", WIDGET_CVAR_SLIDER_FLOAT)
         .CVar("gSettings.Audio.AmbienceVolume")
         .Callback([](WidgetInfo& info) {
@@ -413,7 +420,7 @@ void BenMenu::AddSettings() {
         })
         .Options(FloatSliderOptions()
                      .Tooltip("Adjust the ambient sound volume.")
-                     .ShowButtons(false)
+                     .ShowAdjustmentButtons(false)
                      .Format("")
                      .IsPercentage());
     AddWidget(path, "Audio API", WIDGET_AUDIO_BACKEND);
@@ -445,7 +452,7 @@ void BenMenu::AddSettings() {
             FloatSliderOptions()
                 .Tooltip("Multiplies your output resolution by the value inputted, as a more intensive but effective "
                          "form of anti-aliasing.")
-                .ShowButtons(false)
+                .ShowAdjustmentButtons(false)
                 .IsPercentage()
                 .Format("")
                 .Min(0.5f)

--- a/mm/2s2h/BenGui/HudEditor.cpp
+++ b/mm/2s2h/BenGui/HudEditor.cpp
@@ -289,7 +289,7 @@ void HudEditorWindow::DrawElement() {
                 ImGui::TableNextColumn();
                 UIWidgets::CVarSliderInt("X", hudEditorElements[i].xCvar,
                                          {
-                                             .showButtons = false,
+                                             .showAdjustmentButtons = false,
                                              .format = "X: %d",
                                              .min = -10,
                                              .max = 330,
@@ -299,7 +299,7 @@ void HudEditorWindow::DrawElement() {
                 ImGui::TableNextColumn();
                 UIWidgets::CVarSliderInt("Y", hudEditorElements[i].yCvar,
                                          {
-                                             .showButtons = false,
+                                             .showAdjustmentButtons = false,
                                              .format = "Y: %d",
                                              .min = -10,
                                              .max = 250,
@@ -309,7 +309,7 @@ void HudEditorWindow::DrawElement() {
                 ImGui::TableNextColumn();
                 UIWidgets::CVarSliderFloat("Scale", hudEditorElements[i].scaleCvar,
                                            {
-                                               .showButtons = false,
+                                               .showAdjustmentButtons = false,
                                                .format = "Scale: %.2f",
                                                .min = 0.25f,
                                                .max = 4.0f,

--- a/mm/2s2h/BenGui/UIWidgets.cpp
+++ b/mm/2s2h/BenGui/UIWidgets.cpp
@@ -519,7 +519,7 @@ bool SliderInt(const char* label, int32_t* value, const IntSliderOptions& option
             ImGui::Text(label, *value);
         }
     }
-    if (options.showButtons) {
+    if (options.showAdjustmentButtons) {
         if (Button("-", ButtonOptions{ .color = options.color }.Size(Sizes::Inline)) && *value > options.min) {
             *value -= options.step;
             if (options.clamp) {
@@ -530,9 +530,20 @@ bool SliderInt(const char* label, int32_t* value, const IntSliderOptions& option
             dirty = true;
         }
         ImGui::SameLine(0, 3.0f);
-        ImGui::SetNextItemWidth(width - (ImGui::CalcTextSize("+").x + ImGui::GetStyle().FramePadding.x * 2 + 3) * 2);
+        if (options.showResetButton) {
+            float buttonsWidth = (ImGui::CalcTextSize("+").x + (ImGui::GetStyle().FramePadding.x * 2) + 3) * 2 + (ImGui::CalcTextSize(ICON_FA_UNDO).x + (ImGui::GetStyle().FramePadding.x * 2) + 3);
+            ImGui::SetNextItemWidth(width - buttonsWidth);
+        } else {
+            float buttonsWidth = (ImGui::CalcTextSize("+").x + (ImGui::GetStyle().FramePadding.x * 2) + 3) * 2;
+            ImGui::SetNextItemWidth(width - buttonsWidth);
+        }
     } else {
-        ImGui::SetNextItemWidth(width);
+        if (options.showResetButton) {
+            float buttonsWidth = (ImGui::CalcTextSize(ICON_FA_UNDO).x + (ImGui::GetStyle().FramePadding.x * 2) + 3);
+            ImGui::SetNextItemWidth(width - buttonsWidth);
+        } else {
+            ImGui::SetNextItemWidth(width);
+        }
     }
     if (ImGui::SliderScalar(invisibleLabel, ImGuiDataType_S32, value, &options.min, &options.max, options.format,
                             options.flags)) {
@@ -545,15 +556,23 @@ bool SliderInt(const char* label, int32_t* value, const IntSliderOptions& option
         }
         dirty = true;
     }
-    if (options.showButtons) {
+    if (options.showAdjustmentButtons) {
         ImGui::SameLine(0, 3.0f);
-        ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
+        ImGui::SetNextItemWidth(ImGui::CalcTextSize("+").x);
         if (Button("+", ButtonOptions{ .color = options.color }.Size(Sizes::Inline)) && *value < options.max) {
             *value += options.step;
             if (options.clamp) {
                 if (*value > options.max)
                     *value = options.max;
             }
+            dirty = true;
+        }
+    }
+    if (options.showResetButton) {
+        ImGui::SameLine(0, 3.0f);
+        ImGui::SetNextItemWidth(ImGui::CalcTextSize(ICON_FA_UNDO).x);
+        if (Button(ICON_FA_UNDO, ButtonOptions{ .color = options.color }.Size(Sizes::Inline))) {
+            *value = options.defaultValue;
             dirty = true;
         }
     }
@@ -657,7 +676,7 @@ bool SliderFloat(const char* label, float* value, const FloatSliderOptions& opti
             ImGui::Text(label, *value);
         }
     }
-    if (options.showButtons) {
+    if (options.showAdjustmentButtons) {
         if (Button("-", ButtonOptions{ .color = options.color }.Size(Sizes::Inline)) && *value > options.min) {
             *value -= options.step;
             if (options.clamp) {
@@ -666,9 +685,20 @@ bool SliderFloat(const char* label, float* value, const FloatSliderOptions& opti
             dirty = true;
         }
         ImGui::SameLine(0, 3.0f);
-        ImGui::SetNextItemWidth(width - (ImGui::CalcTextSize("+").x + ImGui::GetStyle().FramePadding.x * 2 + 3) * 2);
+        if (options.showResetButton) {
+            float buttonsWidth = (ImGui::CalcTextSize("+").x + (ImGui::GetStyle().FramePadding.x * 2) + 3) * 2 + (ImGui::CalcTextSize(ICON_FA_UNDO).x + (ImGui::GetStyle().FramePadding.x * 2) + 3);
+            ImGui::SetNextItemWidth(width - buttonsWidth);
+        } else {
+            float buttonsWidth = (ImGui::CalcTextSize("+").x + (ImGui::GetStyle().FramePadding.x * 2) + 3) * 2;
+            ImGui::SetNextItemWidth(width - buttonsWidth);
+        }
     } else {
-        ImGui::SetNextItemWidth(width);
+        if (options.showResetButton) {
+            float buttonsWidth = (ImGui::CalcTextSize(ICON_FA_UNDO).x + (ImGui::GetStyle().FramePadding.x * 2) + 3);
+            ImGui::SetNextItemWidth(width - buttonsWidth);
+        } else {
+            ImGui::SetNextItemWidth(width);
+        }
     }
     if (ImGui::SliderScalar(invisibleLabel, ImGuiDataType_Float, &valueToDisplay, &minToDisplay, &maxToDisplay,
                             options.format, options.flags)) {
@@ -678,14 +708,22 @@ bool SliderFloat(const char* label, float* value, const FloatSliderOptions& opti
         }
         dirty = true;
     }
-    if (options.showButtons) {
+    if (options.showAdjustmentButtons) {
         ImGui::SameLine(0, 3.0f);
-        ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
+        ImGui::SetNextItemWidth(ImGui::CalcTextSize("+").x);
         if (Button("+", ButtonOptions{ .color = options.color }.Size(Sizes::Inline)) && *value < options.max) {
             *value += options.step;
             if (options.clamp) {
                 ClampFloat(value, options.min, options.max, options.step);
             }
+            dirty = true;
+        }
+    }
+    if (options.showResetButton) {
+        ImGui::SameLine(0, 3.0f);
+        ImGui::SetNextItemWidth(ImGui::CalcTextSize(ICON_FA_UNDO).x);
+        if (Button(ICON_FA_UNDO, ButtonOptions{ .color = options.color }.Size(Sizes::Inline))) {
+            *value = options.defaultValue;
             dirty = true;
         }
     }

--- a/mm/2s2h/BenGui/UIWidgets.cpp
+++ b/mm/2s2h/BenGui/UIWidgets.cpp
@@ -519,6 +519,10 @@ bool SliderInt(const char* label, int32_t* value, const IntSliderOptions& option
             ImGui::Text(label, *value);
         }
     }
+    float buttonsWidth = 0;
+    if (options.showResetButton) {
+        buttonsWidth = ImGui::CalcTextSize(ICON_FA_UNDO).x + (ImGui::GetStyle().FramePadding.x * 2) + 3;
+    }
     if (options.showAdjustmentButtons) {
         if (Button("-", ButtonOptions{ .color = options.color }.Size(Sizes::Inline)) && *value > options.min) {
             *value -= options.step;
@@ -530,22 +534,9 @@ bool SliderInt(const char* label, int32_t* value, const IntSliderOptions& option
             dirty = true;
         }
         ImGui::SameLine(0, 3.0f);
-        if (options.showResetButton) {
-            float buttonsWidth = (ImGui::CalcTextSize("+").x + (ImGui::GetStyle().FramePadding.x * 2) + 3) * 2 +
-                                 (ImGui::CalcTextSize(ICON_FA_UNDO).x + (ImGui::GetStyle().FramePadding.x * 2) + 3);
-            ImGui::SetNextItemWidth(width - buttonsWidth);
-        } else {
-            float buttonsWidth = (ImGui::CalcTextSize("+").x + (ImGui::GetStyle().FramePadding.x * 2) + 3) * 2;
-            ImGui::SetNextItemWidth(width - buttonsWidth);
-        }
-    } else {
-        if (options.showResetButton) {
-            float buttonsWidth = (ImGui::CalcTextSize(ICON_FA_UNDO).x + (ImGui::GetStyle().FramePadding.x * 2) + 3);
-            ImGui::SetNextItemWidth(width - buttonsWidth);
-        } else {
-            ImGui::SetNextItemWidth(width);
-        }
+        buttonsWidth += (ImGui::CalcTextSize("+").x + (ImGui::GetStyle().FramePadding.x * 2) + 3) * 2;
     }
+    ImGui::SetNextItemWidth(width - buttonsWidth);
     if (ImGui::SliderScalar(invisibleLabel, ImGuiDataType_S32, value, &options.min, &options.max, options.format,
                             options.flags)) {
         if (options.clamp) {
@@ -677,6 +668,10 @@ bool SliderFloat(const char* label, float* value, const FloatSliderOptions& opti
             ImGui::Text(label, *value);
         }
     }
+    float buttonsWidth = 0;
+    if (options.showResetButton) {
+        buttonsWidth = ImGui::CalcTextSize(ICON_FA_UNDO).x + (ImGui::GetStyle().FramePadding.x * 2) + 3;
+    }
     if (options.showAdjustmentButtons) {
         if (Button("-", ButtonOptions{ .color = options.color }.Size(Sizes::Inline)) && *value > options.min) {
             *value -= options.step;
@@ -686,22 +681,9 @@ bool SliderFloat(const char* label, float* value, const FloatSliderOptions& opti
             dirty = true;
         }
         ImGui::SameLine(0, 3.0f);
-        if (options.showResetButton) {
-            float buttonsWidth = (ImGui::CalcTextSize("+").x + (ImGui::GetStyle().FramePadding.x * 2) + 3) * 2 +
-                                 (ImGui::CalcTextSize(ICON_FA_UNDO).x + (ImGui::GetStyle().FramePadding.x * 2) + 3);
-            ImGui::SetNextItemWidth(width - buttonsWidth);
-        } else {
-            float buttonsWidth = (ImGui::CalcTextSize("+").x + (ImGui::GetStyle().FramePadding.x * 2) + 3) * 2;
-            ImGui::SetNextItemWidth(width - buttonsWidth);
-        }
-    } else {
-        if (options.showResetButton) {
-            float buttonsWidth = (ImGui::CalcTextSize(ICON_FA_UNDO).x + (ImGui::GetStyle().FramePadding.x * 2) + 3);
-            ImGui::SetNextItemWidth(width - buttonsWidth);
-        } else {
-            ImGui::SetNextItemWidth(width);
-        }
+        buttonsWidth += (ImGui::CalcTextSize("+").x + (ImGui::GetStyle().FramePadding.x * 2) + 3) * 2;
     }
+    ImGui::SetNextItemWidth(width - buttonsWidth);
     if (ImGui::SliderScalar(invisibleLabel, ImGuiDataType_Float, &valueToDisplay, &minToDisplay, &maxToDisplay,
                             options.format, options.flags)) {
         *value = options.isPercentage ? valueToDisplay / 100.0f : valueToDisplay;

--- a/mm/2s2h/BenGui/UIWidgets.cpp
+++ b/mm/2s2h/BenGui/UIWidgets.cpp
@@ -594,7 +594,7 @@ bool SliderInt(const char* label, int32_t* value, const IntSliderOptions& option
         !Ship_IsCStringEmpty(options.disabledTooltip)) {
         ImGui::SetTooltip("%s", WrappedText(options.disabledTooltip).c_str());
     } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !Ship_IsCStringEmpty(options.tooltip)) {
-        ImGui::SetTooltip("%s", WrappedText(options.tooltip).c_str());
+        ImGui::SetTooltip("%s\n%s", WrappedText(options.tooltip).c_str(), "Edit (Ctrl + Left Click)");
     }
     ImGui::PopID();
     return dirty;
@@ -744,7 +744,7 @@ bool SliderFloat(const char* label, float* value, const FloatSliderOptions& opti
         !Ship_IsCStringEmpty(options.disabledTooltip)) {
         ImGui::SetTooltip("%s", WrappedText(options.disabledTooltip).c_str());
     } else if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && !Ship_IsCStringEmpty(options.tooltip)) {
-        ImGui::SetTooltip("%s", WrappedText(options.tooltip).c_str());
+        ImGui::SetTooltip("%s\n%s", WrappedText(options.tooltip).c_str(), "Edit (Ctrl + Left Click)");
     }
     ImGui::PopID();
     return dirty;

--- a/mm/2s2h/BenGui/UIWidgets.cpp
+++ b/mm/2s2h/BenGui/UIWidgets.cpp
@@ -531,7 +531,8 @@ bool SliderInt(const char* label, int32_t* value, const IntSliderOptions& option
         }
         ImGui::SameLine(0, 3.0f);
         if (options.showResetButton) {
-            float buttonsWidth = (ImGui::CalcTextSize("+").x + (ImGui::GetStyle().FramePadding.x * 2) + 3) * 2 + (ImGui::CalcTextSize(ICON_FA_UNDO).x + (ImGui::GetStyle().FramePadding.x * 2) + 3);
+            float buttonsWidth = (ImGui::CalcTextSize("+").x + (ImGui::GetStyle().FramePadding.x * 2) + 3) * 2 +
+                                 (ImGui::CalcTextSize(ICON_FA_UNDO).x + (ImGui::GetStyle().FramePadding.x * 2) + 3);
             ImGui::SetNextItemWidth(width - buttonsWidth);
         } else {
             float buttonsWidth = (ImGui::CalcTextSize("+").x + (ImGui::GetStyle().FramePadding.x * 2) + 3) * 2;
@@ -686,7 +687,8 @@ bool SliderFloat(const char* label, float* value, const FloatSliderOptions& opti
         }
         ImGui::SameLine(0, 3.0f);
         if (options.showResetButton) {
-            float buttonsWidth = (ImGui::CalcTextSize("+").x + (ImGui::GetStyle().FramePadding.x * 2) + 3) * 2 + (ImGui::CalcTextSize(ICON_FA_UNDO).x + (ImGui::GetStyle().FramePadding.x * 2) + 3);
+            float buttonsWidth = (ImGui::CalcTextSize("+").x + (ImGui::GetStyle().FramePadding.x * 2) + 3) * 2 +
+                                 (ImGui::CalcTextSize(ICON_FA_UNDO).x + (ImGui::GetStyle().FramePadding.x * 2) + 3);
             ImGui::SetNextItemWidth(width - buttonsWidth);
         } else {
             float buttonsWidth = (ImGui::CalcTextSize("+").x + (ImGui::GetStyle().FramePadding.x * 2) + 3) * 2;

--- a/mm/2s2h/BenGui/UIWidgets.hpp
+++ b/mm/2s2h/BenGui/UIWidgets.hpp
@@ -300,7 +300,8 @@ struct ComboboxOptions : WidgetOptions {
 };
 
 struct IntSliderOptions : WidgetOptions {
-    bool showButtons = true;
+    bool showAdjustmentButtons = true;
+    bool showResetButton = true;
     const char* format = "%d";
     int32_t step = 1;
     int32_t min = 1;
@@ -312,9 +313,14 @@ struct IntSliderOptions : WidgetOptions {
     Colors color = Colors::Gray;
     ImGuiSliderFlags flags = 0;
     ImVec2 size = { 0, 0 };
+    
+    IntSliderOptions& ShowAdjustmentButtons(bool showAdjustmentButtons_) {
+        showAdjustmentButtons = showAdjustmentButtons_;
+        return *this;
+    }
 
-    IntSliderOptions& ShowButtons(bool showButtons_) {
-        showButtons = showButtons_;
+    IntSliderOptions& ShowResetButton(bool showResetButton_) {
+        showResetButton = showResetButton_;
         return *this;
     }
 
@@ -375,7 +381,8 @@ struct IntSliderOptions : WidgetOptions {
 };
 
 struct FloatSliderOptions : WidgetOptions {
-    bool showButtons = true;
+    bool showAdjustmentButtons = true;
+    bool showResetButton = true;
     const char* format = "%f";
     float step = 0.01f;
     float min = 0.01f;
@@ -389,8 +396,12 @@ struct FloatSliderOptions : WidgetOptions {
     ImGuiSliderFlags flags = 0;
     ImVec2 size = { 0, 0 };
 
-    FloatSliderOptions& ShowButtons(bool showButtons_) {
-        showButtons = showButtons_;
+    FloatSliderOptions& ShowAdjustmentButtons(bool showAdjustmentButtons_) {
+        showAdjustmentButtons = showAdjustmentButtons_;
+        return *this;
+    }
+    FloatSliderOptions& ShowResetButton(bool showResetButton_) {
+        showResetButton = showResetButton_;
         return *this;
     }
 


### PR DESCRIPTION
<img width="990" height="718" alt="image" src="https://github.com/user-attachments/assets/995be997-f8ba-4a24-b4e0-4949c650549b" />

- Added a reset button to the settings sliders that resets to the `defaultValue`
- Added to the bottom of the tooltips on sliders that describes how they can be edited with an entered value
- Fixed `Settings -> Audio` and `Settings -> Graphics` tabs being in the center column rather than the left column like the other tabs

#584 

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3661948812.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3661965924.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3662001754.zip)
<!--- section:artifacts:end -->