### PR TITLE
Fix softlock from repeating Kafei's Mask check

### DIFF
--- a/mm/2s2h/Rando/ActorBehavior/EnAl.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnAl.cpp
@@ -15,6 +15,12 @@ void Rando::ActorBehavior::InitEnAlBehavior() {
 
     COND_ID_HOOK(OnActorInit, ACTOR_EN_AL, IS_RANDO, [](Actor* actor) { skipCmds.clear(); });
 
+    // "I'm counting on you"
+    COND_ID_HOOK(OnOpenText, 0x2AA2, IS_RANDO, [](u16* textId, bool* loadFromMessageTable) {
+        Message_BombersNotebookQueueEvent(gPlayState, BOMBERS_NOTEBOOK_EVENT_MET_MADAME_AROMA);
+        Message_BombersNotebookQueueEvent(gPlayState, BOMBERS_NOTEBOOK_EVENT_RECEIVED_KAFEIS_MASK);
+    });
+
     COND_VB_SHOULD(VB_EXEC_MSG_EVENT, IS_RANDO, {
         u32 cmdId = va_arg(args, u32);
         Actor* actor = va_arg(args, Actor*);
@@ -28,14 +34,13 @@ void Rando::ActorBehavior::InitEnAlBehavior() {
                 GetItemId getItemId = (GetItemId)SCRIPT_PACK_16(cmd->itemIdH, cmd->itemIdL);
                 skipCmds.clear();
                 if (getItemId == GI_MASK_KAFEIS_MASK) { // Mayor's Residence
-                    // Prevents the player from moving freely in case a notebook event message pops afterward
-                    Player_SetupWaitForPutAway(gPlayState, player, Player_SetupTalk);
+                    // There is no usable flag for this check, so grant it manually
+                    RANDO_SAVE_CHECKS[RC_MAYORS_OFFICE_KAFEIS_MASK].eligible = true;
                 } else { // Express Mail reward
                     /*
                      * We do something a little tricky here. We manually open a textbox with the message that normally
                      * plays after the player receives the reward (0x2B20), then also skip the MsgScript commands to
-                     * open that textbox and wait on it. The Player_SetupWaitForPutAway call above does not work for
-                     * this scenario, as it will softlock. More naive attempts at handling this actor case resulted in
+                     * open that textbox and wait on it. More naive attempts at handling this actor case resulted in
                      * softlocks, not appropriately locking textboxes, duplicate textboxes, or Bombers' Notebook
                      * messages being eaten. The method below handles the intended behavior, both with or without
                      * notebook messages, even if it is a little counterintuitive.


### PR DESCRIPTION
Madame Aroma followed a hacky solution for handling notebook and no-notebook Get Item states, which results in softlocks on repeating her Mayor's Residence check in repeat cycles in rando. A better approach is to just queue the relevant notebook events from her final textbox in that interaction, which guarantees the player will be in a reading textbox state.

This will almost certainly clash with develop because develop changed some actor behavior flag stuff. Note to self to remember that when doing the next develop-mion->develop merge.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5014737944.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5014769853.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5014833901.zip)
<!--- section:artifacts:end -->