### PR TITLE
Fix slider label clipping when label position is None

### DIFF
--- a/mm/2s2h/BenGui/UIWidgets.cpp
+++ b/mm/2s2h/BenGui/UIWidgets.cpp
@@ -562,7 +562,7 @@ bool SliderInt(const char* label, int32_t* value, const IntSliderOptions& option
         if (options.labelPosition == LabelPosition::Near) {
             ImGui::SameLine();
             ImGui::Text(label, *value);
-        } else if (options.labelPosition == LabelPosition::Far || options.labelPosition == LabelPosition::None) {
+        } else if (options.labelPosition == LabelPosition::Far) {
             ImGui::SameLine(ImGui::GetContentRegionAvail().x - ImGui::CalcTextSize(label).x +
                             ImGui::GetStyle().ItemSpacing.x);
             ImGui::Text(label, *value);
@@ -694,7 +694,7 @@ bool SliderFloat(const char* label, float* value, const FloatSliderOptions& opti
         if (options.labelPosition == LabelPosition::Near) {
             ImGui::SameLine();
             ImGui::Text(label, *value);
-        } else if (options.labelPosition == LabelPosition::Far || options.labelPosition == LabelPosition::None) {
+        } else if (options.labelPosition == LabelPosition::Far) {
             ImGui::SameLine(ImGui::GetContentRegionAvail().x - labelSpacing);
             ImGui::Text(label, *value);
         }


### PR DESCRIPTION
Before:
<img width="687" height="225" alt="image" src="https://github.com/user-attachments/assets/1e7122b7-2470-440a-aac5-d5785fcc276e" />

After:
<img width="695" height="220" alt="image" src="https://github.com/user-attachments/assets/2848fdf0-d18e-4fd7-b5d7-867faa8355b1" />


<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3635280497.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3635299131.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3635372300.zip)
<!--- section:artifacts:end -->