### PR TITLE
[Rando] Fix softlock with Magic Hag's Blue Potion

### DIFF
--- a/mm/2s2h/Rando/ActorBehavior/EnTrt.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnTrt.cpp
@@ -31,7 +31,8 @@ void Rando::ActorBehavior::InitEnTrtBehavior() {
             return;
         }
         if (!RANDO_SAVE_CHECKS[RC_HAGS_POTION_SHOP_KOTAKE].shuffled ||
-            RANDO_SAVE_CHECKS[RC_HAGS_POTION_SHOP_KOTAKE].cycleObtained) {
+            RANDO_SAVE_CHECKS[RC_HAGS_POTION_SHOP_KOTAKE].cycleObtained ||
+            (*item != GI_POTION_RED_BOTTLE && *item != GI_POTION_RED)) {
             return;
         }
 


### PR DESCRIPTION
If you play rando and do not have shops shuffled, the free blue potion check from Kotake will act like the red potion for Koume check. If the Get Item animation plays, the textbox will softlock. If the animation is skipped, the player will receive the wrong check, and Kotake will be left in an invalid state until the scene reloads.

The EnTrt rando item get behavior did not check that this is the red potion check. Even though the blue potion is normally purchased from the shop actor, the initial one received for free actually comes directly from the Kotake actor:

https://github.com/HarbourMasters/2ship2harkinian/blob/9e3d6e9c3f7fd598ef5f84d2972740a9a82db7b4/mm/src/overlays/actors/ovl_En_Trt/z_en_trt.c#L776-L780
https://github.com/HarbourMasters/2ship2harkinian/blob/9e3d6e9c3f7fd598ef5f84d2972740a9a82db7b4/mm/src/overlays/actors/ovl_En_Trt/z_en_trt.c#L669-L672

This issue does not arise if shops are shuffled, where the free blue potion check is awarded immediately without requiring Link to exit and re-enter.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3839969363.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3839993403.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3840130880.zip)
<!--- section:artifacts:end -->