### PR TITLE
Fix Better SoDT bugs with audio and early day change

### DIFF
--- a/mm/2s2h/Enhancements/Songs/BetterSongOfDoubleTime.cpp
+++ b/mm/2s2h/Enhancements/Songs/BetterSongOfDoubleTime.cpp
@@ -136,7 +136,7 @@ void OnPlayerUpdate(Actor* actor) {
                 gSaveContext.respawnFlag = 2;
 
                 // Stop BGM so that new day sequences can play
-                gSaveContext.seqId = (u8)NA_BGM_DISABLED;
+                gSaveContext.seqId = NA_BGM_DISABLED;
 
                 GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::OnActorKill>(onEnTest6KillHookId);
                 onEnTest6KillHookId = 0;
@@ -226,7 +226,8 @@ void OnPlayerUpdate(Actor* actor) {
         sSelectedTime = newTime;
     } else if (adjustMode == ADJUST_DIRECTION_REVERSE) { // Reverse time
         u16 newTime = sSelectedTime - interval;
-        if (sSelectedDay == sOriginalDay && CLOCK_TIME_NORMALIZED(newTime) < CLOCK_TIME_NORMALIZED(sOriginalTime)) {
+        if (sSelectedDay == sOriginalDay && (CLOCK_TIME_NORMALIZED(newTime) < CLOCK_TIME_NORMALIZED(sOriginalTime) ||
+                                             interval > CLOCK_TIME_NORMALIZED(sSelectedTime))) {
             newTime = sOriginalTime;
         }
         // Day decrementing


### PR DESCRIPTION
Fixes two oddly specific bugs with Better SoDT:

- The BGM stop was implemented before [audio seq IDs were bumped from u8 to u16.](https://github.com/HarbourMasters/2ship2harkinian/commit/2d0942a1b187938f55d34c71e0965e37a70b1094#diff-f515aeb3c8118050709d24dd08261033c74a13628ed2ee30926d9bf08c627905) The result is that, when using BSoDT at night to advance a short time, all in-world SFX would stop playing until loading into certain scenes
- Using BSoDT early in a given day (before 7 A.M. or so, depending on the Z/R speed modifier) would allow the player to cycle to earlier times because the interval is bigger than the current selected time, leading to underflow. The resulting value is thus greater than the current time, bypassing the intended range check

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3651182065.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3651226139.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3651625523.zip)
<!--- section:artifacts:end -->