### PR TITLE
[Enhancement] Mark Shooting Gallery Octoroks

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1483,6 +1483,10 @@ void BenMenu::AddEnhancements() {
                      .Min(1)
                      .Max(20)
                      .DefaultValue(20));
+    AddWidget(path, "Mark Shooting Gallery Octoroks", WIDGET_CVAR_CHECKBOX)
+        .CVar("gEnhancements.Minigames.MarkShootingGalleryOctoroks")
+        .Options(CheckboxOptions().Tooltip("Places markers on the Town Shooting Gallery Octoroks, indicating whether "
+                                           "they should be hit."));
     path.column = SECTION_COLUMN_3;
     AddWidget(path, "Other", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Lower Bank Reward Thresholds", WIDGET_CVAR_CHECKBOX)

--- a/mm/2s2h/Enhancements/Minigames/MarkShootingGalleryOctoroks.cpp
+++ b/mm/2s2h/Enhancements/Minigames/MarkShootingGalleryOctoroks.cpp
@@ -1,0 +1,43 @@
+#include "public/bridge/consolevariablebridge.h"
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
+#include "2s2h/ShipInit.hpp"
+
+extern "C" {
+#include "overlays/actors/ovl_En_Syateki_Okuta/z_en_syateki_okuta.h"
+#include "assets/overlays/ovl_En_Syateki_Okuta/ovl_En_Syateki_Okuta.h"
+extern void EnSyatekiOkuta_Die(EnSyatekiOkuta* enSyatekiOkuta, PlayState* play);
+}
+
+#define CVAR_NAME "gEnhancements.Minigames.MarkShootingGalleryOctoroks"
+#define CVAR CVarGetInteger(CVAR_NAME, 0)
+
+// This is almost identical to how EnSyatekiOkuta_Draw draws the symbols, except this draws a white symbol before the
+// Octorok has been hit.
+void RegisterMarkShootingGalleryOctoroks() {
+    COND_ID_HOOK(OnActorDraw, ACTOR_EN_SYATEKI_OKUTA, CVAR, [](Actor* actor) {
+        EnSyatekiOkuta* enSyatekiOkuta = (EnSyatekiOkuta*)actor;
+
+        if (enSyatekiOkuta->actionFunc != EnSyatekiOkuta_Die) {
+            OPEN_DISPS(gPlayState->state.gfxCtx);
+
+            Gfx_SetupDL25_Xlu(gPlayState->state.gfxCtx);
+            Matrix_Translate(enSyatekiOkuta->actor.world.pos.x, enSyatekiOkuta->actor.world.pos.y + 30.0f,
+                             enSyatekiOkuta->actor.world.pos.z + 20.0f, MTXMODE_NEW);
+
+            gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, 255, 255, 255, 192);
+            gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(gPlayState->state.gfxCtx),
+                      G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+
+            if (enSyatekiOkuta->type == SG_OCTO_TYPE_BLUE) {
+                gSPDisplayList(POLY_XLU_DISP++, (Gfx*)&gShootingGalleryOctorokCrossDL);
+            } else {
+                gSPDisplayList(POLY_XLU_DISP++, (Gfx*)&gShootingGalleryOctorokCircleDL);
+            }
+
+            CLOSE_DISPS(gPlayState->state.gfxCtx);
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterMarkShootingGalleryOctoroks, { CVAR_NAME });


### PR DESCRIPTION
Adds a visual marker to Octoroks in the Town Shooting Gallery, indicating whether they should be targeted.

https://github.com/user-attachments/assets/0068aa2e-e5c4-4b5b-83e1-7e971dd9114c



<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3814767995.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3814773004.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3814803317.zip)
<!--- section:artifacts:end -->