### PR TITLE
[Input Viewer] Fixed some issues with the Input viewer.

### DIFF
--- a/mm/2s2h/BenGui/InputViewer.cpp
+++ b/mm/2s2h/BenGui/InputViewer.cpp
@@ -177,12 +177,15 @@ void InputViewer::DrawElement() {
                 ImVec2(scaledBGSize.x,
                        scaledBGSize.y + (showLeftAnalogAngles || showRightAnalogAngles ? 15 * scale * maxScale : 0)));
         } else {
+
+            ImGui::SetNextWindowSize(ImVec2(scaledBGSize.x + 20, scaledBGSize.y + 20));
+
             ImGui::SetNextWindowContentSize(
                 ImVec2(mainPos.x + size.x - scaledBGSize.x - 30, mainPos.y + size.y - scaledBGSize.y - 30));
         }
 
         ImGui::SetNextWindowPos(
-            ImVec2(mainPos.x + size.x - scaledBGSize.x - 30, mainPos.y + size.y - scaledBGSize.y - 30),
+            ImVec2(mainPos.x + size.x - scaledBGSize.x - 30, mainPos.y + size.y - scaledBGSize.y - 50),
             ImGuiCond_FirstUseEver);
 
         ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0, 0, 0, 0));
@@ -403,7 +406,7 @@ void InputViewer::DrawElement() {
             if (showLeftAnalogAngles) {
                 ImGui::SetCursorPos(ImVec2(
                     aPos.x + 10 + CVarGetInteger(CVAR_INPUT_VIEWER("LeftAnalogAngles.HortizontalOffset"), 0) * scale,
-                    aPos.y + 10 + CVarGetInteger(CVAR_INPUT_VIEWER("LeftAnalogAngles.VerticalOffset"), 0) * scale));
+                    aPos.y + 10 + CVarGetInteger(CVAR_INPUT_VIEWER("LeftAnalogAngles.VerticalOffset"), 173) * scale));
                 // Scale font with input viewer scale
                 float oldFontScale = ImGui::GetFont()->Scale;
                 ImGui::GetFont()->Scale *= scale * CVarGetFloat(CVAR_INPUT_VIEWER("LeftAnalogAngles.Scale"), 1.0f);
@@ -449,7 +452,7 @@ void InputViewer::DrawElement() {
             if (showRightAnalogAngles) {
                 ImGui::SetCursorPos(ImVec2(
                     aPos.x + 10 + CVarGetInteger(CVAR_INPUT_VIEWER("RightAnalogAngles.HortizontalOffset"), 170) * scale,
-                    aPos.y + 10 + CVarGetInteger(CVAR_INPUT_VIEWER("RightAnalogAngles.VerticalOffset"), 0) * scale));
+                    aPos.y + 10 + CVarGetInteger(CVAR_INPUT_VIEWER("RightAnalogAngles.VerticalOffset"), 173) * scale));
                 // Scale font with input viewer scale
                 float oldFontScale = ImGui::GetFont()->Scale;
                 ImGui::GetFont()->Scale *= scale * CVarGetFloat(CVAR_INPUT_VIEWER("RightAnalogAngles.Scale"), 1.0f);


### PR DESCRIPTION
Fixed issue where the Input Viewer window on first use would be a large
black box till left or right analog stick angle values text was enabled.

Fixed issue where the analog stick text vertical wasn't set to its
default position.

Moved the Input Viewer window default position up so the analog stick 
text is visible and not a black box due to being considered off the game
window when the left or right analog stick angle values text was enabled.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4759173319.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4759255340.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4759280952.zip)
<!--- section:artifacts:end -->