### PR TITLE
Fix softlock when talking to Toto as FD

### DIFF
--- a/mm/src/code/z_message_nes.c
+++ b/mm/src/code/z_message_nes.c
@@ -28,7 +28,7 @@ void Message_FindMessageNES(PlayState* play, u16 textId) {
 
     while (msgEntry->textId != 0xFFFF) {
         if (msgEntry->textId == textId) {
-            // #region 2SH2 [Port] Just assign the msgEntry, we don't need to change the messageStart and messageEnd
+            // #region 2S2H [Port] Just assign the msgEntry, we don't need to change the messageStart and messageEnd
             font->messageStart = msgEntry;
             return;
             // #endregion

--- a/mm/src/code/z_message_staff.c
+++ b/mm/src/code/z_message_staff.c
@@ -12,7 +12,7 @@ void Message_FindCreditsMessage(PlayState* play, u16 textId) {
 
     while (msgEntry->textId != 0xFFFF) {
         if (msgEntry->textId == textId) {
-            // 2SH2 [Port] Just assign the msgEntry, we don't need to change the messageStart and messageEnd
+            // 2S2H [Port] Just assign the msgEntry, we don't need to change the messageStart and messageEnd
             font->messageStart = msgEntry;
             font->charBuf[font->unk_11D88][0] = msgEntry->typePos;
             break;

--- a/mm/src/overlays/actors/ovl_En_Sob1/z_en_sob1.c
+++ b/mm/src/overlays/actors/ovl_En_Sob1/z_en_sob1.c
@@ -237,7 +237,7 @@ u16 EnSob1_GetWelcome(EnSob1* this, PlayState* play) {
             case PLAYER_MASK_POSTMAN:
                 return 0x644;
 
-            // 2SH2 [FD Enhancement] - Treat FD as any other non-human form
+            // 2S2H [FD Enhancement] - Treat FD as any other non-human form
             case PLAYER_MASK_FIERCE_DEITY:
             case PLAYER_MASK_GORON:
             case PLAYER_MASK_ZORA:

--- a/mm/src/overlays/actors/ovl_En_Stop_heishi/z_en_stop_heishi.c
+++ b/mm/src/overlays/actors/ovl_En_Stop_heishi/z_en_stop_heishi.c
@@ -406,7 +406,7 @@ void func_80AE7F34(EnStopheishi* this, PlayState* play) {
             phi_a2 = 2;
             break;
 
-        // 2SH2 [FD Enhancement] - Guard treats FD as if Human has already talked
+        // 2S2H [FD Enhancement] - Guard treats FD as if Human has already talked
         case PLAYER_FORM_FIERCE_DEITY:
             phi_a2 = 1;
             break;

--- a/mm/src/overlays/actors/ovl_En_Syateki_Man/z_en_syateki_man.c
+++ b/mm/src/overlays/actors/ovl_En_Syateki_Man/z_en_syateki_man.c
@@ -588,7 +588,7 @@ void EnSyatekiMan_Town_StartIntroTextbox(EnSyatekiMan* this, PlayState* play) {
             }
             break;
 
-        // 2SH2 [FD Enhancement]  Don't allow playing town archery with FD becuase Swamp prevents FD archery by default.
+        // 2S2H [FD Enhancement] Don't allow playing town archery with FD because Swamp prevents FD archery by default.
         // Get Goron's "quite the build" text
         case PLAYER_FORM_FIERCE_DEITY:
         case PLAYER_FORM_GORON:

--- a/mm/src/overlays/actors/ovl_En_Toto/z_en_toto.c
+++ b/mm/src/overlays/actors/ovl_En_Toto/z_en_toto.c
@@ -237,7 +237,8 @@ void func_80BA39C8(EnToto* this, PlayState* play) {
         } else {
             this->actor.flags &= ~ACTOR_FLAG_10000;
             Actor_OfferTalk(&this->actor, play, 50.0f);
-            if (play->sceneId == SCENE_SONCHONOIE) {
+            // 2S2H [FD Enhancement] - Do not prompt for song if playing as FD. Default to dialog of cancellation
+            if (play->sceneId == SCENE_SONCHONOIE || player->transformation == PLAYER_FORM_FIERCE_DEITY) {
                 if (player->transformation == PLAYER_FORM_DEKU) {
                     if (!Flags_GetSwitch(play, ENTOTO_GET_SWITCH_FLAG_3(&this->actor))) {
                         this->text = &D_80BA502C[15];


### PR DESCRIPTION
Talking to Toto in the Milk Bar as FD will prompt for a musical performance. Since the Ballad bit only accounts for the normally usable forms, there is an out of bounds array access that results in Toto giving the prompt again and locking. This fix will default to the dialog of the show's cancellation when FD speaks to Toto. Fixes part of #647

Also fixed some port comment typos

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4106205833.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4106248136.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4106520911.zip)
<!--- section:artifacts:end -->