### PR TITLE
Port how "run-clang-format.ps1" displays its progress from Soh

### DIFF
--- a/run-clang-format.ps1
+++ b/run-clang-format.ps1
@@ -41,8 +41,9 @@ $files = Get-ChildItem -Path $basePath\mm -Recurse -File `
                        (-not ($_.FullName -like "*\mm\src\*" -or $_.FullName -like "*\mm\include\*")))) -and `
                      (-not ($_.FullName -like "*\mm\assets\*")) }
 
-foreach ($file in $files) {
+for ($i = 0; $i -lt $files.Length; $i++) {
+    $file = $files[$i]
     $relativePath = $file.FullName.Substring($basePath.Length + 1)
-    Write-Host "Formatting $relativePath"
+    Write-Host "Formatting [$($i+1)/$($files.Length)] $relativePath"
     .\clang-format.exe -i $file.FullName
 }


### PR DESCRIPTION
A small change ported from Soh version of "run-clang-format.ps1"  its helps to know how close the script is done.

TL/DR
 instead of  "Formatting mm\2s2h\DeveloperTools\ActorViewer.cpp" 
 its "Formatting [40/1576] mm\2s2h\DeveloperTools\ActorViewer.cpp"

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5061627701.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5061716493.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5061784986.zip)
<!--- section:artifacts:end -->