### PR TITLE
Check previousBankValue in custom bank thresholds

### DIFF
--- a/mm/2s2h/Enhancements/DifficultyOptions/CustomBankRewardThresholds.cpp
+++ b/mm/2s2h/Enhancements/DifficultyOptions/CustomBankRewardThresholds.cpp
@@ -19,13 +19,15 @@ void RegisterCustomBankRewardThresholds() {
     COND_VB_SHOULD(VB_PASS_FIRST_BANK_THRESHOLD, CVAR, {
         EnGinkoMan* enGinkoMan = va_arg(args, EnGinkoMan*);
 
-        *should = (HS_GET_BANK_RUPEES() >= FIRST_BANK_THRESHOLD) && !CHECK_WEEKEVENTREG(WEEKEVENTREG_10_08);
+        *should = (HS_GET_BANK_RUPEES() >= FIRST_BANK_THRESHOLD) &&
+                  (enGinkoMan->previousBankValue < FIRST_BANK_THRESHOLD) && !CHECK_WEEKEVENTREG(WEEKEVENTREG_10_08);
     });
 
     COND_VB_SHOULD(VB_PASS_INTEREST_BANK_THRESHOLD, CVAR, {
         EnGinkoMan* enGinkoMan = va_arg(args, EnGinkoMan*);
 
-        *should = (HS_GET_BANK_RUPEES() >= INTEREST_BANK_THRESHOLD);
+        *should = (HS_GET_BANK_RUPEES() >= INTEREST_BANK_THRESHOLD &&
+                   enGinkoMan->previousBankValue < INTEREST_BANK_THRESHOLD);
     });
 
     COND_VB_SHOULD(VB_PASS_SECOND_BANK_THRESHOLD, CVAR, {
@@ -39,7 +41,8 @@ void RegisterCustomBankRewardThresholds() {
     COND_VB_SHOULD(VB_PASS_SECOND_BANK_THRESHOLD_ALT, CVAR, {
         EnGinkoMan* enGinkoMan = va_arg(args, EnGinkoMan*);
 
-        if (!CHECK_WEEKEVENTREG(WEEKEVENTREG_59_08) && HS_GET_BANK_RUPEES() >= SECOND_BANK_THRESHOLD) {
+        if (!CHECK_WEEKEVENTREG(WEEKEVENTREG_59_08) && HS_GET_BANK_RUPEES() >= SECOND_BANK_THRESHOLD &&
+            enGinkoMan->previousBankValue < SECOND_BANK_THRESHOLD) {
             *should = true;
         }
     });


### PR DESCRIPTION
Fixes a bug with Lower Bank Reward Thresholds where the interest reward would supersede the second threshold reward. The hook'd condition did not also check `previousBankValue` like the vanilla condition, which caused the interest reward to be true and thus preempt the next reward.

To test this, be sure to reload the scene between thresholds. Without this fix, the bug only happens if the thresholds are not hit in the same scene load.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3654264500.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3654294584.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3654549912.zip)
<!--- section:artifacts:end -->