### PR TITLE
Implement Dinolfos, Gyorg, Wrath reset funcs

### DIFF
--- a/mm/src/overlays/actors/ovl_Boss_03/z_boss_03.c
+++ b/mm/src/overlays/actors/ovl_Boss_03/z_boss_03.c
@@ -81,6 +81,7 @@ void Boss03_Init(Actor* thisx, PlayState* play2);
 void Boss03_Destroy(Actor* thisx, PlayState* play);
 void Boss03_Update(Actor* thisx, PlayState* play2);
 void Boss03_Draw(Actor* thisx, PlayState* play);
+void Boss03_Reset(void);
 
 void func_809E344C(Boss03* this, PlayState* play);
 void func_809E34B8(Boss03* this, PlayState* play);
@@ -288,6 +289,7 @@ ActorProfile Boss_03_Profile = {
     /**/ Boss03_Destroy,
     /**/ Boss03_Update,
     /**/ Boss03_Draw,
+    /**/ Boss03_Reset,
 };
 
 // The limbs referenced here are not used. The spheres are positioned manually by Boss03_PostLimbDraw

--- a/mm/src/overlays/actors/ovl_Boss_07/z_boss_07.c
+++ b/mm/src/overlays/actors/ovl_Boss_07/z_boss_07.c
@@ -371,6 +371,8 @@ void Boss07_Remains_Draw(Actor* thisx, PlayState* play2);
 void Boss07_Top_Draw(Actor* thisx, PlayState* play2);
 void Boss07_BattleHandler_Draw(Actor* thisx, PlayState* play2);
 
+void Boss07_Reset(void);
+
 void Boss07_Wrath_SetupIntroCutscene(Boss07* this, PlayState* play);
 void Boss07_Wrath_IntroCutscene(Boss07* this, PlayState* play);
 void Boss07_Wrath_DeathCutscene(Boss07* this, PlayState* play);
@@ -642,6 +644,7 @@ ActorProfile Boss_07_Profile = {
     /**/ Boss07_Destroy,
     /**/ Boss07_Wrath_Update,
     /**/ Boss07_Wrath_Draw,
+    /**/ Boss07_Reset,
 };
 
 // The limbs referenced here are not used. The spheres are positioned manually by Boss07_Wrath_PostLimbDraw.

--- a/mm/src/overlays/actors/ovl_En_Dinofos/z_en_dinofos.c
+++ b/mm/src/overlays/actors/ovl_En_Dinofos/z_en_dinofos.c
@@ -15,6 +15,7 @@ void EnDinofos_Init(Actor* thisx, PlayState* play);
 void EnDinofos_Destroy(Actor* thisx, PlayState* play);
 void EnDinofos_Update(Actor* thisx, PlayState* play2);
 void EnDinofos_Draw(Actor* thisx, PlayState* play);
+void EnDinofos_Reset(void);
 
 void EnDinofos_Idle(EnDinofos* this, PlayState* play);
 void EnDinofos_PlayCutscene(EnDinofos* this, PlayState* play);
@@ -67,6 +68,7 @@ ActorProfile En_Dinofos_Profile = {
     /**/ EnDinofos_Destroy,
     /**/ EnDinofos_Update,
     /**/ EnDinofos_Draw,
+    /**/ EnDinofos_Reset,
 };
 
 static ColliderJntSphElementInit sJntSphElementsInit[9] = {
@@ -1573,4 +1575,9 @@ void EnDinofos_Draw(Actor* thisx, PlayState* play) {
                             this->drawDmgEffFrozenSteamScale, this->drawDmgEffAlpha, this->drawDmgEffType);
 
     CLOSE_DISPS(play->state.gfxCtx);
+}
+
+void EnDinofos_Reset(void) {
+    sCsId = CS_ID_NONE;
+    sNumAlive = 0;
 }


### PR DESCRIPTION
- Dinolfos has a camera issue in Snowhead Temple. This is caused by static variables governing the cutscene. This PR adds a reset func to fix that. The specific steps to reproduce the bug and test the fix are:
  1. Ensure enemy cutscene skips are disabled
  2. Encounter the Dinolfos in Woodfall Temple and defeat it
  3. Encounter the Dinolfos in Snowhead Temple and defeat them in the same runtime
- The Majora's Wrath reset func was implemented before, but I accidentally wiped it from the actor profile when incorporating decomp changes. This restores it.
- The Gyorg reset func was defined in #98 but not actually implemented in the profile. This adds it to the actor profile.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4714197066.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4714219057.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4714301563.zip)
<!--- section:artifacts:end -->