### PR TITLE
Fix missing texture caused by geometry seams patch

### DIFF
--- a/mm/2s2h/Enhancements/GfxPatcher/AuthenticGfxPatches.cpp
+++ b/mm/2s2h/Enhancements/GfxPatcher/AuthenticGfxPatches.cpp
@@ -14,6 +14,7 @@ void ResourceMgr_PatchGfxByName(const char* path, const char* patchName, int ind
 void ResourceMgr_UnpatchGfxByName(const char* path, const char* patchName);
 char* ResourceMgr_LoadTexOrDListByName(const char* path);
 Gfx* ResourceMgr_LoadGfxByName(const char* path);
+char* ResourceMgr_LoadVtxArrayByName(const char* path);
 }
 
 #define dgameplay_keep_Tex_00CA30_Overflow "__OTR__objects/gameplay_keep/gameplay_keep_Tex_00CA30_Overflow"
@@ -317,22 +318,23 @@ Vtx southClockTownRampVtx[5] = {
     { { { -640, 100, -1253 }, 0, { 1253, 1024 }, { 208, 118, 0, 255 } } },
 };
 
-Gfx southClockTownRampDL[] = {
-    gsSPVertex(southClockTownRampVtx + 0, 5, 0),
-    gsSP2Triangles(0, 1, 2, 0, 1, 3, 2, 0),
-    gsSP1Triangle(3, 4, 2, 0),
-    gsSPEndDisplayList(),
-};
-
 void PatchGeometrySeams() {
+    static Gfx southClockTownRampDL[] = {
+        gsSPVertex(southClockTownRampVtx + 0, 5, 0),
+        gsSP2Triangles(0, 1, 2, 0, 1, 3, 2, 0),
+        gsSP1Triangle(3, 4, 2, 0),
+        // Restore the unmodified vertices after the seam patch
+        gsSPVertex(
+            (Vtx*)ResourceMgr_LoadVtxArrayByName("__OTR__scenes/nonmq/Z2_CLOCKTOWER/Z2_CLOCKTOWER_room_00Vtx_002A90") +
+                14,
+            32, 0),
+        gsSPEndDisplayList(),
+    };
     if (CVarGetInteger("gEnhancements.Graphics.FixSceneGeometrySeams", 0)) {
-        ResourceMgr_PatchGfxByName("scenes/nonmq/Z2_CLOCKTOWER/Z2_CLOCKTOWER_room_00DL_0032D0", "clockTownRampSeam1",
-                                   49, gsSPDisplayList(southClockTownRampDL));
-        ResourceMgr_PatchGfxByName("scenes/nonmq/Z2_CLOCKTOWER/Z2_CLOCKTOWER_room_00DL_0032D0", "clockTownRampSeam2",
-                                   50, gsSPNoOp());
+        ResourceMgr_PatchGfxByName("scenes/nonmq/Z2_CLOCKTOWER/Z2_CLOCKTOWER_room_00DL_0032D0", "clockTownRampSeam", 49,
+                                   gsSPDisplayList(southClockTownRampDL));
     } else {
-        ResourceMgr_UnpatchGfxByName("scenes/nonmq/Z2_CLOCKTOWER/Z2_CLOCKTOWER_room_00DL_0032D0", "clockTownRampSeam1");
-        ResourceMgr_UnpatchGfxByName("scenes/nonmq/Z2_CLOCKTOWER/Z2_CLOCKTOWER_room_00DL_0032D0", "clockTownRampSeam2");
+        ResourceMgr_UnpatchGfxByName("scenes/nonmq/Z2_CLOCKTOWER/Z2_CLOCKTOWER_room_00DL_0032D0", "clockTownRampSeam");
     }
 }
 


### PR DESCRIPTION
The "Fix Geometry Seams" enhancement fixes a seam with the rear clock tower ramp, but results in a missing texture on another one. After many attempts of manipulating triangles, I never got anywhere that was correct. The solution I arrived at was to just restore the original vertices after the patch does its thing.

2.0.0 behavior, off and on:
<img width="1025" height="912" alt="image" src="https://github.com/user-attachments/assets/6e9a8a5f-f102-48df-b927-4c6f61bc5781" />
<img width="1070" height="866" alt="image" src="https://github.com/user-attachments/assets/7167e6b9-3ed1-4c77-878c-9fcd474dfa54" />

This fix:
<img width="1157" height="975" alt="image" src="https://github.com/user-attachments/assets/a894a48f-670f-4983-952a-39c713e0acf3" />


<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3676175818.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3676185991.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3676270828.zip)
<!--- section:artifacts:end -->