### PR TITLE
Add authentic patch to Smithy chimney fire

### DIFF
--- a/mm/2s2h/Enhancements/GfxPatcher/AuthenticGfxPatches.cpp
+++ b/mm/2s2h/Enhancements/GfxPatcher/AuthenticGfxPatches.cpp
@@ -367,8 +367,8 @@ void GfxPatcher_ApplyFierceDeityGIPatch() {
 }
 
 void GfxPatcher_ApplySmithyChimneyFirePatch() {
-    // object_omoya_obj_DL_0001A0 has an extraneous gsSPPopMatrix(G_MTX_MODELVIEW) command, which can deplete the matrix
-    // stack and result in sometimes fatal UB. Just no-op the pop command.
+    // object_yukimura_obj_DL_000F98 has an extraneous gsSPPopMatrix(G_MTX_MODELVIEW) command, which can deplete the
+    // matrix stack and result in sometimes fatal UB. Just no-op the pop command.
     ResourceMgr_PatchGfxByName(object_yukimura_obj_DL_000F98, "smithyChimneyFireFix", 31, gsSPNoOp());
 }
 

--- a/mm/2s2h/Enhancements/GfxPatcher/AuthenticGfxPatches.cpp
+++ b/mm/2s2h/Enhancements/GfxPatcher/AuthenticGfxPatches.cpp
@@ -6,6 +6,7 @@ extern "C" {
 #include "objects/object_fz/object_fz.h"
 #include "objects/object_ik/object_ik.h"
 #include "objects/object_gi_mask03/object_gi_mask03.h"
+#include "objects/object_yukimura_obj/object_yukimura_obj.h"
 #include "overlays/ovl_En_Syateki_Okuta/ovl_En_Syateki_Okuta.h"
 #include "overlays/ovl_fbdemo_wipe1/ovl_fbdemo_wipe1.h"
 #include "overlays/ovl_Obj_Jgame_Light/ovl_Obj_Jgame_Light.h"
@@ -365,6 +366,12 @@ void GfxPatcher_ApplyFierceDeityGIPatch() {
     ResourceMgr_PatchGfxByName(gGiFierceDeityMaskHairAndHatDL, "TEXEL1Fix", 3, gsSPDisplayList(loadGrassDL));
 }
 
+void GfxPatcher_ApplySmithyChimneyFirePatch() {
+    // object_omoya_obj_DL_0001A0 has an extraneous gsSPPopMatrix(G_MTX_MODELVIEW) command, which can deplete the matrix
+    // stack and result in sometimes fatal UB. Just no-op the pop command.
+    ResourceMgr_PatchGfxByName(object_yukimura_obj_DL_000F98, "smithyChimneyFireFix", 31, gsSPNoOp());
+}
+
 // Applies required patches for authentic bugs to allow the game to play and render properly
 void GfxPatcher_ApplyNecessaryAuthenticPatches() {
     PatchMiniGameCrossAndCircleSymbols();
@@ -376,4 +383,6 @@ void GfxPatcher_ApplyNecessaryAuthenticPatches() {
     GfxPatcher_ApplyTransitionWipePatch();
 
     GfxPatcher_ApplyFierceDeityGIPatch();
+
+    GfxPatcher_ApplySmithyChimneyFirePatch();
 }


### PR DESCRIPTION
The object used for the chimney fire for the Mountain Smithy contains an extraneous matrix pop command in its DL. As certain objects come into and go out of view, this can fully deplete the matrix stack, which results in an OOB read within LUS. This has always been an issue, but because it's UB, it did not do anything fatal until it did.

Given the inconsistency of this UB from build to build and playtest to playtest, if you *really* want to test this fix, you'll want to build this with the following added before the final line in `Interpreter::GfxSpMatrix` in LUS:

```c++
    if(mRsp->modelview_matrix_stack_size < 1 || mRsp->modelview_matrix_stack_size >= 11) {
        assert(false);
    }
```

Thanks to everyone who helped troubleshoot this nuisance. Fixes #1262

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4186106585.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4186115486.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4186187060.zip)
<!--- section:artifacts:end -->