### PR TITLE
[Rando] Grant starting enemy souls if not shuffled

### DIFF
--- a/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
+++ b/mm/2s2h/Rando/MiscBehavior/OnFileCreate.cpp
@@ -33,6 +33,12 @@ void GrantStarters() {
         startingItems.push_back(RI_ABILITY_SWIM);
     }
 
+    if (RANDO_SAVE_OPTIONS[RO_SHUFFLE_ENEMY_SOULS] != RO_GENERIC_YES) {
+        for (int i = RI_SOUL_ENEMY_ALIEN; i <= RI_SOUL_ENEMY_WOLFOS; i++) {
+            startingItems.push_back((RandoItemId)i);
+        }
+    }
+
     for (RandoItemId startingItem : startingItems) {
         Rando::GiveItem(Rando::ConvertItem(startingItem));
     }


### PR DESCRIPTION
Got lost in the mix when merging develop into enemy souls

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5043638936.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5043697774.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5043764610.zip)
<!--- section:artifacts:end -->