### PR TITLE
[Rando] Logically gate Gorman grass behind aliens

### DIFF
--- a/mm/2s2h/Rando/Logic/Regions/MilkRoad.cpp
+++ b/mm/2s2h/Rando/Logic/Regions/MilkRoad.cpp
@@ -44,15 +44,15 @@ static RegisterShipInitFunc initFunc([]() {
         },
         .connections = {
             // TODO: Also apparently can be reached using a trick with Goron mask and Bombs. Add trick later here
-            CONNECTION(RR_GORMAN_TRACK_INNER, CAN_PLAY_SONG(EPONA) || RANDO_EVENTS[RE_COWS_FROM_ALIENS]),
+            CONNECTION(RR_GORMAN_TRACK_INNER, RANDO_EVENTS[RE_COWS_FROM_ALIENS]),
         },
     };
     Regions[RR_GORMAN_TRACK_INNER] = RandoRegion{ .sceneId = SCENE_KOEPONARACE,
         .checks = {
-            // The grass is reachable either by racing the Gorman brothers on Epona OR by entering through the second
-            // night alternate route after saving the Romani Ranch cows. The crate cannot be interacted with via the
-            // former method; it is only accessible via the second night route after saving the cows.
-            CHECK(RC_GORMAN_TRACK_LARGE_CRATE, RANDO_EVENTS[RE_COWS_FROM_ALIENS]), 
+            // The grass is technically reachable while racing on Epona, but successfully picking up the drops can be
+            // dubious. We can make this a trick in the future. For now, gate the entire region behind saving the ranch
+            // from aliens.
+            CHECK(RC_GORMAN_TRACK_LARGE_CRATE, true), 
             CHECK(RC_GORMAN_TRACK_GRASS_01, true),
             CHECK(RC_GORMAN_TRACK_GRASS_02, true),
             CHECK(RC_GORMAN_TRACK_GRASS_03, true),

--- a/mm/2s2h/Rando/Logic/Regions/MilkRoad.cpp
+++ b/mm/2s2h/Rando/Logic/Regions/MilkRoad.cpp
@@ -82,7 +82,7 @@ static RegisterShipInitFunc initFunc([]() {
             EXIT(ENTRANCE(MILK_ROAD, 2),                    ENTRANCE(GORMAN_TRACK, 3), RANDO_EVENTS[RE_COWS_FROM_ALIENS]),
         },
         .connections = {
-            CONNECTION(RR_GORMAN_TRACK, CAN_PLAY_SONG(EPONA) || RANDO_EVENTS[RE_COWS_FROM_ALIENS]),
+            CONNECTION(RR_GORMAN_TRACK, RANDO_EVENTS[RE_COWS_FROM_ALIENS]),
         },
     };
     Regions[RR_MILK_ROAD] = RandoRegion{ .sceneId = SCENE_ROMANYMAE,


### PR DESCRIPTION
Current logic considers Gorman Track grass to be reachable with Epona via the Gorman race. While this is technically true, actually grabbing all of those grass drops can be dubious and require multiple attempts. This change gates the entire region behind saving the ranch from aliens (as the crate already was) with a TODO comment that we can make Epona grass pickup a trick later.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4690677150.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4690752574.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4690812758.zip)
<!--- section:artifacts:end -->