### PR TITLE
Common Readable Check Names

### DIFF
--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -707,6 +707,7 @@ extern "C" void InitOTR() {
     GameInteractor::Instance->RegisterOwnHooks();
     CustomItem::RegisterHooks();
     CustomMessage::RegisterHooks();
+    Rando::StaticData::PopulateCheckNames();
 
     OTRMessage_Init();
     OTRAudio_Init();

--- a/mm/2s2h/Rando/CheckTracker/CheckTracker.cpp
+++ b/mm/2s2h/Rando/CheckTracker/CheckTracker.cpp
@@ -60,7 +60,6 @@ ImVec4 trackerBG = ImVec4{ 0, 0, 0, 0.5f };
 
 std::map<SceneId, std::vector<RandoCheckId>> sceneChecks;
 std::vector<SceneId> sortedSceneIds;
-std::unordered_map<RandoCheckId, std::string> readableCheckNames;
 std::unordered_map<RandoCheckId, std::string> accessLogicFuncs;
 
 std::vector<const char*> checkTypeIconList = {
@@ -188,7 +187,7 @@ void CheckTrackerDrawLogicalList() {
                     continue;
                 }
 
-                if (!sCheckTrackerFilter.PassFilter(readableCheckNames[randoCheckId].c_str())) {
+                if (!sCheckTrackerFilter.PassFilter(Rando::StaticData::CheckNames[randoCheckId].c_str())) {
                     continue;
                 }
 
@@ -250,7 +249,7 @@ void CheckTrackerDrawLogicalList() {
                             DrawCheckTypeIcon(checkId);
                             ImGui::TableNextColumn();
                             ImGui::SetCursorPosY(cursorPosY);
-                            ImGui::Text("%s", readableCheckNames[checkId].c_str());
+                            ImGui::Text("%s", Rando::StaticData::CheckNames[checkId].c_str());
                             if (accessLogicString != "") {
                                 UIWidgets::Tooltip(accessLogicString.c_str());
                             }
@@ -349,7 +348,7 @@ void CheckTrackerDrawNonLogicalList() {
                 }
             }
 
-            if (!sCheckTrackerFilter.PassFilter(readableCheckNames[checkId].c_str())) {
+            if (!sCheckTrackerFilter.PassFilter(Rando::StaticData::CheckNames[checkId].c_str())) {
                 continue;
             }
 
@@ -414,7 +413,7 @@ void CheckTrackerDrawNonLogicalList() {
                         ImGui::TableNextColumn();
 
                         ImGui::SetCursorPosY(cursorPosY);
-                        ImGui::Text("%s", readableCheckNames[randoCheckId].c_str());
+                        ImGui::Text("%s", Rando::StaticData::CheckNames[randoCheckId].c_str());
                         if (randoSaveCheck.obtained) {
                             ImGui::SameLine(0, 25.0f);
                             ImGui::Text("(%s)", Rando::StaticData::Items[randoSaveCheck.randoItemId].name);
@@ -557,9 +556,6 @@ void SettingsWindow::DrawElement() {
 }
 
 void Init() {
-    for (auto& [randoCheckId, randoStaticCheck] : Rando::StaticData::Checks) {
-        readableCheckNames[randoCheckId] = convertEnumToReadableName(randoStaticCheck.name);
-    }
     for (auto& [randoRegionId, randoRegion] : Rando::Logic::Regions) {
         for (auto& [randoCheckId, accessLogicFunc] : randoRegion.checks) {
             accessLogicFuncs[randoCheckId] = accessLogicFunc.second;

--- a/mm/2s2h/Rando/Menu.cpp
+++ b/mm/2s2h/Rando/Menu.cpp
@@ -492,8 +492,7 @@ static void DrawLocationsTab() {
                 continue;
             }
 
-            if (!includedFilter.PassFilter(
-                    convertEnumToReadableName(Rando::StaticData::Checks[includedChecks.first].name).c_str())) {
+            if (!includedFilter.PassFilter(Rando::StaticData::CheckNames[includedChecks.first].c_str())) {
                 continue;
             }
 
@@ -503,7 +502,7 @@ static void DrawLocationsTab() {
             }
 
             ImGui::BeginGroup();
-            ImGui::Text("%s", convertEnumToReadableName(Rando::StaticData::Checks[includedChecks.first].name).c_str());
+            ImGui::Text("%s", Rando::StaticData::CheckNames[includedChecks.first].c_str());
             ImGui::SameLine();
             ImGui::Dummy(ImVec2(ImGui::GetContentRegionAvail().x, 0));
             ImGui::EndGroup();
@@ -540,12 +539,11 @@ static void DrawLocationsTab() {
         ImGui::TableNextColumn();
         int16_t index = 0;
         for (auto& excludedChecks : checkExclusionList) {
-            if (!excludedFilter.PassFilter(
-                    convertEnumToReadableName(Rando::StaticData::Checks[excludedChecks].name).c_str())) {
+            if (!excludedFilter.PassFilter(Rando::StaticData::CheckNames[excludedChecks].c_str())) {
                 continue;
             }
 
-            ImGui::Text("%s", convertEnumToReadableName(Rando::StaticData::Checks[excludedChecks].name).c_str());
+            ImGui::Text("%s", Rando::StaticData::CheckNames[excludedChecks].c_str());
 
             ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg0,
                                    ImGui::IsItemHovered() ? IM_COL32(255, 255, 0, 128) : IM_COL32(255, 255, 255, 0));

--- a/mm/2s2h/Rando/StaticData/Checks.cpp
+++ b/mm/2s2h/Rando/StaticData/Checks.cpp
@@ -1,4 +1,5 @@
 #include "StaticData.h"
+#include "ShipUtils.h"
 
 extern "C" {
 s16 Play_GetOriginalSceneId(s16 sceneId);
@@ -7,6 +8,7 @@ s16 Play_GetOriginalSceneId(s16 sceneId);
 namespace Rando {
 
 namespace StaticData {
+std::array<std::string, RC_MAX> CheckNames = std::array<std::string, RC_MAX>();
 
 #define RC(id, type, scene, flagType, flag, item)      \
     {                                                  \
@@ -2261,6 +2263,12 @@ RandoCheckId GetCheckIdFromName(const char* name) {
         }
     }
     return RC_UNKNOWN;
+}
+
+void PopulateCheckNames() {
+    for (auto& [randoCheckId, randoStaticCheck] : Rando::StaticData::Checks) {
+        CheckNames[randoCheckId] = convertEnumToReadableName(randoStaticCheck.name);
+    }
 }
 
 } // namespace StaticData

--- a/mm/2s2h/Rando/StaticData/StaticData.h
+++ b/mm/2s2h/Rando/StaticData/StaticData.h
@@ -2,6 +2,7 @@
 #define RANDO_STATIC_DATA_H
 
 #include <map>
+#include <array>
 #include "Rando/Types.h"
 #include "2s2h/GameInteractor/GameInteractor.h"
 
@@ -27,9 +28,11 @@ struct RandoStaticCheck {
 };
 
 extern std::map<RandoCheckId, RandoStaticCheck> Checks;
+extern std::array<std::string, RC_MAX> CheckNames;
 
 RandoStaticCheck GetCheckFromFlag(FlagType flagType, s32 flag, s16 sceneId = SCENE_MAX);
 RandoCheckId GetCheckIdFromName(const char* name);
+void PopulateCheckNames();
 
 struct RandoStaticItem {
     RandoItemId randoItemId;


### PR DESCRIPTION
This moves `readableCheckNames` from check tracker to `StaticData::CheckNames`, and initialize from `InitOTR()`, then references it from both the check tracker and the menu's location exclusion page. Resolves menu lag in debug mode.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4283494200.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4283544012.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4283728178.zip)
<!--- section:artifacts:end -->