### PR TITLE
[Enhancement] Song of Time does not reset time speed

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1265,6 +1265,9 @@ void BenMenu::AddEnhancements() {
     AddWidget(path, "Skip Song of Time cutscenes", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Songs.SkipSoTCutscenes")
         .Options(CheckboxOptions().Tooltip("Skips the cutscenes when playing any of the Song of Time songs."));
+    AddWidget(path, "Song of Time Maintains Speed", WIDGET_CVAR_CHECKBOX)
+        .CVar("gEnhancements.Songs.SoTDoesNotResetSpeed")
+        .Options(CheckboxOptions().Tooltip("The Song of Time will not reset the time speed to normal."));
 
     // Time Savers
     path = { "Enhancements", "Time Savers", SECTION_COLUMN_1 };

--- a/mm/2s2h/Enhancements/Songs/SoTDoesNotResetSpeed.cpp
+++ b/mm/2s2h/Enhancements/Songs/SoTDoesNotResetSpeed.cpp
@@ -1,0 +1,23 @@
+#include <libultraship/bridge/consolevariablebridge.h>
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/ShipInit.hpp"
+
+#define CVAR_NAME "gEnhancements.Songs.SoTDoesNotResetSpeed"
+#define CVAR CVarGetInteger(CVAR_NAME, 0)
+
+static int32_t timeSpeedBackup = 0;
+
+static void RememberTimeSpeed() {
+    timeSpeedBackup = gSaveContext.save.timeSpeedOffset;
+}
+
+static void RestoreTimeSpeed() {
+    gSaveContext.save.timeSpeedOffset = timeSpeedBackup;
+}
+
+static void RegisterSoTDoesNotReset() {
+    COND_HOOK(BeforeEndOfCycleSave, CVAR, RememberTimeSpeed);
+    COND_HOOK(AfterEndOfCycleSave, CVAR, RestoreTimeSpeed);
+}
+
+static RegisterShipInitFunc initFunc(RegisterSoTDoesNotReset, { CVAR_NAME });


### PR DESCRIPTION
Pretty self-explanatory. Time speed for your save file is maintained even if you reset or exit the game.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4802055160.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4802217222.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4802229212.zip)
<!--- section:artifacts:end -->