### PR TITLE
[Fix] Bomb Shopkeeper Held Item Distortion 

### DIFF
--- a/mm/2s2h/Rando/ActorBehavior/EnSob1.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnSob1.cpp
@@ -1,8 +1,6 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
 
 extern "C" {
-#include "variables.h"
 #include "overlays/actors/ovl_En_Sob1/z_en_sob1.h"
 }
 
@@ -18,12 +16,21 @@ void EnSob1_DrawCustomItem(Actor* thisx, PlayState* play) {
     Rando::DrawItem(randoSaveCheck.randoItemId);
 }
 
+static MtxF sLeftHandMtxF;
+
 void Rando::ActorBehavior::InitEnSob1Behavior() {
     COND_VB_SHOULD(VB_DRAW_ITEM_FROM_SOB1, IS_RANDO, {
         Actor* actor = va_arg(args, Actor*);
         if (RANDO_SAVE_CHECKS[RC_BOMB_SHOP_ITEM_01].shuffled) {
-            EnSob1_DrawCustomItem(actor, gPlayState);
+            Matrix_MtxFCopy(&sLeftHandMtxF, Matrix_GetCurrent());
             *should = false;
+        }
+    });
+
+    COND_ID_HOOK(OnActorDraw, ACTOR_EN_OSSAN, IS_RANDO, [](Actor* actor) {
+        if (RANDO_SAVE_CHECKS[RC_BOMB_SHOP_ITEM_01].shuffled) {
+            Matrix_Put(&sLeftHandMtxF);
+            EnSob1_DrawCustomItem(actor, gPlayState);
         }
     });
 }


### PR DESCRIPTION
This addresses #1260 
I just deferred drawing until after actor is complete using OnActorDraw, but save/restore the left hand matrix to maintain positioning. 

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3999122001.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3999124320.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/3999204434.zip)
<!--- section:artifacts:end -->