### PR TITLE
Fix Astral Observatory BGM bug

### DIFF
--- a/mm/2s2h/Enhancements/Fixes/BgmReplay.cpp
+++ b/mm/2s2h/Enhancements/Fixes/BgmReplay.cpp
@@ -5,6 +5,7 @@
 extern "C" {
 #include "variables.h"
 #include "functions.h"
+extern u8 sStartSeqDisabled;
 }
 
 #define CVAR_NAME_FASTER_SCENE_TRANSITIONS "gEnhancements.Timesavers.FasterSceneTransitions"
@@ -29,6 +30,11 @@ extern "C" {
 
 void RegisterFixBgmReplay() {
     COND_VB_SHOULD(VB_PLAY_SCENE_SEQUENCE, CVAR_FASTER_SCENE_TRANSITIONS || CVAR_PAUSE_SAVE || CVAR_DEBUG_MODE, {
+        // The Astral Observatory telescope and moon crash set this flag. No need to meddle further.
+        if (sStartSeqDisabled) {
+            return;
+        }
+
         u16 sRequestedSceneSeqId = *va_arg(args, u16*);
         u16 sPrevMainBgmSeqId = *va_arg(args, u16*);
         u16 seqId = *va_arg(args, u16*);


### PR DESCRIPTION
The BGM replay bug fix inadvertently introduced its own BGM bug. Transitioning between scenes with different BGMs normally triggers a command to kill the main BGM sequence player. The replay bug fix replicates this behavior when using enhancements that bypass that command. One unique case where this shouldn't happen is the Astral Observatory. The BGM should persist when looking at Termina Field through the telescope. The bugfix did not account for this state, thus incorrectly killing the Astral Observatory BGM when looking through the telescope.

This disables the forced sequence player quit when the associated flag is enabled. The Astral Observatory and moon crash are seemingly the only cases of this flag getting set, via `SEQCMD_DISABLE_PLAY_SEQUENCES`.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4209829806.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4209848340.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4209989649.zip)
<!--- section:artifacts:end -->