### PR TITLE
Port fix for soil patch Skulltula sounds

### DIFF
--- a/mm/src/overlays/actors/ovl_Bg_Kin2_Picture/z_bg_kin2_picture.h
+++ b/mm/src/overlays/actors/ovl_Bg_Kin2_Picture/z_bg_kin2_picture.h
@@ -4,7 +4,12 @@
 #include "global.h"
 
 #define BG_KIN2_PICTURE_SKULLTULA_COLLECTED(thisx) (((thisx)->params >> 5) & 1)
-#define BG_KIN2_PICTURE_GET_3FC(thisx) ((u8)(((thisx & 0x3FC)) >> 2))
+// #region 2S2H [Port] The original calculation is ((u8)(((thisx & 0x3FC)) >> 2)), but this results in values well
+// over 100. This value is ultimately used to left shift 1 to get the treasure flag. Bit shifts greater than the bit
+// width are undefined behavior. On N64, this likely truncates to a value below 32. The correction below matches other
+// uses of the Skulltula Token chest flag (see ENSI_GET_CHEST_FLAG and inline uses in z_tg_sw.c):
+#define BG_KIN2_PICTURE_GET_3FC(thisx) ((u8)(((thisx & 0xFC)) >> 2))
+// #endregion
 #define BG_KIN2_PICTURE_SKULLTULA_SPAWN_PARAM(thisx) ((((thisx)->params & 0x1F) << 2) | 0xFF03)
 
 struct BgKin2Picture;

--- a/mm/src/overlays/actors/ovl_Obj_Makekinsuta/z_obj_makekinsuta.h
+++ b/mm/src/overlays/actors/ovl_Obj_Makekinsuta/z_obj_makekinsuta.h
@@ -7,7 +7,12 @@ struct ObjMakekinsuta;
 
 #define OBJMAKEKINSUTA_GET_1F(thisx) (((thisx)->params >> 8) & 0x1F)
 #define OBJMAKEKINSUTA_GETS_3(params) ((params & 3) & 0xFF)
-#define OBJMAKEKINSUTA_GETS_3FC(params) (((params & 0x3FC) >> 2) & 0xFF)
+// #region 2S2H [Port] The original calculation is (((params & 0x3FC) >> 2) & 0xFF), but this results in values well
+// over 100. This value is ultimately used to left shift 1 to get the treasure flag. Bit shifts greater than the bit
+// width are undefined behavior. On N64, this likely truncates to a value below 32. The correction below matches other
+// uses of the Skulltula Token chest flag (see ENSI_GET_CHEST_FLAG and inline uses in z_tg_sw.c):
+#define OBJMAKEKINSUTA_GETS_3FC(params) (((params & 0xFC) >> 2) & 0xFF)
+// #endregion
 #define OBJMAKEKINSUTA_GET_SWITCH_FLAG(thisx) ((thisx)->params & 0x7F)
 
 typedef struct ObjMakekinsuta {


### PR DESCRIPTION
The big tl;dr to this one is that the actor responsible for whether the soil patches should behave as if they contain a Skulltula ultimately causes a left shift by a large value. That is undefined behavior, causing certain compiled builds of 2ship to have the soil patches always play Skulltula sounds. This fix changes the bit mask to more closely mirror how the token actor itself checks its associated flag.

Unfortunately, I could not figure out a way to produce matching non-UB code that could be shared upstream. I simply changed a macro to AND by 0xFC instead of by 0x3FC, so only the relevant bits end up making it into `Flags_GetTreasure`.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4375571371.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4375571463.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4375599248.zip)
<!--- section:artifacts:end -->