### PR TITLE
[Enhancement] Show Full Maze

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1622,6 +1622,10 @@ void BenMenu::AddEnhancements() {
     AddWidget(path, "Invincible", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Minigames.BoatArcheryInvincible")
         .Options(CheckboxOptions().Tooltip("Koume's health does not decrease when hit."));
+    AddWidget(path, "Treasure Chest Shop Show Full Maze", WIDGET_CVAR_CHECKBOX)
+        .CVar("gEnhancements.Minigames.TreasureChestShopShowFullMaze")
+        .Options(CheckboxOptions().Tooltip("Shows the entire maze layout in the Treasure Chest Shop minigame "
+                                           "instead of only revealing tiles near Link."));
 
     path.column = SECTION_COLUMN_3;
     AddWidget(path, "Other", WIDGET_SEPARATOR_TEXT);

--- a/mm/2s2h/Enhancements/Minigames/TreasureChestShopFullMaze.cpp
+++ b/mm/2s2h/Enhancements/Minigames/TreasureChestShopFullMaze.cpp
@@ -1,0 +1,40 @@
+#include <libultraship/bridge/consolevariablebridge.h>
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/ShipInit.hpp"
+
+// Re-definitions to avoid modifying source headers
+#define TAKARAYA_WALL_ROWS 11
+#define TAKARAYA_WALL_COLUMNS 8
+
+extern "C" {
+extern f32 sTakarayaWallHeights[TAKARAYA_WALL_ROWS][TAKARAYA_WALL_COLUMNS];
+extern u8 sTakarayaWallStates[TAKARAYA_WALL_ROWS][TAKARAYA_WALL_COLUMNS];
+}
+
+// Re-definition to avoid modifying source headers
+typedef enum { TAKARAYA_WALL_INACTIVE, TAKARAYA_WALL_RISING, TAKARAYA_WALL_FALLING } TakarayaWallCellState;
+
+#define CVAR_NAME "gEnhancements.Minigames.TreasureChestShopShowFullMaze"
+#define CVAR CVarGetInteger(CVAR_NAME, 0)
+
+static void RegisterTreasureChestShopFullMaze() {
+    COND_ID_HOOK(OnActorUpdate, ACTOR_OBJ_TAKARAYA_WALL, CVAR, [](Actor* actor) {
+        if (gSaveContext.timerStates[TIMER_ID_MINIGAME_2] == TIMER_STATE_OFF) {
+            return;
+        }
+
+        for (int i = 0; i < TAKARAYA_WALL_ROWS; i++) {
+            for (int j = 0; j < TAKARAYA_WALL_COLUMNS; j++) {
+                if (sTakarayaWallHeights[i][j] >= 0.0f) {
+                    if (Math_StepToF(&sTakarayaWallHeights[i][j], 120.0f, 15.0f)) {
+                        sTakarayaWallStates[i][j] = TAKARAYA_WALL_INACTIVE;
+                    } else {
+                        sTakarayaWallStates[i][j] = TAKARAYA_WALL_RISING;
+                    }
+                }
+            }
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterTreasureChestShopFullMaze, { CVAR_NAME });


### PR DESCRIPTION
In a effort to provide some convenience without making the minigame trivial, this reveals all wall segments as soon as the minigame timer starts. 

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4987230688.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4987267648.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/4987305712.zip)
<!--- section:artifacts:end -->