### PR TITLE
Do not allow gameover audio to be changed

### DIFF
--- a/mm/2s2h/Enhancements/Audio/AudioCollection.cpp
+++ b/mm/2s2h/Enhancements/Audio/AudioCollection.cpp
@@ -61,7 +61,7 @@ AudioCollection::AudioCollection() {
                            "NA_BGM_CLOCK_TOWN_MAIN_SEQUENCE", SEQ_BGM_WORLD, false, false),
         SEQUENCE_MAP_ENTRY(NA_BGM_OPENING, "Opening", "NA_BGM_OPENING", SEQ_BGM_WORLD, true, true),
         SEQUENCE_MAP_ENTRY(NA_BGM_INSIDE_A_HOUSE, "Inside House", "NA_BGM_INSIDE_A_HOUSE", SEQ_BGM_WORLD, true, true),
-        SEQUENCE_MAP_ENTRY(NA_BGM_GAME_OVER, "Game Over", "NA_BGM_GAME_OVER", SEQ_BGM_EVENT, true, true),
+        SEQUENCE_MAP_ENTRY(NA_BGM_GAME_OVER, "Game Over", "NA_BGM_GAME_OVER", SEQ_BGM_EVENT, false, true),
         SEQUENCE_MAP_ENTRY(NA_BGM_CLEAR_BOSS, "Clear Boss", "NA_BGM_CLEAR_BOSS", SEQ_BGM_BATTLE, true, true),
         SEQUENCE_MAP_ENTRY(NA_BGM_GET_ITEM, "Get Item", "NA_BGM_GET_ITEM", SEQ_FANFARE, true, true),
         SEQUENCE_MAP_ENTRY(NA_BGM_CLOCK_TOWN_DAY_2_PTR, "Clock Town Day 2 (Alt)", "NA_BGM_CLOCK_TOWN_DAY_2_PTR",


### PR DESCRIPTION
The game over code waits for the game over BGM to finish playing before respawning the player. If another audio track is assigned here via the editor, the result can be a game over that lasts really long. If the BGM loops, the game over will never finish.

https://github.com/HarbourMasters/2ship2harkinian/blob/cf3fc8c8cb2f768529513c52adf3ecc3ce4b7c15/mm/src/code/z_game_over.c#L94-L107


<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3625374716.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3625391851.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3625478505.zip)
<!--- section:artifacts:end -->