### PR TITLE
Reset Invadepoh state

### DIFF
--- a/mm/src/overlays/actors/ovl_En_Invadepoh/z_en_invadepoh.c
+++ b/mm/src/overlays/actors/ovl_En_Invadepoh/z_en_invadepoh.c
@@ -5490,7 +5490,7 @@ void EnInvadepoh_Reset() {
     sInvasionState = INVASION_STATE_NONE;
     sRewardFinished = false;
     sAliensExtremeThreat = false;
-    for (int i = 0; i < ALIEN_COUNT; i ++) {
+    for (int i = 0; i < ALIEN_COUNT; i++) {
         sAliens[i] = NULL;
         sAlienStateFlags[i] = 0;
     }

--- a/mm/src/overlays/actors/ovl_En_Invadepoh/z_en_invadepoh.c
+++ b/mm/src/overlays/actors/ovl_En_Invadepoh/z_en_invadepoh.c
@@ -5489,4 +5489,9 @@ void EnInvadepoh_Cremia_Draw(Actor* thisx, PlayState* play) {
 void EnInvadepoh_Reset() {
     sInvasionState = INVASION_STATE_NONE;
     sRewardFinished = false;
+    sAliensExtremeThreat = false;
+    for(int i = 0; i < ALIEN_COUNT; i ++) {
+        sAliens[i] = NULL;
+        sAlienStateFlags[i] = 0;
+    }
 }

--- a/mm/src/overlays/actors/ovl_En_Invadepoh/z_en_invadepoh.c
+++ b/mm/src/overlays/actors/ovl_En_Invadepoh/z_en_invadepoh.c
@@ -96,6 +96,7 @@ typedef enum FaceAnimationType {
 void EnInvadepoh_Init(Actor* thisx, PlayState* play2);
 void EnInvadepoh_Destroy(Actor* thisx, PlayState* play2);
 void EnInvadepoh_InvasionHandler_Update(Actor* thisx, PlayState* play2);
+void EnInvadepoh_Reset(void);
 
 // Update functions
 void EnInvadepoh_Alien_WaitForObject(Actor* thisx, PlayState* play2);
@@ -242,6 +243,7 @@ ActorProfile En_Invadepoh_Profile = {
     /**/ EnInvadepoh_Destroy,
     /**/ EnInvadepoh_InvasionHandler_Update,
     /**/ NULL,
+    /**/ EnInvadepoh_Reset,
 };
 
 static ColliderCylinderInit sAlienCylinderInit = {
@@ -5482,4 +5484,8 @@ void EnInvadepoh_Cremia_Draw(Actor* thisx, PlayState* play) {
                           EnInvadepoh_Cremia_OverrideLimbDraw, EnInvadepoh_Cremia_PostLimbDraw, &this->actor);
 
     CLOSE_DISPS(play->state.gfxCtx);
+}
+
+void EnInvadepoh_Reset() {
+    sInvasionState = INVASION_STATE_NONE;
 }

--- a/mm/src/overlays/actors/ovl_En_Invadepoh/z_en_invadepoh.c
+++ b/mm/src/overlays/actors/ovl_En_Invadepoh/z_en_invadepoh.c
@@ -5488,4 +5488,5 @@ void EnInvadepoh_Cremia_Draw(Actor* thisx, PlayState* play) {
 
 void EnInvadepoh_Reset() {
     sInvasionState = INVASION_STATE_NONE;
+    sRewardFinished = false;
 }

--- a/mm/src/overlays/actors/ovl_En_Invadepoh/z_en_invadepoh.c
+++ b/mm/src/overlays/actors/ovl_En_Invadepoh/z_en_invadepoh.c
@@ -5490,7 +5490,7 @@ void EnInvadepoh_Reset() {
     sInvasionState = INVASION_STATE_NONE;
     sRewardFinished = false;
     sAliensExtremeThreat = false;
-    for(int i = 0; i < ALIEN_COUNT; i ++) {
+    for (int i = 0; i < ALIEN_COUNT; i ++) {
         sAliens[i] = NULL;
         sAlienStateFlags[i] = 0;
     }


### PR DESCRIPTION
Fixes an issue where the invasion would not start if re-attempted during the same play session.

`z_en_invadepoh.c` has a static variable, `sInvasionState`, for tracking the alien invasion. If the player triggers the invasion once, it will have some value besides `INVASION_STATE_NONE`, which means that the setup in `EnInvadepoh_InvasionHandler_SetInitialInvasionState` will not run on repeat attempts, thus no invasion happens.

The following should behave correctly:

- Leave the invasion in progress and come back immediately to see the invasion still in progress
- Leave the invasion in progress and come back hours later to see the empty barn
- Successfully fend off the invasion, then come back in another cycle and verify that the invasion commences orrectly
- Fail the invasion, then come back in another cycle and verify that the invasion commences correctly

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4631246652.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4631372905.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4631657756.zip)
<!--- section:artifacts:end -->