### PR TITLE
Save play time, support timer display options

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -132,6 +132,12 @@ static const std::vector<const char*> maskOfTruthGrottoOptions = {
     "Always",             // HIDDEN_GROTTOS_VISIBLITY_ALWAYS
 };
 
+static const std::vector<const char*> timerDisplayOptions = {
+    "Off",          // TIMER_DISPLAY_NONE
+    "Real-Time",    // TIMER_DISPLAY_RTA
+    "In-Game Time", // TIMER_DISPLAY_IGT
+};
+
 static const std::unordered_map<int32_t, const char*> damageMultiplierOptions = {
     { 0, "1x" }, { 1, "2x" }, { 2, "4x" }, { 3, "8x" }, { 4, "16x" }, { 10, "1 Hit KO" },
 };
@@ -577,10 +583,17 @@ void BenMenu::AddSettings() {
         .Options(ButtonOptions().Tooltip("Displays a test notification."));
     path.column = SECTION_COLUMN_2;
     AddWidget(path, "In-Game Timer", WIDGET_SEPARATOR_TEXT);
-    AddWidget(path, "Toggle Display Overlay", WIDGET_WINDOW_BUTTON)
+    AddWidget(path, "Display", WIDGET_CVAR_COMBOBOX)
         .CVar("gWindows.DisplayOverlay")
         .WindowName("Display Overlay")
-        .Options(ButtonOptions().Tooltip("Toggles the Display Overlay window for In-game Timers."));
+        .Options(
+            ComboboxOptions()
+                .Tooltip(
+                    "How the timer should be displayed in the overlay.\n\n"
+                    "- Off: Do not display a timer\n"
+                    "- Real-Time: Display the time that has elapsed since creating the save file, regardless of play.\n"
+                    "- In-Game Time: Display the time spent playing the save file")
+                .ComboVec(&timerDisplayOptions));
     AddWidget(path, "Hide Window Background", WIDGET_CVAR_CHECKBOX)
         .CVar("gDisplayOverlay.Background")
         .Options(CheckboxOptions().Tooltip("Hides the background of the Display Overlay window."));

--- a/mm/2s2h/BenJsonConversions.hpp
+++ b/mm/2s2h/BenJsonConversions.hpp
@@ -70,7 +70,7 @@ void from_json(const json& j, RandoSaveInfo& rando) {
 
     // The value of Starting Items is a string in code but is stored as a char in the RandoSaveInfo
     std::string startingItemsStr = j.value("randoStartingItems", "");
-    strncpy(rando.randoStartingItems, startingItemsStr.c_str(), startingItemsStr.size() +1);
+    strncpy(rando.randoStartingItems, startingItemsStr.c_str(), startingItemsStr.size() + 1);
 
     j.at("foundDungeonKeys").get_to(rando.foundDungeonKeys);
     j.at("foundTriforcePieces").get_to(rando.foundTriforcePieces);
@@ -80,12 +80,13 @@ void to_json(json& j, const ShipSaveInfo& shipSaveInfo) {
     uint8_t commitHash[8];
     memcpy(commitHash, shipSaveInfo.commitHash, sizeof(commitHash));
 
-    j = json {
+    j = json{
         { "dpadEquips", shipSaveInfo.dpadEquips },
         { "pauseSaveEntrance", shipSaveInfo.pauseSaveEntrance },
         { "saveType", shipSaveInfo.saveType },
         { "fileCreatedAt", shipSaveInfo.fileCreatedAt },
         { "fileCompletedAt", shipSaveInfo.fileCompletedAt },
+        { "filePlaytime", shipSaveInfo.filePlaytime },
         { "commitHash", commitHash },
     };
 
@@ -100,6 +101,7 @@ void from_json(const json& j, ShipSaveInfo& shipSaveInfo) {
     j.at("saveType").get_to(shipSaveInfo.saveType);
     j.at("fileCreatedAt").get_to(shipSaveInfo.fileCreatedAt);
     j.at("fileCompletedAt").get_to(shipSaveInfo.fileCompletedAt);
+    j.at("filePlaytime").get_to(shipSaveInfo.filePlaytime);
     j.at("commitHash").get_to(shipSaveInfo.commitHash);
 
     if (shipSaveInfo.saveType == SAVETYPE_RANDO) {

--- a/mm/2s2h/Enhancements/Enhancements.h
+++ b/mm/2s2h/Enhancements/Enhancements.h
@@ -46,6 +46,12 @@ enum HiddenGrottosVisibilityOptions {
     HIDDEN_GROTTOS_VISIBLITY_ALWAYS,
 };
 
+enum TimerDisplayOptions {
+    TIMER_DISPLAY_NONE,
+    TIMER_DISPLAY_RTA,
+    TIMER_DISPLAY_IGT,
+};
+
 // Old Entry Point
 void InitEnhancements();
 

--- a/mm/2s2h/Enhancements/Saving/SavingEnhancements.cpp
+++ b/mm/2s2h/Enhancements/Saving/SavingEnhancements.cpp
@@ -5,8 +5,6 @@
 extern "C" {
 #include <variables.h>
 #include <functions.h>
-#include "overlays/actors/ovl_Boss_07/z_boss_07.h"
-void Boss07_Wrath_Death(Boss07*, PlayState*);
 }
 
 static uint32_t autosaveInterval = 0;
@@ -91,8 +89,8 @@ extern "C" bool SavingEnhancements_CanSave() {
 extern "C" void SavingEnhancements_AdvancePlaytime() {
     if (gSaveContext.save.shipSaveInfo.fileCompletedAt == 0) {
         uint64_t timestamp = GetUnixTimestamp();
-        gSaveContext.save.shipSaveInfo.filePlaytime += timestamp - gSaveContext.save.shipSaveInfo.lastTimeLog;
-        gSaveContext.save.shipSaveInfo.lastTimeLog = timestamp;
+        gSaveContext.save.shipSaveInfo.filePlaytime += timestamp - gSaveContext.shipSaveContext.lastTimeLog;
+        gSaveContext.shipSaveContext.lastTimeLog = timestamp;
     }
 }
 
@@ -172,21 +170,20 @@ void RegisterSavingEnhancements() {
         if (gSaveContext.save.shipSaveInfo.fileCreatedAt == 0) {
             gSaveContext.save.shipSaveInfo.fileCreatedAt = GetUnixTimestamp();
         }
-        gSaveContext.save.shipSaveInfo.lastTimeLog = GetUnixTimestamp();
+        gSaveContext.shipSaveContext.lastTimeLog = GetUnixTimestamp();
     });
 
     // Owl statue prompt
     COND_ID_HOOK(OnOpenText, 0xC01, true,
                  [](u16* textId, bool* loadFromMessageTable) { SavingEnhancements_AdvancePlaytime(); });
 
-    // Defeated Majora's Wrath, mark fileCompletedAt accordingly
-    COND_ID_HOOK(OnActorUpdate, ACTOR_BOSS_07, true, [](Actor* actor) {
-        Boss07* boss = (Boss07*)actor;
-        if (boss->actionFunc == Boss07_Wrath_Death && gSaveContext.save.shipSaveInfo.fileCompletedAt == 0) {
+    // Finished the game, mark fileCompletedAt accordingly
+    COND_HOOK(OnGameCompletion, true, []() {
+        if (gSaveContext.save.shipSaveInfo.fileCompletedAt == 0) {
             SavingEnhancements_AdvancePlaytime();
             gSaveContext.save.shipSaveInfo.fileCompletedAt = GetUnixTimestamp();
         }
-    })
+    });
 
     GameInteractor::Instance->RegisterGameHook<GameInteractor::BeforeEndOfCycleSave>([]() {
         SavingEnhancements_AdvancePlaytime();

--- a/mm/2s2h/Enhancements/Saving/SavingEnhancements.cpp
+++ b/mm/2s2h/Enhancements/Saving/SavingEnhancements.cpp
@@ -5,6 +5,8 @@
 extern "C" {
 #include <variables.h>
 #include <functions.h>
+#include "overlays/actors/ovl_Boss_07/z_boss_07.h"
+void Boss07_Wrath_Death(Boss07*, PlayState*);
 }
 
 static uint32_t autosaveInterval = 0;
@@ -86,6 +88,14 @@ extern "C" bool SavingEnhancements_CanSave() {
     return true;
 }
 
+extern "C" void SavingEnhancements_AdvancePlaytime() {
+    if (gSaveContext.save.shipSaveInfo.fileCompletedAt == 0) {
+        uint64_t timestamp = GetUnixTimestamp();
+        gSaveContext.save.shipSaveInfo.filePlaytime += timestamp - gSaveContext.save.shipSaveInfo.lastTimeLog;
+        gSaveContext.save.shipSaveInfo.lastTimeLog = timestamp;
+    }
+}
+
 void DeleteOwlSave() {
     // Remove Owl Save on time cycle reset, needed when persisting owl saves and/or when
     // creating owl saves without the player being send back to the file select screen.
@@ -137,6 +147,7 @@ void HandleAutoSave() {
         // Create owl save
         gSaveContext.save.isOwlSave = true;
         gSaveContext.save.shipSaveInfo.pauseSaveEntrance = SavingEnhancements_GetSaveEntrance();
+        SavingEnhancements_AdvancePlaytime();
         Play_SaveCycleSceneFlags(gPlayState);
         gSaveContext.save.saveInfo.playerData.savedSceneId = gPlayState->sceneId;
         func_8014546C(&gPlayState->sramCtx);
@@ -157,7 +168,30 @@ void RegisterSavingEnhancements() {
         }
     });
 
-    GameInteractor::Instance->RegisterGameHook<GameInteractor::BeforeEndOfCycleSave>([]() { DeleteOwlSave(); });
+    COND_HOOK(OnSaveLoad, true, [](s16 fileNum) {
+        if (gSaveContext.save.shipSaveInfo.fileCreatedAt == 0) {
+            gSaveContext.save.shipSaveInfo.fileCreatedAt = GetUnixTimestamp();
+        }
+        gSaveContext.save.shipSaveInfo.lastTimeLog = GetUnixTimestamp();
+    });
+
+    // Owl statue prompt
+    COND_ID_HOOK(OnOpenText, 0xC01, true,
+                 [](u16* textId, bool* loadFromMessageTable) { SavingEnhancements_AdvancePlaytime(); });
+
+    // Defeated Majora's Wrath, mark fileCompletedAt accordingly
+    COND_ID_HOOK(OnActorUpdate, ACTOR_BOSS_07, true, [](Actor* actor) {
+        Boss07* boss = (Boss07*)actor;
+        if (boss->actionFunc == Boss07_Wrath_Death && gSaveContext.save.shipSaveInfo.fileCompletedAt == 0) {
+            SavingEnhancements_AdvancePlaytime();
+            gSaveContext.save.shipSaveInfo.fileCompletedAt = GetUnixTimestamp();
+        }
+    })
+
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::BeforeEndOfCycleSave>([]() {
+        SavingEnhancements_AdvancePlaytime();
+        DeleteOwlSave();
+    });
 
     GameInteractor::Instance->RegisterGameHook<GameInteractor::BeforeMoonCrashSaveReset>([]() { DeleteOwlSave(); });
 }

--- a/mm/2s2h/Enhancements/Saving/SavingEnhancements.h
+++ b/mm/2s2h/Enhancements/Saving/SavingEnhancements.h
@@ -10,6 +10,7 @@ extern "C" {
 
 int SavingEnhancements_GetSaveEntrance();
 bool SavingEnhancements_CanSave();
+void SavingEnhancements_AdvancePlaytime();
 
 #ifdef __cplusplus
 }

--- a/mm/2s2h/Enhancements/Trackers/DisplayOverlay.cpp
+++ b/mm/2s2h/Enhancements/Trackers/DisplayOverlay.cpp
@@ -7,14 +7,12 @@
 
 extern "C" {
 #include "variables.h"
-#include "overlays/actors/ovl_Boss_07/z_boss_07.h"
 uint64_t GetUnixTimestamp();
-void Boss07_Wrath_DeathCutscene(Boss07*, PlayState*);
 }
 
 #include "ShipUtils.h"
 #include "interface/parameter_static/parameter_static.h"
-#include "GameInteractor/GameInteractor.h"
+#include "2s2h/Enhancements/Enhancements.h"
 
 float windowScale = 1.0f;
 ImVec4 windowBG = ImVec4(0, 0, 0, 0.5f);
@@ -48,7 +46,8 @@ void DisplayOverlayWindow::Draw() {
     if (!gPlayState) {
         return;
     }
-    if (!CVarGetInteger("gWindows.DisplayOverlay", 0)) {
+    int displayOverlay = CVarGetInteger("gWindows.DisplayOverlay", 0);
+    if (displayOverlay == TIMER_DISPLAY_NONE) {
         return;
     }
 
@@ -68,12 +67,34 @@ void DisplayOverlayWindow::Draw() {
     ImGui::Image(Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName(gTimerClockIconTex),
                  ImVec2(16.0f * windowScale, 16.0f * windowScale));
     ImGui::SameLine(0, 10.0f);
-    if (gSaveContext.save.shipSaveInfo.fileCompletedAt == 0) {
-        DrawInGameTimer((GetUnixTimestamp() - gSaveContext.save.shipSaveInfo.fileCreatedAt) / 100);
-    } else {
-        DrawInGameTimer(
-            (gSaveContext.save.shipSaveInfo.fileCompletedAt - gSaveContext.save.shipSaveInfo.fileCreatedAt) / 100,
-            ImVec4(0, 1, 0, 1));
+
+    uint64_t timeToDisplay = 0;
+    if (gSaveContext.save.shipSaveInfo.fileCompletedAt == 0) { // Player has not beaten the game
+        switch (displayOverlay) {
+            case TIMER_DISPLAY_RTA:
+                timeToDisplay = (GetUnixTimestamp() - gSaveContext.save.shipSaveInfo.fileCreatedAt);
+                break;
+            case TIMER_DISPLAY_IGT:
+                timeToDisplay = ((GetUnixTimestamp() - gSaveContext.save.shipSaveInfo.lastTimeLog) +
+                                 gSaveContext.save.shipSaveInfo.filePlaytime);
+                break;
+            default:
+                break;
+        }
+        DrawInGameTimer(timeToDisplay / 100);
+    } else { // Player has beaten the game
+        switch (displayOverlay) {
+            case TIMER_DISPLAY_RTA:
+                timeToDisplay =
+                    (gSaveContext.save.shipSaveInfo.fileCompletedAt - gSaveContext.save.shipSaveInfo.fileCreatedAt);
+                break;
+            case TIMER_DISPLAY_IGT:
+                timeToDisplay = gSaveContext.save.shipSaveInfo.filePlaytime;
+                break;
+            default:
+                break;
+        }
+        DrawInGameTimer(timeToDisplay / 100, ImVec4(0, 1, 0, 1));
     }
 
     ImGui::End();
@@ -83,16 +104,4 @@ void DisplayOverlayWindow::Draw() {
 }
 
 void DisplayOverlayWindow::InitElement() {
-    COND_HOOK(OnSaveLoad, true, [](s16 fileNum) {
-        if (gSaveContext.save.shipSaveInfo.fileCreatedAt == 0) {
-            gSaveContext.save.shipSaveInfo.fileCreatedAt = GetUnixTimestamp();
-        }
-    });
-
-    COND_ID_HOOK(OnActorUpdate, ACTOR_BOSS_07, true, [](Actor* actor) {
-        Boss07* boss = (Boss07*)actor;
-        if (boss->actionFunc == Boss07_Wrath_DeathCutscene && gSaveContext.save.shipSaveInfo.fileCompletedAt == 0) {
-            gSaveContext.save.shipSaveInfo.fileCompletedAt = GetUnixTimestamp();
-        }
-    })
 }

--- a/mm/2s2h/Enhancements/Trackers/DisplayOverlay.cpp
+++ b/mm/2s2h/Enhancements/Trackers/DisplayOverlay.cpp
@@ -75,7 +75,7 @@ void DisplayOverlayWindow::Draw() {
                 timeToDisplay = (GetUnixTimestamp() - gSaveContext.save.shipSaveInfo.fileCreatedAt);
                 break;
             case TIMER_DISPLAY_IGT:
-                timeToDisplay = ((GetUnixTimestamp() - gSaveContext.save.shipSaveInfo.lastTimeLog) +
+                timeToDisplay = ((GetUnixTimestamp() - gSaveContext.shipSaveContext.lastTimeLog) +
                                  gSaveContext.save.shipSaveInfo.filePlaytime);
                 break;
             default:

--- a/mm/2s2h/GameInteractor/GameInteractor.cpp
+++ b/mm/2s2h/GameInteractor/GameInteractor.cpp
@@ -82,6 +82,10 @@ void GameInteractor_ExecuteBeforeInterfaceClockDraw() {
     GameInteractor::Instance->ExecuteHooks<GameInteractor::BeforeInterfaceClockDraw>();
 }
 
+void GameInteractor_ExecuteOnGameCompletion() {
+    GameInteractor::Instance->ExecuteHooks<GameInteractor::OnGameCompletion>();
+}
+
 void GameInteractor_ExecuteOnSceneInit(s16 sceneId, s8 spawnNum) {
     SPDLOG_DEBUG("OnSceneInit: sceneId: {}, spawnNum: {}", sceneId, spawnNum);
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnSceneInit>(sceneId, spawnNum);

--- a/mm/2s2h/GameInteractor/GameInteractor.h
+++ b/mm/2s2h/GameInteractor/GameInteractor.h
@@ -724,6 +724,7 @@ void GameInteractor_ExecuteBeforeMoonCrashSaveReset();
 void GameInteractor_ExecuteOnInterfaceDrawStart();
 void GameInteractor_ExecuteAfterInterfaceClockDraw();
 void GameInteractor_ExecuteBeforeInterfaceClockDraw();
+void GameInteractor_ExecuteOnGameCompletion();
 
 void GameInteractor_ExecuteOnSceneInit(s16 sceneId, s8 spawnNum);
 void GameInteractor_ExecuteOnRoomInit(s16 sceneId, s8 roomNum);

--- a/mm/2s2h/GameInteractor/GameInteractor_HookTable.h
+++ b/mm/2s2h/GameInteractor/GameInteractor_HookTable.h
@@ -15,6 +15,7 @@ DEFINE_HOOK(BeforeMoonCrashSaveReset, ())
 DEFINE_HOOK(OnInterfaceDrawStart, ())
 DEFINE_HOOK(AfterInterfaceClockDraw, ())
 DEFINE_HOOK(BeforeInterfaceClockDraw, ())
+DEFINE_HOOK(OnGameCompletion, ())
 
 DEFINE_HOOK(OnSceneInit, (s8 sceneId, s8 spawnNum))
 DEFINE_HOOK(OnRoomInit, (s8 sceneId, s8 roomNum))

--- a/mm/2s2h/Rando/GiveItem.cpp
+++ b/mm/2s2h/Rando/GiveItem.cpp
@@ -113,6 +113,7 @@ void Rando::GiveItem(RandoItemId randoItemId) {
                 if (!Flags_GetRandoInf(RANDO_INF_OBTAINED_SOUL_OF_MAJORA)) {
                     Rando::GiveItem(RI_SOUL_MAJORA);
                 }
+                GameInteractor_ExecuteOnGameCompletion();
                 GameInteractor::Instance->events.emplace_back(
                     GIEventTransition{ .entrance = ENTRANCE(TERMINA_FIELD, 0),
                                        .cutsceneIndex = 0xFFF7,

--- a/mm/2s2h/SaveManager/Migrations/7.cpp
+++ b/mm/2s2h/SaveManager/Migrations/7.cpp
@@ -1,0 +1,8 @@
+#include "2s2h/SaveManager/SaveManager.h"
+#include "z64.h"
+
+void SaveManager_Migration_7(nlohmann::json& j) {
+    if (!j["save"]["shipSaveInfo"].contains("filePlaytime")) {
+        j["save"]["shipSaveInfo"]["filePlaytime"] = 0;
+    }
+}

--- a/mm/2s2h/SaveManager/SaveManager.cpp
+++ b/mm/2s2h/SaveManager/SaveManager.cpp
@@ -40,7 +40,7 @@ const std::filesystem::path savesFolderPath(Ship::Context::GetPathRelativeToAppD
 // - Create the migration file in the Migrations folder with the name `{CURRENT_SAVE_VERSION}.cpp`
 // - Add the migration function definition below and add it to the `migrations` map with the key being the previous
 // version
-const uint32_t CURRENT_SAVE_VERSION = 6;
+const uint32_t CURRENT_SAVE_VERSION = 7;
 
 void SaveManager_Migration_1(nlohmann::json& j);
 void SaveManager_Migration_2(nlohmann::json& j);
@@ -48,6 +48,7 @@ void SaveManager_Migration_3(nlohmann::json& j);
 void SaveManager_Migration_4(nlohmann::json& j);
 void SaveManager_Migration_5(nlohmann::json& j);
 void SaveManager_Migration_6(nlohmann::json& j);
+void SaveManager_Migration_7(nlohmann::json& j);
 
 const std::unordered_map<uint32_t, std::function<void(nlohmann::json&)>> migrations = {
     // Pre-1.0.0 Migrations, deprecated
@@ -58,6 +59,7 @@ const std::unordered_map<uint32_t, std::function<void(nlohmann::json&)>> migrati
     // Base Migration
     { 4, SaveManager_Migration_5 },
     { 5, SaveManager_Migration_6 },
+    { 6, SaveManager_Migration_7 },
 };
 
 int SaveManager_MigrateSave(nlohmann::json& j) {

--- a/mm/include/z64save.h
+++ b/mm/include/z64save.h
@@ -397,8 +397,7 @@ typedef struct ShipSaveInfo {
     s32 pauseSaveEntrance;
     SaveType saveType;
     uint64_t fileCreatedAt;
-    uint64_t fileCompletedAt; // For now this is always Majora final blow, has the potential to be something else later on
-    uint64_t lastTimeLog; // Persisted value not relevant, but needs stored to calculate filePlaytime
+    uint64_t fileCompletedAt;
     uint64_t filePlaytime;
     char commitHash[8];
     RandoSaveInfo rando;
@@ -435,6 +434,7 @@ typedef struct DpadSaveContext {
 // See `ShipSaveInfo` for values on the SaveContext that are persisted.
 typedef struct ShipSaveContext {
     DpadSaveContext dpad;
+    uint64_t lastTimeLog;
 } ShipSaveContext;
 // #endregion
 

--- a/mm/include/z64save.h
+++ b/mm/include/z64save.h
@@ -398,6 +398,8 @@ typedef struct ShipSaveInfo {
     SaveType saveType;
     uint64_t fileCreatedAt;
     uint64_t fileCompletedAt; // For now this is always Majora final blow, has the potential to be something else later on
+    uint64_t lastTimeLog; // Persisted value not relevant, but needs stored to calculate filePlaytime
+    uint64_t filePlaytime;
     char commitHash[8];
     RandoSaveInfo rando;
 } ShipSaveInfo;

--- a/mm/src/code/z_sram_NES.c
+++ b/mm/src/code/z_sram_NES.c
@@ -1018,8 +1018,8 @@ void Sram_InitNewSave(void) {
     gSaveContext.save.shipSaveInfo.saveType = SAVETYPE_VANILLA;
     gSaveContext.save.shipSaveInfo.fileCreatedAt = 0;
     gSaveContext.save.shipSaveInfo.fileCompletedAt = 0;
-    gSaveContext.save.shipSaveInfo.lastTimeLog = 0;
     gSaveContext.save.shipSaveInfo.filePlaytime = 0;
+    gSaveContext.shipSaveContext.lastTimeLog = 0;
     //  #endregion
 
     Sram_GenerateRandomSaveFields();
@@ -1250,8 +1250,8 @@ void Sram_InitDebugSave(void) {
     gSaveContext.save.shipSaveInfo.saveType = SAVETYPE_VANILLA;
     gSaveContext.save.shipSaveInfo.fileCreatedAt = 0;
     gSaveContext.save.shipSaveInfo.fileCompletedAt = 0;
-    gSaveContext.save.shipSaveInfo.lastTimeLog = 0;
     gSaveContext.save.shipSaveInfo.filePlaytime = 0;
+    gSaveContext.shipSaveContext.lastTimeLog = 0;
     // #endregion
 
     Sram_GenerateRandomSaveFields();

--- a/mm/src/code/z_sram_NES.c
+++ b/mm/src/code/z_sram_NES.c
@@ -5,6 +5,7 @@
 #include "BenPort.h"
 #include "build.h"
 
+#include "2s2h/Enhancements/Saving/SavingEnhancements.h"
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include <libultraship/bridge/consolevariablebridge.h>
 
@@ -1017,6 +1018,8 @@ void Sram_InitNewSave(void) {
     gSaveContext.save.shipSaveInfo.saveType = SAVETYPE_VANILLA;
     gSaveContext.save.shipSaveInfo.fileCreatedAt = 0;
     gSaveContext.save.shipSaveInfo.fileCompletedAt = 0;
+    gSaveContext.save.shipSaveInfo.lastTimeLog = 0;
+    gSaveContext.save.shipSaveInfo.filePlaytime = 0;
     //  #endregion
 
     Sram_GenerateRandomSaveFields();
@@ -1247,6 +1250,8 @@ void Sram_InitDebugSave(void) {
     gSaveContext.save.shipSaveInfo.saveType = SAVETYPE_VANILLA;
     gSaveContext.save.shipSaveInfo.fileCreatedAt = 0;
     gSaveContext.save.shipSaveInfo.fileCompletedAt = 0;
+    gSaveContext.save.shipSaveInfo.lastTimeLog = 0;
+    gSaveContext.save.shipSaveInfo.filePlaytime = 0;
     // #endregion
 
     Sram_GenerateRandomSaveFields();
@@ -2019,6 +2024,8 @@ void Sram_SaveSpecialEnterClockTown(PlayState* play) {
 
     gSaveContext.save.isFirstCycle = true;
     gSaveContext.save.isOwlSave = false;
+    // 2S2H [Enhancement] Store playtime before saving
+    SavingEnhancements_AdvancePlaytime();
     func_80145698(sramCtx);
     SysFlashrom_WriteDataSync(sramCtx->saveBuf, gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER],
                               gFlashSpecialSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER]);

--- a/mm/src/overlays/actors/ovl_Boss_07/z_boss_07.c
+++ b/mm/src/overlays/actors/ovl_Boss_07/z_boss_07.c
@@ -1771,6 +1771,7 @@ void Boss07_Wrath_SetupDeathCutscene(Boss07* this, PlayState* play) {
     this->damagedTimer = 1000;
 
     GameInteractor_ExecuteOnBossDefeated(this->actor.id); // 2S2H Time Splits
+    GameInteractor_ExecuteOnGameCompletion();
 }
 
 void Boss07_Wrath_DeathCutscene(Boss07* this, PlayState* play) {

--- a/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_scope_NES.c
+++ b/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_scope_NES.c
@@ -3580,6 +3580,7 @@ void KaleidoScope_Update(PlayState* play) {
                                 // but we need to first identify and fix edge cases where that doesn't work properly
                                 // like grottos and cutscenes
                                 gSaveContext.save.shipSaveInfo.pauseSaveEntrance = SavingEnhancements_GetSaveEntrance();
+                                SavingEnhancements_AdvancePlaytime();
                             }
                             Play_SaveCycleSceneFlags(play);
                             gSaveContext.save.saveInfo.playerData.savedSceneId = play->sceneId;


### PR DESCRIPTION
Currently, save files have a timer display that shows the naive difference between the current time and the time when the file was created. This PR improves the time tracking so that it tracks the time actually spent between saves and not real time elapsed regardless of play.

2ship needs to update the tracked time in chunks with `SavingEnhancements_AdvancePlaytime()`. This gets called when:
* Saving or speaking to an owl statue
* Defeating Majora's Wrath, i.e. beating the game

Some logic for initializing and marking game completion were handled in the timer display element. I moved that to `SavingEnhancements.cpp`.

This necessitates and adds a save migration.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4649375382.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4649400698.zip)
<!--- section:artifacts:end -->