### PR TITLE
[Difficulty Option] Skip Younger Beaver Brother Races

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1589,6 +1589,9 @@ void BenMenu::AddEnhancements() {
                      .Min(1)
                      .Max(20)
                      .DefaultValue(20));
+    AddWidget(path, "Skip Little Beaver Brother Races", WIDGET_CVAR_CHECKBOX)
+        .CVar("gEnhancements.Minigames.SkipLittleBeaver")
+        .Options(CheckboxOptions().Tooltip("Only Race the Older Beaver."));
     AddWidget(path, "Goron Race", WIDGET_CVAR_COMBOBOX)
         .CVar("gEnhancements.DifficultyOptions.GoronRace")
         .Options(ComboboxOptions()

--- a/mm/2s2h/Enhancements/Minigames/BeaverRace.cpp
+++ b/mm/2s2h/Enhancements/Minigames/BeaverRace.cpp
@@ -1,6 +1,7 @@
 #include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
+#include "CustomMessage/CustomMessage.h"
 
 extern "C" {
 #include "overlays/actors/ovl_En_Az/z_en_az.h"
@@ -9,18 +10,21 @@ void func_80A979DC(EnAz* thisx, PlayState* play);
 void func_80A97F9C(EnAz* thisx, PlayState* play);
 }
 
-#define CVAR_NAME "gEnhancements.Minigames.BeaverRaceRingsCollected"
-#define CVAR CVarGetInteger(CVAR_NAME, 20)
+#define CVAR_RINGS_NAME "gEnhancements.Minigames.BeaverRaceRingsCollected"
+#define CVAR_RINGS CVarGetInteger(CVAR_RINGS_NAME, 20)
+
+#define CVAR_SPEEDUP_NAME "gEnhancements.Minigames.SkipLittleBeaver"
+#define CVAR_SPEEDUP CVarGetInteger(CVAR_SPEEDUP_NAME, 0)
 
 static bool minigameScoreSet = false; // Flag to track if the score has been set
 
-void RegisterBeaverRace() {
-    COND_ID_HOOK(ShouldActorUpdate, ACTOR_EN_AZ, CVAR < 20, [](Actor* actor, bool* should) {
+void RegisterBeaverRaceRings() {
+    COND_ID_HOOK(ShouldActorUpdate, ACTOR_EN_AZ, CVAR_RINGS < 20, [](Actor* actor, bool* should) {
         EnAz* enAz = (EnAz*)actor;
         Player* player = GET_PLAYER(gPlayState);
 
         if (!minigameScoreSet) {
-            gSaveContext.minigameScore = CVAR;
+            gSaveContext.minigameScore = CVAR_RINGS;
             minigameScoreSet = true; // Set the flag after assignment
         }
 
@@ -60,4 +64,32 @@ void RegisterBeaverRace() {
     });
 }
 
-static RegisterShipInitFunc initFunc(RegisterBeaverRace, { CVAR_NAME });
+void RegisterBeaverRaceSpeedup() {
+    COND_ID_HOOK(ShouldActorUpdate, ACTOR_EN_AZ, CVAR_SPEEDUP, [](Actor* actor, bool* should) {
+        if (!CHECK_WEEKEVENTREG(WEEKEVENTREG_24_04)) {
+            SET_WEEKEVENTREG(WEEKEVENTREG_24_04);
+        }
+    });
+
+    COND_ID_HOOK(OnOpenText, 0x10D6, CVAR_SPEEDUP, [](u16* textId, bool* loadFromMessageTable) {
+        std::string replaceMsg = "My older brother will show you\x11the way, so follow him and\x11"
+                                 "don't get separated!";
+        auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
+        entry.msg.replace(entry.msg.begin(), entry.msg.end(), replaceMsg);
+
+        CustomMessage::LoadCustomMessageIntoFont(entry);
+        *loadFromMessageTable = false;
+    });
+
+    COND_ID_HOOK(OnOpenText, 0x10FA, CVAR_SPEEDUP, [](u16* textId, bool* loadFromMessageTable) {
+        std::string replaceMsg = "The time limit is %r1:50%w, let's race.";
+        auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
+        entry.msg.replace(entry.msg.begin(), entry.msg.end(), replaceMsg);
+
+        CustomMessage::LoadCustomMessageIntoFont(entry);
+        *loadFromMessageTable = false;
+    });
+}
+
+static RegisterShipInitFunc initRingsFunc(RegisterBeaverRaceRings, { CVAR_RINGS_NAME });
+static RegisterShipInitFunc initSpeedupFunc(RegisterBeaverRaceSpeedup, { CVAR_SPEEDUP_NAME });

--- a/mm/2s2h/Enhancements/Minigames/BeaverRace.cpp
+++ b/mm/2s2h/Enhancements/Minigames/BeaverRace.cpp
@@ -72,10 +72,9 @@ void RegisterBeaverRaceSpeedup() {
     });
 
     COND_ID_HOOK(OnOpenText, 0x10D6, CVAR_SPEEDUP, [](u16* textId, bool* loadFromMessageTable) {
-        std::string replaceMsg = "My older brother will show you\x11the way, so follow him and\x11"
-                                 "don't get separated!";
         auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
-        entry.msg.replace(entry.msg.begin(), entry.msg.end(), replaceMsg);
+        entry.msg = "My older brother will show you\x11the way, so follow him and\x11"
+                    "don't get separated!";
 
         CustomMessage::LoadCustomMessageIntoFont(entry);
         *loadFromMessageTable = false;

--- a/mm/2s2h/Enhancements/Minigames/BeaverRace.cpp
+++ b/mm/2s2h/Enhancements/Minigames/BeaverRace.cpp
@@ -81,9 +81,8 @@ void RegisterBeaverRaceSpeedup() {
     });
 
     COND_ID_HOOK(OnOpenText, 0x10FA, CVAR_SPEEDUP, [](u16* textId, bool* loadFromMessageTable) {
-        std::string replaceMsg = "The time limit is %r1:50%w, let's race.";
         auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
-        entry.msg.replace(entry.msg.begin(), entry.msg.end(), replaceMsg);
+        entry.msg = "The time limit is %r1:50%w, let's race.";
 
         CustomMessage::LoadCustomMessageIntoFont(entry);
         *loadFromMessageTable = false;


### PR DESCRIPTION
This skips the need to Race the younger Beaver brother for each reward. You will only need to race the Older Brother, once for the Empty Bottle and once for the Heart Piece.

Modifies the existing BeaverRace.cpp file to incorporate both settings separately but also allows for Rings to be adjusted simultaneously to skipping the races.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4975718955.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4975739437.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4975756981.zip)
<!--- section:artifacts:end -->