### PR TITLE
Fix Infinite Deku Hop on Death

### DIFF
--- a/mm/2s2h/Enhancements/Player/InfiniteDekuHopping.cpp
+++ b/mm/2s2h/Enhancements/Player/InfiniteDekuHopping.cpp
@@ -13,7 +13,9 @@ void RegisterInfiniteDekuHopping() {
     COND_VB_SHOULD(VB_DEKU_LINK_SPIN_ON_LAST_HOP, CVAR, {
         if (*should) {
             Player* player = GET_PLAYER(gPlayState);
-            player->remainingHopsCounter = 5;
+            if (gSaveContext.save.saveInfo.playerData.health != 0) {
+                player->remainingHopsCounter = 5;
+            }
         }
     });
 


### PR DESCRIPTION
Simply adds a heath check to ensure the hop counter is not reset on player death... This should resolve issue #1138 


<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3600754614.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3600755015.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3600944648.zip)
<!--- section:artifacts:end -->