### PR TITLE
Fix lens actors not showing

### DIFF
--- a/mm/src/code/z_actor.c
+++ b/mm/src/code/z_actor.c
@@ -3116,7 +3116,7 @@ void Actor_DrawLensActors(PlayState* play, s32 numLensActors, Actor** lensActors
             POLY_XLU_DISP = gfx;
             // BENTODO: Since actor masking is diabled for actors that would normally
             // be "hidden", we are opting to just not render them at all
-            if (play->roomCtx.curRoom.lensMode == LENS_MODE_HIDE_ACTORS) {
+            if (play->roomCtx.curRoom.lensMode == LENS_MODE_SHOW_ACTORS) {
                 Actor_Draw(play, *lensActor);
             }
             gfx = POLY_XLU_DISP;


### PR DESCRIPTION
The two lens mode names were flipped with the cherry-pick. Similar to the ice melt crash, I probably resolved a merge conflict incorrectly.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4425048783.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4425054068.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4425101122.zip)
<!--- section:artifacts:end -->