### PR TITLE
Exclude Triforce from plentiful items, add error handling

### DIFF
--- a/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
+++ b/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
@@ -416,7 +416,9 @@ void Rando::MiscBehavior::OnFileCreate(s16 fileNum) {
                     }
 
                     if (RANDO_SAVE_OPTIONS[RO_TRIFORCE_PIECES_MAX] < 1 ||
-                        RANDO_SAVE_OPTIONS[RO_TRIFORCE_PIECES_REQUIRED] < 1) {
+                        RANDO_SAVE_OPTIONS[RO_TRIFORCE_PIECES_MAX] > 1000 ||
+                        RANDO_SAVE_OPTIONS[RO_TRIFORCE_PIECES_REQUIRED] < 1 ||
+                        RANDO_SAVE_OPTIONS[RO_TRIFORCE_PIECES_REQUIRED] > 1000) {
                         SPDLOG_ERROR("Error with adjusting Triforce Piece placement. Resulting shuffle requires {} "
                                      "pieces and out of a total of {}",
                                      RANDO_SAVE_OPTIONS[RO_TRIFORCE_PIECES_REQUIRED],

--- a/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
+++ b/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
@@ -280,6 +280,11 @@ void Rando::MiscBehavior::OnFileCreate(s16 fileNum) {
                     std::vector<RandoItemId> plentifulItems;
                     std::vector<RandoItemId> potentialPlentifulItems;
                     for (size_t i = 0; i < itemPool.size(); i++) {
+                        // The user can specify exactly how many pieces they want to shuffle, so skip those
+                        if (Rando::StaticData::Items[itemPool[i]].randoItemId == RI_TRIFORCE_PIECE) {
+                            continue;
+                        }
+
                         switch (Rando::StaticData::Items[itemPool[i]].randoItemType) {
                             case RITYPE_BOSS_KEY:
                             case RITYPE_SMALL_KEY:
@@ -408,6 +413,15 @@ void Rando::MiscBehavior::OnFileCreate(s16 fileNum) {
 
                         RANDO_SAVE_OPTIONS[RO_TRIFORCE_PIECES_MAX] = piecesShuffled;
                         RANDO_SAVE_OPTIONS[RO_TRIFORCE_PIECES_REQUIRED] = (piecesShuffled * currentRatio) + 1;
+                    }
+
+                    if (RANDO_SAVE_OPTIONS[RO_TRIFORCE_PIECES_MAX] < 1 ||
+                        RANDO_SAVE_OPTIONS[RO_TRIFORCE_PIECES_REQUIRED] < 1) {
+                        SPDLOG_ERROR("Error with adjusting Triforce Piece placement. Resulting shuffle requires {} "
+                                     "pieces and out of a total of {}",
+                                     RANDO_SAVE_OPTIONS[RO_TRIFORCE_PIECES_REQUIRED],
+                                     RANDO_SAVE_OPTIONS[RO_TRIFORCE_PIECES_MAX]);
+                        throw std::runtime_error("Invalid Triforce Piece count");
                     }
                 }
 


### PR DESCRIPTION
If the player has Plentiful Items and Triforce Hunt both enabled, they can step on each other and result in seeds where the required and total Triforce piece counts are not valid. Since Triforce Hunt itself allows the player to control the total, it's redundant to include Triforce pieces in Plentiful Items. This simply excludes them.

Also added minor error handling after the Triforce piece ratio calculation, just in case there are other ways to generate invalid counts.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5014758809.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5014784839.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5014818531.zip)
<!--- section:artifacts:end -->