### PR TITLE
Fix OOB in AudioSeq_ResetReverb

### DIFF
--- a/mm/src/audio/sequence.c
+++ b/mm/src/audio/sequence.c
@@ -895,10 +895,15 @@ u8 AudioSeq_ResetReverb(void) {
         } else {
             while (fadeReverb != 0) {
                 if (fadeReverb & 1) {
-                    AUDIOCMD_GLOBAL_SET_REVERB_DATA(
-                        reverbIndex, REVERB_DATA_TYPE_SETTINGS,
-                        (uintptr_t)(gReverbSettingsTable[(u8)(sResetAudioHeapSeqCmd & 0xFF)] + reverbIndex));
-                    AudioThread_ScheduleProcessCmds();
+                    //! @bug Triggering the ending cutscene during final hours can give an index of 12 here, which is
+                    // OOB. This does not normally happen in the game, but Triforce Hunt makes this a possibility.
+                    // Follow a condition similar to what is found in Audio_ResetForAudioHeapStep2.
+                    if (((u8)(sResetAudioHeapSeqCmd & 0xFF)) < ARRAY_COUNT(gReverbSettingsTable)) {
+                        AUDIOCMD_GLOBAL_SET_REVERB_DATA(
+                            reverbIndex, REVERB_DATA_TYPE_SETTINGS,
+                            (uintptr_t)(gReverbSettingsTable[(u8)(sResetAudioHeapSeqCmd & 0xFF)] + reverbIndex));
+                        AudioThread_ScheduleProcessCmds();
+                    }
                 }
                 reverbIndex++;
                 fadeReverb = fadeReverb >> 1;


### PR DESCRIPTION
tl;dr reaching the ending cutscene during final hours will cause a crash. This is not normally possible in the regular game, but Triforce Hunt makes it a possibility. Add a bound check to the affected area, which matches an existing bound check for the same array in `Audio_ResetForAudioHeapStep2`:

https://github.com/HarbourMasters/2ship2harkinian/blob/d80c046d0d8aeab06b0519cad2e9f690142cf765/mm/src/audio/code_8019AF00.c#L6537-L6542

Fixes #1391 

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4866064193.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4866110879.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4866453259.zip)
<!--- section:artifacts:end -->