### PR TITLE
Bump LUS and OTRExporter, add null audio backend

### DIFF
--- a/mm/2s2h/BenGui/BenGui.cpp
+++ b/mm/2s2h/BenGui/BenGui.cpp
@@ -11,7 +11,7 @@
 #include "2s2h/Rando/CheckTracker/CheckTracker.h"
 
 #ifdef __APPLE__
-#include "graphic/Fast3D/backends/gfx_metal.h"
+#include <fast/backends/gfx_metal.h>
 #endif
 
 #ifdef __SWITCH__

--- a/mm/2s2h/BenGui/BenInputEditorWindow.cpp
+++ b/mm/2s2h/BenGui/BenInputEditorWindow.cpp
@@ -1,11 +1,11 @@
 #include "BenInputEditorWindow.h"
-#include <Context.h>
-#include "public/bridge/consolevariablebridge.h"
-#include "controller/controldevice/controller/mapping/ControllerRumbleMapping.h"
-#include "controller/controldeck/ControlDeck.h"
-#include "utils/StringHelper.h"
+#include <ship/Context.h>
+#include <libultraship/bridge/consolevariablebridge.h>
+#include <ship/controller/controldevice/controller/mapping/ControllerRumbleMapping.h>
+#include <ship/controller/controldeck/ControlDeck.h>
+#include <ship/utils/StringHelper.h>
 #ifndef __WIIU__
-#include "controller/controldevice/controller/mapping/sdl/SDLAxisDirectionToButtonMapping.h"
+#include <ship/controller/controldevice/controller/mapping/sdl/SDLAxisDirectionToButtonMapping.h>
 #endif
 
 #define SCALE_IMGUI_SIZE(value) ((value / 13.0f) * ImGui::GetFontSize())

--- a/mm/2s2h/BenGui/BenInputEditorWindow.h
+++ b/mm/2s2h/BenGui/BenInputEditorWindow.h
@@ -6,9 +6,9 @@
 #include <list>
 #include <memory>
 #include "stdint.h"
-#include "GuiWindow.h"
-#include "controller/controldevice/controller/mapping/ControllerAxisDirectionMapping.h"
-#include "controller/physicaldevice/PhysicalDeviceType.h"
+#include <ship/window/gui/GuiWindow.h>
+#include <ship/controller/controldevice/controller/mapping/ControllerAxisDirectionMapping.h>
+#include <ship/controller/physicaldevice/PhysicalDeviceType.h>
 
 #include <imgui.h>
 #include <libultraship/libultra/controller.h>

--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -9,7 +9,7 @@
 #include "HudEditor.h"
 #include "Notification.h"
 #include <variant>
-#include "StringHelper.h"
+#include <ship/utils/StringHelper.h>
 #include <spdlog/fmt/fmt.h>
 #include "variables.h"
 #include <variant>

--- a/mm/2s2h/BenGui/BenMenu.h
+++ b/mm/2s2h/BenGui/BenMenu.h
@@ -5,7 +5,7 @@
 #include "Menu.h"
 #include "2s2h/Enhancements/Enhancements.h"
 #include "2s2h/DeveloperTools/DeveloperTools.h"
-#include "graphic/Fast3D/backends/gfx_rendering_api.h"
+#include <fast/backends/gfx_rendering_api.h>
 
 namespace BenGui {
 

--- a/mm/2s2h/BenGui/BenMenuBar.h
+++ b/mm/2s2h/BenGui/BenMenuBar.h
@@ -1,7 +1,7 @@
 #ifndef BenMenuBar_h
 #define BenMenuBar_h
 
-#include "window/gui/GuiMenuBar.h"
+#include <ship/window/gui/GuiMenuBar.h>
 
 namespace BenGui {
 class BenMenuBar : public Ship::GuiMenuBar {

--- a/mm/2s2h/BenGui/HudEditor.h
+++ b/mm/2s2h/BenGui/HudEditor.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #ifdef __cplusplus
-#include "GuiWindow.h"
+#include <ship/window/gui/GuiWindow.h>
 #include "UIWidgets.hpp"
 
 class HudEditorWindow : public Ship::GuiWindow {

--- a/mm/2s2h/BenGui/Menu.cpp
+++ b/mm/2s2h/BenGui/Menu.cpp
@@ -2,13 +2,13 @@
 #include "UIWidgets.hpp"
 #include "BenPort.h"
 #include "BenInputEditorWindow.h"
-#include "window/gui/GuiElement.h"
+#include <ship/window/gui/GuiElement.h>
 #include "Notification.h"
 #include <variant>
 #include <spdlog/fmt/fmt.h>
 #include "variables.h"
 #include <tuple>
-#include "Config.h"
+#include <ship/config/Config.h>
 
 extern "C" {
 #include "z64.h"

--- a/mm/2s2h/BenGui/Menu.h
+++ b/mm/2s2h/BenGui/Menu.h
@@ -1,7 +1,7 @@
 #ifndef MENU_H
 #define MENU_H
 
-#include "GuiWindow.h"
+#include <ship/window/gui/GuiWindow.h>
 #include "UIWidgets.hpp"
 #include "MenuTypes.h"
 #include <string>

--- a/mm/2s2h/BenGui/MenuTypes.h
+++ b/mm/2s2h/BenGui/MenuTypes.h
@@ -266,6 +266,7 @@ struct MainMenuEntry {
 static const std::unordered_map<Ship::AudioBackend, const char*> audioBackendsMap = {
     { Ship::AudioBackend::WASAPI, "Windows Audio Session API" },
     { Ship::AudioBackend::SDL, "SDL" },
+    { Ship::AudioBackend::NUL, "Null" },
 };
 
 static const std::unordered_map<Ship::WindowBackend, const char*> windowBackendsMap = {

--- a/mm/2s2h/BenGui/Notification.h
+++ b/mm/2s2h/BenGui/Notification.h
@@ -4,7 +4,7 @@
 
 #include <string>
 #include <cstdint>
-#include <GuiWindow.h>
+#include <ship/window/gui/GuiWindow.h>
 namespace Notification {
 
 struct Options {

--- a/mm/2s2h/BenGui/ResolutionEditor.cpp
+++ b/mm/2s2h/BenGui/ResolutionEditor.cpp
@@ -1,7 +1,7 @@
 #include "ResolutionEditor.h"
 #include <imgui.h>
 
-#include <graphic/Fast3D/Fast3dWindow.h>
+#include <fast/Fast3dWindow.h>
 #include <graphic/Fast3D/interpreter.h>
 #include "2s2h/BenPort.h"
 #include "2s2h/BenGui/BenMenu.h"

--- a/mm/2s2h/BenGui/ResolutionEditor.cpp
+++ b/mm/2s2h/BenGui/ResolutionEditor.cpp
@@ -2,7 +2,7 @@
 #include <imgui.h>
 
 #include <fast/Fast3dWindow.h>
-#include <graphic/Fast3D/interpreter.h>
+#include <fast/interpreter.h>
 #include "2s2h/BenPort.h"
 #include "2s2h/BenGui/BenMenu.h"
 #include "2s2h/BenGui/BenGui.hpp"

--- a/mm/2s2h/BenGui/UIWidgets.hpp
+++ b/mm/2s2h/BenGui/UIWidgets.hpp
@@ -12,10 +12,10 @@
 #include "2s2h/ShipUtils.h"
 #include "2s2h/ShipInit.hpp"
 #include "DeveloperTools/SaveEditor.h"
-#include "GuiWindow.h"
-#include "Context.h"
-#include "public/bridge/consolevariablebridge.h"
-#include "Window.h"
+#include <ship/window/gui/GuiWindow.h>
+#include <ship/Context.h>
+#include <libultraship/bridge/consolevariablebridge.h>
+#include <ship/window/Window.h>
 
 namespace UIWidgets {
 

--- a/mm/2s2h/BenJsonConversions.hpp
+++ b/mm/2s2h/BenJsonConversions.hpp
@@ -2,7 +2,7 @@
 #define BenJsonConversions_hpp
 
 #include <nlohmann/json.hpp>
-#include "spdlog/spdlog.h"
+#include <spdlog/spdlog.h>
 #include "build.h"
 
 extern "C" {

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -5,31 +5,30 @@
 #include <fstream>
 #include <chrono>
 
-#include <ResourceManager.h>
-#include "graphic/Fast3D/Fast3dWindow.h"
-#include <File.h>
-#include <DisplayList.h>
-#include <Window.h>
+#include <ship/resource/ResourceManager.h>
+#include <fast/Fast3dWindow.h>
+#include <ship/resource/File.h>
+#include <ship/window/Window.h>
 
 #include "z64animation.h"
 #include "z64bgcheck.h"
 #include <libultraship/libultra/gbi.h>
-#include <Fonts.h>
+#include <ship/window/gui/Fonts.h>
 #ifdef _WIN32
 #include <Windows.h>
 #else
 #include <time.h>
 #endif
-#include <AudioPlayer.h>
+#include <ship/audio/AudioPlayer.h>
 #include "variables.h"
 #include "z64.h"
 #include "macros.h"
-#include <utils/StringHelper.h>
+#include <ship/utils/StringHelper.h>
 #include <nlohmann/json.hpp>
 #include "build.h"
 
-#include <Fast3D/interpreter.h>
-#include <Fast3D/backends/gfx_rendering_api.h>
+#include <fast/interpreter.h>
+#include <fast/backends/gfx_rendering_api.h>
 
 #ifdef __APPLE__
 #include <SDL_scancode.h>
@@ -47,6 +46,8 @@ CrowdControl* CrowdControl::Instance;
 #endif
 
 #include <libultraship/libultraship.h>
+#include <libultraship/controller/controldeck/ControlDeck.h>
+#include <fast/resource/ResourceType.h>
 #include <BenGui/BenGui.hpp>
 
 #include "2s2h/GameInteractor/GameInteractor.h"
@@ -64,11 +65,11 @@ CrowdControl* CrowdControl::Instance;
 #include "2s2h/PresetManager/PresetManager.h"
 
 // Resource Types/Factories
-#include "resource/type/Blob.h"
-#include "resource/type/DisplayList.h"
-#include "resource/type/Matrix.h"
-#include "resource/type/Texture.h"
-#include "resource/type/Vertex.h"
+#include <ship/resource/type/Blob.h>
+#include <fast/resource/type/DisplayList.h>
+#include <fast/resource/type/Matrix.h>
+#include <fast/resource/type/Texture.h>
+#include <fast/resource/type/Vertex.h>
 #include "2s2h/resource/type/2shResourceType.h"
 #include "2s2h/resource/type/Animation.h"
 #include "2s2h/resource/type/Array.h"
@@ -82,11 +83,11 @@ CrowdControl* CrowdControl::Instance;
 #include "2s2h/resource/type/Scene.h"
 #include "2s2h/resource/type/Skeleton.h"
 #include "2s2h/resource/type/SkeletonLimb.h"
-#include "resource/factory/BlobFactory.h"
-#include "resource/factory/DisplayListFactory.h"
-#include "resource/factory/MatrixFactory.h"
-#include "resource/factory/TextureFactory.h"
-#include "resource/factory/VertexFactory.h"
+#include <ship/resource/factory/BlobFactory.h>
+#include <fast/resource/factory/DisplayListFactory.h>
+#include <fast/resource/factory/MatrixFactory.h>
+#include <fast/resource/factory/TextureFactory.h>
+#include <fast/resource/factory/VertexFactory.h>
 #include "2s2h/resource/importer/AnimationFactory.h"
 #include "2s2h/resource/importer/ArrayFactory.h"
 #include "2s2h/resource/importer/AudioSampleFactory.h"
@@ -103,9 +104,9 @@ CrowdControl* CrowdControl::Instance;
 #include "2s2h/resource/importer/BackgroundFactory.h"
 #include "2s2h/resource/importer/TextureAnimationFactory.h"
 #include "2s2h/resource/importer/KeyFrameFactory.h"
-#include "window/gui/resource/Font.h"
-#include "window/FileDropMgr.h"
-#include "window/gui/resource/FontFactory.h"
+#include <ship/window/gui/resource/Font.h>
+#include <ship/window/FileDropMgr.h>
+#include <ship/window/gui/resource/FontFactory.h>
 #include "2s2h/Enhancements/Audio/AudioCollection.h"
 #include "BenGui/BenInputEditorWindow.h"
 

--- a/mm/2s2h/BenPort.h
+++ b/mm/2s2h/BenPort.h
@@ -13,7 +13,7 @@
 #define MM_NTSC_US_GC 0xB443EB08
 
 #ifdef __cplusplus
-#include <Context.h>
+#include <ship/Context.h>
 
 #include <vector>
 

--- a/mm/2s2h/DeveloperTools/ActorViewer.h
+++ b/mm/2s2h/DeveloperTools/ActorViewer.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "GuiWindow.h"
+#include <ship/window/gui/GuiWindow.h>
 
 class ActorViewerWindow : public Ship::GuiWindow {
   public:

--- a/mm/2s2h/DeveloperTools/BetterMapSelect.c
+++ b/mm/2s2h/DeveloperTools/BetterMapSelect.c
@@ -2,7 +2,7 @@
 #include "BetterMapSelect.h"
 #include "overlays/gamestates/ovl_file_choose/z_file_select.h"
 #include "overlays/gamestates/ovl_select/z_select.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 void BetterMapSelect_LoadGame(MapSelectState* mapSelectState, u32 entrance, s32 spawn);
 void BetterMapSelect_LoadFileSelect(MapSelectState* mapSelectState);

--- a/mm/2s2h/DeveloperTools/CollisionViewer.h
+++ b/mm/2s2h/DeveloperTools/CollisionViewer.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #ifdef __cplusplus
-#include "GuiWindow.h"
+#include <ship/window/gui/GuiWindow.h>
 
 extern "C" {
 #endif

--- a/mm/2s2h/DeveloperTools/DebugConsole.cpp
+++ b/mm/2s2h/DeveloperTools/DebugConsole.cpp
@@ -1,8 +1,8 @@
 #include "DebugConsole.h"
 
-#include "public/bridge/consolevariablebridge.h"
-#include "Window.h"
-#include "ConsoleWindow.h"
+#include <libultraship/bridge/consolevariablebridge.h>
+#include <ship/window/Window.h>
+#include <ship/window/gui/ConsoleWindow.h>
 #include "2s2h/BenPort.h"
 #include <vector>
 #include <string>

--- a/mm/2s2h/DeveloperTools/DeveloperTools.cpp
+++ b/mm/2s2h/DeveloperTools/DeveloperTools.cpp
@@ -1,6 +1,6 @@
 #include "DeveloperTools.h"
 #include "BenPort.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/DeveloperTools/EventLog.h
+++ b/mm/2s2h/DeveloperTools/EventLog.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "GuiWindow.h"
+#include <ship/window/gui/GuiWindow.h>
 
 class EventLogWindow : public Ship::GuiWindow {
   public:

--- a/mm/2s2h/DeveloperTools/HookDebugger.h
+++ b/mm/2s2h/DeveloperTools/HookDebugger.h
@@ -1,7 +1,7 @@
 #ifndef HOOK_DEBUGGER_H
 #define HOOK_DEBUGGER_H
 
-#include "GuiWindow.h"
+#include <ship/window/gui/GuiWindow.h>
 
 class HookDebuggerWindow : public Ship::GuiWindow {
   public:

--- a/mm/2s2h/DeveloperTools/SaveEditor.h
+++ b/mm/2s2h/DeveloperTools/SaveEditor.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <GuiWindow.h>
+#include <ship/window/gui/GuiWindow.h>
 #include <vector>
 
 extern "C" {

--- a/mm/2s2h/DeveloperTools/WarpPoint.cpp
+++ b/mm/2s2h/DeveloperTools/WarpPoint.cpp
@@ -1,5 +1,5 @@
 #include "2s2h/BenGui/UIWidgets.hpp"
-#include "window/gui/IconsFontAwesome4.h"
+#include <ship/window/gui/IconsFontAwesome4.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/DeveloperTools/DeveloperTools.h"
 #include "2s2h/ShipInit.hpp"

--- a/mm/2s2h/Enhancements/Audio/AudioCollection.cpp
+++ b/mm/2s2h/Enhancements/Audio/AudioCollection.cpp
@@ -1,8 +1,8 @@
 #include "AudioCollection.h"
 #include "sequence.h"
-#include <utils/StringHelper.h>
-#include "public/bridge/consolevariablebridge.h"
-#include "Window.h"
+#include <ship/utils/StringHelper.h>
+#include <libultraship/bridge/consolevariablebridge.h>
+#include <ship/window/Window.h>
 #include <2s2h/BenPort.h>
 #include <locale>
 #include <filesystem>

--- a/mm/2s2h/Enhancements/Audio/AudioEditor.cpp
+++ b/mm/2s2h/Enhancements/Audio/AudioEditor.cpp
@@ -8,7 +8,7 @@
 #include <sequence.h>
 // #include "../randomizer/3drando/random.hpp"
 #include "../../BenPort.h"
-#include <utils/StringHelper.h>
+#include <ship/utils/StringHelper.h>
 #include "../../BenGui/UIWidgets.hpp"
 #include "AudioCollection.h"
 #include <random>

--- a/mm/2s2h/Enhancements/Audio/AudioEditor.cpp
+++ b/mm/2s2h/Enhancements/Audio/AudioEditor.cpp
@@ -3,7 +3,7 @@
 #include <map>
 #include <set>
 #include <string>
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include <functions.h>
 #include <sequence.h>
 // #include "../randomizer/3drando/random.hpp"

--- a/mm/2s2h/Enhancements/Audio/AudioEditor.h
+++ b/mm/2s2h/Enhancements/Audio/AudioEditor.h
@@ -3,7 +3,7 @@
 
 #include "libultraship/libultra/types.h"
 #ifdef __cplusplus
-#include "window/gui/GuiWindow.h"
+#include <ship/window/gui/GuiWindow.h>
 #include "AudioCollection.h"
 
 #ifndef IMGUI_DEFINE_MATH_OPERATORS

--- a/mm/2s2h/Enhancements/Audio/AudioSeqQueue.cpp
+++ b/mm/2s2h/Enhancements/Audio/AudioSeqQueue.cpp
@@ -2,7 +2,7 @@
 #include "AudioSeqQueue.h"
 
 #include "resource/type/AudioSequence.h"
-#include "Context.h"
+#include <ship/Context.h>
 
 static SafeQueue<char*> audioQueue;
 

--- a/mm/2s2h/Enhancements/Camera/DebugCam.cpp
+++ b/mm/2s2h/Enhancements/Camera/DebugCam.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 #include "CameraUtils.h"

--- a/mm/2s2h/Enhancements/Camera/FreeLook.cpp
+++ b/mm/2s2h/Enhancements/Camera/FreeLook.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 #include "CameraUtils.h"

--- a/mm/2s2h/Enhancements/Cheats/ClimbAnywhere.cpp
+++ b/mm/2s2h/Enhancements/Cheats/ClimbAnywhere.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cheats/EasyFrameAdvance.cpp
+++ b/mm/2s2h/Enhancements/Cheats/EasyFrameAdvance.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cheats/ElegyAnywhere.cpp
+++ b/mm/2s2h/Enhancements/Cheats/ElegyAnywhere.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cheats/HookshotAnywhere.cpp
+++ b/mm/2s2h/Enhancements/Cheats/HookshotAnywhere.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cheats/Infinite.cpp
+++ b/mm/2s2h/Enhancements/Cheats/Infinite.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cheats/LongerFlowerGlide.cpp
+++ b/mm/2s2h/Enhancements/Cheats/LongerFlowerGlide.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/ShipInit.hpp"
 
 extern "C" {

--- a/mm/2s2h/Enhancements/Cheats/MoonJump.cpp
+++ b/mm/2s2h/Enhancements/Cheats/MoonJump.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cheats/TimeStop.cpp
+++ b/mm/2s2h/Enhancements/Cheats/TimeStop.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/Enhancements/Enhancements.h"
 #include "2s2h/ShipInit.hpp"

--- a/mm/2s2h/Enhancements/Cheats/UnbreakableRazorSword.cpp
+++ b/mm/2s2h/Enhancements/Cheats/UnbreakableRazorSword.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 #include "2s2h/Rando/Rando.h"

--- a/mm/2s2h/Enhancements/Cheats/UnrestrictedItems.cpp
+++ b/mm/2s2h/Enhancements/Cheats/UnrestrictedItems.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cutscenes/HideTitleCards.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/HideTitleCards.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipAlienStartAndFail.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipAlienStartAndFail.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipAlienWarning.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipAlienWarning.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipBankerDialogue.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipBankerDialogue.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipBossWarpPrompt.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipBossWarpPrompt.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipBothersomeMonkey.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipBothersomeMonkey.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipDekuSalesman.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipDekuSalesman.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipDekuTelescope.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipDekuTelescope.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipEponaReveal.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipEponaReveal.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipEvanSong.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipEvanSong.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipFallingMoonsTear.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipFallingMoonsTear.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipGateGuards.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipGateGuards.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipGivingBombersNotebook.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipGivingBombersNotebook.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipGreatFairyCutscene.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipGreatFairyCutscene.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/CustomItem/CustomItem.h"

--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipKafeiReveal.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipKafeiReveal.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/CustomItem/CustomItem.h"
 #include "2s2h/CustomMessage/CustomMessage.h"

--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipKamaroTeachDance.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipKamaroTeachDance.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipKotakeFlying.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipKotakeFlying.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/CustomItem/CustomItem.h"

--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipMayorsOfficeCutscene.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipMayorsOfficeCutscene.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipOwlInteractions.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipOwlInteractions.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipPushingMikau.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipPushingMikau.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 #include "2s2h/Rando/Rando.h"

--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipRosaSistersDance.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipRosaSistersDance.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/CustomItem/CustomItem.h"

--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipScarecrowDance.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipScarecrowDance.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipTatlInterrupts.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipTatlInterrupts.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipTingleTime.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipTingleTime.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipTurtleGoodbye.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipTurtleGoodbye.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/CustomItem/CustomItem.h"

--- a/mm/2s2h/Enhancements/Cutscenes/SkipEnemyCutscenes.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/SkipEnemyCutscenes.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cutscenes/SkipEntranceCutscenes.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/SkipEntranceCutscenes.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cutscenes/SkipIntroSequence.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/SkipIntroSequence.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cutscenes/SkipOnePointCutscenes.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/SkipOnePointCutscenes.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cutscenes/SkipToFileSelect.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/SkipToFileSelect.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/HealingMikauAudio.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/HealingMikauAudio.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipBiggoronSnowheadLullaby.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipBiggoronSnowheadLullaby.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipBombBagTheftCutscene.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipBombBagTheftCutscene.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipClockTowerOpen.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipClockTowerOpen.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipClockTowerSkullKidEncounter.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipClockTowerSkullKidEncounter.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/Rando/Rando.h"
 #include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipDefeatCaptainSequence.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipDefeatCaptainSequence.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipFirstSongOfTimeFlashbacks.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipFirstSongOfTimeFlashbacks.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipGiantsChamber.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipGiantsChamber.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/CustomItem/CustomItem.h"

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipHealingDarmani.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipHealingDarmani.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/CustomItem/CustomItem.h"

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipHealingMikau.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipHealingMikau.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/CustomItem/CustomItem.h"

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipIkanaCurseCutscenes.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipIkanaCurseCutscenes.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/CustomItem/CustomItem.h"

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningElegyOfEmptiness.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningElegyOfEmptiness.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/CustomItem/CustomItem.h"

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningEponasSong.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningEponasSong.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 #include "2s2h/CustomItem/CustomItem.h"

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningGoronLullaby.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningGoronLullaby.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/CustomItem/CustomItem.h"

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningGoronLullabyIntro.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningGoronLullabyIntro.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/CustomItem/CustomItem.h"

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningNewWaveBossaNova.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningNewWaveBossaNova.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/CustomItem/CustomItem.h"
 #include "2s2h/Rando/Rando.h"

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSonataOfAwakening.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSonataOfAwakening.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/CustomItem/CustomItem.h"

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSongOfHealing.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSongOfHealing.cpp
@@ -1,10 +1,10 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/Rando/Rando.h"
 #include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/CustomItem/CustomItem.h"
 #include "2s2h/ShipInit.hpp"
-#include "spdlog/spdlog.h"
+#include <spdlog/spdlog.h>
 
 extern "C" {
 #include "functions.h"

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSongOfSoaring.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSongOfSoaring.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/CustomItem/CustomItem.h"

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSongOfStorms.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSongOfStorms.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/CustomItem/CustomItem.h"

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSongOfTime.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipLearningSongOfTime.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/CustomItem/CustomItem.h"
 #include "2s2h/CustomMessage/CustomMessage.h"

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipMilkRunCutscenes.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipMilkRunCutscenes.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipMoonCrash.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipMoonCrash.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipPrincessDelivery.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipPrincessDelivery.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipRaisingWoodfall.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipRaisingWoodfall.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipStoppingMoonCutscene.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipStoppingMoonCutscene.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/CustomItem/CustomItem.h"

--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipWakingAndRidingTurtle.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipWakingAndRidingTurtle.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cycle/EndOfCycle.cpp
+++ b/mm/2s2h/Enhancements/Cycle/EndOfCycle.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/Rando/Rando.h"
 #include "2s2h/ShipInit.hpp"

--- a/mm/2s2h/Enhancements/Cycle/KeepExpressMail.cpp
+++ b/mm/2s2h/Enhancements/Cycle/KeepExpressMail.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Cycle/OceansideSpiderHouseSquatter.cpp
+++ b/mm/2s2h/Enhancements/Cycle/OceansideSpiderHouseSquatter.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 #include "2s2h/Rando/Rando.h"

--- a/mm/2s2h/Enhancements/Cycle/OceansideWalletAnyDay.cpp
+++ b/mm/2s2h/Enhancements/Cycle/OceansideWalletAnyDay.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 #include "2s2h/Rando/Rando.h"

--- a/mm/2s2h/Enhancements/DemoBehavior.cpp
+++ b/mm/2s2h/Enhancements/DemoBehavior.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/CustomItem/CustomItem.h"

--- a/mm/2s2h/Enhancements/Dialogue/AutoBombersCode.cpp
+++ b/mm/2s2h/Enhancements/Dialogue/AutoBombersCode.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Dialogue/FastBankSelection.cpp
+++ b/mm/2s2h/Enhancements/Dialogue/FastBankSelection.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/DifficultyOptions/CustomBankRewardThresholds.cpp
+++ b/mm/2s2h/Enhancements/DifficultyOptions/CustomBankRewardThresholds.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 #include "2s2h/CustomMessage/CustomMessage.h"

--- a/mm/2s2h/Enhancements/DifficultyOptions/DamageMultiplier.cpp
+++ b/mm/2s2h/Enhancements/DifficultyOptions/DamageMultiplier.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/DifficultyOptions/DekuGuardSearchBalls.cpp
+++ b/mm/2s2h/Enhancements/DifficultyOptions/DekuGuardSearchBalls.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "Enhancements/Enhancements.h"
 #include "2s2h/ShipInit.hpp"

--- a/mm/2s2h/Enhancements/DifficultyOptions/DeleteFileOnDeath.cpp
+++ b/mm/2s2h/Enhancements/DifficultyOptions/DeleteFileOnDeath.cpp
@@ -1,7 +1,7 @@
-#include "public/bridge/consolevariablebridge.h"
-#include "ConsoleWindow.h"
-#include "Context.h"
-#include "Window.h"
+#include <libultraship/bridge/consolevariablebridge.h>
+#include <ship/window/gui/ConsoleWindow.h>
+#include <ship/Context.h>
+#include <ship/window/Window.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/DifficultyOptions/DisableTakkuriSteal.cpp
+++ b/mm/2s2h/Enhancements/DifficultyOptions/DisableTakkuriSteal.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/DifficultyOptions/GibdoTradeSequenceOptions.cpp
+++ b/mm/2s2h/Enhancements/DifficultyOptions/GibdoTradeSequenceOptions.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/Enhancements/Enhancements.h"
 #include "2s2h/ShipInit.hpp"

--- a/mm/2s2h/Enhancements/DifficultyOptions/HiddenGrottosVisibility.cpp
+++ b/mm/2s2h/Enhancements/DifficultyOptions/HiddenGrottosVisibility.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 #include "2s2h/Enhancements/Enhancements.h"

--- a/mm/2s2h/Enhancements/DifficultyOptions/HyperEnemies.cpp
+++ b/mm/2s2h/Enhancements/DifficultyOptions/HyperEnemies.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/DifficultyOptions/JinxedTimer.cpp
+++ b/mm/2s2h/Enhancements/DifficultyOptions/JinxedTimer.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 #include "variables.h"

--- a/mm/2s2h/Enhancements/DifficultyOptions/PermanentHeartLoss.cpp
+++ b/mm/2s2h/Enhancements/DifficultyOptions/PermanentHeartLoss.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Equipment/ArrowCycle.cpp
+++ b/mm/2s2h/Enhancements/Equipment/ArrowCycle.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Equipment/BetterPictoMessage.cpp
+++ b/mm/2s2h/Enhancements/Equipment/BetterPictoMessage.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 #include "2s2h/CustomMessage/CustomMessage.h"

--- a/mm/2s2h/Enhancements/Equipment/ChuDrops.cpp
+++ b/mm/2s2h/Enhancements/Equipment/ChuDrops.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 #include "2s2h/CustomItem/CustomItem.h"

--- a/mm/2s2h/Enhancements/Equipment/InstantRecall.cpp
+++ b/mm/2s2h/Enhancements/Equipment/InstantRecall.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Equipment/RemoteBombchu.cpp
+++ b/mm/2s2h/Enhancements/Equipment/RemoteBombchu.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Equipment/SkipMagicArrowEquip.cpp
+++ b/mm/2s2h/Enhancements/Equipment/SkipMagicArrowEquip.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Equipment/TwoHandedSwordSpinAttack.cpp
+++ b/mm/2s2h/Enhancements/Equipment/TwoHandedSwordSpinAttack.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Fixes/BgmReplay.cpp
+++ b/mm/2s2h/Enhancements/Fixes/BgmReplay.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Fixes/CompletedHeartContainerAudio.cpp
+++ b/mm/2s2h/Enhancements/Fixes/CompletedHeartContainerAudio.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Fixes/FierceDeityZTargetMovement.cpp
+++ b/mm/2s2h/Enhancements/Fixes/FierceDeityZTargetMovement.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Fixes/FixEponaStealingSword.cpp
+++ b/mm/2s2h/Enhancements/Fixes/FixEponaStealingSword.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 #include "variables.h"

--- a/mm/2s2h/Enhancements/FrameInterpolation/FrameInterpolation.cpp
+++ b/mm/2s2h/Enhancements/FrameInterpolation/FrameInterpolation.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 #include <vector>
 #include <map>

--- a/mm/2s2h/Enhancements/GfxPatcher/AuthenticGfxPatches.cpp
+++ b/mm/2s2h/Enhancements/GfxPatcher/AuthenticGfxPatches.cpp
@@ -1,5 +1,5 @@
 #include "AuthenticGfxPatches.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 extern "C" {
 #include "gfx.h"
 #include "objects/gameplay_keep/gameplay_keep.h"

--- a/mm/2s2h/Enhancements/Graphics/3DItemDrops.cpp
+++ b/mm/2s2h/Enhancements/Graphics/3DItemDrops.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
 #include "2s2h/ShipInit.hpp"

--- a/mm/2s2h/Enhancements/Graphics/3DSClock.cpp
+++ b/mm/2s2h/Enhancements/Graphics/3DSClock.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/BenGui/HudEditor.h"
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/Enhancements/Enhancements.h"

--- a/mm/2s2h/Enhancements/Graphics/BowReticle.cpp
+++ b/mm/2s2h/Enhancements/Graphics/BowReticle.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
 #include "2s2h/ShipInit.hpp"

--- a/mm/2s2h/Enhancements/Graphics/DisableBlackBars.cpp
+++ b/mm/2s2h/Enhancements/Graphics/DisableBlackBars.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Graphics/EnemyHealthBars.cpp
+++ b/mm/2s2h/Enhancements/Graphics/EnemyHealthBars.cpp
@@ -4,7 +4,7 @@
 #include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
 #include "2s2h/ShipInit.hpp"
 #include "2s2h/ShipUtils.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include <cassert>
 
 extern "C" {

--- a/mm/2s2h/Enhancements/Graphics/MotionBlur.cpp
+++ b/mm/2s2h/Enhancements/Graphics/MotionBlur.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/BenGui/UIWidgets.hpp"
 
 extern "C" {

--- a/mm/2s2h/Enhancements/Graphics/TextBasedClock.cpp
+++ b/mm/2s2h/Enhancements/Graphics/TextBasedClock.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/BenGui/HudEditor.h"
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/Enhancements/Enhancements.h"

--- a/mm/2s2h/Enhancements/Masks/BlastMaskKeg.cpp
+++ b/mm/2s2h/Enhancements/Masks/BlastMaskKeg.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Masks/FastTransformation.cpp
+++ b/mm/2s2h/Enhancements/Masks/FastTransformation.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Masks/FierceDeityAnywhere.cpp
+++ b/mm/2s2h/Enhancements/Masks/FierceDeityAnywhere.cpp
@@ -1,5 +1,5 @@
 #include "2s2h/ActorExtension/ActorExtension.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Masks/GoronRollingFastSpikes.cpp
+++ b/mm/2s2h/Enhancements/Masks/GoronRollingFastSpikes.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Masks/GoronRollingIgnoresMagic.cpp
+++ b/mm/2s2h/Enhancements/Masks/GoronRollingIgnoresMagic.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Masks/NoBlastMaskCooldown.cpp
+++ b/mm/2s2h/Enhancements/Masks/NoBlastMaskCooldown.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Masks/PersistentMasks.cpp
+++ b/mm/2s2h/Enhancements/Masks/PersistentMasks.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
 #include "2s2h/ShipInit.hpp"

--- a/mm/2s2h/Enhancements/Minigames/AlwaysWinDoggyRace.cpp
+++ b/mm/2s2h/Enhancements/Minigames/AlwaysWinDoggyRace.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/Enhancements/Enhancements.h"
 #include "2s2h/ShipInit.hpp"

--- a/mm/2s2h/Enhancements/Minigames/Archery.cpp
+++ b/mm/2s2h/Enhancements/Minigames/Archery.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Minigames/BeaverRace.cpp
+++ b/mm/2s2h/Enhancements/Minigames/BeaverRace.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Minigames/CremiaHugs.cpp
+++ b/mm/2s2h/Enhancements/Minigames/CremiaHugs.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/Enhancements/Enhancements.h"
 #include "2s2h/ShipInit.hpp"

--- a/mm/2s2h/Enhancements/Minigames/CuccoShackCuccoCount.cpp
+++ b/mm/2s2h/Enhancements/Minigames/CuccoShackCuccoCount.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Minigames/FrogChoirCount.cpp
+++ b/mm/2s2h/Enhancements/Minigames/FrogChoirCount.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Minigames/HoneyAndDarling.cpp
+++ b/mm/2s2h/Enhancements/Minigames/HoneyAndDarling.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Minigames/MarkShootingGalleryOctoroks.cpp
+++ b/mm/2s2h/Enhancements/Minigames/MarkShootingGalleryOctoroks.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
 #include "2s2h/ShipInit.hpp"

--- a/mm/2s2h/Enhancements/Minigames/RomaniTargetPractice.cpp
+++ b/mm/2s2h/Enhancements/Minigames/RomaniTargetPractice.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Minigames/SkipBalladOfWindfish.cpp
+++ b/mm/2s2h/Enhancements/Minigames/SkipBalladOfWindfish.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Minigames/SkipHorseRace.cpp
+++ b/mm/2s2h/Enhancements/Minigames/SkipHorseRace.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/Enhancements/Enhancements.h"
 #include "2s2h/ShipInit.hpp"

--- a/mm/2s2h/Enhancements/Minigames/SkipPowderKegCertification.cpp
+++ b/mm/2s2h/Enhancements/Minigames/SkipPowderKegCertification.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 #include "2s2h/Rando/Rando.h"

--- a/mm/2s2h/Enhancements/Minigames/SwordsmanSchool.cpp
+++ b/mm/2s2h/Enhancements/Minigames/SwordsmanSchool.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Modes/HyruleWarriorsStyledLink.cpp
+++ b/mm/2s2h/Enhancements/Modes/HyruleWarriorsStyledLink.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "Enhancements/FrameInterpolation/FrameInterpolation.h"
 #include "2s2h/ShipInit.hpp"

--- a/mm/2s2h/Enhancements/Modes/PlayAsKafei.cpp
+++ b/mm/2s2h/Enhancements/Modes/PlayAsKafei.cpp
@@ -1,6 +1,6 @@
-#include "public/bridge/consolevariablebridge.h"
-#include "Context.h"
-#include "ResourceManager.h"
+#include <libultraship/bridge/consolevariablebridge.h>
+#include <ship/Context.h>
+#include <ship/resource/ResourceManager.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Modes/TimeMovesWhenYouMove.cpp
+++ b/mm/2s2h/Enhancements/Modes/TimeMovesWhenYouMove.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Player/ClimbSpeed.cpp
+++ b/mm/2s2h/Enhancements/Player/ClimbSpeed.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Player/FastFlowerLaunch.cpp
+++ b/mm/2s2h/Enhancements/Player/FastFlowerLaunch.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Player/FasterPushAndPull.cpp
+++ b/mm/2s2h/Enhancements/Player/FasterPushAndPull.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Player/FierceDeityPutaway.cpp
+++ b/mm/2s2h/Enhancements/Player/FierceDeityPutaway.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Player/InfiniteDekuHopping.cpp
+++ b/mm/2s2h/Enhancements/Player/InfiniteDekuHopping.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Player/InstantPutaway.cpp
+++ b/mm/2s2h/Enhancements/Player/InstantPutaway.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Player/ManualJump.cpp
+++ b/mm/2s2h/Enhancements/Player/ManualJump.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Player/PreventDiveOverWater.cpp
+++ b/mm/2s2h/Enhancements/Player/PreventDiveOverWater.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Player/UnderwaterOcarina.cpp
+++ b/mm/2s2h/Enhancements/Player/UnderwaterOcarina.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Restorations/FlipHopVariable.cpp
+++ b/mm/2s2h/Enhancements/Restorations/FlipHopVariable.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Restorations/N64WeirdFrames/N64WeirdFrames.cpp
+++ b/mm/2s2h/Enhancements/Restorations/N64WeirdFrames/N64WeirdFrames.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Restorations/N64WeirdFrames/WeirdAnimation.cpp
+++ b/mm/2s2h/Enhancements/Restorations/N64WeirdFrames/WeirdAnimation.cpp
@@ -1,7 +1,7 @@
 #include "WeirdAnimation.h"
 
-#include "ResourceManager.h"
-#include "Context.h"
+#include <ship/resource/ResourceManager.h>
+#include <ship/Context.h>
 
 #include <cassert>
 #include <cstring>

--- a/mm/2s2h/Enhancements/Restorations/OoTFasterSwim.cpp
+++ b/mm/2s2h/Enhancements/Restorations/OoTFasterSwim.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Restorations/PauseBufferInputs.cpp
+++ b/mm/2s2h/Enhancements/Restorations/PauseBufferInputs.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Restorations/PowerCrouchStab.cpp
+++ b/mm/2s2h/Enhancements/Restorations/PowerCrouchStab.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Restorations/SideRoll.cpp
+++ b/mm/2s2h/Enhancements/Restorations/SideRoll.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Restorations/TatlISG.cpp
+++ b/mm/2s2h/Enhancements/Restorations/TatlISG.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Restorations/WoodfallMountainAppearance.cpp
+++ b/mm/2s2h/Enhancements/Restorations/WoodfallMountainAppearance.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Saving/FileSlot3.cpp
+++ b/mm/2s2h/Enhancements/Saving/FileSlot3.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/ShipInit.hpp"
 
 extern "C" {

--- a/mm/2s2h/Enhancements/Saving/SavingEnhancements.cpp
+++ b/mm/2s2h/Enhancements/Saving/SavingEnhancements.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "BenPort.h"
 #include "2s2h/GameInteractor/GameInteractor.h"
 

--- a/mm/2s2h/Enhancements/Sfx/MuteCarpenterSfx.cpp
+++ b/mm/2s2h/Enhancements/Sfx/MuteCarpenterSfx.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Sfx/MuteCryingGoronChild.cpp
+++ b/mm/2s2h/Enhancements/Sfx/MuteCryingGoronChild.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Sfx/MuteLowHpAlarm.cpp
+++ b/mm/2s2h/Enhancements/Sfx/MuteLowHpAlarm.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Songs/BetterSongOfDoubleTime.cpp
+++ b/mm/2s2h/Enhancements/Songs/BetterSongOfDoubleTime.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/BenGui/HudEditor.h"
 #include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
 #include "2s2h/GameInteractor/GameInteractor.h"

--- a/mm/2s2h/Enhancements/Songs/EnableSunsSong.cpp
+++ b/mm/2s2h/Enhancements/Songs/EnableSunsSong.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Songs/FasterSongPlayback.cpp
+++ b/mm/2s2h/Enhancements/Songs/FasterSongPlayback.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Songs/PauseOwlWarp.cpp
+++ b/mm/2s2h/Enhancements/Songs/PauseOwlWarp.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Songs/SkipScarecrowSong.cpp
+++ b/mm/2s2h/Enhancements/Songs/SkipScarecrowSong.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Songs/SkipSoTCutscenes.cpp
+++ b/mm/2s2h/Enhancements/Songs/SkipSoTCutscenes.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Songs/ZoraEggCount.cpp
+++ b/mm/2s2h/Enhancements/Songs/ZoraEggCount.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Timesavers/BombersHideAndSeek.cpp
+++ b/mm/2s2h/Enhancements/Timesavers/BombersHideAndSeek.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Timesavers/DampeDiggingSkip.cpp
+++ b/mm/2s2h/Enhancements/Timesavers/DampeDiggingSkip.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Timesavers/FastChests.cpp
+++ b/mm/2s2h/Enhancements/Timesavers/FastChests.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 #include "2s2h/Rando/Rando.h"

--- a/mm/2s2h/Enhancements/Timesavers/FasterSceneTransitions.cpp
+++ b/mm/2s2h/Enhancements/Timesavers/FasterSceneTransitions.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Timesavers/GalleryTwofer.cpp
+++ b/mm/2s2h/Enhancements/Timesavers/GalleryTwofer.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 #include "2s2h/Rando/Rando.h"

--- a/mm/2s2h/Enhancements/Timesavers/MarineLabHP.cpp
+++ b/mm/2s2h/Enhancements/Timesavers/MarineLabHP.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Timesavers/SwampBoatSkip.cpp
+++ b/mm/2s2h/Enhancements/Timesavers/SwampBoatSkip.cpp
@@ -1,4 +1,4 @@
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 

--- a/mm/2s2h/Enhancements/Trackers/DisplayOverlay.cpp
+++ b/mm/2s2h/Enhancements/Trackers/DisplayOverlay.cpp
@@ -1,9 +1,9 @@
 
 #include "DisplayOverlay.h"
 #include <spdlog/fmt/fmt.h>
-#include "public/bridge/consolevariablebridge.h"
-#include "Context.h"
-#include "Window.h"
+#include <libultraship/bridge/consolevariablebridge.h>
+#include <ship/Context.h>
+#include <ship/window/Window.h>
 
 extern "C" {
 #include "variables.h"

--- a/mm/2s2h/Enhancements/Trackers/DisplayOverlay.h
+++ b/mm/2s2h/Enhancements/Trackers/DisplayOverlay.h
@@ -1,4 +1,4 @@
-#include "GuiWindow.h"
+#include <ship/window/gui/GuiWindow.h>
 
 void DisplayOverlayInitSettings();
 

--- a/mm/2s2h/Enhancements/Trackers/ItemTracker.cpp
+++ b/mm/2s2h/Enhancements/Trackers/ItemTracker.cpp
@@ -1,7 +1,7 @@
 #include "ItemTracker.h"
-#include "public/bridge/consolevariablebridge.h"
-#include "Context.h"
-#include "config/Config.h"
+#include <libultraship/bridge/consolevariablebridge.h>
+#include <ship/Context.h>
+#include <ship/config/Config.h>
 #include <bit>
 #include "Rando/Rando.h"
 

--- a/mm/2s2h/Enhancements/Trackers/ItemTracker.h
+++ b/mm/2s2h/Enhancements/Trackers/ItemTracker.h
@@ -1,5 +1,5 @@
-#include "window/gui/Gui.h"
-#include "window/gui/GuiWindow.h"
+#include <ship/window/gui/Gui.h>
+#include <ship/window/gui/GuiWindow.h>
 #include <array>
 
 typedef enum class TrackerWindowType : uint8_t {

--- a/mm/2s2h/Enhancements/Trackers/ItemTrackerSettings.h
+++ b/mm/2s2h/Enhancements/Trackers/ItemTrackerSettings.h
@@ -1,5 +1,5 @@
-#include "window/gui/Gui.h"
-#include "window/gui/GuiWindow.h"
+#include <ship/window/gui/Gui.h>
+#include <ship/window/gui/GuiWindow.h>
 
 class ItemTrackerSettingsWindow : public Ship::GuiWindow {
   public:

--- a/mm/2s2h/Enhancements/Trackers/TimeSplits/TimeSplitsActions.cpp
+++ b/mm/2s2h/Enhancements/Trackers/TimeSplits/TimeSplitsActions.cpp
@@ -1,9 +1,9 @@
 #include "Timesplits.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
-#include "Context.h"
-#include "Window.h"
+#include <ship/Context.h>
+#include <ship/window/Window.h>
 #include "2s2h/BenGui/UIWidgets.hpp"
 #include <fstream>
 #include <filesystem>

--- a/mm/2s2h/Enhancements/Trackers/TimeSplits/Timesplits.cpp
+++ b/mm/2s2h/Enhancements/Trackers/TimeSplits/Timesplits.cpp
@@ -1,8 +1,8 @@
 
 #include "Timesplits.h"
-#include "public/bridge/consolevariablebridge.h"
-#include "Context.h"
-#include "Window.h"
+#include <libultraship/bridge/consolevariablebridge.h>
+#include <ship/Context.h>
+#include <ship/window/Window.h>
 #include "2s2h/BenGui/UIWidgets.hpp"
 
 extern "C" {

--- a/mm/2s2h/Enhancements/Trackers/TimeSplits/Timesplits.h
+++ b/mm/2s2h/Enhancements/Trackers/TimeSplits/Timesplits.h
@@ -1,4 +1,4 @@
-#include "GuiWindow.h"
+#include <ship/window/gui/GuiWindow.h>
 #include <vector>
 #include <map>
 

--- a/mm/2s2h/Enhancements/Trackers/TimeSplits/TimesplitsSettings.cpp
+++ b/mm/2s2h/Enhancements/Trackers/TimeSplits/TimesplitsSettings.cpp
@@ -1,9 +1,9 @@
 
 #include "TimesplitsSettings.h"
 #include "Timesplits.h"
-#include "public/bridge/consolevariablebridge.h"
-#include "Context.h"
-#include "Window.h"
+#include <libultraship/bridge/consolevariablebridge.h>
+#include <ship/Context.h>
+#include <ship/window/Window.h>
 #include "2s2h/BenGui/UIWidgets.hpp"
 
 extern "C" {

--- a/mm/2s2h/Enhancements/Trackers/TimeSplits/TimesplitsSettings.h
+++ b/mm/2s2h/Enhancements/Trackers/TimeSplits/TimesplitsSettings.h
@@ -1,4 +1,4 @@
-#include "GuiWindow.h"
+#include <ship/window/gui/GuiWindow.h>
 
 class TimesplitsSettingsWindow : public Ship::GuiWindow {
   public:

--- a/mm/2s2h/Extractor/Extract.cpp
+++ b/mm/2s2h/Extractor/Extract.cpp
@@ -6,7 +6,7 @@
 #endif
 #include "Extract.h"
 #include "portable-file-dialogs.h"
-#include <utils/binarytools/BitConverter.h>
+#include <ship/utils/binarytools/BitConverter.h>
 #include "build.h"
 
 #ifdef unix

--- a/mm/2s2h/GameInteractor/GameInteractor.cpp
+++ b/mm/2s2h/GameInteractor/GameInteractor.cpp
@@ -1,7 +1,7 @@
 #include "GameInteractor.h"
 #include <variant>
-#include "spdlog/spdlog.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <spdlog/spdlog.h>
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/CustomItem/CustomItem.h"
 #include "2s2h/CustomMessage/CustomMessage.h"
 

--- a/mm/2s2h/NameTag/NameTag.cpp
+++ b/mm/2s2h/NameTag/NameTag.cpp
@@ -1,5 +1,5 @@
 #include "NameTag.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include <vector>
 #include <algorithm>
 #include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"

--- a/mm/2s2h/PresetManager/PresetManager.cpp
+++ b/mm/2s2h/PresetManager/PresetManager.cpp
@@ -1,12 +1,12 @@
 #include "PresetManager.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include <filesystem>
 #include <fstream>
 #include <set>
 #include "2s2h/BenPort.h"
 #include "2s2h/BenGui/UIWidgets.hpp"
 #include "2s2h/BenGui/Notification.h"
-#include "FileDropMgr.h"
+#include <ship/window/FileDropMgr.h>
 
 std::unordered_map<std::string, std::string> tagMap = {
     { "gEventLog", "Developer Tools" },

--- a/mm/2s2h/Rando/ActorBehavior/ActorBehavior.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ActorBehavior.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/ActorExtension/ActorExtension.h"
 
 extern "C" {

--- a/mm/2s2h/Rando/ActorBehavior/DmChar01.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/DmChar01.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "overlays/actors/ovl_Dm_Char01/z_dm_char01.h"

--- a/mm/2s2h/Rando/ActorBehavior/DmChar08.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/DmChar08.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "overlays/actors/ovl_Dm_Char08/z_dm_char08.h"

--- a/mm/2s2h/Rando/ActorBehavior/DmStk.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/DmStk.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/ShipUtils.h"
 #include "2s2h/Rando/Logic/Logic.h"

--- a/mm/2s2h/Rando/ActorBehavior/DoorWarp1.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/DoorWarp1.cpp
@@ -1,6 +1,6 @@
 #include "ActorBehavior.h"
 #include "2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipGiantsChamber.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "overlays/actors/ovl_Door_Warp1/z_door_warp1.h"

--- a/mm/2s2h/Rando/ActorBehavior/EnAkindonuts.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnAkindonuts.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/ShipUtils.h"
 #include "2s2h/CustomMessage/CustomMessage.h"
 

--- a/mm/2s2h/Rando/ActorBehavior/EnAl.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnAl.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "variables.h"

--- a/mm/2s2h/Rando/ActorBehavior/EnAn.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnAn.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "variables.h"

--- a/mm/2s2h/Rando/ActorBehavior/EnAob01.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnAob01.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "variables.h"

--- a/mm/2s2h/Rando/ActorBehavior/EnAz.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnAz.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "variables.h"

--- a/mm/2s2h/Rando/ActorBehavior/EnBaba.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnBaba.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "variables.h"

--- a/mm/2s2h/Rando/ActorBehavior/EnBal.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnBal.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/CustomMessage/CustomMessage.h"
 
 extern "C" {

--- a/mm/2s2h/Rando/ActorBehavior/EnBjt.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnBjt.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "variables.h"

--- a/mm/2s2h/Rando/ActorBehavior/EnBomBowlMan.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnBomBowlMan.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "variables.h"

--- a/mm/2s2h/Rando/ActorBehavior/EnBox.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnBox.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
 #include "2s2h/Rando/StaticData/StaticData.h"
 #include "2s2h/ShipInit.hpp"

--- a/mm/2s2h/Rando/ActorBehavior/EnCow.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnCow.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "variables.h"

--- a/mm/2s2h/Rando/ActorBehavior/EnDai.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnDai.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "overlays/actors/ovl_En_Dai/z_en_dai.h"

--- a/mm/2s2h/Rando/ActorBehavior/EnDnh.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnDnh.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "variables.h"

--- a/mm/2s2h/Rando/ActorBehavior/EnElfgrp.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnElfgrp.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/ShipUtils.h"
 #include "2s2h/CustomMessage/CustomMessage.h"
 

--- a/mm/2s2h/Rando/ActorBehavior/EnElforg.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnElforg.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "variables.h"

--- a/mm/2s2h/Rando/ActorBehavior/EnFish2.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnFish2.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "CustomItem/CustomItem.h"
 
 extern "C" {

--- a/mm/2s2h/Rando/ActorBehavior/EnFsn.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnFsn.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "variables.h"

--- a/mm/2s2h/Rando/ActorBehavior/EnFu.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnFu.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "variables.h"

--- a/mm/2s2h/Rando/ActorBehavior/EnGamelupy.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnGamelupy.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "CustomItem/CustomItem.h"
 
 extern "C" {

--- a/mm/2s2h/Rando/ActorBehavior/EnGb2.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnGb2.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/CustomMessage/CustomMessage.h"
 
 extern "C" {

--- a/mm/2s2h/Rando/ActorBehavior/EnGeg.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnGeg.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/CustomMessage/CustomMessage.h"
 
 extern "C" {

--- a/mm/2s2h/Rando/ActorBehavior/EnGinko.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnGinko.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "variables.h"

--- a/mm/2s2h/Rando/ActorBehavior/EnGirlA.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnGirlA.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/CustomMessage/CustomMessage.h"
 
 extern "C" {

--- a/mm/2s2h/Rando/ActorBehavior/EnGk.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnGk.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "variables.h"

--- a/mm/2s2h/Rando/ActorBehavior/EnGs.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnGs.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/ShipUtils.h"
 #include "2s2h/CustomMessage/CustomMessage.h"
 

--- a/mm/2s2h/Rando/ActorBehavior/EnIn.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnIn.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/CustomMessage/CustomMessage.h"
 
 extern "C" {

--- a/mm/2s2h/Rando/ActorBehavior/EnItem00.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnItem00.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/CustomItem/CustomItem.h"
 
 extern "C" {

--- a/mm/2s2h/Rando/ActorBehavior/EnJg.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnJg.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "variables.h"

--- a/mm/2s2h/Rando/ActorBehavior/EnJgameTsn.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnJgameTsn.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/CustomMessage/CustomMessage.h"
 
 extern "C" {

--- a/mm/2s2h/Rando/ActorBehavior/EnJs.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnJs.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/Rando/Logic/Logic.h"
 #include "2s2h/CustomMessage/CustomMessage.h"
 

--- a/mm/2s2h/Rando/ActorBehavior/EnKitan.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnKitan.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "overlays/actors/ovl_En_Kitan/z_en_kitan.h"

--- a/mm/2s2h/Rando/ActorBehavior/EnKujiya.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnKujiya.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/CustomMessage/CustomMessage.h"
 
 extern "C" {

--- a/mm/2s2h/Rando/ActorBehavior/EnLiftNuts.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnLiftNuts.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "variables.h"

--- a/mm/2s2h/Rando/ActorBehavior/EnMaYto.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnMaYto.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "variables.h"

--- a/mm/2s2h/Rando/ActorBehavior/EnMinifrog.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnMinifrog.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/CustomMessage/CustomMessage.h"
 
 extern "C" {

--- a/mm/2s2h/Rando/ActorBehavior/EnOsn.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnOsn.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "variables.h"

--- a/mm/2s2h/Rando/ActorBehavior/EnOwl.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnOwl.cpp
@@ -1,6 +1,6 @@
 #include "ActorBehavior.h"
 #include "2s2h/Rando/Logic/Logic.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "variables.h"

--- a/mm/2s2h/Rando/ActorBehavior/EnPm.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnPm.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "variables.h"

--- a/mm/2s2h/Rando/ActorBehavior/EnRuppecrow.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnRuppecrow.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "CustomItem/CustomItem.h"
 
 extern "C" {

--- a/mm/2s2h/Rando/ActorBehavior/EnRz.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnRz.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "variables.h"

--- a/mm/2s2h/Rando/ActorBehavior/EnScopenuts.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnScopenuts.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/CustomMessage/CustomMessage.h"
 
 extern "C" {

--- a/mm/2s2h/Rando/ActorBehavior/EnSellnuts.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnSellnuts.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "variables.h"

--- a/mm/2s2h/Rando/ActorBehavior/EnSi.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnSi.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "functions.h"

--- a/mm/2s2h/Rando/ActorBehavior/EnSsh.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnSsh.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipUtils.h"
 #include "2s2h/CustomMessage/CustomMessage.h"

--- a/mm/2s2h/Rando/ActorBehavior/EnStoneheishi.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnStoneheishi.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "variables.h"

--- a/mm/2s2h/Rando/ActorBehavior/EnSyatekiMan.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnSyatekiMan.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "variables.h"

--- a/mm/2s2h/Rando/ActorBehavior/EnTab.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnTab.cpp
@@ -1,6 +1,6 @@
 #include "ActorBehavior.h"
 #include "Rando/MiscBehavior/MiscBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/CustomMessage/CustomMessage.h"
 
 extern "C" {

--- a/mm/2s2h/Rando/ActorBehavior/EnToto.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnToto.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "variables.h"

--- a/mm/2s2h/Rando/ActorBehavior/EnTrt.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnTrt.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "variables.h"

--- a/mm/2s2h/Rando/ActorBehavior/EnYb.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnYb.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "variables.h"

--- a/mm/2s2h/Rando/ActorBehavior/EnZot.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnZot.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "variables.h"

--- a/mm/2s2h/Rando/ActorBehavior/ItemBHeart.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ItemBHeart.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "functions.h"

--- a/mm/2s2h/Rando/ActorBehavior/ObjGrass.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ObjGrass.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 #include "2s2h/CustomItem/CustomItem.h"
 #include "2s2h/Rando/Rando.h"

--- a/mm/2s2h/Rando/ActorBehavior/ObjKibako.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ObjKibako.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/CustomItem/CustomItem.h"
 #include "assets/2s2h_assets.h"
 

--- a/mm/2s2h/Rando/ActorBehavior/ObjMoonStone.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ObjMoonStone.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "variables.h"

--- a/mm/2s2h/Rando/ActorBehavior/ObjSnowball.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ObjSnowball.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/CustomItem/CustomItem.h"
 #include "assets/2s2h_assets.h"
 #include "2s2h/ActorExtension/ActorListIndex.h"

--- a/mm/2s2h/Rando/ActorBehavior/ObjTaru.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ObjTaru.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/CustomItem/CustomItem.h"
 #include "assets/2s2h_assets.h"
 

--- a/mm/2s2h/Rando/ActorBehavior/ObjTsubo.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ObjTsubo.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 #include "2s2h/CustomItem/CustomItem.h"
 #include "2s2h/Rando/Rando.h"

--- a/mm/2s2h/Rando/ActorBehavior/ObjWarpstone.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ObjWarpstone.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "variables.h"

--- a/mm/2s2h/Rando/ActorBehavior/Player.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/Player.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "variables.h"

--- a/mm/2s2h/Rando/ActorBehavior/Souls.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/Souls.cpp
@@ -1,5 +1,5 @@
 #include "ActorBehavior.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 extern "C" {
 #include "variables.h"

--- a/mm/2s2h/Rando/CheckTracker/CheckTracker.h
+++ b/mm/2s2h/Rando/CheckTracker/CheckTracker.h
@@ -2,7 +2,7 @@
 #define RANDO_CHECK_TRACKER_H
 
 #include "Rando/Rando.h"
-#include "GuiWindow.h"
+#include <ship/window/gui/GuiWindow.h>
 
 namespace Rando {
 

--- a/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
+++ b/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
@@ -2,7 +2,7 @@
 #include "Rando/Spoiler/Spoiler.h"
 #include "Rando/Logic/Logic.h"
 #include "2s2h/ShipUtils.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include <spdlog/spdlog.h>
 
 extern "C" {

--- a/mm/2s2h/Rando/Rando.cpp
+++ b/mm/2s2h/Rando/Rando.cpp
@@ -5,8 +5,8 @@
 #include "Rando/Spoiler/Spoiler.h"
 #include "Rando/CheckTracker/CheckTracker.h"
 #include "2s2h/ShipInit.hpp"
-#include "FileDropMgr.h"
-#include "Context.h"
+#include <ship/window/FileDropMgr.h>
+#include <ship/Context.h>
 
 // When a save is loaded, we want to unregister all hooks and re-register them if it's a rando save
 void OnSaveLoadHandler(s16 fileNum) {

--- a/mm/2s2h/Rando/Spoiler/Apply.cpp
+++ b/mm/2s2h/Rando/Spoiler/Apply.cpp
@@ -1,6 +1,6 @@
 #include "Spoiler.h"
 #include "Rando/Rando.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "ShipUtils.h"
 
 namespace Rando {

--- a/mm/2s2h/Rando/Spoiler/HandleFileDropped.cpp
+++ b/mm/2s2h/Rando/Spoiler/HandleFileDropped.cpp
@@ -4,8 +4,8 @@
 #include <filesystem>
 #include <spdlog/spdlog.h>
 #include "BenPort.h"
-#include "public/bridge/consolevariablebridge.h"
-#include "Window.h"
+#include <libultraship/bridge/consolevariablebridge.h>
+#include <ship/window/Window.h>
 
 extern "C" {
 #include "sfx.h"

--- a/mm/2s2h/Rando/Spoiler/RefreshOptions.cpp
+++ b/mm/2s2h/Rando/Spoiler/RefreshOptions.cpp
@@ -1,5 +1,5 @@
 #include "Spoiler.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include <filesystem>
 #include "BenPort.h"
 

--- a/mm/2s2h/Rando/StaticData/Items.cpp
+++ b/mm/2s2h/Rando/StaticData/Items.cpp
@@ -1,5 +1,5 @@
 #include "StaticData.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/ShipUtils.h"
 #include "2s2h/Rando/Rando.h"
 

--- a/mm/2s2h/SaveManager/BinarySaveConverter.cpp
+++ b/mm/2s2h/SaveManager/BinarySaveConverter.cpp
@@ -3,11 +3,11 @@
 #include <nlohmann/json.hpp>
 
 #include "2s2h/SaveManager/SaveManager.h"
-#include "utils/binarytools/BinaryReader.h"
+#include <ship/utils/binarytools/BinaryReader.h>
 #include <string>
-#include "spdlog/spdlog.h"
-#include "Context.h"
-#include "Window.h"
+#include <spdlog/spdlog.h>
+#include <ship/Context.h>
+#include <ship/window/Window.h>
 
 extern "C" {
 #include "z64math.h"

--- a/mm/2s2h/SaveManager/SaveManager.cpp
+++ b/mm/2s2h/SaveManager/SaveManager.cpp
@@ -6,7 +6,7 @@
 
 #include "BenJsonConversions.hpp"
 #include "BenPort.h"
-#include "Window.h"
+#include <ship/window/Window.h>
 
 extern "C" {
 #include "z64save.h"

--- a/mm/2s2h/ShipUtils.cpp
+++ b/mm/2s2h/ShipUtils.cpp
@@ -5,9 +5,9 @@
 #include <random>
 #include <vector>
 #include <cassert>
-#include "public/bridge/consolevariablebridge.h"
-#include "Context.h"
-#include "Window.h"
+#include <libultraship/bridge/consolevariablebridge.h>
+#include <ship/Context.h>
+#include <ship/window/Window.h>
 // Image Icons
 #include "assets/interface/parameter_static/parameter_static.h"
 #include "assets/archives/icon_item_24_static/icon_item_24_static_yar.h"

--- a/mm/2s2h/resource/importer/AnimationFactory.cpp
+++ b/mm/2s2h/resource/importer/AnimationFactory.cpp
@@ -1,8 +1,8 @@
 #include "2s2h/resource/importer/AnimationFactory.h"
 #include "2s2h/resource/type/Animation.h"
 #include "2s2h/resource/importer/PlayerAnimationFactory.h"
-#include "Context.h"
-#include "ResourceManager.h"
+#include <ship/Context.h>
+#include <ship/resource/ResourceManager.h>
 
 #include <spdlog/spdlog.h>
 

--- a/mm/2s2h/resource/importer/AnimationFactory.h
+++ b/mm/2s2h/resource/importer/AnimationFactory.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "Resource.h"
-#include "ResourceFactoryBinary.h"
+#include <ship/resource/Resource.h>
+#include <ship/resource/ResourceFactoryBinary.h>
 
 namespace SOH {
 class ResourceFactoryBinaryAnimationV0 : public Ship::ResourceFactoryBinary {

--- a/mm/2s2h/resource/importer/ArrayFactory.cpp
+++ b/mm/2s2h/resource/importer/ArrayFactory.cpp
@@ -1,6 +1,6 @@
 #include "2s2h/resource/importer/ArrayFactory.h"
 #include "2s2h/resource/type/Array.h"
-#include "graphic/Fast3D/lus_gbi.h"
+#include <fast/lus_gbi.h>
 
 namespace SOH {
 std::shared_ptr<Ship::IResource>

--- a/mm/2s2h/resource/importer/ArrayFactory.h
+++ b/mm/2s2h/resource/importer/ArrayFactory.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "Resource.h"
-#include "ResourceFactoryBinary.h"
+#include <ship/resource/Resource.h>
+#include <ship/resource/ResourceFactoryBinary.h>
 
 namespace SOH {
 class ResourceFactoryBinaryArrayV0 : public Ship::ResourceFactoryBinary {

--- a/mm/2s2h/resource/importer/AudioSampleFactory.cpp
+++ b/mm/2s2h/resource/importer/AudioSampleFactory.cpp
@@ -2,8 +2,8 @@
 #include "2s2h/resource/type/AudioSample.h"
 #include "2s2h/resource/importer/AudioSoundFontFactory.h"
 #include "audio/soundfont.h"
-#include "Context.h"
-#include "resource/archive/Archive.h"
+#include <ship/Context.h>
+#include <ship/resource/archive/Archive.h>
 #include <tinyxml2.h>
 #include <thread>
 
@@ -14,7 +14,7 @@
 #include <dr_mp3.h>
 
 #define DR_FLAC_IMPLEMENTATION
-#include "ResourceManager.h"
+#include <ship/resource/ResourceManager.h>
 
 #include <dr_flac.h>
 

--- a/mm/2s2h/resource/importer/AudioSampleFactory.h
+++ b/mm/2s2h/resource/importer/AudioSampleFactory.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "Resource.h"
-#include "ResourceFactoryBinary.h"
-#include "ResourceFactoryXML.h"
+#include <ship/resource/Resource.h>
+#include <ship/resource/ResourceFactoryBinary.h>
+#include <ship/resource/ResourceFactoryXML.h>
 
 namespace SOH {
 class ResourceFactoryBinaryAudioSampleV2 : public Ship::ResourceFactoryBinary {

--- a/mm/2s2h/resource/importer/AudioSequenceFactory.cpp
+++ b/mm/2s2h/resource/importer/AudioSequenceFactory.cpp
@@ -1,10 +1,10 @@
 #include "2s2h/resource/importer/AudioSequenceFactory.h"
 #include "2s2h/resource/type/AudioSequence.h"
 #include "2s2h/resource/importer/AudioSoundFontFactory.h"
-#include "Context.h"
-#include "resource/archive/Archive.h"
-#include "BinaryWriter.h"
-#include "ResourceManager.h"
+#include <ship/Context.h>
+#include <ship/resource/archive/Archive.h>
+#include <ship/utils/binarytools/BinaryWriter.h>
+#include <ship/resource/ResourceManager.h>
 
 #include <type_traits>
 #include <tinyxml2.h>

--- a/mm/2s2h/resource/importer/AudioSequenceFactory.h
+++ b/mm/2s2h/resource/importer/AudioSequenceFactory.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "Resource.h"
-#include "ResourceFactoryBinary.h"
-#include "ResourceFactoryXML.h"
+#include <ship/resource/Resource.h>
+#include <ship/resource/ResourceFactoryBinary.h>
+#include <ship/resource/ResourceFactoryXML.h>
 
 namespace SOH {
 class ResourceFactoryBinaryAudioSequenceV2 : public Ship::ResourceFactoryBinary {

--- a/mm/2s2h/resource/importer/AudioSoundFontFactory.cpp
+++ b/mm/2s2h/resource/importer/AudioSoundFontFactory.cpp
@@ -2,9 +2,9 @@
 #include "2s2h/resource/type/AudioSoundFont.h"
 #include "audio/soundfont.h"
 #include "audio/load.h"
-#include "Context.h"
-#include "ResourceManager.h"
-#include "resource/archive/Archive.h"
+#include <ship/Context.h>
+#include <ship/resource/ResourceManager.h>
+#include <ship/resource/archive/Archive.h>
 #include <tinyxml2.h>
 
 namespace SOH {

--- a/mm/2s2h/resource/importer/AudioSoundFontFactory.h
+++ b/mm/2s2h/resource/importer/AudioSoundFontFactory.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "Resource.h"
-#include "ResourceFactoryBinary.h"
-#include "ResourceFactoryXML.h"
+#include <ship/resource/Resource.h>
+#include <ship/resource/ResourceFactoryBinary.h>
+#include <ship/resource/ResourceFactoryXML.h>
 #include "resource/type/AudioSoundFont.h"
 
 namespace SOH {

--- a/mm/2s2h/resource/importer/AudioSoundFontFactory.h.1
+++ b/mm/2s2h/resource/importer/AudioSoundFontFactory.h.1
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "Resource.h"
-#include "ResourceFactoryBinary.h"
+#include <ship/resource/Resource.h>
+#include <ship/resource/ResourceFactoryBinary.h>
 
 namespace SOH {
 class ResourceFactoryBinaryAudioSoundFontV2 : public Ship::ResourceFactoryBinary {

--- a/mm/2s2h/resource/importer/BackgroundFactory.h
+++ b/mm/2s2h/resource/importer/BackgroundFactory.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "resource/Resource.h"
-#include "resource/ResourceFactoryBinary.h"
+#include <ship/resource/Resource.h>
+#include <ship/resource/ResourceFactoryBinary.h>
 
 namespace SOH {
 class ResourceFactoryBinaryBackgroundV0 : public Ship::ResourceFactoryBinary {

--- a/mm/2s2h/resource/importer/CollisionHeaderFactory.h
+++ b/mm/2s2h/resource/importer/CollisionHeaderFactory.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "Resource.h"
-#include "ResourceFactoryBinary.h"
-#include "ResourceFactoryXML.h"
+#include <ship/resource/Resource.h>
+#include <ship/resource/ResourceFactoryBinary.h>
+#include <ship/resource/ResourceFactoryXML.h>
 
 namespace SOH {
 class ResourceFactoryBinaryCollisionHeaderV0 : public Ship::ResourceFactoryBinary {

--- a/mm/2s2h/resource/importer/CutsceneFactory.h
+++ b/mm/2s2h/resource/importer/CutsceneFactory.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "Resource.h"
-#include "ResourceFactoryBinary.h"
+#include <ship/resource/Resource.h>
+#include <ship/resource/ResourceFactoryBinary.h>
 
 namespace SOH {
 class ResourceFactoryBinaryCutsceneV0 : public Ship::ResourceFactoryBinary {

--- a/mm/2s2h/resource/importer/KeyFrameFactory.cpp
+++ b/mm/2s2h/resource/importer/KeyFrameFactory.cpp
@@ -1,7 +1,7 @@
 #include "2s2h/resource/importer/KeyFrameFactory.h"
 #include "2s2h/resource/type/KeyFrame.h"
-#include "Context.h"
-#include "ResourceManager.h"
+#include <ship/Context.h>
+#include <ship/resource/ResourceManager.h>
 
 namespace SOH {
 std::shared_ptr<Ship::IResource>

--- a/mm/2s2h/resource/importer/KeyFrameFactory.h
+++ b/mm/2s2h/resource/importer/KeyFrameFactory.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "Resource.h"
-#include "ResourceFactoryBinary.h"
+#include <ship/resource/Resource.h>
+#include <ship/resource/ResourceFactoryBinary.h>
 
 namespace SOH {
 class ResourceFactoryBinaryKeyFrameSkel : public Ship::ResourceFactoryBinary {

--- a/mm/2s2h/resource/importer/PathFactory.h
+++ b/mm/2s2h/resource/importer/PathFactory.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "Resource.h"
-#include "ResourceFactoryBinary.h"
+#include <ship/resource/Resource.h>
+#include <ship/resource/ResourceFactoryBinary.h>
 
 namespace SOH {
 class ResourceFactoryBinaryPathMMV0 : public Ship::ResourceFactoryBinary {

--- a/mm/2s2h/resource/importer/PlayerAnimationFactory.h
+++ b/mm/2s2h/resource/importer/PlayerAnimationFactory.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "Resource.h"
-#include "ResourceFactoryBinary.h"
+#include <ship/resource/Resource.h>
+#include <ship/resource/ResourceFactoryBinary.h>
 
 namespace SOH {
 class ResourceFactoryBinaryPlayerAnimationV0 : public Ship::ResourceFactoryBinary {

--- a/mm/2s2h/resource/importer/SceneFactory.cpp
+++ b/mm/2s2h/resource/importer/SceneFactory.cpp
@@ -32,7 +32,7 @@
 #include "2s2h/resource/importer/scenecommand/SetMinimapListFactory.h"
 #include "2s2h/resource/importer/scenecommand/SetMinimapChestsFactory.h"
 #include "2s2h/resource/importer/scenecommand/SetActorCutsceneListFactory.h"
-#include "spdlog/spdlog.h"
+#include <spdlog/spdlog.h>
 
 namespace SOH {
 ResourceFactoryBinarySceneV0::ResourceFactoryBinarySceneV0() {

--- a/mm/2s2h/resource/importer/SceneFactory.h
+++ b/mm/2s2h/resource/importer/SceneFactory.h
@@ -3,8 +3,8 @@
 #include "2s2h/resource/type/Scene.h"
 #include "2s2h/resource/type/scenecommand/SceneCommand.h"
 #include "2s2h/resource/importer/scenecommand/SceneCommandFactory.h"
-#include "Resource.h"
-#include "ResourceFactoryBinary.h"
+#include <ship/resource/Resource.h>
+#include <ship/resource/ResourceFactoryBinary.h>
 #include <unordered_map>
 
 namespace SOH {

--- a/mm/2s2h/resource/importer/SkeletonFactory.cpp
+++ b/mm/2s2h/resource/importer/SkeletonFactory.cpp
@@ -2,8 +2,8 @@
 #include "2s2h/resource/type/Skeleton.h"
 #include <spdlog/spdlog.h>
 #include <tinyxml2.h>
-#include "Context.h"
-#include "ResourceManager.h"
+#include <ship/Context.h>
+#include <ship/resource/ResourceManager.h>
 
 namespace SOH {
 std::shared_ptr<Ship::IResource>

--- a/mm/2s2h/resource/importer/SkeletonFactory.h
+++ b/mm/2s2h/resource/importer/SkeletonFactory.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "Resource.h"
-#include "ResourceFactoryBinary.h"
-#include "ResourceFactoryXML.h"
+#include <ship/resource/Resource.h>
+#include <ship/resource/ResourceFactoryBinary.h>
+#include <ship/resource/ResourceFactoryXML.h>
 
 namespace SOH {
 class ResourceFactoryBinarySkeletonV0 : public Ship::ResourceFactoryBinary {

--- a/mm/2s2h/resource/importer/SkeletonLimbFactory.h
+++ b/mm/2s2h/resource/importer/SkeletonLimbFactory.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "Resource.h"
-#include "ResourceFactoryBinary.h"
-#include "ResourceFactoryXML.h"
+#include <ship/resource/Resource.h>
+#include <ship/resource/ResourceFactoryBinary.h>
+#include <ship/resource/ResourceFactoryXML.h>
 
 namespace SOH {
 class ResourceFactoryBinarySkeletonLimbV0 : public Ship::ResourceFactoryBinary {

--- a/mm/2s2h/resource/importer/TextMMFactory.h
+++ b/mm/2s2h/resource/importer/TextMMFactory.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "Resource.h"
-#include "ResourceFactoryBinary.h"
-#include "ResourceFactoryXML.h"
+#include <ship/resource/Resource.h>
+#include <ship/resource/ResourceFactoryBinary.h>
+#include <ship/resource/ResourceFactoryXML.h>
 
 namespace SOH {
 class ResourceFactoryBinaryTextMMV0 : public Ship::ResourceFactoryBinary {

--- a/mm/2s2h/resource/importer/TextureAnimationFactory.cpp
+++ b/mm/2s2h/resource/importer/TextureAnimationFactory.cpp
@@ -1,7 +1,7 @@
 #include "2s2h/resource/importer/TextureAnimationFactory.h"
 #include "2s2h/resource/type/TextureAnimation.h"
 #include "gbi.h"
-#include "spdlog/spdlog.h"
+#include <spdlog/spdlog.h>
 
 namespace SOH {
 

--- a/mm/2s2h/resource/importer/TextureAnimationFactory.h
+++ b/mm/2s2h/resource/importer/TextureAnimationFactory.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "Resource.h"
-#include "ResourceFactoryBinary.h"
+#include <ship/resource/Resource.h>
+#include <ship/resource/ResourceFactoryBinary.h>
 
 namespace SOH {
 class ResourceFactoryBinaryTextureAnimationV0 : public Ship::ResourceFactoryBinary {

--- a/mm/2s2h/resource/importer/scenecommand/SceneCommandFactory.h
+++ b/mm/2s2h/resource/importer/scenecommand/SceneCommandFactory.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <memory>
-#include "Resource.h"
-#include "ResourceFactory.h"
+#include <ship/resource/Resource.h>
+#include <ship/resource/ResourceFactory.h>
 #include "2s2h/resource/type/scenecommand/SceneCommand.h"
 
 namespace SOH {

--- a/mm/2s2h/resource/importer/scenecommand/SetAlternateHeadersFactory.cpp
+++ b/mm/2s2h/resource/importer/scenecommand/SetAlternateHeadersFactory.cpp
@@ -1,7 +1,7 @@
 #include "2s2h/resource/importer/scenecommand/SetAlternateHeadersFactory.h"
 #include "2s2h/resource/type/scenecommand/SetAlternateHeaders.h"
-#include "Context.h"
-#include "ResourceManager.h"
+#include <ship/Context.h>
+#include <ship/resource/ResourceManager.h>
 
 namespace SOH {
 std::shared_ptr<Ship::IResource>

--- a/mm/2s2h/resource/importer/scenecommand/SetAnimatedMaterialListFactory.cpp
+++ b/mm/2s2h/resource/importer/scenecommand/SetAnimatedMaterialListFactory.cpp
@@ -1,8 +1,8 @@
 #include "2s2h/resource/importer/scenecommand/SetAnimatedMaterialListFactory.h"
 #include "2s2h/resource/type/scenecommand/SetAnimatedMaterialList.h"
 #include "2s2h/resource/type/TextureAnimation.h"
-#include "Context.h"
-#include "ResourceManager.h"
+#include <ship/Context.h>
+#include <ship/resource/ResourceManager.h>
 
 namespace SOH {
 

--- a/mm/2s2h/resource/importer/scenecommand/SetCollisionHeaderFactory.cpp
+++ b/mm/2s2h/resource/importer/scenecommand/SetCollisionHeaderFactory.cpp
@@ -1,7 +1,7 @@
 #include "2s2h/resource/importer/scenecommand/SetCollisionHeaderFactory.h"
 #include "2s2h/resource/type/scenecommand/SetCollisionHeader.h"
-#include "Context.h"
-#include "ResourceManager.h"
+#include <ship/Context.h>
+#include <ship/resource/ResourceManager.h>
 
 namespace SOH {
 std::shared_ptr<Ship::IResource>

--- a/mm/2s2h/resource/importer/scenecommand/SetCutscenesFactory.cpp
+++ b/mm/2s2h/resource/importer/scenecommand/SetCutscenesFactory.cpp
@@ -1,7 +1,7 @@
 #include "2s2h/resource/importer/scenecommand/SetCutscenesFactory.h"
 #include "2s2h/resource/type/scenecommand/SetCutscenes.h"
-#include "Context.h"
-#include "ResourceManager.h"
+#include <ship/Context.h>
+#include <ship/resource/ResourceManager.h>
 
 namespace SOH {
 std::shared_ptr<Ship::IResource> SetCutsceneFactoryMM::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData,

--- a/mm/2s2h/resource/importer/scenecommand/SetMeshFactory.cpp
+++ b/mm/2s2h/resource/importer/scenecommand/SetMeshFactory.cpp
@@ -1,7 +1,7 @@
 #include "2s2h/resource/importer/scenecommand/SetMeshFactory.h"
 #include "2s2h/resource/type/scenecommand/SetMesh.h"
-#include "spdlog/spdlog.h"
-#include "Context.h"
+#include <spdlog/spdlog.h>
+#include <ship/Context.h>
 
 namespace SOH {
 std::shared_ptr<Ship::IResource> SetMeshFactory::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData,

--- a/mm/2s2h/resource/importer/scenecommand/SetPathwaysFactory.cpp
+++ b/mm/2s2h/resource/importer/scenecommand/SetPathwaysFactory.cpp
@@ -1,7 +1,7 @@
 #include "2s2h/resource/importer/scenecommand/SetPathwaysFactory.h"
 #include "2s2h/resource/type/scenecommand/SetPathways.h"
-#include "Context.h"
-#include "ResourceManager.h"
+#include <ship/Context.h>
+#include <ship/resource/ResourceManager.h>
 
 namespace SOH {
 std::shared_ptr<Ship::IResource> SetPathwaysMMFactory::ReadResource(std::shared_ptr<Ship::ResourceInitData> initData,

--- a/mm/2s2h/resource/type/Animation.h
+++ b/mm/2s2h/resource/type/Animation.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Resource.h"
+#include <ship/resource/Resource.h>
 #include <libultraship/libultra/types.h>
 
 namespace SOH {

--- a/mm/2s2h/resource/type/Array.cpp
+++ b/mm/2s2h/resource/type/Array.cpp
@@ -1,5 +1,5 @@
 #include "Array.h"
-#include "graphic/Fast3D/lus_gbi.h"
+#include <fast/lus_gbi.h>
 
 namespace SOH {
 Array::Array() : Resource(std::shared_ptr<Ship::ResourceInitData>()) {

--- a/mm/2s2h/resource/type/Array.h
+++ b/mm/2s2h/resource/type/Array.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Resource.h"
+#include <ship/resource/Resource.h>
 
 namespace Fast {
 union F3DVtx;

--- a/mm/2s2h/resource/type/AudioSample.h
+++ b/mm/2s2h/resource/type/AudioSample.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <cstdint>
-#include "Resource.h"
+#include <ship/resource/Resource.h>
 #include <libultraship/libultra/types.h>
 
 namespace SOH {

--- a/mm/2s2h/resource/type/AudioSequence.h
+++ b/mm/2s2h/resource/type/AudioSequence.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <cstdint>
-#include "Resource.h"
+#include <ship/resource/Resource.h>
 
 namespace SOH {
 

--- a/mm/2s2h/resource/type/AudioSoundFont.h
+++ b/mm/2s2h/resource/type/AudioSoundFont.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 #include <vector>
-#include "Resource.h"
+#include <ship/resource/Resource.h>
 #include "2s2h/resource/type/AudioSample.h"
 #include <libultraship/libultra/types.h>
 

--- a/mm/2s2h/resource/type/Background.h
+++ b/mm/2s2h/resource/type/Background.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "resource/Resource.h"
+#include <ship/resource/Resource.h>
 
 namespace SOH {
 class Background : public Ship::Resource<uint8_t> {

--- a/mm/2s2h/resource/type/CollisionHeader.h
+++ b/mm/2s2h/resource/type/CollisionHeader.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 #include <vector>
-#include "Resource.h"
+#include <ship/resource/Resource.h>
 #include <libultraship/libultra.h>
 #include "z64math.h"
 

--- a/mm/2s2h/resource/type/Cutscene.h
+++ b/mm/2s2h/resource/type/Cutscene.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <vector>
-#include "Resource.h"
+#include <ship/resource/Resource.h>
 
 namespace SOH {
 

--- a/mm/2s2h/resource/type/KeyFrame.h
+++ b/mm/2s2h/resource/type/KeyFrame.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Resource.h"
+#include <ship/resource/Resource.h>
 #include <libultraship/libultra/types.h>
 
 namespace SOH {

--- a/mm/2s2h/resource/type/Path.h
+++ b/mm/2s2h/resource/type/Path.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 #include <vector>
-#include "Resource.h"
+#include <ship/resource/Resource.h>
 #include <libultraship/libultra/types.h>
 #include "z64math.h"
 

--- a/mm/2s2h/resource/type/PlayerAnimation.h
+++ b/mm/2s2h/resource/type/PlayerAnimation.h
@@ -2,7 +2,7 @@
 
 #include <vector>
 #include <string>
-#include "Resource.h"
+#include <ship/resource/Resource.h>
 
 namespace SOH {
 

--- a/mm/2s2h/resource/type/Scene.h
+++ b/mm/2s2h/resource/type/Scene.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <vector>
-#include "Resource.h"
+#include <ship/resource/Resource.h>
 #include "scenecommand/SceneCommand.h"
 
 namespace SOH {

--- a/mm/2s2h/resource/type/Skeleton.cpp
+++ b/mm/2s2h/resource/type/Skeleton.cpp
@@ -1,4 +1,4 @@
-#include "resource/ResourceManager.h"
+#include <ship/resource/ResourceManager.h>
 #include "Skeleton.h"
 #include "2s2h/BenPort.h"
 

--- a/mm/2s2h/resource/type/Skeleton.h
+++ b/mm/2s2h/resource/type/Skeleton.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <cstdint>
-#include "Resource.h"
+#include <ship/resource/Resource.h>
 #include "SkeletonLimb.h"
 #include <z64animation.h>
 

--- a/mm/2s2h/resource/type/SkeletonLimb.h
+++ b/mm/2s2h/resource/type/SkeletonLimb.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Resource.h"
+#include <ship/resource/Resource.h>
 #include "z64math.h"
 #include "gbi.h"
 

--- a/mm/2s2h/resource/type/TextMM.h
+++ b/mm/2s2h/resource/type/TextMM.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 #include <vector>
-#include "Resource.h"
+#include <ship/resource/Resource.h>
 #include <libultraship/libultra/types.h>
 
 namespace SOH {

--- a/mm/2s2h/resource/type/TextureAnimation.h
+++ b/mm/2s2h/resource/type/TextureAnimation.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "Resource.h"
+#include <ship/resource/Resource.h>
 
 namespace SOH {
 enum class TextureAnimationParamsType {

--- a/mm/2s2h/resource/type/scenecommand/SceneCommand.h
+++ b/mm/2s2h/resource/type/scenecommand/SceneCommand.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 #include <memory>
-#include "Resource.h"
+#include <ship/resource/Resource.h>
 
 namespace SOH {
 

--- a/mm/2s2h/resource/type/scenecommand/SetActorCutsceneList.h
+++ b/mm/2s2h/resource/type/scenecommand/SetActorCutsceneList.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Resource.h"
+#include <ship/resource/Resource.h>
 #include "SceneCommand.h"
 
 namespace SOH {

--- a/mm/2s2h/resource/type/scenecommand/SetActorList.h
+++ b/mm/2s2h/resource/type/scenecommand/SetActorList.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 #include <vector>
-#include "Resource.h"
+#include <ship/resource/Resource.h>
 #include "SceneCommand.h"
 #include "z64math.h"
 

--- a/mm/2s2h/resource/type/scenecommand/SetAlternateHeaders.h
+++ b/mm/2s2h/resource/type/scenecommand/SetAlternateHeaders.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 #include <vector>
-#include "Resource.h"
+#include <ship/resource/Resource.h>
 #include "SceneCommand.h"
 #include "2s2h/resource/type/Scene.h"
 

--- a/mm/2s2h/resource/type/scenecommand/SetCutscenes.h
+++ b/mm/2s2h/resource/type/scenecommand/SetCutscenes.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 #include <vector>
-#include "Resource.h"
+#include <ship/resource/Resource.h>
 #include "2s2h/resource/type/scenecommand/SceneCommand.h"
 #include "2s2h/resource/type/Cutscene.h"
 

--- a/mm/2s2h/resource/type/scenecommand/SetEchoSettings.h
+++ b/mm/2s2h/resource/type/scenecommand/SetEchoSettings.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <cstdint>
-#include "Resource.h"
+#include <ship/resource/Resource.h>
 #include "SceneCommand.h"
 
 namespace SOH {

--- a/mm/2s2h/resource/type/scenecommand/SetMinimapChests.h
+++ b/mm/2s2h/resource/type/scenecommand/SetMinimapChests.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "Resource.h"
+#include <ship/resource/Resource.h>
 #include "SceneCommand.h"
 
 namespace SOH {

--- a/mm/2s2h/z_message_OTR.cpp
+++ b/mm/2s2h/z_message_OTR.cpp
@@ -1,7 +1,7 @@
 #include "BenPort.h"
-#include "ResourceManager.h"
+#include <ship/resource/ResourceManager.h>
 #include "2s2h/resource/type/Scene.h"
-#include <utils/StringHelper.h>
+#include <ship/utils/StringHelper.h>
 #include "2s2h/resource/type/TextMM.h"
 #include <message_data_static.h>
 

--- a/mm/2s2h/z_play_2SH.cpp
+++ b/mm/2s2h/z_play_2SH.cpp
@@ -1,8 +1,8 @@
 #include "BenPort.h"
 #include "2s2h/resource/type/Scene.h"
-#include <utils/StringHelper.h>
+#include <ship/utils/StringHelper.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
-#include "ResourceManager.h"
+#include <ship/resource/ResourceManager.h>
 
 extern "C" {
 #include "global.h"

--- a/mm/2s2h/z_scene_2SH.cpp
+++ b/mm/2s2h/z_scene_2SH.cpp
@@ -1,11 +1,11 @@
 ﻿#include "BenPort.h"
 #include "global.h"
-#include <Blob.h>
+#include <ship/resource/type/Blob.h>
 #include <memory>
 #include <cassert>
-#include <utils/StringHelper.h>
-#include <DisplayList.h>
-#include <public/bridge/resourcebridge.h>
+#include <ship/utils/StringHelper.h>
+#include <fast/resource/type/DisplayList.h>
+#include <libultraship/bridge/resourcebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/resource/type/Scene.h"
 #include "2s2h/resource/type/CollisionHeader.h"

--- a/mm/CMakeLists.txt
+++ b/mm/CMakeLists.txt
@@ -232,32 +232,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE assets
 	${CMAKE_CURRENT_SOURCE_DIR}/include/
 	${CMAKE_CURRENT_SOURCE_DIR}/include/PR
 	${CMAKE_CURRENT_SOURCE_DIR}/src/
-    ${CMAKE_CURRENT_SOURCE_DIR}/../libultraship
     ${CMAKE_CURRENT_SOURCE_DIR}/../libultraship/include
-	${CMAKE_CURRENT_SOURCE_DIR}/../libultraship/src
-    ${CMAKE_CURRENT_SOURCE_DIR}/../libultraship/src/log
-    ${CMAKE_CURRENT_SOURCE_DIR}/../libultraship/src/debug
-    ${CMAKE_CURRENT_SOURCE_DIR}/../libultraship/src/menu
-    ${CMAKE_CURRENT_SOURCE_DIR}/../libultraship/src/utils
-	${CMAKE_CURRENT_SOURCE_DIR}/../libultraship/src/utils/binarytools
-    ${CMAKE_CURRENT_SOURCE_DIR}/../libultraship/src/config
-    ${CMAKE_CURRENT_SOURCE_DIR}/../libultraship/src/resource
-    ${CMAKE_CURRENT_SOURCE_DIR}/../libultraship/src/resource/type
-	${CMAKE_CURRENT_SOURCE_DIR}/../libultraship/src/resource/factory
-    ${CMAKE_CURRENT_SOURCE_DIR}/../libultraship/src/audio
-	${CMAKE_CURRENT_SOURCE_DIR}/../libultraship/src/window
-	${CMAKE_CURRENT_SOURCE_DIR}/../libultraship/src/window/gui
-	${CMAKE_CURRENT_SOURCE_DIR}/../libultraship/src/config
-	${CMAKE_CURRENT_SOURCE_DIR}/../libultraship/src/public
-	${CMAKE_CURRENT_SOURCE_DIR}/../libultraship/src/public/libultra
-	${CMAKE_CURRENT_SOURCE_DIR}/../libultraship/src/public/bridge
-    ${CMAKE_CURRENT_SOURCE_DIR}/../libultraship/extern
-    ${CMAKE_CURRENT_SOURCE_DIR}/../libultraship/extern/tinyxml2
-    ${CMAKE_CURRENT_SOURCE_DIR}/../libultraship/libultraship/Lib/
-	${CMAKE_CURRENT_SOURCE_DIR}/../libultraship/libultraship/Lib/libjpeg/include/
-	${CMAKE_CURRENT_SOURCE_DIR}/../libultraship/libultraship/Lib/spdlog/include/
-    ${CMAKE_CURRENT_SOURCE_DIR}/../libultraship/src/graphic/Fast3D/U64/PR
-    ${CMAKE_CURRENT_SOURCE_DIR}/../libultraship/src/graphic
     ${CMAKE_CURRENT_SOURCE_DIR}/../ZAPDTR/ZAPD/resource/type
 	${CMAKE_CURRENT_SOURCE_DIR}
 	${CMAKE_CURRENT_SOURCE_DIR}/2s2h/

--- a/mm/src/audio/code_8019AF00.c
+++ b/mm/src/audio/code_8019AF00.c
@@ -3,7 +3,7 @@
 
 #include "GameInteractor/GameInteractor.h"
 #include "2s2h/Enhancements/Audio/AudioEditor.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 typedef struct {
     /* 0x0 */ s8 x;

--- a/mm/src/audio/lib/data.c
+++ b/mm/src/audio/lib/data.c
@@ -1,5 +1,5 @@
 #include "global.h"
-#include "endianness.h"
+#include <ship/utils/binarytools/endianness.h>
 
 s16 gLowPassFilterData[16 * 8] ALIGNED(16) = {
     /* 0x0 */ 0,     0,     0,    32767, 0,    0,     0,     0,    // Identity filter (delta function)

--- a/mm/src/audio/lib/effects.c
+++ b/mm/src/audio/lib/effects.c
@@ -11,7 +11,7 @@
  */
 #include "global.h"
 #include "audio/effects.h"
-#include "endianness.h"
+#include <ship/utils/binarytools/endianness.h>
 
 void AudioScript_SequenceChannelProcessSound(SequenceChannel* channel, s32 recalculateVolume, s32 applyBend) {
     f32 channelVolume;

--- a/mm/src/audio/lib/load.c
+++ b/mm/src/audio/lib/load.c
@@ -18,7 +18,7 @@
 #include "2s2h/Enhancements/Audio/AudioCollection.h"
 #include "2s2h/Enhancements/Audio/AudioEditor.h"
 #include "BenPort.h"
-#include "luslog.h"
+#include <libultraship/log/luslog.h>
 // Windows deprecated the use of `strdup` it uses _strdup. Linux/Unix doesn't have _strdup.
 #ifdef _MSC_VER
 #define strdup _strdup
@@ -1141,7 +1141,7 @@ int strcmp_sort(const void* str1, const void* str2) {
 
 extern AudioContext gAudioCtx;
 // #end region
-#include "resourcebridge.h"
+#include <libultraship/bridge/resourcebridge.h>
 
 void AudioLoad_Init(void* heap, size_t heapSize) {
     s32 pad1[9];

--- a/mm/src/audio/lib/playback.c
+++ b/mm/src/audio/lib/playback.c
@@ -1,7 +1,7 @@
 #include "global.h"
 #include "audio/effects.h"
 #include "BenPort.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 void AudioPlayback_NoteSetResamplingRate(NoteSampleState* sampleState, f32 resamplingRateInput);
 void AudioPlayback_AudioListPushFront(AudioListItem* list, AudioListItem* item);

--- a/mm/src/audio/lib/seqplayer.c
+++ b/mm/src/audio/lib/seqplayer.c
@@ -14,7 +14,7 @@
  *     Otherwise, each set of instructions has its own command interpreter
  */
 
-#include "endianness.h"
+#include <ship/utils/binarytools/endianness.h>
 #include "global.h"
 #include "BenPort.h"
 #include "2s2h/Enhancements/Audio/AudioEditor.h"

--- a/mm/src/audio/lib/synthesis.c
+++ b/mm/src/audio/lib/synthesis.c
@@ -1,7 +1,7 @@
 #include "global.h"
-#include "resourcebridge.h"
+#include <libultraship/bridge/resourcebridge.h>
 #include "2s2h/mixer.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 // DMEM Addresses for the RSP
 #define DMEM_TEMP 0x3B0

--- a/mm/src/code/PreRender.c
+++ b/mm/src/code/PreRender.c
@@ -18,7 +18,7 @@
 #include "stackcheck.h"
 #include <stdlib.h>
 #include <string.h>
-#include "public/bridge/gfxbridge.h"
+#include <libultraship/bridge/gfxbridge.h>
 
 /**
  * Assigns the "save" values in PreRender

--- a/mm/src/code/audio_thread_manager.c
+++ b/mm/src/code/audio_thread_manager.c
@@ -1,7 +1,7 @@
 #include "global.h"
 #include "audiomgr.h"
 #include <string.h>
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 void AudioMgr_NotifyTaskDone(AudioMgr* audioMgr) {
     AudioTask* task = audioMgr->rspTask;

--- a/mm/src/code/graph.c
+++ b/mm/src/code/graph.c
@@ -3,9 +3,9 @@
 #include "regs.h"
 #include "functions.h"
 #include "fault.h"
-#include "public/bridge/gfxdebuggerbridge.h"
-#include "public/bridge/consolevariablebridge.h"
-#include "public/bridge/windowbridge.h"
+#include <libultraship/bridge/gfxdebuggerbridge.h>
+#include <libultraship/bridge/consolevariablebridge.h>
+#include <libultraship/bridge/windowbridge.h>
 #include <string.h>
 
 // Variables are put before most headers as a hacky way to bypass bss reordering

--- a/mm/src/code/sys_cfb.c
+++ b/mm/src/code/sys_cfb.c
@@ -5,7 +5,7 @@
 #include "macros.h"
 #include "2s2h/framebuffer_effects.h"
 #include "BenPort.h"
-#include "public/bridge/gfxbridge.h"
+#include <libultraship/bridge/gfxbridge.h>
 
 // Variables are put before most headers as a hacky way to bypass bss reordering
 OSViMode sNotebookViMode; // placeholder name

--- a/mm/src/code/sys_ucode.c
+++ b/mm/src/code/sys_ucode.c
@@ -3,7 +3,7 @@
  * Description: Functions for obtaining locations and sizes of microcode
  */
 #include "global.h"
-#include "public/bridge/gfxbridge.h"
+#include <libultraship/bridge/gfxbridge.h>
 
 UcodeHandlers initialgspUcodeText = ucode_f3dex2;
 // u64* initialgspUcodeData = gspF3DZEX2_NoN_PosLight_fifoDataStart;

--- a/mm/src/code/z_actor.c
+++ b/mm/src/code/z_actor.c
@@ -30,7 +30,7 @@
 #include "2s2h/ShipUtils.h"
 #include "2s2h/ActorExtension/ActorExtension.h"
 #include "2s2h/ActorExtension/ActorListIndex.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 // bss
 // FaultClient sActorFaultClient; // 2 funcs

--- a/mm/src/code/z_bgcheck.c
+++ b/mm/src/code/z_bgcheck.c
@@ -6,7 +6,7 @@
 #include <stdio.h>
 #include "2s2h/BenPort.h"
 #include "2s2h/GameInteractor/GameInteractor.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 #define DYNA_RAYCAST_FLOORS 1
 #define DYNA_RAYCAST_WALLS 2

--- a/mm/src/code/z_camera.c
+++ b/mm/src/code/z_camera.c
@@ -54,7 +54,7 @@
 #include "2s2h/BenPort.h"
 #include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
 #include "2s2h/GameInteractor/GameInteractor.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 void func_800DDFE0(Camera* camera);
 s32 Camera_ChangeMode(Camera* camera, s16 mode);

--- a/mm/src/code/z_demo.c
+++ b/mm/src/code/z_demo.c
@@ -9,7 +9,7 @@
 #include "overlays/actors/ovl_En_Elf/z_en_elf.h"
 #include <string.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
-#include "luslog.h"
+#include <libultraship/log/luslog.h>
 
 s16 sCutsceneQuakeIndex;
 struct CutsceneCamera sCutsceneCameraInfo;

--- a/mm/src/code/z_game_over.c
+++ b/mm/src/code/z_game_over.c
@@ -6,7 +6,7 @@
 #include "variables.h"
 #include "macros.h"
 #include "overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_scope.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 void GameOver_Init(PlayState* play) {
     play->gameOverCtx.state = GAMEOVER_INACTIVE;

--- a/mm/src/code/z_kankyo.c
+++ b/mm/src/code/z_kankyo.c
@@ -1,7 +1,7 @@
 #include "ultra64.h"
 #include "z64light.h"
 #include "z64math.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 typedef enum {
     /* 0x00 */ LIGHTNING_BOLT_START,

--- a/mm/src/code/z_lifemeter.c
+++ b/mm/src/code/z_lifemeter.c
@@ -5,7 +5,7 @@
 #include "2s2h/BenGui/HudEditor.h"
 #include "2s2h/BenGui/CosmeticEditor.h"
 #include "2s2h/GameInteractor/GameInteractor.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 s16 sHeartsPrimColors[3][3] = { { 255, 70, 50 }, { 255, 190, 0 }, { 100, 100, 255 } };
 s16 sHeartsEnvColors[3][3] = { { 50, 40, 60 }, { 255, 0, 0 }, { 0, 0, 255 } };

--- a/mm/src/code/z_map_disp.c
+++ b/mm/src/code/z_map_disp.c
@@ -12,7 +12,7 @@
 #include "2s2h/BenGui/CosmeticEditor.h"
 #include "2s2h/BenGui/HudEditor.h"
 #include "assets/2s2h_assets.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 void MapDisp_DestroyMapI(PlayState* play);
 void MapDisp_InitMapI(PlayState* play);

--- a/mm/src/code/z_message.c
+++ b/mm/src/code/z_message.c
@@ -17,7 +17,7 @@
 #include <string.h>
 
 #include "2s2h_assets.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 const char* gBombersNotebookPhotos[] = {
     gBombersNotebookPhotoAnjuTex,

--- a/mm/src/code/z_message_nes.c
+++ b/mm/src/code/z_message_nes.c
@@ -3,7 +3,7 @@
 #include "message_data_static.h"
 #include "assets/interface/message_texture_static/message_texture_static.h"
 #include <stdio.h>
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 f32 sNESFontWidths[160] = {
     8.0f,  8.0f,  6.0f,  9.0f,  9.0f,  14.0f, 12.0f, 3.0f,  7.0f,  7.0f,  7.0f,  9.0f,  4.0f,  6.0f,  4.0f,  9.0f,

--- a/mm/src/code/z_parameter.c
+++ b/mm/src/code/z_parameter.c
@@ -23,8 +23,8 @@
 #include "2s2h/BenGui/CosmeticEditor.h"
 #include "2s2h_assets.h"
 #include "2s2h/GameInteractor/GameInteractor.h"
-#include "public/bridge/gfxbridge.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/gfxbridge.h>
+#include <libultraship/bridge/consolevariablebridge.h>
 
 // 2S2H [Port] This was originally static but needs to be global so it can be accessed in z_kaleido_collect,
 // z_kaleido_debug, and z_kaleido_draw.

--- a/mm/src/code/z_pause.c
+++ b/mm/src/code/z_pause.c
@@ -23,7 +23,7 @@
 #include "libc/stdbool.h"
 #include "controller.h"
 #include "padutils.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 void FrameAdvance_Init(FrameAdvanceContext* frameAdvCtx) {
     frameAdvCtx->timer = 0;

--- a/mm/src/code/z_play.c
+++ b/mm/src/code/z_play.c
@@ -3,7 +3,7 @@
 #include "functions.h"
 #include "z64vismono.h"
 #include "z64visfbuf.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 // Variables are put before most headers as a hacky way to bypass bss reordering
 s16 sTransitionFillTimer;

--- a/mm/src/code/z_player_lib.c
+++ b/mm/src/code/z_player_lib.c
@@ -46,7 +46,7 @@
 #include "2s2h/BenPort.h"
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 typedef struct {
     /* 0x00 */ Vec3f unk_00;

--- a/mm/src/code/z_room.c
+++ b/mm/src/code/z_room.c
@@ -2,7 +2,7 @@
 #include "PR/gs2dex.h"
 #include "debug.h"
 
-#include "public/bridge/gfxbridge.h"
+#include <libultraship/bridge/gfxbridge.h>
 
 void Room_Noop(PlayState* play, Room* room, Input* input, s32 arg3) {
 }

--- a/mm/src/code/z_scene.c
+++ b/mm/src/code/z_scene.c
@@ -1,5 +1,5 @@
 #include "global.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 /**
  * Spawn an object file of a specified ID that will persist through room changes.

--- a/mm/src/code/z_sram_NES.c
+++ b/mm/src/code/z_sram_NES.c
@@ -6,7 +6,7 @@
 #include "build.h"
 
 #include "2s2h/GameInteractor/GameInteractor.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 void Sram_SyncWriteToFlash(SramContext* sramCtx, s32 curPage, s32 numPages);
 void func_80147414(SramContext* sramCtx, s32 fileNum, s32 arg2);

--- a/mm/src/code/z_view.c
+++ b/mm/src/code/z_view.c
@@ -3,7 +3,7 @@
 #include "z64view.h"
 #include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
 #include "2s2h/GameInteractor/GameInteractor.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 s32 View_ApplyPerspective(View* view);
 s32 View_ApplyOrtho(View* view);

--- a/mm/src/code/z_visfbuf.c
+++ b/mm/src/code/z_visfbuf.c
@@ -15,7 +15,7 @@
 #include "sys_cfb.h"
 #include <string.h>
 #include "2s2h/framebuffer_effects.h"
-#include "public/bridge/gfxbridge.h"
+#include <libultraship/bridge/gfxbridge.h>
 #include "BenPort.h"
 
 #define SCALE_MIN 0.032f

--- a/mm/src/overlays/actors/ovl_En_Fsn/z_en_fsn.c
+++ b/mm/src/overlays/actors/ovl_En_Fsn/z_en_fsn.c
@@ -7,7 +7,7 @@
 #include "z_en_fsn.h"
 #include "objects/gameplay_keep/gameplay_keep.h"
 #include "2s2h/GameInteractor/GameInteractor.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY | ACTOR_FLAG_UPDATE_CULLING_DISABLED)
 

--- a/mm/src/overlays/actors/ovl_En_Gakufu/z_en_gakufu.c
+++ b/mm/src/overlays/actors/ovl_En_Gakufu/z_en_gakufu.c
@@ -6,7 +6,7 @@
 
 #include "z_en_gakufu.h"
 #include "interface/parameter_static/parameter_static.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 #define FLAGS (ACTOR_FLAG_UPDATE_CULLING_DISABLED | ACTOR_FLAG_UPDATE_DURING_OCARINA)
 

--- a/mm/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
+++ b/mm/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
@@ -7,7 +7,7 @@
 #include "z_en_ossan.h"
 #include "objects/gameplay_keep/gameplay_keep.h"
 #include "2s2h/GameInteractor/GameInteractor.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY | ACTOR_FLAG_UPDATE_CULLING_DISABLED)
 

--- a/mm/src/overlays/actors/ovl_En_Sob1/z_en_sob1.c
+++ b/mm/src/overlays/actors/ovl_En_Sob1/z_en_sob1.c
@@ -9,7 +9,7 @@
 #include "objects/object_masterzoora/object_masterzoora.h"
 #include "objects/gameplay_keep/gameplay_keep.h"
 #include "2s2h/GameInteractor/GameInteractor.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY | ACTOR_FLAG_UPDATE_CULLING_DISABLED)
 

--- a/mm/src/overlays/actors/ovl_En_Trt/z_en_trt.c
+++ b/mm/src/overlays/actors/ovl_En_Trt/z_en_trt.c
@@ -8,7 +8,7 @@
 #include "objects/object_trt/object_trt.h"
 #include "objects/gameplay_keep/gameplay_keep.h"
 #include "2s2h/GameInteractor/GameInteractor.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_FRIENDLY)
 

--- a/mm/src/overlays/actors/ovl_En_Wood02/z_en_wood02.c
+++ b/mm/src/overlays/actors/ovl_En_Wood02/z_en_wood02.c
@@ -6,7 +6,7 @@
 
 #include "z_en_wood02.h"
 #include "objects/object_wood02/object_wood02.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 #define FLAGS 0x00000000
 

--- a/mm/src/overlays/actors/ovl_Obj_Grass/z_obj_grass.c
+++ b/mm/src/overlays/actors/ovl_Obj_Grass/z_obj_grass.c
@@ -13,7 +13,7 @@
 
 #include "2s2h/ShipUtils.h"
 #include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "GameInteractor/GameInteractor.h"
 
 #define FLAGS (ACTOR_FLAG_UPDATE_CULLING_DISABLED | ACTOR_FLAG_DRAW_CULLING_DISABLED)

--- a/mm/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/mm/src/overlays/actors/ovl_player_actor/z_player.c
@@ -48,7 +48,7 @@
 #include "2s2h/BenPort.h"
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/CustomMessage/CustomMessage.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 void Player_Init(Actor* thisx, PlayState* play);
 void Player_Destroy(Actor* thisx, PlayState* play);

--- a/mm/src/overlays/fbdemos/ovl_fbdemo_wipe5/z_fbdemo_wipe5.c
+++ b/mm/src/overlays/fbdemos/ovl_fbdemo_wipe5/z_fbdemo_wipe5.c
@@ -9,7 +9,7 @@
 #include "sys_cfb.h"
 #include "z_fbdemo_wipe5.h"
 #include <string.h>
-#include "public/bridge/gfxbridge.h"
+#include <libultraship/bridge/gfxbridge.h>
 
 void* TransitionWipe5_Init(void* thisx);
 void TransitionWipe5_Destroy(void* thisx);

--- a/mm/src/overlays/gamestates/ovl_file_choose/z_file_choose_NES.c
+++ b/mm/src/overlays/gamestates/ovl_file_choose/z_file_choose_NES.c
@@ -18,7 +18,7 @@
 #include <string.h>
 #include "BenPort.h"
 #include "2s2h/BenGui/CosmeticEditor.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 s32 D_808144F10 = 100;
 f32 D_808144F14 = 8.0f;

--- a/mm/src/overlays/gamestates/ovl_file_choose/z_file_copy_erase.c
+++ b/mm/src/overlays/gamestates/ovl_file_choose/z_file_copy_erase.c
@@ -6,7 +6,7 @@
 
 #include "z_file_select.h"
 #include "z64rumble.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 // When choosing a file to copy or erase, the 6 main menu buttons are placed at these offsets
 s16 sChooseFileYOffsets[] = { -48, -48, -48, -24, -24, 0 };

--- a/mm/src/overlays/gamestates/ovl_select/z_select.c
+++ b/mm/src/overlays/gamestates/ovl_select/z_select.c
@@ -9,7 +9,7 @@
 #include "z64view.h"
 #include "libc/alloca.h"
 #include "overlays/gamestates/ovl_title/z_title.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/DeveloperTools/BetterMapSelect.h"
 #include "2s2h/GameInteractor/GameInteractor.h"
 

--- a/mm/src/overlays/gamestates/ovl_title/z_title.c
+++ b/mm/src/overlays/gamestates/ovl_title/z_title.c
@@ -16,7 +16,7 @@
 #include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include <stdlib.h>
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 #define dgShipLogoDL "__OTR__misc/nintendo_rogo_static/gShipLogoDL"
 static const ALIGN_ASSET(2) char gShipLogoDL[] = dgShipLogoDL;

--- a/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_item.c
+++ b/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_item.c
@@ -9,7 +9,7 @@
 
 #include "2s2h/BenGui/HudEditor.h"
 #include "2s2h/GameInteractor/GameInteractor.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 s16 sEquipState = EQUIP_STATE_MAGIC_ARROW_GROW_ORB;
 

--- a/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_map.c
+++ b/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_map.c
@@ -14,7 +14,7 @@
 #include "BenPort.h"
 
 #include "2s2h/Enhancements/Songs/Songs.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 // 2S2H [Port] (and line 26) don't do pointer math and access the list of digits directly.
 extern const char* sCounterTextures[];

--- a/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_mask.c
+++ b/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_mask.c
@@ -9,7 +9,7 @@
 
 #include "2s2h/BenGui/HudEditor.h"
 #include "2s2h/GameInteractor/GameInteractor.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 s16 sMaskEquipState = EQUIP_STATE_MAGIC_ARROW_GROW_ORB;
 

--- a/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_scope_NES.c
+++ b/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_scope_NES.c
@@ -15,7 +15,7 @@
 #include "interface/icon_item_jpn_static/icon_item_jpn_static.h"
 #include "interface/icon_item_vtx_static/icon_item_vtx_static.h"
 #include "BenPort.h"
-#include "gfxdebuggerbridge.h"
+#include <libultraship/bridge/gfxdebuggerbridge.h>
 #include "archives/item_name_static/item_name_static.h"
 #include "archives/map_name_static/map_name_static.h"
 #include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
@@ -26,7 +26,7 @@
 #include "2s2h/GameInteractor/GameInteractor.h"
 
 #include "2s2h/Enhancements/Songs/Songs.h"
-#include "public/bridge/consolevariablebridge.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 #pragma increment_block_number "n64-us:128"
 


### PR DESCRIPTION
Most of this PR is header changes. The LUS bump includes mouse updates, but 2ship does not currently have mouse support. The one new update in this PR is the null audio backend.

- Fixes an issue where the application will not boot if Metal is the backend renderer
- Fixes #1220

Followup TODO: Revise any pending/approved PRs that use includes that no longer match this.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4400414860.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4400453019.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4400496679.zip)
<!--- section:artifacts:end -->