### PR TITLE
Fix errant merge conflict resolution

### DIFF
--- a/mm/src/code/z_eventmgr.c
+++ b/mm/src/code/z_eventmgr.c
@@ -322,7 +322,7 @@ void CutsceneManager_Queue(s16 csId) {
     if (!GameInteractor_Should(VB_QUEUE_CUTSCENE, true, &csId)) {
         return;
     }
-    if (csId >= CS_ID_NONE) {
+    if (csId > CS_ID_NONE) {
         sWaitingCutsceneList[csId >> 3] |= 1 << (csId & 7);
     }
 }


### PR DESCRIPTION
The upstream cherry-pick changed many CutsceneManager guards from `csId >= 0` to `csId > CS_ID_NONE`. One of them was a merge conflict because of the VB. I resolved it incorrectly, leading to UB that could cause fatal crashes when destroying ice.

Fixes #1304

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4374544546.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4374633348.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4374735168.zip)
<!--- section:artifacts:end -->