### PR TITLE
[Fix] Clear Pictograph State on POW

### DIFF
--- a/mm/2s2h/Enhancements/Songs/PauseOwlWarp.cpp
+++ b/mm/2s2h/Enhancements/Songs/PauseOwlWarp.cpp
@@ -43,6 +43,9 @@ void HandleConfirmingState(PauseContext* pauseCtx, Input* input) {
                 gHorseIsMounted = false;
             }
 
+            // Clear pictograph/camera event flag to prevent UI state from persisting after warp
+            CLEAR_EVENTINF(EVENTINF_41);
+
             Interface_SetAButtonDoAction(gPlayState, DO_ACTION_NONE);
             pauseCtx->state = PAUSE_STATE_UNPAUSE_SETUP;
             sPauseMenuVerticalOffset = -6240.0f;

--- a/mm/2s2h/Enhancements/Songs/PauseOwlWarp.cpp
+++ b/mm/2s2h/Enhancements/Songs/PauseOwlWarp.cpp
@@ -20,7 +20,8 @@ extern s32 gHorseIsMounted;
 extern "C" bool PauseOwlWarp_IsOwlWarpEnabled() {
     return CVAR && CHECK_QUEST_ITEM(QUEST_SONG_SOARING) &&
            gSaveContext.save.saveInfo.playerData.owlActivationFlags != 0 &&
-           gPlayState->pauseCtx.debugEditor == DEBUG_EDITOR_NONE;
+           gPlayState->pauseCtx.debugEditor == DEBUG_EDITOR_NONE &&
+           gPlayState->interfaceCtx.restrictions.songOfSoaring == 0;
 }
 
 void HandleConfirmingState(PauseContext* pauseCtx, Input* input) {


### PR DESCRIPTION
Addresses #1017 
This simply clears EVENTINF_41 to prevent UI state from persisting after warp. 

#1017 states "The rules dictating whether or not this enhancement can be used should match the Song of Soaring's in game". I would prefer to address edge cases as they are reported to maintain player freedom. If a player wants to warp during the pictograph tour, I don't want to dictate they can't. I'm totally down to discuss it further though should someone disagree.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4064429130.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4064436431.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4064449445.zip)
<!--- section:artifacts:end -->