### PR TITLE
Fix cow softlock when cows are not shuffled

### DIFF
--- a/mm/2s2h/Rando/ActorBehavior/EnCow.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnCow.cpp
@@ -66,13 +66,15 @@ void Rando::ActorBehavior::InitEnCowBehavior() {
             *should = false;
             return;
         }
+
+        ((EnCow*)actor)->flags |= EN_COW_FLAG_WONT_GIVE_MILK;
+
         RandoCheckId randoCheckId = IdentifyCow(actor);
 
         if (randoCheckId == RC_UNKNOWN) {
             *should = true;
             return;
         }
-        ((EnCow*)actor)->flags |= EN_COW_FLAG_WONT_GIVE_MILK;
 
         RandoSaveCheck& randoSaveCheck = RANDO_SAVE_CHECKS[randoCheckId];
         if (!randoSaveCheck.shuffled || randoSaveCheck.cycleObtained) {

--- a/mm/2s2h/Rando/ActorBehavior/EnCow.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnCow.cpp
@@ -58,7 +58,9 @@ RandoCheckId IdentifyCow(Actor* actor) {
 }
 
 void Rando::ActorBehavior::InitEnCowBehavior() {
-    COND_VB_SHOULD(VB_GIVE_ITEM_FROM_COW, IS_RANDO, {
+    bool shouldRegister = IS_RANDO && RANDO_SAVE_OPTIONS[RO_SHUFFLE_COWS];
+
+    COND_VB_SHOULD(VB_GIVE_ITEM_FROM_COW, shouldRegister, {
         // Original Should is the Range check, if it fails just Return.
         Actor* actor = va_arg(args, Actor*);
         if (!((actor->xzDistToPlayer < 90.0f) &&
@@ -85,7 +87,7 @@ void Rando::ActorBehavior::InitEnCowBehavior() {
         *should = false;
     });
 
-    COND_VB_SHOULD(VB_COW_CONSIDER_EPONAS_SONG_PLAYED, IS_RANDO, {
+    COND_VB_SHOULD(VB_COW_CONSIDER_EPONAS_SONG_PLAYED, shouldRegister, {
         EnCow* actor = va_arg(args, EnCow*);
         if (actor->flags & EN_COW_FLAG_WONT_GIVE_MILK) {
             gPlayState->msgCtx.songPlayed = 0;
@@ -93,7 +95,7 @@ void Rando::ActorBehavior::InitEnCowBehavior() {
         *should = gPlayState->msgCtx.songPlayed == OCARINA_SONG_EPONAS;
     });
 
-    COND_ID_HOOK(ShouldActorInit, ACTOR_EN_COW, IS_RANDO, [](Actor* refActor, bool* should) {
+    COND_ID_HOOK(ShouldActorInit, ACTOR_EN_COW, shouldRegister, [](Actor* refActor, bool* should) {
         RandoCheckId randoCheckId = IdentifyCow(refActor);
         switch (randoCheckId) {
             case RC_ROMANI_RANCH_BARN_COW_LEFT:


### PR DESCRIPTION
Fixes a softlock when playing Epona's Song for cows in a rando seed where cows are *not* shuffled

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4866666987.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4866719277.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4866902903.zip)
<!--- section:artifacts:end -->