### PR TITLE
Add tooltips to  2 starting item checkboxes

### DIFF
--- a/mm/2s2h/Rando/Menu.cpp
+++ b/mm/2s2h/Rando/Menu.cpp
@@ -279,9 +279,15 @@ static void DrawItemsTab() {
     ImGui::BeginChild("randoItemsStarting", ImVec2(0, 0));
     ImGui::BeginChild("randoStartingItemsColumn1", ImVec2(columnWidth, 0));
     ImGui::SeparatorText("Starting Options");
-    CVarCheckbox("Wallet Full", Rando::StaticData::Options[RO_STARTING_RUPEES].cvar);
+    CVarCheckbox("Wallet Full", Rando::StaticData::Options[RO_STARTING_RUPEES].cvar,
+                 CheckboxOptions({ {
+                     .tooltip = "Start with a full wallet",
+                 } }));
     CVarCheckbox("Consumables Full", Rando::StaticData::Options[RO_STARTING_CONSUMABLES].cvar);
-    CVarCheckbox("Maps and Compasses", Rando::StaticData::Options[RO_STARTING_MAPS_AND_COMPASSES].cvar);
+    CVarCheckbox("Maps and Compasses", Rando::StaticData::Options[RO_STARTING_MAPS_AND_COMPASSES].cvar,
+                 CheckboxOptions({ {
+                     .tooltip = "Enables maps and compasses everywhere",
+                 } }));
     CVarSliderInt("Health", Rando::StaticData::Options[RO_STARTING_HEALTH].cvar,
                   IntSliderOptions()
                       .Min(1)


### PR DESCRIPTION
adds  tooltips to  2 starting item checkboxes

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3595974533.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3595984613.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3596148268.zip)
<!--- section:artifacts:end -->