### PR TITLE
[Enhancement] GFS Attack With B

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -987,6 +987,11 @@ void BenMenu::AddEnhancements() {
         .CVar("gEnhancements.Equipment.InvertShieldY")
         .Options(CheckboxOptions().Tooltip(
             "Invert the Y axis while holding the shield so that it moves up with the left stick."));
+    AddWidget(path, "Great Fairy Sword B-Button Attack", WIDGET_CVAR_CHECKBOX)
+        .CVar("gEnhancements.Equipment.GreatFairySwordBButton")
+        .Options(CheckboxOptions().Tooltip(
+            "When the Great Fairy's Sword is held, pressing B attacks with it instead of drawing "
+            "your equipped sword. The sword can still be put away with A as normal."));
 
     path.column = SECTION_COLUMN_2;
     AddWidget(path, "Modes", WIDGET_SEPARATOR_TEXT);

--- a/mm/2s2h/Enhancements/Equipment/GreatFairySwordBButton.cpp
+++ b/mm/2s2h/Enhancements/Equipment/GreatFairySwordBButton.cpp
@@ -13,12 +13,11 @@ extern Input* sPlayerControlInput;
 void RegisterGreatFairySwordBButton() {
     COND_VB_SHOULD(VB_GET_ITEM_ON_BUTTON, CVAR, {
         Player* player = GET_PLAYER(gPlayState);
-        EquipSlot slot = va_arg(args, EquipSlot);
+        EquipSlot slot = (EquipSlot)va_arg(args, int);
         ItemId* item = va_arg(args, ItemId*);
 
         if (slot == EQUIP_SLOT_B && player->transformation == PLAYER_FORM_HUMAN &&
             player->heldItemId == ITEM_SWORD_GREAT_FAIRY) {
-            *should = true;
             *item = ITEM_SWORD_GREAT_FAIRY;
         }
     });

--- a/mm/2s2h/Enhancements/Equipment/GreatFairySwordBButton.cpp
+++ b/mm/2s2h/Enhancements/Equipment/GreatFairySwordBButton.cpp
@@ -1,0 +1,27 @@
+#include <libultraship/bridge/consolevariablebridge.h>
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/ShipInit.hpp"
+
+extern "C" {
+#include "variables.h"
+extern Input* sPlayerControlInput;
+}
+
+#define CVAR_NAME "gEnhancements.Equipment.GreatFairySwordBButton"
+#define CVAR CVarGetInteger(CVAR_NAME, 0)
+
+void RegisterGreatFairySwordBButton() {
+    COND_VB_SHOULD(VB_GET_ITEM_ON_BUTTON, CVAR, {
+        Player* player = GET_PLAYER(gPlayState);
+        EquipSlot slot = va_arg(args, EquipSlot);
+        ItemId* item = va_arg(args, ItemId*);
+
+        if (slot == EQUIP_SLOT_B && player->transformation == PLAYER_FORM_HUMAN &&
+            player->heldItemId == ITEM_SWORD_GREAT_FAIRY) {
+            *should = true;
+            *item = ITEM_SWORD_GREAT_FAIRY;
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterGreatFairySwordBButton, { CVAR_NAME });

--- a/mm/2s2h/GameInteractor/GameInteractor_VanillaBehavior.h
+++ b/mm/2s2h/GameInteractor/GameInteractor_VanillaBehavior.h
@@ -630,6 +630,16 @@ typedef enum {
     VB_GET_ITEM_ACTION_FROM_MASK,
 
     // #### `result`
+    // #### In `Player_GetItemOnButton`:
+    // ```c
+    // item
+    // ```
+    // #### `args`
+    // - `EquipSlot`
+    // - `*ItemId`
+    VB_GET_ITEM_ON_BUTTON,
+
+    // #### `result`
     // ```c
     // false
     // ```

--- a/mm/src/code/z_player_lib.c
+++ b/mm/src/code/z_player_lib.c
@@ -4,6 +4,7 @@
  */
 
 #include "global.h"
+#include "2s2h/GameInteractor/GameInteractor.h"
 
 #include "objects/gameplay_keep/gameplay_keep.h"
 
@@ -789,6 +790,8 @@ ItemId Player_GetItemOnButton(PlayState* play, Player* player, EquipSlot slot) {
             (play->interfaceCtx.bButtonPlayerDoAction == DO_ACTION_DANCE)) {
             return ITEM_F2;
         }
+
+        GameInteractor_Should(VB_GET_ITEM_ON_BUTTON, item, slot, &item);
 
         return item;
     }


### PR DESCRIPTION
It seems to me that the primary complaint is that players just want a way to use GFS with B, not necessarily have GFS slotted to B. This simply redirects the B button press to use the GFS item leaving the B button slot untouched. You can still unequip GFS with A. 

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4984133350.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4984182249.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4984831261.zip)
<!--- section:artifacts:end -->