### PR TITLE
[Rando] Remove Special Character from Seed Generation

### DIFF
--- a/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
+++ b/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
@@ -43,7 +43,7 @@ void Rando::MiscBehavior::OnFileCreate(s16 fileNum) {
             // SpoilerFileIndex == 0 means we're generating a new one
             if (CVarGetInteger("gRando.SpoilerFileIndex", 0) == 0) {
                 bool hadInputSeed = true;
-                std::string inputSeed = CVarGetString("gRando.InputSeed", "");
+                std::string inputSeed = Ship_RemoveSpecialCharacters(CVarGetString("gRando.InputSeed", ""));
                 if (inputSeed.empty()) {
                     inputSeed = std::to_string(Ship_Random(0, 1000000));
                     hadInputSeed = false;

--- a/mm/2s2h/ShipUtils.cpp
+++ b/mm/2s2h/ShipUtils.cpp
@@ -109,6 +109,17 @@ std::string Ship_FormatTimeDisplay(uint32_t value) {
     return fmt::format("{}:{:0>2}:{:0>2}.{}", hh, mm, ss, ds);
 }
 
+std::string Ship_RemoveSpecialCharacters(const std::string& str) {
+    std::string result;
+    for (char ch : str) {
+        // Only keep alphanumeric characters (letters and digits)
+        if (std::isalnum(static_cast<unsigned char>(ch))) {
+            result += ch;
+        }
+    }
+    return result;
+}
+
 constexpr f32 fourByThree = 4.0f / 3.0f;
 
 // Gets the additional ratio of the screen compared to the original 4:3 ratio, clamping to 1 if smaller

--- a/mm/2s2h/ShipUtils.h
+++ b/mm/2s2h/ShipUtils.h
@@ -12,6 +12,7 @@
 #include <imgui.h>
 void LoadGuiTextures();
 std::string convertEnumToReadableName(const std::string& input);
+std::string Ship_RemoveSpecialCharacters(const std::string& str);
 extern std::array<const char*, 11> digitList;
 extern std::string Ship_FormatTimeDisplay(uint32_t value);
 extern std::map<uint32_t, ImVec4> itemColorMap;


### PR DESCRIPTION
This removes any Special Characters (% ^ & * #, etc.) from the Seed Generation Input.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4279892344.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4279993625.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4280787147.zip)
<!--- section:artifacts:end -->