### PR TITLE
Port search tweaks from SoH

### DIFF
--- a/mm/2s2h/BenGui/Menu.cpp
+++ b/mm/2s2h/BenGui/Menu.cpp
@@ -494,6 +494,7 @@ void Menu::Draw() {
     SyncVisibilityConsoleVariable();
 }
 
+static bool freshOpen = true;
 void Menu::DrawElement() {
     for (auto& [reason, info] : disabledMap) {
         info.active = info.evaluation(info);
@@ -531,6 +532,7 @@ void Menu::DrawElement() {
         if (!popout) {
             ImGui::PopStyleVar();
         }
+        freshOpen = true;
         ImGui::End();
         return;
     }
@@ -659,13 +661,13 @@ void Menu::DrawElement() {
     std::string menuSearchText = "";
     if (headerSearch) {
         ImGui::SameLine();
-        if (autoFocus && ImGui::IsWindowFocused(ImGuiFocusedFlags_RootAndChildWindows) && !ImGui::IsAnyItemActive() &&
-            !ImGui::IsMouseClicked(0)) {
-            ImGui::SetKeyboardFocusHere(0);
+        if (autoFocus && freshOpen) {
+            ImGui::SetKeyboardFocusHere();
         }
         auto color = UIWidgets::ColorValues.at(menuThemeIndex);
-        color.w = 0.2f;
+        color.w = 0.6f;
         ImGui::PushStyleColor(ImGuiCol_FrameBg, color);
+        ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 3.0f);
         menuSearch.Draw("##search", 200.0f);
         menuSearchText = menuSearch.InputBuf;
         menuSearchText.erase(std::remove(menuSearchText.begin(), menuSearchText.end(), ' '), menuSearchText.end());
@@ -673,6 +675,7 @@ void Menu::DrawElement() {
             ImGui::SameLine(headerWidth - 200.0f + style.ItemSpacing.x);
             ImGui::TextColored(ImVec4(1.0f, 1.0f, 1.0f, 0.4f), "Search...");
         }
+        ImGui::PopStyleVar();
         ImGui::PopStyleColor();
     }
     ImGui::EndChild();
@@ -832,6 +835,9 @@ void Menu::DrawElement() {
     if (popout) {
         poppedSize = ImGui::GetWindowSize();
         poppedPos = ImGui::GetWindowPos();
+    }
+    if (freshOpen) {
+        freshOpen = false;
     }
     ImGui::End();
 }


### PR DESCRIPTION
Copied from https://github.com/HarbourMasters/Shipwright/pull/5767

Fixes bug with combo boxes losing focus and increases vibrancy of search field color

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3919052491.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3919093836.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3919374565.zip)
<!--- section:artifacts:end -->