### PR TITLE
[Rando] Restrict Ossan draw hook to Bomb Shop Owner

### DIFF
--- a/mm/2s2h/Rando/ActorBehavior/EnSob1.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnSob1.cpp
@@ -28,7 +28,7 @@ void Rando::ActorBehavior::InitEnSob1Behavior() {
     });
 
     COND_ID_HOOK(OnActorDraw, ACTOR_EN_OSSAN, IS_RANDO, [](Actor* actor) {
-        if (RANDO_SAVE_CHECKS[RC_BOMB_SHOP_ITEM_01].shuffled) {
+        if (RANDO_SAVE_CHECKS[RC_BOMB_SHOP_ITEM_01].shuffled && actor->params == 2) { // Bomb Shop Owner
             Matrix_Put(&sLeftHandMtxF);
             EnSob1_DrawCustomItem(actor, gPlayState);
         }


### PR DESCRIPTION
The actor for the bomb shop owner curiously uses actor id `ACTOR_EN_OSSAN` even though the actor is `ACTOR_EN_SOB1`. The enhancement to draw the bomb shop owner's held item does not qualify based on which shop owner it is, leading to a bug where the trading post will draw the bomb shop owner's held item in the small stream of water. This corrects it to check that the actor is the bomb shop owner.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4440159687.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4440164374.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4440204234.zip)
<!--- section:artifacts:end -->