### PR TITLE
Revert "Fix cracking/buzzing with streamed audio (#1153)"

### DIFF
--- a/mm/src/audio/lib/synthesis.c
+++ b/mm/src/audio/lib/synthesis.c
@@ -1157,9 +1157,8 @@ Acmd* AudioSynth_ProcessSample(s32 noteIndex, NoteSampleState* sampleState, Note
                         numSamplesProcessed += numSamplesToLoadAdj;
                         dmemUncompressedAddrOffset1 = numSamplesToLoadAdj;
 
-                        if (((synthState->samplePosInt * 2) + (numSamplesToLoadAdj + 16) * SAMPLE_SIZE) <
-                            sample->size) {
-                            bytesToRead = (numSamplesToLoadAdj + 16) * SAMPLE_SIZE;
+                        if (((synthState->samplePosInt * 2) + (numSamplesToLoadAdj)*SAMPLE_SIZE) < sample->size) {
+                            bytesToRead = (numSamplesToLoadAdj)*SAMPLE_SIZE;
                         } else {
                             bytesToRead = sample->size - (synthState->samplePosInt * 2);
                         }


### PR DESCRIPTION
Putting this out there for feedback on the crackling issue with streamed audio. When streamed audio was first added to nightly builds, some users reported crackling audio, which led to #1153. After the 2.0.0 release, users have reported crackling again. I get the crackling on some audio tracks but not others. I'm not sure what the difference is.

When making this revert locally, I don't get crackling on any audio I've tried. Furthermore, this revert matches how [SoH handles streamed audio](https://github.com/HarbourMasters/Shipwright/blob/1d20000411c120d81144c736f81e5552498a3e77/soh/src/code/audio_synthesis.c#L863-L864). I'd like to get some feedback to help isolate the problem.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3654400237.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3654432206.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3654660209.zip)
<!--- section:artifacts:end -->