### PR TITLE
Bugfix: Don't skip Dotour's entry into Bomber's Notebook

### DIFF
--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipMayorsOfficeCutscene.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipMayorsOfficeCutscene.cpp
@@ -9,6 +9,7 @@ extern "C" {
 #define CVAR_NAME "gEnhancements.Cutscenes.SkipMiscInteractions"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
+// These skips still allow the first textboxes to display, but they do ignore most of the scenes
 static bool ShouldStartMayorsOfficeCutscene(s16 csId) {
     /*
      * The Mayor starts these cutscenes but passes the target actor, which always seems to be Viscen for the start.
@@ -37,7 +38,6 @@ static bool ShouldStartMayorsOfficeCutscene(s16 csId) {
     return true;
 }
 
-// These skips still allow the first textboxes to display, but they do ignore most of the scenes
 static void RegisterSkipMayorsOfficeCutscene() {
     COND_VB_SHOULD(VB_START_CUTSCENE, CVAR, {
         if (gPlayState->sceneId != SCENE_SONCHONOIE) {

--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipMayorsOfficeCutscene.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipMayorsOfficeCutscene.cpp
@@ -45,7 +45,7 @@ static void RegisterSkipMayorsOfficeCutscene() {
         }
 
         s16* csId = va_arg(args, s16*);
-        *should = ShouldSkipMayorsOfficeCutscene(*csId);
+        *should = !ShouldSkipMayorsOfficeCutscene(*csId);
     });
 }
 

--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipMayorsOfficeCutscene.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipMayorsOfficeCutscene.cpp
@@ -4,42 +4,48 @@
 
 extern "C" {
 #include "overlays/actors/ovl_En_Dt/z_en_dt.h"
-void EnDt_UpdateMeetingCutscene(EnDt* enDt, PlayState* play);
 }
 
 #define CVAR_NAME "gEnhancements.Cutscenes.SkipMiscInteractions"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
-// These skips still allow the first textboxes to display, but they do ignore most of the scenes
-void RegisterSkipMayorsOfficeCutscene() {
-    COND_VB_SHOULD(VB_START_CUTSCENE, CVAR, {
-        if (gPlayState->sceneId == SCENE_SONCHONOIE) { // At Mayor's Residence
-            s16* csId = va_arg(args, s16*);
-            /*
-             * The Mayor starts these cutscenes but passes the target actor, which always seems to be Viscen for
-             * the start. The Mayor also handles the logic for progressing and ending these cutscenes. We need to
-             * alter Dotour's state but cannot rely on the cutscene start actor for that. Because of this, we use
-             * Actor_FindNearby to find the EnDt in this scene.
-             */
-            EnDt* enDt = (EnDt*)Actor_FindNearby(gPlayState, &GET_PLAYER(gPlayState)->actor, ACTOR_EN_DT, ACTORCAT_NPC,
-                                                 99999.9f);
-            if (enDt != nullptr) {
-                if (*csId == 17) { // Argument scenes without Couples Mask
-                    enDt->actionFunc = EnDt_UpdateMeetingCutscene;
-                    enDt->csIdIndex = 26;
-                    enDt->cutsceneState = 2; // EN_DT_CS_STATE_PLAYING
-                    enDt->textIdIndex = 8;
-                    *should = false;
-                } else if (*csId == 21) { // Couples Mask scene
-                    // Set flags to trigger scene transition and reward
-                    enDt->actionFunc = EnDt_UpdateMeetingCutscene;
-                    enDt->timer = 0;
-                    enDt->textIdIndex = 20;
-                    enDt->cutsceneState = 0; // EN_DT_CS_STATE_NONE
-                    *should = false;
-                }
-            }
+static bool ShouldSkipMayorsOfficeCutscene(s16 csId) {
+    /*
+     * The Mayor starts these cutscenes but passes the target actor, which always seems to be Viscen for the start.
+     * The Mayor also handles the logic for progressing and ending these cutscenes. We need to alter Dotour's state
+     * but cannot rely on the cutscene start actor for that. Because of this, we use Actor_FindNearby to find the
+     * EnDt in this scene.
+     */
+    EnDt* enDt =
+        (EnDt*)Actor_FindNearby(gPlayState, &GET_PLAYER(gPlayState)->actor, ACTOR_EN_DT, ACTORCAT_NPC, 99999.9f);
+    if (enDt != nullptr) {
+        if (csId == 17) { // Argument scenes without Couples Mask
+            enDt->csIdIndex = 26;
+            enDt->cutsceneState = 2; // EN_DT_CS_STATE_PLAYING
+            enDt->textIdIndex = 8;
+            Message_BombersNotebookQueueEvent(gPlayState, BOMBERS_NOTEBOOK_PERSON_MAYOR_DOTOUR);
+            return true;
+        } else if (csId == 21) { // Couples Mask scene
+            // Set flags to trigger scene transition and reward
+            enDt->timer = 0;
+            enDt->textIdIndex = 20;
+            enDt->cutsceneState = 0; // EN_DT_CS_STATE_NONE
+            return true;
         }
+    }
+
+    return false;
+}
+
+// These skips still allow the first textboxes to display, but they do ignore most of the scenes
+static void RegisterSkipMayorsOfficeCutscene() {
+    COND_VB_SHOULD(VB_START_CUTSCENE, CVAR, {
+        if (gPlayState->sceneId != SCENE_SONCHONOIE) {
+            return;
+        }
+
+        s16* csId = va_arg(args, s16*);
+        *should = ShouldSkipMayorsOfficeCutscene(*csId);
     });
 }
 

--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipMayorsOfficeCutscene.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipMayorsOfficeCutscene.cpp
@@ -9,7 +9,7 @@ extern "C" {
 #define CVAR_NAME "gEnhancements.Cutscenes.SkipMiscInteractions"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
-static bool ShouldSkipMayorsOfficeCutscene(s16 csId) {
+static bool ShouldStartMayorsOfficeCutscene(s16 csId) {
     /*
      * The Mayor starts these cutscenes but passes the target actor, which always seems to be Viscen for the start.
      * The Mayor also handles the logic for progressing and ending these cutscenes. We need to alter Dotour's state
@@ -24,17 +24,17 @@ static bool ShouldSkipMayorsOfficeCutscene(s16 csId) {
             enDt->cutsceneState = 2; // EN_DT_CS_STATE_PLAYING
             enDt->textIdIndex = 8;
             Message_BombersNotebookQueueEvent(gPlayState, BOMBERS_NOTEBOOK_PERSON_MAYOR_DOTOUR);
-            return true;
+            return false;
         } else if (csId == 21) { // Couples Mask scene
             // Set flags to trigger scene transition and reward
             enDt->timer = 0;
             enDt->textIdIndex = 20;
             enDt->cutsceneState = 0; // EN_DT_CS_STATE_NONE
-            return true;
+            return false;
         }
     }
 
-    return false;
+    return true;
 }
 
 // These skips still allow the first textboxes to display, but they do ignore most of the scenes
@@ -45,7 +45,7 @@ static void RegisterSkipMayorsOfficeCutscene() {
         }
 
         s16* csId = va_arg(args, s16*);
-        *should = !ShouldSkipMayorsOfficeCutscene(*csId);
+        *should = ShouldStartMayorsOfficeCutscene(*csId);
     });
 }
 


### PR DESCRIPTION
Actions taken:
- Extracted the hook to its own function, because otherwise I can't debug it.
- Removed the `enDt->actionFunc = EnDt_UpdateMeetingCutscene` lines, because that's its current value already.
- Added the Bomber's Notebook queue event, which gets skipped otherwise.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4782206481.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4782332361.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4782510591.zip)
<!--- section:artifacts:end -->