### PR TITLE
Add tooltip for 'Consumables Full' checkbox

### DIFF
--- a/mm/2s2h/Rando/Menu.cpp
+++ b/mm/2s2h/Rando/Menu.cpp
@@ -283,7 +283,11 @@ static void DrawItemsTab() {
                  CheckboxOptions({ {
                      .tooltip = "Start with a full wallet",
                  } }));
-    CVarCheckbox("Consumables Full", Rando::StaticData::Options[RO_STARTING_CONSUMABLES].cvar);
+    CVarCheckbox("Consumables Full", Rando::StaticData::Options[RO_STARTING_CONSUMABLES].cvar,
+                 CheckboxOptions({ {
+                     .tooltip = "Start with full Deku Sticks and Deku Nuts",
+                 } }));
+
     CVarCheckbox("Maps and Compasses", Rando::StaticData::Options[RO_STARTING_MAPS_AND_COMPASSES].cvar,
                  CheckboxOptions({ {
                      .tooltip = "Enables maps and compasses everywhere",


### PR DESCRIPTION
Adds a tool tip for 'Consumables Full' checkbox , would like some feedback  in terms of wordage /verbage 

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3676581676.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3676586334.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3676597873.zip)
<!--- section:artifacts:end -->