### PR TITLE
[Enhancement] Auto Bank Deposit

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1374,6 +1374,12 @@ void BenMenu::AddEnhancements() {
         .CVar("gEnhancements.Timesavers.SkipBalladOfWindfish")
         .Options(CheckboxOptions().Tooltip(
             "Play the complete Ballad after playing in one form if you have all three transformation masks."));
+    AddWidget(path, "Auto Bank Deposit", WIDGET_CVAR_CHECKBOX)
+        .CVar("gEnhancements.Timesavers.AutoBankDeposit")
+        .Options(CheckboxOptions().Tooltip(
+            "Automatically deposits excess rupees into your bank account when your wallet is full. "
+            "Deposits stop when the bank reaches maximum capacity of 5000 rupees. "
+            "Bank rewards are granted automatically. Notifications display deposit amount and new balance."));
 
     // Fixes
     path = { "Enhancements", "Fixes", SECTION_COLUMN_1 };

--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1377,8 +1377,8 @@ void BenMenu::AddEnhancements() {
     AddWidget(path, "Auto Bank Deposit", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Timesavers.AutoBankDeposit")
         .Options(CheckboxOptions().Tooltip(
-            "Automatically deposits excess rupees into your bank account when your wallet is full. "
-            "Deposits stop when the bank reaches maximum capacity of 5000 rupees. "
+            "Automatically deposits excess Rupees into your bank account when your wallet is full. "
+            "Deposits stop when the bank reaches maximum capacity. "
             "Bank rewards are granted automatically. Notifications display deposit amount and new balance."));
 
     // Fixes

--- a/mm/2s2h/Enhancements/Timesavers/AutoBankDeposit.cpp
+++ b/mm/2s2h/Enhancements/Timesavers/AutoBankDeposit.cpp
@@ -23,65 +23,69 @@ static void EmitDepositNotification(s16 depositAmount, s16 newBalance) {
 }
 
 static void GrantWalletReward() {
-    u32 walletLevel = CUR_UPG_VALUE(UPG_WALLET);
-    s16 itemDrawId = (walletLevel == 0) ? (s16)GID_WALLET_ADULT : (s16)GID_WALLET_GIANT;
+    if (IS_RANDO) {
+        SET_WEEKEVENTREG(WEEKEVENTREG_RECEIVED_BANK_WALLET_UPGRADE);
+        RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_WEST_BANK_ADULTS_WALLET].eligible = true;
+    } else {
+        u32 walletLevel = CUR_UPG_VALUE(UPG_WALLET);
+        s16 itemDrawId = (walletLevel == 0) ? (s16)GID_WALLET_ADULT : (s16)GID_WALLET_GIANT;
 
-    GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
-        .showGetItemCutscene = true, .param = itemDrawId, .giveItem = [](Actor* actor, PlayState* play) {
-            u32 walletLevel = CUR_UPG_VALUE(UPG_WALLET);
-            ItemId wallet = (walletLevel == 0) ? ITEM_WALLET_ADULT : ITEM_WALLET_GIANT;
-            const char* walletName = (walletLevel == 0) ? "Adult's Wallet" : "Giant's Wallet";
+        GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+            .showGetItemCutscene = true, .param = itemDrawId, .giveItem = [](Actor* actor, PlayState* play) {
+                u32 walletLevel = CUR_UPG_VALUE(UPG_WALLET);
+                ItemId wallet = (walletLevel == 0) ? ITEM_WALLET_ADULT : ITEM_WALLET_GIANT;
+                const char* walletName = (walletLevel == 0) ? "Adult's Wallet" : "Giant's Wallet";
 
-            if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
-                CustomMessage::SetActiveCustomMessage(std::string("You got ") + walletName + "!", { .textboxType = 2 });
-            } else {
-                CustomMessage::StartTextbox(std::string("You got ") + walletName + "!\x1C\x02\x10",
-                                            { .textboxType = 2 });
-            }
+                if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
+                    CustomMessage::SetActiveCustomMessage(std::string("You got ") + walletName + "!",
+                                                          { .textboxType = 2 });
+                } else {
+                    CustomMessage::StartTextbox(std::string("You got ") + walletName + "!\x1C\x02\x10",
+                                                { .textboxType = 2 });
+                }
 
-            SET_WEEKEVENTREG(WEEKEVENTREG_RECEIVED_BANK_WALLET_UPGRADE);
-            Item_Give(play, wallet);
-
-            if (IS_RANDO) {
-                RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_WEST_BANK_ADULTS_WALLET].eligible = true;
-            }
-        } });
+                SET_WEEKEVENTREG(WEEKEVENTREG_RECEIVED_BANK_WALLET_UPGRADE);
+                Item_Give(play, wallet);
+            } });
+    }
 }
 
 static void GrantBlueRupeeReward() {
-    GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
-        .showGetItemCutscene = true, .param = GID_RUPEE_BLUE, .giveItem = [](Actor* actor, PlayState* play) {
-            if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
-                CustomMessage::SetActiveCustomMessage("You got a Blue Rupee!", { .textboxType = 2 });
-            } else {
-                CustomMessage::StartTextbox("You got a Blue Rupee!\x1C\x02\x10", { .textboxType = 2 });
-            }
+    if (IS_RANDO) {
+        SET_WEEKEVENTREG(WEEKEVENTREG_59_80);
+        RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_WEST_BANK_INTEREST].eligible = true;
+    } else {
+        GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+            .showGetItemCutscene = true, .param = GID_RUPEE_BLUE, .giveItem = [](Actor* actor, PlayState* play) {
+                if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
+                    CustomMessage::SetActiveCustomMessage("You got a Blue Rupee!", { .textboxType = 2 });
+                } else {
+                    CustomMessage::StartTextbox("You got a Blue Rupee!\x1C\x02\x10", { .textboxType = 2 });
+                }
 
-            SET_WEEKEVENTREG(WEEKEVENTREG_59_80);
-            Item_Give(play, ITEM_RUPEE_BLUE);
-
-            if (IS_RANDO) {
-                RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_WEST_BANK_INTEREST].eligible = true;
-            }
-        } });
+                SET_WEEKEVENTREG(WEEKEVENTREG_59_80);
+                Item_Give(play, ITEM_RUPEE_BLUE);
+            } });
+    }
 }
 
 static void GrantHeartPieceReward() {
-    GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
-        .showGetItemCutscene = true, .param = GID_HEART_PIECE, .giveItem = [](Actor* actor, PlayState* play) {
-            if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
-                CustomMessage::SetActiveCustomMessage("You got a Piece of Heart!", { .textboxType = 2 });
-            } else {
-                CustomMessage::StartTextbox("You got a Piece of Heart!\x1C\x02\x10", { .textboxType = 2 });
-            }
+    if (IS_RANDO) {
+        SET_WEEKEVENTREG(WEEKEVENTREG_RECEIVED_BANK_HEART_PIECE);
+        RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_WEST_BANK_PIECE_OF_HEART].eligible = true;
+    } else {
+        GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+            .showGetItemCutscene = true, .param = GID_HEART_PIECE, .giveItem = [](Actor* actor, PlayState* play) {
+                if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
+                    CustomMessage::SetActiveCustomMessage("You got a Piece of Heart!", { .textboxType = 2 });
+                } else {
+                    CustomMessage::StartTextbox("You got a Piece of Heart!\x1C\x02\x10", { .textboxType = 2 });
+                }
 
-            SET_WEEKEVENTREG(WEEKEVENTREG_RECEIVED_BANK_HEART_PIECE);
-            Item_Give(play, ITEM_HEART_PIECE);
-
-            if (IS_RANDO) {
-                RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_WEST_BANK_PIECE_OF_HEART].eligible = true;
-            }
-        } });
+                SET_WEEKEVENTREG(WEEKEVENTREG_RECEIVED_BANK_HEART_PIECE);
+                Item_Give(play, ITEM_HEART_PIECE);
+            } });
+    }
 }
 
 static void GrantBankerReward(s16 balanceBeforeDeposit, s16 balanceAfterDeposit) {

--- a/mm/2s2h/Enhancements/Timesavers/AutoBankDeposit.cpp
+++ b/mm/2s2h/Enhancements/Timesavers/AutoBankDeposit.cpp
@@ -22,9 +22,10 @@ static void EmitDepositNotification(s16 depositAmount, s16 newBalance) {
     Notification::Emit(notif);
 }
 
-static void GrantWalletReward() {
+static void GrantBankFirstReward() {
+    SET_WEEKEVENTREG(WEEKEVENTREG_RECEIVED_BANK_WALLET_UPGRADE);
+
     if (IS_RANDO) {
-        SET_WEEKEVENTREG(WEEKEVENTREG_RECEIVED_BANK_WALLET_UPGRADE);
         RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_WEST_BANK_ADULTS_WALLET].eligible = true;
     } else {
         u32 walletLevel = CUR_UPG_VALUE(UPG_WALLET);
@@ -44,15 +45,15 @@ static void GrantWalletReward() {
                                                 { .textboxType = 2 });
                 }
 
-                SET_WEEKEVENTREG(WEEKEVENTREG_RECEIVED_BANK_WALLET_UPGRADE);
                 Item_Give(play, wallet);
             } });
     }
 }
 
-static void GrantBlueRupeeReward() {
+static void GrantBankInterestReward() {
+    SET_WEEKEVENTREG(WEEKEVENTREG_59_80);
+
     if (IS_RANDO) {
-        SET_WEEKEVENTREG(WEEKEVENTREG_59_80);
         RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_WEST_BANK_INTEREST].eligible = true;
     } else {
         GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
@@ -63,15 +64,15 @@ static void GrantBlueRupeeReward() {
                     CustomMessage::StartTextbox("You got a Blue Rupee!\x1C\x02\x10", { .textboxType = 2 });
                 }
 
-                SET_WEEKEVENTREG(WEEKEVENTREG_59_80);
                 Item_Give(play, ITEM_RUPEE_BLUE);
             } });
     }
 }
 
-static void GrantHeartPieceReward() {
+static void GrantBankFinalReward() {
+    SET_WEEKEVENTREG(WEEKEVENTREG_RECEIVED_BANK_HEART_PIECE);
+
     if (IS_RANDO) {
-        SET_WEEKEVENTREG(WEEKEVENTREG_RECEIVED_BANK_HEART_PIECE);
         RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_WEST_BANK_PIECE_OF_HEART].eligible = true;
     } else {
         GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
@@ -82,7 +83,6 @@ static void GrantHeartPieceReward() {
                     CustomMessage::StartTextbox("You got a Piece of Heart!\x1C\x02\x10", { .textboxType = 2 });
                 }
 
-                SET_WEEKEVENTREG(WEEKEVENTREG_RECEIVED_BANK_HEART_PIECE);
                 Item_Give(play, ITEM_HEART_PIECE);
             } });
     }
@@ -97,17 +97,17 @@ static void GrantBankerReward(s16 balanceBeforeDeposit, s16 balanceAfterDeposit)
 
     if (balanceBeforeDeposit < walletThreshold && balanceAfterDeposit >= walletThreshold &&
         !CHECK_WEEKEVENTREG(WEEKEVENTREG_RECEIVED_BANK_WALLET_UPGRADE)) {
-        GrantWalletReward();
+        GrantBankFirstReward();
     }
 
     if (balanceBeforeDeposit < interestThreshold && balanceAfterDeposit >= interestThreshold &&
         !CHECK_WEEKEVENTREG(WEEKEVENTREG_59_80)) {
-        GrantBlueRupeeReward();
+        GrantBankInterestReward();
     }
 
     if (balanceBeforeDeposit < heartPieceThreshold && balanceAfterDeposit >= heartPieceThreshold &&
         !CHECK_WEEKEVENTREG(WEEKEVENTREG_RECEIVED_BANK_HEART_PIECE)) {
-        GrantHeartPieceReward();
+        GrantBankFinalReward();
     }
 }
 

--- a/mm/2s2h/Enhancements/Timesavers/AutoBankDeposit.cpp
+++ b/mm/2s2h/Enhancements/Timesavers/AutoBankDeposit.cpp
@@ -1,0 +1,142 @@
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/ShipInit.hpp"
+#include "2s2h/BenGui/Notification.h"
+#include "2s2h/Rando/Rando.h"
+#include "2s2h/CustomMessage/CustomMessage.h"
+#include "2s2h/CustomItem/CustomItem.h"
+
+#define CVAR_NAME "gEnhancements.Timesavers.AutoBankDeposit"
+#define CVAR CVarGetInteger(CVAR_NAME, 0)
+
+#define BANK_MAX_CAPACITY 5000
+
+static void EmitDepositNotification(s16 depositAmount, s16 newBalance) {
+    Notification::Options notif = {};
+    notif.prefix = "Deposit Amount:";
+    notif.prefixColor = ImVec4(0.4f, 0.7f, 1.0f, 1.0f);
+    notif.message = std::to_string(depositAmount);
+    notif.messageColor = ImVec4(0.9f, 0.9f, 0.9f, 1.0f);
+    notif.suffix = "New Balance: " + std::to_string(newBalance);
+    notif.suffixColor = ImVec4(0.3f, 1.0f, 0.3f, 1.0f);
+    notif.remainingTime = 6.0f;
+    Notification::Emit(notif);
+}
+
+static void GrantWalletReward() {
+    u32 walletLevel = CUR_UPG_VALUE(UPG_WALLET);
+    s16 itemDrawId = (walletLevel == 0) ? (s16)GID_WALLET_ADULT : (s16)GID_WALLET_GIANT;
+
+    GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+        .showGetItemCutscene = true, .param = itemDrawId, .giveItem = [](Actor* actor, PlayState* play) {
+            u32 walletLevel = CUR_UPG_VALUE(UPG_WALLET);
+            ItemId wallet = (walletLevel == 0) ? ITEM_WALLET_ADULT : ITEM_WALLET_GIANT;
+            const char* walletName = (walletLevel == 0) ? "Adult's Wallet" : "Giant's Wallet";
+
+            if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
+                CustomMessage::SetActiveCustomMessage(std::string("You got ") + walletName + "!", { .textboxType = 2 });
+            } else {
+                CustomMessage::StartTextbox(std::string("You got ") + walletName + "!\x1C\x02\x10",
+                                            { .textboxType = 2 });
+            }
+
+            SET_WEEKEVENTREG(WEEKEVENTREG_RECEIVED_BANK_WALLET_UPGRADE);
+            Item_Give(play, wallet);
+
+            if (IS_RANDO) {
+                RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_WEST_BANK_ADULTS_WALLET].eligible = true;
+            }
+        } });
+}
+
+static void GrantBlueRupeeReward() {
+    GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+        .showGetItemCutscene = true, .param = GID_RUPEE_BLUE, .giveItem = [](Actor* actor, PlayState* play) {
+            if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
+                CustomMessage::SetActiveCustomMessage("You got a Blue Rupee!", { .textboxType = 2 });
+            } else {
+                CustomMessage::StartTextbox("You got a Blue Rupee!\x1C\x02\x10", { .textboxType = 2 });
+            }
+
+            SET_WEEKEVENTREG(WEEKEVENTREG_59_80);
+            Item_Give(play, ITEM_RUPEE_BLUE);
+
+            if (IS_RANDO) {
+                RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_WEST_BANK_INTEREST].eligible = true;
+            }
+        } });
+}
+
+static void GrantHeartPieceReward() {
+    GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+        .showGetItemCutscene = true, .param = GID_HEART_PIECE, .giveItem = [](Actor* actor, PlayState* play) {
+            if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
+                CustomMessage::SetActiveCustomMessage("You got a Piece of Heart!", { .textboxType = 2 });
+            } else {
+                CustomMessage::StartTextbox("You got a Piece of Heart!\x1C\x02\x10", { .textboxType = 2 });
+            }
+
+            SET_WEEKEVENTREG(WEEKEVENTREG_RECEIVED_BANK_HEART_PIECE);
+            Item_Give(play, ITEM_HEART_PIECE);
+
+            if (IS_RANDO) {
+                RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_WEST_BANK_PIECE_OF_HEART].eligible = true;
+            }
+        } });
+}
+
+static void GrantBankerReward(s16 balanceBeforeDeposit, s16 balanceAfterDeposit) {
+    bool useCustomThresholds = CVarGetInteger("gEnhancements.DifficultyOptions.LowerBankRewardThresholds", 0);
+
+    s16 walletThreshold = useCustomThresholds ? 100 : 200;
+    s16 interestThreshold = useCustomThresholds ? 500 : 1000;
+    s16 heartPieceThreshold = useCustomThresholds ? 1000 : 5000;
+
+    if (balanceBeforeDeposit < walletThreshold && balanceAfterDeposit >= walletThreshold &&
+        !CHECK_WEEKEVENTREG(WEEKEVENTREG_RECEIVED_BANK_WALLET_UPGRADE)) {
+        GrantWalletReward();
+    }
+
+    if (balanceBeforeDeposit < interestThreshold && balanceAfterDeposit >= interestThreshold &&
+        !CHECK_WEEKEVENTREG(WEEKEVENTREG_59_80)) {
+        GrantBlueRupeeReward();
+    }
+
+    if (balanceBeforeDeposit < heartPieceThreshold && balanceAfterDeposit >= heartPieceThreshold &&
+        !CHECK_WEEKEVENTREG(WEEKEVENTREG_RECEIVED_BANK_HEART_PIECE)) {
+        GrantHeartPieceReward();
+    }
+}
+
+static void HandleWalletOverflow() {
+    s16 currentBankBalance = HS_GET_BANK_RUPEES();
+
+    if (currentBankBalance >= BANK_MAX_CAPACITY) {
+        return;
+    }
+
+    s16 spaceInBank = BANK_MAX_CAPACITY - currentBankBalance;
+    s16 depositAmount = MIN(gSaveContext.rupeeAccumulator, spaceInBank);
+
+    if (depositAmount > 0) {
+        s16 balanceBeforeDeposit = currentBankBalance;
+        s16 balanceAfterDeposit = currentBankBalance + depositAmount;
+
+        HS_SET_BANK_RUPEES(balanceAfterDeposit);
+        gSaveContext.rupeeAccumulator -= depositAmount;
+
+        EmitDepositNotification(depositAmount, balanceAfterDeposit);
+        GrantBankerReward(balanceBeforeDeposit, balanceAfterDeposit);
+    }
+}
+
+static void RegisterAutoBankDeposit() {
+    COND_VB_SHOULD(VB_DISCARD_EXCESS_RUPEES, CVAR, {
+        HandleWalletOverflow();
+
+        if (gSaveContext.rupeeAccumulator == 0) {
+            *should = true;
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterAutoBankDeposit, { CVAR_NAME });

--- a/mm/2s2h/GameInteractor/GameInteractor_VanillaBehavior.h
+++ b/mm/2s2h/GameInteractor/GameInteractor_VanillaBehavior.h
@@ -403,6 +403,14 @@ typedef enum {
 
     // #### `result`
     // ```c
+    // gSaveContext.save.saveInfo.playerData.rupees >= CUR_CAPACITY(UPG_WALLET)
+    // ```
+    // #### `args`
+    // - None
+    VB_DISCARD_EXCESS_RUPEES,
+
+    // #### `result`
+    // ```c
     // true
     // ```
     // #### `args`

--- a/mm/src/code/z_parameter.c
+++ b/mm/src/code/z_parameter.c
@@ -9663,8 +9663,10 @@ void Interface_Update(PlayState* play) {
                 Audio_PlaySfx(NA_SE_SY_RUPY_COUNT);
             } else {
                 // Max rupees
-                gSaveContext.save.saveInfo.playerData.rupees = CUR_CAPACITY(UPG_WALLET);
-                gSaveContext.rupeeAccumulator = 0;
+                if (!GameInteractor_Should(VB_DISCARD_EXCESS_RUPEES, false)) {
+                    gSaveContext.save.saveInfo.playerData.rupees = CUR_CAPACITY(UPG_WALLET);
+                    gSaveContext.rupeeAccumulator = 0;
+                }
             }
         } else if (gSaveContext.save.saveInfo.playerData.rupees != 0) {
             if (gSaveContext.rupeeAccumulator <= -50) {


### PR DESCRIPTION
This automatically deposits excess rupees into the player's bank account when their wallet is full. Deposits stop when the bank reaches its maximum capacity of 5000 rupees. Bank rewards (both rando and vanilla) are granted automatically when deposit thresholds are crossed (accounts for LowerBankRewardThresholds if enabled), and notifications display deposit amounts and new balances.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5004561564.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5004584124.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5004675756.zip)
<!--- section:artifacts:end -->