### PR TITLE
Cleanup heap

### DIFF
--- a/mm/src/buffers/heaps.c
+++ b/mm/src/buffers/heaps.c
@@ -2,7 +2,7 @@
 #include "z64.h"
 #include <assert.h>
 #include <stdlib.h>
-#ifdef __unix__
+#if defined (__unix__ )|| defined(__APPLE__)
 #include <sys/mman.h>
 #endif
 
@@ -13,7 +13,7 @@ void Heaps_Alloc(void) {
 #ifdef _MSC_VER
     gAudioHeap = (u8*)_aligned_malloc(AUDIO_HEAP_SIZE, 0x10);
     gSystemHeap = (u8*)_aligned_malloc(SYSTEM_HEAP_SIZE, 0x10);
-#elif defined(__unix__)
+#elif defined (__unix__ )|| defined(__APPLE__)
     gAudioHeap = mmap(NULL, AUDIO_HEAP_SIZE, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
     gSystemHeap = mmap(NULL, SYSTEM_HEAP_SIZE, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
     assert(gAudioHeap != MAP_FAILED);
@@ -31,7 +31,7 @@ void Heaps_Free(void) {
 #ifdef _MSC_VER
     _aligned_free(gAudioHeap);
     _aligned_free(gSystemHeap);
-#elif defined(__unix__)
+#elif defined (__unix__ )|| defined(__APPLE__)
     munmap(gAudioHeap, AUDIO_HEAP_SIZE);
     munmap(gSystemHeap, SYSTEM_HEAP_SIZE);
 #else
@@ -39,3 +39,4 @@ void Heaps_Free(void) {
     free(gSystemHeap);
 #endif
 }
+

--- a/mm/src/buffers/heaps.c
+++ b/mm/src/buffers/heaps.c
@@ -1,7 +1,6 @@
 #include "buffers.h"
 #include "z64.h"
 #include <assert.h>
-#include <stdio.h>
 #include <stdlib.h>
 #ifdef __unix__
 #include <sys/mman.h>

--- a/mm/src/buffers/heaps.c
+++ b/mm/src/buffers/heaps.c
@@ -2,7 +2,7 @@
 #include "z64.h"
 #include <assert.h>
 #include <stdlib.h>
-#if defined (__unix__ )|| defined(__APPLE__)
+#if defined(__unix__) || defined(__APPLE__)
 #include <sys/mman.h>
 #endif
 
@@ -13,7 +13,7 @@ void Heaps_Alloc(void) {
 #ifdef _MSC_VER
     gAudioHeap = (u8*)_aligned_malloc(AUDIO_HEAP_SIZE, 0x10);
     gSystemHeap = (u8*)_aligned_malloc(SYSTEM_HEAP_SIZE, 0x10);
-#elif defined (__unix__ )|| defined(__APPLE__)
+#elif defined(__unix__) || defined(__APPLE__)
     gAudioHeap = mmap(NULL, AUDIO_HEAP_SIZE, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
     gSystemHeap = mmap(NULL, SYSTEM_HEAP_SIZE, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
     assert(gAudioHeap != MAP_FAILED);
@@ -31,7 +31,7 @@ void Heaps_Free(void) {
 #ifdef _MSC_VER
     _aligned_free(gAudioHeap);
     _aligned_free(gSystemHeap);
-#elif defined (__unix__ )|| defined(__APPLE__)
+#elif defined(__unix__) || defined(__APPLE__)
     munmap(gAudioHeap, AUDIO_HEAP_SIZE);
     munmap(gSystemHeap, SYSTEM_HEAP_SIZE);
 #else
@@ -39,4 +39,3 @@ void Heaps_Free(void) {
     free(gSystemHeap);
 #endif
 }
-

--- a/mm/src/buffers/heaps.c
+++ b/mm/src/buffers/heaps.c
@@ -30,7 +30,7 @@ void Heaps_Alloc(void) {
 void Heaps_Free(void) {
 #ifdef _MSC_VER
     _aligned_free(gAudioHeap);
-    _aigned_free(gSystemHeap);
+    _aligned_free(gSystemHeap);
 #elif defined(__unix__)
     munmap(gAudioHeap, AUDIO_HEAP_SIZE);
     munmap(gSystemHeap, SYSTEM_HEAP_SIZE);

--- a/mm/src/buffers/heaps.c
+++ b/mm/src/buffers/heaps.c
@@ -1,24 +1,24 @@
 #include "buffers.h"
 #include "z64.h"
 #include <assert.h>
+#include <stdio.h>
 #include <stdlib.h>
-#ifndef _MSC_VER
-#include <unistd.h>
+#ifdef __unix__
+#include <sys/mman.h>
 #endif
 
 u8* gAudioHeap;
-
 u8* gSystemHeap;
 
 void Heaps_Alloc(void) {
 #ifdef _MSC_VER
     gAudioHeap = (u8*)_aligned_malloc(AUDIO_HEAP_SIZE, 0x10);
     gSystemHeap = (u8*)_aligned_malloc(SYSTEM_HEAP_SIZE, 0x10);
-#elif defined(_POSIX_VERSION) && (_POSIX_VERSION >= 200112L)
-    if (posix_memalign((void**)&gAudioHeap, 0x10, AUDIO_HEAP_SIZE) != 0)
-        gAudioHeap = NULL;
-    if (posix_memalign((void**)&gSystemHeap, 0x10, SYSTEM_HEAP_SIZE) != 0)
-        gSystemHeap = NULL;
+#elif defined(__unix__)
+    gAudioHeap = mmap(NULL, AUDIO_HEAP_SIZE, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+    gSystemHeap = mmap(NULL, SYSTEM_HEAP_SIZE, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+    assert(gAudioHeap != MAP_FAILED);
+    assert(gSystemHeap != MAP_FAILED);
 #else
     gAudioHeap = (u8*)memalign(0x10, AUDIO_HEAP_SIZE);
     gSystemHeap = (u8*)memalign(0x10, SYSTEM_HEAP_SIZE);
@@ -26,4 +26,17 @@ void Heaps_Alloc(void) {
 
     assert(gAudioHeap != NULL);
     assert(gSystemHeap != NULL);
+}
+
+void Heaps_Free(void) {
+#ifdef _MSC_VER
+    _aligned_free(gAudioHeap);
+    _aigned_free(gSystemHeap);
+#elif defined(__unix__)
+    munmap(gAudioHeap, AUDIO_HEAP_SIZE);
+    munmap(gSystemHeap, SYSTEM_HEAP_SIZE);
+#else
+    free(gAudioHeap);
+    free(gSystemHeap);
+#endif
 }

--- a/mm/src/code/main.c
+++ b/mm/src/code/main.c
@@ -47,7 +47,7 @@ s32 gScreenHeight = SCREEN_HEIGHT;
 size_t gSystemHeapSize = 0;
 
 void InitOTR();
-
+void Heaps_Free(void);
 #ifdef __GNUC__
 #define SDL_main main
 #endif
@@ -148,4 +148,5 @@ void SDL_main(int argc, char** argv /* void* arg*/) {
 #ifdef _WIN32
     FreeConsole();
 #endif
+    Heaps_Free();
 }


### PR DESCRIPTION
Remove the posix version checks in favor of using the universal unix `mmap` call. `mmap` will always align the block of memory to a page boundary which should always be more than 16.
I need to test this on Windows which I can do once an artifact is created. Linux and MacOS should be the same.
I also noticed the heaps were never freed so I went ahead and added that.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4371939229.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4372017972.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4372108325.zip)
<!--- section:artifacts:end -->