### PR TITLE
Only apply fast push to skateblock, not pull

### DIFF
--- a/mm/2s2h/Enhancements/Player/FasterPushAndPull.cpp
+++ b/mm/2s2h/Enhancements/Player/FasterPushAndPull.cpp
@@ -6,6 +6,7 @@ extern "C" {
 #include "overlays/actors/ovl_Bg_Dblue_Movebg/z_bg_dblue_movebg.h"
 #include "overlays/actors/ovl_Bg_Ikana_Block/z_bg_ikana_block.h"
 #include "overlays/actors/ovl_Obj_Oshihiki/z_obj_oshihiki.h"
+#include "overlays/actors/ovl_Obj_Skateblock/z_obj_skateblock.h"
 }
 
 #define CVAR_NAME "gEnhancements.Player.FasterPushAndPull"
@@ -34,7 +35,12 @@ void RegisterFasterPushAndPull() {
         *should = false;
     });
 
-    COND_VB_SHOULD(VB_SKATE_BLOCK_BEGIN_MOVE, CVAR, { *should = true; });
+    COND_VB_SHOULD(VB_SKATE_BLOCK_BEGIN_MOVE, CVAR, {
+        // These blocks can only be pushed, not pulled
+        ObjSkateblock* objSkateblock = va_arg(args, ObjSkateblock*);
+        s32 directionIndex = va_arg(args, s32);
+        *should = objSkateblock->unk_172[directionIndex] > 0;
+    });
 
     COND_VB_SHOULD(VB_BLOCK_BEGIN_MOVE, CVAR, { *should = true; });
 

--- a/mm/src/overlays/actors/ovl_Obj_Skateblock/z_obj_skateblock.c
+++ b/mm/src/overlays/actors/ovl_Obj_Skateblock/z_obj_skateblock.c
@@ -529,10 +529,9 @@ void func_80A22334(ObjSkateblock* this, PlayState* play) {
 
     if (sp2C == -1) {
         sp30 = false;
-    } else if (GameInteractor_Should(VB_SKATE_BLOCK_BEGIN_MOVE,
-                                     !(this->unk_1C1 & 2) && (this->unk_172[sp2C] > 10) && (D_80A22A10 == 0) &&
-                                         !func_80A216D4(this, play, 2.0f, &sp20) && !Player_InCsMode(play),
-                                     this)) {
+    } else if (!(this->unk_1C1 & 2) &&
+               GameInteractor_Should(VB_SKATE_BLOCK_BEGIN_MOVE, (this->unk_172[sp2C] > 10), this, sp2C) &&
+               (D_80A22A10 == 0) && !func_80A216D4(this, play, 2.0f, &sp20) && !Player_InCsMode(play)) {
         func_80A21C88(this, sp2C);
         func_80A2244C(this);
         sp30 = false;


### PR DESCRIPTION
Fixes #1417. Obj_Skateblock should only be pushed, not pulled.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4976044725.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4976067256.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4976192848.zip)
<!--- section:artifacts:end -->