### PR TITLE
Separate Stone Tower Temple save entrances

### DIFF
--- a/mm/2s2h/Enhancements/Saving/SavingEnhancements.cpp
+++ b/mm/2s2h/Enhancements/Saving/SavingEnhancements.cpp
@@ -30,11 +30,13 @@ extern "C" int SavingEnhancements_GetSaveEntrance() {
         case SCENE_SEA:
         case SCENE_SEA_BS:
             return ENTRANCE(GREAT_BAY_TEMPLE, 0);
-        // Stone Tower Temple (+ inverted) + Twinmold
+        // Stone Tower Temple
         case SCENE_INISIE_N:
+            return ENTRANCE(STONE_TOWER_TEMPLE, 0);
+        // Stone Tower Temple (inverted) + Twinmold
         case SCENE_INISIE_R:
         case SCENE_INISIE_BS:
-            return ENTRANCE(STONE_TOWER_TEMPLE, 0);
+            return ENTRANCE(STONE_TOWER_TEMPLE_INVERTED, 0);
         default:
             return ENTRANCE(SOUTH_CLOCK_TOWN, 0);
     }


### PR DESCRIPTION
Separates STT and the inverted variant so that they don't both load into the normal entrance. This is consistent with game over respawns and removes an annoyance where the player would be forced to watch the flip cutscene when loading into this state and exiting the dungeon.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3676979529.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3676979892.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3676992917.zip)
<!--- section:artifacts:end -->