### PR TITLE
[Playtest] Refactor junk cycling and trap models

### DIFF
--- a/mm/2s2h/DeveloperTools/SaveEditor.cpp
+++ b/mm/2s2h/DeveloperTools/SaveEditor.cpp
@@ -1030,7 +1030,7 @@ void DrawItemsAndMasksTab() {
                             }
 
                             Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
-                            Rando::DrawItem(randoItemId);
+                            Rando::DrawItem(randoItemId, RC_UNKNOWN, actor);
                         } });
             }
         }

--- a/mm/2s2h/GameInteractor/GameInteractor.cpp
+++ b/mm/2s2h/GameInteractor/GameInteractor.cpp
@@ -528,10 +528,17 @@ void ProcessEvents(Actor* actor) {
         }
         GameInteractor::Instance->currentEvent = GIEventNone{};
     } else if (auto e = std::get_if<GIEventTrap>(&nextEvent)) {
-        if (e->action) {
-            e->action();
+        if (player->stateFlags1 & PLAYER_STATE1_800000) {
+            // Player is riding a horse, requeue the event
+            auto lostEvent = GameInteractor::Instance->currentEvent;
+            GameInteractor::Instance->currentEvent = GIEventNone{};
+            GameInteractor::Instance->events.push_back(lostEvent);
+        } else {
+            if (e->action) {
+                e->action();
+            }
+            GameInteractor::Instance->currentEvent = GIEventNone{};
         }
-        GameInteractor::Instance->currentEvent = GIEventNone{};
     }
 
     GameInteractor::Instance->events.erase(GameInteractor::Instance->events.begin());

--- a/mm/2s2h/GameInteractor/GameInteractor_VanillaBehavior.h
+++ b/mm/2s2h/GameInteractor/GameInteractor_VanillaBehavior.h
@@ -496,6 +496,7 @@ typedef enum {
     // ```
     // #### `args`
     // - `GetItemDrawId`
+    // - `DmChar05*`
     VB_DRAW_ITEM_FROM_DMCHAR05,
 
     // #### `result`

--- a/mm/2s2h/Rando/ActorBehavior/DmChar05.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/DmChar05.cpp
@@ -1,6 +1,10 @@
 #include "ActorBehavior.h"
 #include "2s2h/CustomMessage/CustomMessage.h"
 
+extern "C" {
+#include "overlays/actors/ovl_Dm_Char05/z_dm_char05.h"
+}
+
 // These come from corresponding entries in z_message.c.
 #define GORON_MASK_TEXT 0x79
 #define ZORA_MASK_TEXT 0x7A
@@ -14,8 +18,9 @@ void replaceGetItemText(RandoCheckId randoCheckId, u16* textId, bool* loadFromMe
 
     auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
     entry.autoFormat = false;
-    entry.msg.assign("You received " + std::string(randoStaticItem.article) + " " + std::string(randoStaticItem.name) +
-                     "!\x1C\x02\x10");
+    entry.msg.assign("You received {{itemName}}!\x1C\x02\x10");
+    CustomMessage::Replace(&entry.msg, "{{itemName}}",
+                           Rando::StaticData::GetItemName(randoSaveCheck.randoItemId, true, randoCheckId));
     entry.icon = 0xFE; // No icon
 
     CustomMessage::LoadCustomMessageIntoFont(entry);
@@ -50,18 +55,23 @@ void Rando::ActorBehavior::InitDmChar05Behavior() {
      */
     COND_VB_SHOULD(VB_DRAW_ITEM_FROM_DMCHAR05, IS_RANDO, {
         GetItemDrawId vanillaItemId = (GetItemDrawId)va_arg(args, int);
+        Actor* dmChar05 = va_arg(args, Actor*);
         switch (vanillaItemId) {
             case GID_MASK_GIBDO:
-                Rando::DrawItem(RANDO_SAVE_CHECKS[RC_MUSIC_BOX_HOUSE_FATHER].randoItemId);
+                Rando::DrawItem(RANDO_SAVE_CHECKS[RC_MUSIC_BOX_HOUSE_FATHER].randoItemId, RC_MUSIC_BOX_HOUSE_FATHER,
+                                dmChar05);
                 break;
             case GID_MASK_GORON:
-                Rando::DrawItem(RANDO_SAVE_CHECKS[RC_GORON_GRAVEYARD_DARMANI].randoItemId);
+                Rando::DrawItem(RANDO_SAVE_CHECKS[RC_GORON_GRAVEYARD_DARMANI].randoItemId, RC_GORON_GRAVEYARD_DARMANI,
+                                dmChar05);
                 break;
             case GID_MASK_ZORA:
-                Rando::DrawItem(RANDO_SAVE_CHECKS[RC_GREAT_BAY_COAST_MIKAU].randoItemId);
+                Rando::DrawItem(RANDO_SAVE_CHECKS[RC_GREAT_BAY_COAST_MIKAU].randoItemId, RC_GREAT_BAY_COAST_MIKAU,
+                                dmChar05);
                 break;
             case GID_MASK_COUPLE:
-                Rando::DrawItem(RANDO_SAVE_CHECKS[RC_STOCK_POT_INN_COUPLES_MASK].randoItemId);
+                Rando::DrawItem(RANDO_SAVE_CHECKS[RC_STOCK_POT_INN_COUPLES_MASK].randoItemId,
+                                RC_STOCK_POT_INN_COUPLES_MASK, dmChar05);
                 break;
             default:
                 break;

--- a/mm/2s2h/Rando/ActorBehavior/DmHina.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/DmHina.cpp
@@ -25,7 +25,7 @@ void Rando::ActorBehavior::InitDmHinaBehavior() {
         auto randoSaveCheck = RANDO_SAVE_CHECKS[checkId];
         // Do not display if already obtained (i.e. for repeat visits)
         if (!randoSaveCheck.obtained) {
-            Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, checkId), actor);
+            Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, checkId), checkId, actor);
         }
     });
 }

--- a/mm/2s2h/Rando/ActorBehavior/DmStk.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/DmStk.cpp
@@ -69,6 +69,8 @@ void Rando::ActorBehavior::InitDmStkBehavior() {
                  [](Actor* actor, bool* should) { actor->update = DmChar02_UpdateCustom; });
 
     COND_VB_SHOULD(VB_DRAW_OCARINA_IN_STK_HAND, IS_RANDO, {
+        Actor* dmStk = va_arg(args, Actor*);
+
         if (*should) {
             *should = false;
 
@@ -84,7 +86,8 @@ void Rando::ActorBehavior::InitDmStkBehavior() {
             Matrix_TranslateRotateZYX(&pos, &rot);
 
             auto randoSaveCheck = RANDO_SAVE_CHECKS[RC_CLOCK_TOWER_ROOF_OCARINA];
-            Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, RC_CLOCK_TOWER_ROOF_OCARINA));
+            Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, RC_CLOCK_TOWER_ROOF_OCARINA),
+                            RC_CLOCK_TOWER_ROOF_OCARINA, dmStk);
         }
     });
 
@@ -95,6 +98,8 @@ void Rando::ActorBehavior::InitDmStkBehavior() {
     });
 
     COND_VB_SHOULD(VB_POST_CHAR02_LIMB, IS_RANDO, {
+        Actor* dmChar02 = va_arg(args, Actor*);
+
         Matrix_Scale(15.0f, 15.0f, 15.0f, MTXMODE_APPLY);
         Vec3s rot;
         rot.x = -11554;
@@ -105,7 +110,8 @@ void Rando::ActorBehavior::InitDmStkBehavior() {
         Matrix_TranslateRotateZYX(&pos, &rot);
 
         auto randoSaveCheck = RANDO_SAVE_CHECKS[RC_CLOCK_TOWER_ROOF_OCARINA];
-        Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, RC_CLOCK_TOWER_ROOF_OCARINA));
+        Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, RC_CLOCK_TOWER_ROOF_OCARINA),
+                        RC_CLOCK_TOWER_ROOF_OCARINA, dmChar02);
     });
 
     COND_VB_SHOULD(VB_STK_HAVE_OCARINA, IS_RANDO, {

--- a/mm/2s2h/Rando/ActorBehavior/EnAkindonuts.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnAkindonuts.cpp
@@ -25,7 +25,8 @@ void EnAkindonuts_ReplacePurchaseMessage(RandoCheckId randoCheckId, RandoInf ran
     auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
     entry.msg = "I'll sell you %g{{item}}%w for %r{{rupees}} Rupees%w!\xE0";
 
-    CustomMessage::Replace(&entry.msg, "{{item}}", Rando::StaticData::GetItemName(randoSaveCheck.randoItemId));
+    CustomMessage::Replace(&entry.msg, "{{item}}",
+                           Rando::StaticData::GetItemName(randoSaveCheck.randoItemId, true, randoCheckId));
     CustomMessage::Replace(&entry.msg, "{{rupees}}", std::to_string(cost));
 
     CustomMessage::LoadCustomMessageIntoFont(entry);
@@ -112,7 +113,8 @@ void Rando::ActorBehavior::InitEnAkindonutsBehavior() {
 
         CustomMessage::Replace(
             &entry.msg, "{{item}}",
-            Rando::StaticData::GetItemName(RANDO_SAVE_CHECKS[RC_SOUTHERN_SWAMP_SCRUB_BEANS].randoItemId));
+            Rando::StaticData::GetItemName(RANDO_SAVE_CHECKS[RC_SOUTHERN_SWAMP_SCRUB_BEANS].randoItemId, true,
+                                           RC_SOUTHERN_SWAMP_SCRUB_BEANS));
         CustomMessage::LoadCustomMessageIntoFont(entry);
         *loadFromMessageTable = false;
     });

--- a/mm/2s2h/Rando/ActorBehavior/EnBal.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnBal.cpp
@@ -29,10 +29,12 @@ void OnOpenShopText(u16* textId, bool* loadFromMessageTable) {
                 "\x02{item2}\x01 {price2} Rupees\x11"
                 "\x02No thanks";
 
-    CustomMessage::Replace(&entry.msg, "{item1}",
-                           Rando::StaticData::GetItemName(RANDO_SAVE_CHECKS[randoCheckId1].randoItemId, false));
-    CustomMessage::Replace(&entry.msg, "{item2}",
-                           Rando::StaticData::GetItemName(RANDO_SAVE_CHECKS[randoCheckId2].randoItemId, false));
+    CustomMessage::Replace(
+        &entry.msg, "{item1}",
+        Rando::StaticData::GetItemName(RANDO_SAVE_CHECKS[randoCheckId1].randoItemId, false, randoCheckId1));
+    CustomMessage::Replace(
+        &entry.msg, "{item2}",
+        Rando::StaticData::GetItemName(RANDO_SAVE_CHECKS[randoCheckId2].randoItemId, false, randoCheckId2));
     CustomMessage::Replace(&entry.msg, "{price1}", std::to_string(RANDO_SAVE_CHECKS[randoCheckId1].price));
     CustomMessage::Replace(&entry.msg, "{price2}", std::to_string(RANDO_SAVE_CHECKS[randoCheckId2].price));
     CustomMessage::EnsureMessageEnd(&entry.msg);

--- a/mm/2s2h/Rando/ActorBehavior/EnElfgrp.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnElfgrp.cpp
@@ -19,29 +19,19 @@ std::map<u8, RandoCheckId> fairyCheckMap = {
 
 void ApplyClockTownGreatFairyHint(u16* textId, bool* loadFromMessageTable) {
     CustomMessage::Entry entry = {
-        .msg = "%wPlease, find the Stray Fairy who's lost! We will reward you with %g{{article1}}{{item1}}%w and maybe "
-               "even %g{{article2}}{{item2}}%w if you are worthy."
+        .msg = "%wPlease, find the Stray Fairy who's lost! We will reward you with %g{{item1}}%w and maybe "
+               "even %g{{item2}}%w if you are worthy."
     };
 
-    auto& randoStaticItem1 = Rando::StaticData::Items[RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_GREAT_FAIRY].randoItemId];
+    auto randoItem1Name = Rando::StaticData::GetItemName(RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_GREAT_FAIRY].randoItemId, true,
+                                                         RC_CLOCK_TOWN_GREAT_FAIRY);
 
-    if (!Ship_IsCStringEmpty(randoStaticItem1.article)) {
-        CustomMessage::Replace(&entry.msg, "{{article1}}", std::string(randoStaticItem1.article) + " ");
-    } else {
-        CustomMessage::Replace(&entry.msg, "{{article1}}", "");
-    }
+    CustomMessage::Replace(&entry.msg, "{{item1}}", randoItem1Name);
 
-    CustomMessage::Replace(&entry.msg, "{{item1}}", randoStaticItem1.name);
+    auto randoItem2Name = Rando::StaticData::GetItemName(RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_GREAT_FAIRY_ALT].randoItemId,
+                                                         true, RC_CLOCK_TOWN_GREAT_FAIRY_ALT);
 
-    auto& randoStaticItem2 = Rando::StaticData::Items[RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_GREAT_FAIRY_ALT].randoItemId];
-
-    if (!Ship_IsCStringEmpty(randoStaticItem2.article)) {
-        CustomMessage::Replace(&entry.msg, "{{article2}}", std::string(randoStaticItem2.article) + " ");
-    } else {
-        CustomMessage::Replace(&entry.msg, "{{article2}}", "");
-    }
-
-    CustomMessage::Replace(&entry.msg, "{{item2}}", randoStaticItem2.name);
+    CustomMessage::Replace(&entry.msg, "{{item2}}", randoItem2Name);
 
     CustomMessage::LoadCustomMessageIntoFont(entry);
     *loadFromMessageTable = false;
@@ -49,18 +39,11 @@ void ApplyClockTownGreatFairyHint(u16* textId, bool* loadFromMessageTable) {
 
 void ApplyGreatFairyHint(u16* textId, bool* loadFromMessageTable, RandoCheckId randoCheckId) {
     CustomMessage::Entry entry = {
-        .msg = "%wPlease, find the Stray Fairies who match our color! We will reward you with %g{{article}}{{item}}%w."
+        .msg = "%wPlease, find the Stray Fairies who match our color! We will reward you with %g{{itemName}}%w."
     };
-
-    auto& randoStaticItem = Rando::StaticData::Items[RANDO_SAVE_CHECKS[randoCheckId].randoItemId];
-
-    if (!Ship_IsCStringEmpty(randoStaticItem.article)) {
-        CustomMessage::Replace(&entry.msg, "{{article}}", std::string(randoStaticItem.article) + " ");
-    } else {
-        CustomMessage::Replace(&entry.msg, "{{article}}", "");
-    }
-
-    CustomMessage::Replace(&entry.msg, "{{item}}", randoStaticItem.name);
+    CustomMessage::Replace(
+        &entry.msg, "{{itemName}}",
+        Rando::StaticData::GetItemName(RANDO_SAVE_CHECKS[randoCheckId].randoItemId, true, randoCheckId));
 
     CustomMessage::LoadCustomMessageIntoFont(entry);
     *loadFromMessageTable = false;

--- a/mm/2s2h/Rando/ActorBehavior/EnElforg.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnElforg.cpp
@@ -30,7 +30,8 @@ void EnElforg_DrawCustom(Actor* thisx, PlayState* play) {
         return;
     }
 
-    Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, (RandoCheckId)CUSTOM_PARAM));
+    Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, (RandoCheckId)CUSTOM_PARAM),
+                    (RandoCheckId)CUSTOM_PARAM, thisx);
 }
 
 void EnElforg_Setup(EnElforg* enElforg) {

--- a/mm/2s2h/Rando/ActorBehavior/EnFish2.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnFish2.cpp
@@ -28,7 +28,8 @@ void Rando::ActorBehavior::InitEnFish2Behavior() {
                 auto& randoSaveCheck = RANDO_SAVE_CHECKS[CUSTOM_ITEM_PARAM];
                 RandoItemId randoItemId = Rando::ConvertItem(randoSaveCheck.randoItemId);
                 Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
-                Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, (RandoCheckId)CUSTOM_ITEM_PARAM), actor);
+                Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, (RandoCheckId)CUSTOM_ITEM_PARAM),
+                                (RandoCheckId)CUSTOM_ITEM_PARAM, actor);
             });
 
         CLEAR_WEEKEVENTREG(WEEKEVENTREG_81_10);

--- a/mm/2s2h/Rando/ActorBehavior/EnGamelupy.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnGamelupy.cpp
@@ -67,7 +67,8 @@ void Gamelupy_RandoDrawFunc(Actor* actor, PlayState* play) {
     auto randoSaveCheck = RANDO_SAVE_CHECKS[(RandoCheckId)actor->home.rot.x];
 
     Matrix_Scale(20.0f, 20.0f, 20.0f, MTXMODE_APPLY);
-    Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, (RandoCheckId)actor->home.rot.x), actor);
+    Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, (RandoCheckId)actor->home.rot.x),
+                    (RandoCheckId)actor->home.rot.x, actor);
 }
 
 void Rando::ActorBehavior::InitEnGamelupyBehavior() {

--- a/mm/2s2h/Rando/ActorBehavior/EnGb2.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnGb2.cpp
@@ -44,7 +44,8 @@ void Rando::ActorBehavior::InitEnGb2Behavior() {
         }
 
         std::string checkItemName =
-            Rando::StaticData::GetItemName(RANDO_SAVE_CHECKS[RC_IKANA_CANYON_GHOST_HUT_PIECE_OF_HEART].randoItemId);
+            Rando::StaticData::GetItemName(RANDO_SAVE_CHECKS[RC_IKANA_CANYON_GHOST_HUT_PIECE_OF_HEART].randoItemId,
+                                           true, RC_IKANA_CANYON_GHOST_HUT_PIECE_OF_HEART);
 
         auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
         entry.msg = "If you are seeking the one who is\n";

--- a/mm/2s2h/Rando/ActorBehavior/EnGeg.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnGeg.cpp
@@ -28,7 +28,8 @@ void Rando::ActorBehavior::InitEnGegBehavior() {
         RandoItemId randoItemId = RANDO_SAVE_CHECKS[RC_MOUNTAIN_VILLAGE_DON_GERO_MASK].randoItemId;
         entry.msg = "I could tell you really wanted %y{{itemName}}%w! I'm going back to Goron Village.\xE0";
 
-        CustomMessage::Replace(&entry.msg, "{{itemName}}", Rando::StaticData::GetItemName(randoItemId));
+        CustomMessage::Replace(&entry.msg, "{{itemName}}",
+                               Rando::StaticData::GetItemName(randoItemId, true, RC_MOUNTAIN_VILLAGE_DON_GERO_MASK));
         CustomMessage::LoadCustomMessageIntoFont(entry);
         *loadFromMessageTable = false;
     });

--- a/mm/2s2h/Rando/ActorBehavior/EnGirlA.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnGirlA.cpp
@@ -32,7 +32,7 @@ void EnGirlA_RandoDrawFunc(Actor* actor, PlayState* play) {
 
     Matrix_RotateYS(enGirlA->rotY, MTXMODE_APPLY);
 
-    Rando::DrawItem(randoSaveCheck.randoItemId, actor);
+    Rando::DrawItem(randoSaveCheck.randoItemId, (RandoCheckId)actor->world.rot.z, actor);
 }
 
 void EnGirlA_RandoBought(PlayState* play, EnGirlA* enGirlA) {
@@ -119,7 +119,9 @@ void renameStolenBombBag(u16* textId, bool* loadFromMessageTable) {
     auto randoStaticItem = Rando::StaticData::Items[randoSaveCheck.randoItemId];
     auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
     entry.msg = "Tonight's special, stolen from the Bomb Shop: %r{{itemName}}%w. Check it out!\x19\xA8";
-    CustomMessage::Replace(&entry.msg, "{{itemName}}", randoStaticItem.name);
+    CustomMessage::Replace(
+        &entry.msg, "{{itemName}}",
+        Rando::StaticData::GetItemName(randoSaveCheck.randoItemId, false, RC_BOMB_SHOP_ITEM_04_OR_CURIOSITY_SHOP_ITEM));
     CustomMessage::LoadCustomMessageIntoFont(entry);
     *loadFromMessageTable = false;
 }
@@ -129,7 +131,9 @@ void renameSpecialBargain(u16* textId, bool* loadFromMessageTable) {
     auto randoStaticItem = Rando::StaticData::Items[randoSaveCheck.randoItemId];
     auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
     entry.msg = "Tonight's bargain: %r{{itemName}}%w. Check it out!\x19\xA8";
-    CustomMessage::Replace(&entry.msg, "{{itemName}}", randoStaticItem.name);
+    CustomMessage::Replace(
+        &entry.msg, "{{itemName}}",
+        Rando::StaticData::GetItemName(randoSaveCheck.randoItemId, false, RC_CURIOSITY_SHOP_SPECIAL_ITEM));
     CustomMessage::LoadCustomMessageIntoFont(entry);
     *loadFromMessageTable = false;
 }
@@ -292,7 +296,8 @@ void Rando::ActorBehavior::InitEnGirlABehavior() {
         entry.autoFormat = false;
         entry.msg = "\x01{{itemName}}: {{rupees}} Rupees\x11\x00";
         entry.msg += '\x00';
-        CustomMessage::Replace(&entry.msg, "{{itemName}}", randoStaticItem.name);
+        CustomMessage::Replace(&entry.msg, "{{itemName}}",
+                               Rando::StaticData::GetItemName(randoSaveCheck.randoItemId, false, randoCheckId));
         CustomMessage::Replace(&entry.msg, "{{rupees}}", std::to_string(randoSaveCheck.price));
 
         if (!Rando::IsItemObtainable(randoSaveCheck.randoItemId, randoCheckId) && randoSaveCheck.obtained) {
@@ -322,7 +327,8 @@ void Rando::ActorBehavior::InitEnGirlABehavior() {
         entry.autoFormat = false;
         entry.firstItemCost = randoSaveCheck.price;
         entry.msg = "\x01{{itemName}}: {{rupees}} Rupees\x02\x11\xC2I'll buy it\x11No thanks\xBF";
-        CustomMessage::Replace(&entry.msg, "{{itemName}}", randoStaticItem.name);
+        CustomMessage::Replace(&entry.msg, "{{itemName}}",
+                               Rando::StaticData::GetItemName(randoSaveCheck.randoItemId, false, randoCheckId));
         CustomMessage::Replace(&entry.msg, "{{rupees}}", std::to_string(randoSaveCheck.price));
 
         CustomMessage::LoadCustomMessageIntoFont(entry);
@@ -347,7 +353,8 @@ void Rando::ActorBehavior::InitEnGirlABehavior() {
         entry.msg = "\x01{{itemName}}: {{itemPrice}} Rupees\x11\x00";
         entry.msg += '\x00';
         entry.msg += "I need a mushroom to make this.\x1A";
-        CustomMessage::Replace(&entry.msg, "{{itemName}}", randoStaticItem.name);
+        CustomMessage::Replace(&entry.msg, "{{itemName}}",
+                               Rando::StaticData::GetItemName(randoSaveCheck.randoItemId, false, randoCheckId));
         CustomMessage::Replace(&entry.msg, "{{itemPrice}}", std::to_string(randoSaveCheck.price));
         CustomMessage::LoadCustomMessageIntoFont(entry);
         *loadFromMessageTable = false;
@@ -364,7 +371,8 @@ void Rando::ActorBehavior::InitEnGirlABehavior() {
 
         auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
         entry.msg = "I used this to make %r{{itemName}}%w, take it!\x19";
-        CustomMessage::Replace(&entry.msg, "{{itemName}}", Rando::StaticData::GetItemName(randoSaveCheck.randoItemId));
+        CustomMessage::Replace(&entry.msg, "{{itemName}}",
+                               Rando::StaticData::GetItemName(randoSaveCheck.randoItemId, true, randoCheckId));
 
         // Mark the item as eligible for purchase
         randoSaveCheck.eligible = true;
@@ -389,7 +397,9 @@ void Rando::ActorBehavior::InitEnGirlABehavior() {
         auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
         entry.msg =
             "If nothing devastating happens to Mommy tonight, we should be able to sell %r{{itemName}}%w.\x19\xA8";
-        CustomMessage::Replace(&entry.msg, "{{itemName}}", Rando::StaticData::GetItemName(randoSaveCheck.randoItemId));
+        CustomMessage::Replace(&entry.msg, "{{itemName}}",
+                               Rando::StaticData::GetItemName(randoSaveCheck.randoItemId, true,
+                                                              RC_BOMB_SHOP_ITEM_04_OR_CURIOSITY_SHOP_ITEM));
         CustomMessage::LoadCustomMessageIntoFont(entry);
         *loadFromMessageTable = false;
     });
@@ -400,7 +410,9 @@ void Rando::ActorBehavior::InitEnGirlABehavior() {
         auto randoStaticItem = Rando::StaticData::Items[randoSaveCheck.randoItemId];
         auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
         entry.msg = "Thanks to a mishap, we did not receive our %r{{itemName}}%w stock. Maybe next time...\x19\xA8";
-        CustomMessage::Replace(&entry.msg, "{{itemName}}", randoStaticItem.name);
+        CustomMessage::Replace(&entry.msg, "{{itemName}}",
+                               Rando::StaticData::GetItemName(randoSaveCheck.randoItemId, true,
+                                                              RC_BOMB_SHOP_ITEM_04_OR_CURIOSITY_SHOP_ITEM));
         CustomMessage::LoadCustomMessageIntoFont(entry);
         *loadFromMessageTable = false;
     });
@@ -411,7 +423,9 @@ void Rando::ActorBehavior::InitEnGirlABehavior() {
 
         auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
         entry.msg = "It's over... Now we'll never sell %r{{itemName}}%w...\x19\xA8";
-        CustomMessage::Replace(&entry.msg, "{{itemName}}", Rando::StaticData::GetItemName(randoSaveCheck.randoItemId));
+        CustomMessage::Replace(&entry.msg, "{{itemName}}",
+                               Rando::StaticData::GetItemName(randoSaveCheck.randoItemId, true,
+                                                              RC_BOMB_SHOP_ITEM_04_OR_CURIOSITY_SHOP_ITEM));
 
         CustomMessage::LoadCustomMessageIntoFont(entry);
         *loadFromMessageTable = false;
@@ -424,7 +438,9 @@ void Rando::ActorBehavior::InitEnGirlABehavior() {
 
         auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
         entry.msg = "We just got some new stock: %r{{itemName}}%w.\x19\xA8";
-        CustomMessage::Replace(&entry.msg, "{{itemName}}", randoStaticItem.name);
+        CustomMessage::Replace(&entry.msg, "{{itemName}}",
+                               Rando::StaticData::GetItemName(randoSaveCheck.randoItemId, true,
+                                                              RC_BOMB_SHOP_ITEM_04_OR_CURIOSITY_SHOP_ITEM));
 
         CustomMessage::LoadCustomMessageIntoFont(entry);
         *loadFromMessageTable = false;

--- a/mm/2s2h/Rando/ActorBehavior/EnGo.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnGo.cpp
@@ -153,9 +153,9 @@ void Rando::ActorBehavior::InitEnGoBehavior() {
         entry.msg += "%g{randoItem}%w.";
         entry.msg += "\x19";
 
-        CustomMessage::Replace(
-            &entry.msg, "{randoItem}",
-            Rando::StaticData::GetItemName(RANDO_SAVE_CHECKS[RC_GORON_VILLAGE_MEDIGORON].randoItemId, true));
+        CustomMessage::Replace(&entry.msg, "{randoItem}",
+                               Rando::StaticData::GetItemName(RANDO_SAVE_CHECKS[RC_GORON_VILLAGE_MEDIGORON].randoItemId,
+                                                              true, RC_GORON_VILLAGE_MEDIGORON));
         CustomMessage::LoadCustomMessageIntoFont(entry);
         *loadFromMessageTable = false;
     });

--- a/mm/2s2h/Rando/ActorBehavior/EnGs.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnGs.cpp
@@ -94,7 +94,8 @@ void Rando::ActorBehavior::InitEnGsBehavior() {
 
             entry.msg = "They say %g{{item}}%w is hidden at %y{{location}}%w.";
 
-            CustomMessage::Replace(&entry.msg, "{{item}}", Rando::StaticData::GetItemName(saveCheck.randoItemId));
+            CustomMessage::Replace(&entry.msg, "{{item}}",
+                                   Rando::StaticData::GetItemName(saveCheck.randoItemId, true, randoCheckId));
             CustomMessage::Replace(&entry.msg, "{{location}}",
                                    Ship_GetSceneName(Rando::StaticData::Checks[randoCheckId].sceneId));
 
@@ -143,7 +144,7 @@ void Rando::ActorBehavior::InitEnGsBehavior() {
                     entry.msg = "Wise choice... They say %g{{item}}%w is hidden at %y{{location}}%w.";
 
                     CustomMessage::Replace(&entry.msg, "{{item}}",
-                                           Rando::StaticData::GetItemName(saveCheck.randoItemId));
+                                           Rando::StaticData::GetItemName(saveCheck.randoItemId, true, randoCheckId));
                     CustomMessage::Replace(&entry.msg, "{{location}}",
                                            Ship_GetSceneName(Rando::StaticData::Checks[randoCheckId].sceneId));
 

--- a/mm/2s2h/Rando/ActorBehavior/EnIn.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnIn.cpp
@@ -18,11 +18,11 @@ void EnIn_OnOpenPurchaseText(u16* textId, bool* loadFromMessageTable) {
 
     auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
 
-    entry.msg = "%p{{price}} Rupees%w will do ya for one %y{{item}}%w!\x11"
+    entry.msg = "%p{{price}} Rupees%w will do ya for %y{{item}}%w!\x11"
                 "\xC2%gYes\x11"
                 "No";
 
-    std::string itemName = Rando::StaticData::Items[riMilkPurchase].name;
+    std::string itemName = Rando::StaticData::GetItemName(riMilkPurchase, true, RC_GORMAN_MILK_PURCHASE);
     std::string itemPrice = std::to_string(milkPurchaseCheck.price);
 
     CustomMessage::ReplaceColorChars(&entry.msg);

--- a/mm/2s2h/Rando/ActorBehavior/EnItem00.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnItem00.cpp
@@ -46,7 +46,8 @@ EnItem00* spawnReplacementItem(Vec3f& pos, Rando::StaticData::RandoStaticCheck& 
         [](Actor* actor, PlayState* play) {
             auto& randoSaveCheck = RANDO_SAVE_CHECKS[CUSTOM_ITEM_PARAM];
             Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
-            Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, (RandoCheckId)CUSTOM_ITEM_PARAM), actor);
+            Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, (RandoCheckId)CUSTOM_ITEM_PARAM),
+                            (RandoCheckId)CUSTOM_ITEM_PARAM, actor);
         });
 }
 

--- a/mm/2s2h/Rando/ActorBehavior/EnJgameTsn.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnJgameTsn.cpp
@@ -31,9 +31,11 @@ void Rando::ActorBehavior::InitEnJgameTsnBehavior() {
         entry.msg =
             "Want to try my %rjumping game%w for %p20 Rupees%w? Win, and I'll give you %r{{itemName}}%w!\x19\xA8";
         // The same-cycle repeat reward is a purple Rupee
-        CustomMessage::Replace(
-            &entry.msg, "{{itemName}}",
-            randoSaveCheck.cycleObtained ? "50 Rupees" : Rando::StaticData::GetItemName(randoSaveCheck.randoItemId));
+        CustomMessage::Replace(&entry.msg, "{{itemName}}",
+                               randoSaveCheck.cycleObtained
+                                   ? "50 Rupees"
+                                   : Rando::StaticData::GetItemName(randoSaveCheck.randoItemId, true,
+                                                                    RC_GREAT_BAY_COAST_FISHERMAN_MINIGAME));
 
         CustomMessage::LoadCustomMessageIntoFont(entry);
         *loadFromMessageTable = false;

--- a/mm/2s2h/Rando/ActorBehavior/EnKgy.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnKgy.cpp
@@ -50,7 +50,8 @@ void Rando::ActorBehavior::InitEnKgyBehavior() {
             entry.msg = "\nIf you want %y{itemName}%w, it will cost you %p100 Rupees%w.\n\x10";
             entry.msg += "So, do we have a deal?\n\xC2%gI'll buy it\nNo thanks\xBF";
             CustomMessage::Replace(&entry.msg, "{itemName}",
-                                   Rando::StaticData::GetItemName(randoRazorSwordSaveCheck.randoItemId));
+                                   Rando::StaticData::GetItemName(randoRazorSwordSaveCheck.randoItemId, true,
+                                                                  RC_MOUNTAIN_VILLAGE_SMITHY_RAZOR_SWORD));
         }
 
         CustomMessage::LoadCustomMessageIntoFont(entry);
@@ -64,7 +65,8 @@ void Rando::ActorBehavior::InitEnKgyBehavior() {
 
         if (!RANDO_SAVE_CHECKS[RC_MOUNTAIN_VILLAGE_SMITHY_GILDED_SWORD].eligible) {
             itemName =
-                Rando::StaticData::GetItemName(RANDO_SAVE_CHECKS[RC_MOUNTAIN_VILLAGE_SMITHY_GILDED_SWORD].randoItemId);
+                Rando::StaticData::GetItemName(RANDO_SAVE_CHECKS[RC_MOUNTAIN_VILLAGE_SMITHY_GILDED_SWORD].randoItemId,
+                                               true, RC_MOUNTAIN_VILLAGE_SMITHY_GILDED_SWORD);
         }
         entry.msg = "Want to know a secret? If you bring me some gold dust, I can offer you %r{itemName}%w.\xE0";
         CustomMessage::Replace(&entry.msg, "{itemName}", itemName);

--- a/mm/2s2h/Rando/ActorBehavior/EnKujiya.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnKujiya.cpp
@@ -22,7 +22,8 @@ void Rando::ActorBehavior::InitEnKujiyaBehavior() {
         entry.msg = "Step right up! For a measly %p10 Rupees%w, your dreams could come true!\x11\x13\x12";
         entry.msg += "Guess all three numbers to win %p{{itemName}}%w!\x19";
         RandoItemId randoItemId = RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_WEST_LOTTERY].randoItemId;
-        CustomMessage::Replace(&entry.msg, "{{itemName}}", Rando::StaticData::GetItemName(randoItemId));
+        CustomMessage::Replace(&entry.msg, "{{itemName}}",
+                               Rando::StaticData::GetItemName(randoItemId, true, RC_CLOCK_TOWN_WEST_LOTTERY));
 
         CustomMessage::LoadCustomMessageIntoFont(entry);
         *loadFromMessageTable = false;
@@ -32,7 +33,8 @@ void Rando::ActorBehavior::InitEnKujiyaBehavior() {
         auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
         entry.msg = "Congratulations! You win the jackpot: %p{{itemName}}%w!\x19";
         RandoItemId randoItemId = RANDO_SAVE_CHECKS[RC_CLOCK_TOWN_WEST_LOTTERY].randoItemId;
-        CustomMessage::Replace(&entry.msg, "{{itemName}}", Rando::StaticData::GetItemName(randoItemId));
+        CustomMessage::Replace(&entry.msg, "{{itemName}}",
+                               Rando::StaticData::GetItemName(randoItemId, true, RC_CLOCK_TOWN_WEST_LOTTERY));
 
         CustomMessage::LoadCustomMessageIntoFont(entry);
         *loadFromMessageTable = false;

--- a/mm/2s2h/Rando/ActorBehavior/EnRuppecrow.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnRuppecrow.cpp
@@ -25,7 +25,8 @@ void Rando::ActorBehavior::InitEnRuppecrowBehavior() {
             [](Actor* actor, PlayState* play) {
                 auto& randoSaveCheck = RANDO_SAVE_CHECKS[CUSTOM_ITEM_PARAM];
                 Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
-                Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, (RandoCheckId)CUSTOM_ITEM_PARAM), actor);
+                Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, (RandoCheckId)CUSTOM_ITEM_PARAM),
+                                (RandoCheckId)CUSTOM_ITEM_PARAM, actor);
             });
 
         // Apply rupee drop heavy gravity

--- a/mm/2s2h/Rando/ActorBehavior/EnScopenuts.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnScopenuts.cpp
@@ -33,7 +33,8 @@ void Rando::ActorBehavior::InitEnScopenutsBehavior() {
         RandoItemId randoItemId = RANDO_SAVE_CHECKS[RC_TERMINA_FIELD_GROTTO_SCRUB].randoItemId;
         entry.msg = "Please! I'll sell you %y{{itemName}}%w if you just keep this place a secret...\xE0";
 
-        CustomMessage::Replace(&entry.msg, "{{itemName}}", Rando::StaticData::GetItemName(randoItemId));
+        CustomMessage::Replace(&entry.msg, "{{itemName}}",
+                               Rando::StaticData::GetItemName(randoItemId, true, RC_TERMINA_FIELD_GROTTO_SCRUB));
         CustomMessage::LoadCustomMessageIntoFont(entry);
         *loadFromMessageTable = false;
     });

--- a/mm/2s2h/Rando/ActorBehavior/EnSi.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnSi.cpp
@@ -19,7 +19,8 @@ void EnSi_DrawCustom(Actor* thisx, PlayState* play) {
 
     auto randoSaveCheck = RANDO_SAVE_CHECKS[randoStaticCheck.randoCheckId];
 
-    Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, randoStaticCheck.randoCheckId), thisx);
+    Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, randoStaticCheck.randoCheckId),
+                    randoStaticCheck.randoCheckId, thisx);
 }
 
 void Rando::ActorBehavior::InitEnSiBehavior() {

--- a/mm/2s2h/Rando/ActorBehavior/EnSob1.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnSob1.cpp
@@ -13,7 +13,7 @@ void EnSob1_DrawCustomItem(Actor* thisx, PlayState* play) {
     s16 rotX = (s16)((-90.0f / 180.0f) * 32768.0f);
     Matrix_RotateZYX(rotX, 0, 0, MTXMODE_APPLY);
 
-    Rando::DrawItem(randoSaveCheck.randoItemId);
+    Rando::DrawItem(randoSaveCheck.randoItemId, RC_BOMB_SHOP_ITEM_01, thisx);
 }
 
 static MtxF sLeftHandMtxF;

--- a/mm/2s2h/Rando/ActorBehavior/EnSsh.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnSsh.cpp
@@ -11,19 +11,13 @@ extern "C" {
 
 void ApplySwampSpiderHouseHint(u16* textId, bool* loadFromMessageTable) {
     CustomMessage::Entry entry = {
-        .msg = "Make me...normal again...I'll give you %g{{article}}{{item}}%w...Please...help me...\xE0",
+        .msg = "Make me...normal again...I'll give you %g{{itemName}}%w...Please...help me...\xE0",
     };
 
-    auto& randoStaticItem =
-        Rando::StaticData::Items[RANDO_SAVE_CHECKS[RC_SWAMP_SPIDER_HOUSE_MASK_OF_TRUTH].randoItemId];
-
-    if (!Ship_IsCStringEmpty(randoStaticItem.article)) {
-        CustomMessage::Replace(&entry.msg, "{{article}}", std::string(randoStaticItem.article) + " ");
-    } else {
-        CustomMessage::Replace(&entry.msg, "{{article}}", "");
-    }
-
-    CustomMessage::Replace(&entry.msg, "{{item}}", randoStaticItem.name);
+    CustomMessage::Replace(
+        &entry.msg, "{{item}}",
+        Rando::StaticData::GetItemName(RANDO_SAVE_CHECKS[RC_SWAMP_SPIDER_HOUSE_MASK_OF_TRUTH].randoItemId, true,
+                                       RC_SWAMP_SPIDER_HOUSE_MASK_OF_TRUTH));
 
     CustomMessage::LoadCustomMessageIntoFont(entry);
     *loadFromMessageTable = false;
@@ -34,15 +28,9 @@ void ApplyOceanSpiderHouseHint(u16* textId, bool* loadFromMessageTable) {
         .msg = "Huh? How'd I get up here... Why do I have %g{{article}}{{item}}%w in my pocket...?\xE0",
     };
 
-    auto& randoStaticItem = Rando::StaticData::Items[RANDO_SAVE_CHECKS[RC_OCEAN_SPIDER_HOUSE_WALLET].randoItemId];
-
-    if (!Ship_IsCStringEmpty(randoStaticItem.article)) {
-        CustomMessage::Replace(&entry.msg, "{{article}}", std::string(randoStaticItem.article) + " ");
-    } else {
-        CustomMessage::Replace(&entry.msg, "{{article}}", "");
-    }
-
-    CustomMessage::Replace(&entry.msg, "{{item}}", randoStaticItem.name);
+    CustomMessage::Replace(&entry.msg, "{{item}}",
+                           Rando::StaticData::GetItemName(RANDO_SAVE_CHECKS[RC_OCEAN_SPIDER_HOUSE_WALLET].randoItemId,
+                                                          false, RC_OCEAN_SPIDER_HOUSE_WALLET));
 
     CustomMessage::LoadCustomMessageIntoFont(entry);
     *loadFromMessageTable = false;

--- a/mm/2s2h/Rando/ActorBehavior/EnTab.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnTab.cpp
@@ -36,14 +36,14 @@ void EnTab_OnOpenShopText(u16* textId, bool* loadFromMessageTable) {
     std::string itemName1 = "Milk";
     std::string itemPrice1 = "20";
     if (!milkPurchaseCheck.cycleObtained) {
-        itemName1 = Rando::StaticData::Items[riMilkPurchase].name;
+        itemName1 = Rando::StaticData::GetItemName(riMilkPurchase, false, RC_MILK_BAR_PURCHASE_MILK);
         itemPrice1 = std::to_string(milkPurchaseCheck.price);
     }
 
     std::string itemName2 = "Chateau Romani";
     std::string itemPrice2 = "200";
     if (!chateauPurchaseCheck.cycleObtained) {
-        itemName2 = Rando::StaticData::Items[riChateauPurchase].name;
+        itemName2 = Rando::StaticData::GetItemName(riChateauPurchase, false, RC_MILK_BAR_PURCHASE_CHATEAU);
         itemPrice2 = std::to_string(chateauPurchaseCheck.price);
     }
 

--- a/mm/2s2h/Rando/ActorBehavior/EnemyDrops.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnemyDrops.cpp
@@ -98,7 +98,8 @@ void SpawnDropItem(Vec3f position, RandoCheckId randoCheckId) {
             auto& randoSaveCheck = RANDO_SAVE_CHECKS[CUSTOM_ITEM_PARAM];
             RandoItemId randoItemId = Rando::ConvertItem(randoSaveCheck.randoItemId);
             Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
-            Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, (RandoCheckId)CUSTOM_ITEM_PARAM), actor);
+            Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, (RandoCheckId)CUSTOM_ITEM_PARAM),
+                            (RandoCheckId)CUSTOM_ITEM_PARAM, actor);
         });
 }
 
@@ -220,7 +221,7 @@ void Rando::ActorBehavior::InitEnemyDropBehavior() {
             EnSlime* slime = va_arg(args, EnSlime*);
             Matrix_RotateYS(slime->actor.shape.rot.y, MTXMODE_APPLY);
             Matrix_Scale(0.25f, 0.25f, 0.25f, MTXMODE_APPLY);
-            Rando::DrawItem(randoItemId);
+            Rando::DrawItem(randoItemId, RC_ENEMY_DROP_CHUCHU, (Actor*)&slime->actor);
 
             *should = false;
         }

--- a/mm/2s2h/Rando/ActorBehavior/ItemBHeart.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ItemBHeart.cpp
@@ -17,7 +17,8 @@ void ItemBHeart_DrawCustom(Actor* thisx, PlayState* play) {
 
     auto randoSaveCheck = RANDO_SAVE_CHECKS[randoStaticCheck.randoCheckId];
 
-    Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, randoStaticCheck.randoCheckId), thisx);
+    Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, randoStaticCheck.randoCheckId),
+                    randoStaticCheck.randoCheckId, thisx);
 }
 
 void ItemBHeart_UpdateCustom(Actor* thisx, PlayState* play) {

--- a/mm/2s2h/Rando/ActorBehavior/ObjGrass.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ObjGrass.cpp
@@ -154,7 +154,8 @@ void SpawnGrassDrop(Vec3f pos, RandoCheckId randoCheckId) {
             auto& randoSaveCheck = RANDO_SAVE_CHECKS[CUSTOM_ITEM_PARAM];
             RandoItemId randoItemId = Rando::ConvertItem(randoSaveCheck.randoItemId);
             Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
-            Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, (RandoCheckId)CUSTOM_ITEM_PARAM), actor);
+            Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, (RandoCheckId)CUSTOM_ITEM_PARAM),
+                            (RandoCheckId)CUSTOM_ITEM_PARAM, actor);
         });
 }
 

--- a/mm/2s2h/Rando/ActorBehavior/ObjKibako.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ObjKibako.cpp
@@ -271,7 +271,8 @@ void Rando::ActorBehavior::InitObjKibakoBehavior() {
             [](Actor* actor, PlayState* play) {
                 auto& randoSaveCheck = RANDO_SAVE_CHECKS[CUSTOM_ITEM_PARAM];
                 Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
-                Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, (RandoCheckId)CUSTOM_ITEM_PARAM), actor);
+                Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, (RandoCheckId)CUSTOM_ITEM_PARAM),
+                                (RandoCheckId)CUSTOM_ITEM_PARAM, actor);
             });
     });
 }

--- a/mm/2s2h/Rando/ActorBehavior/ObjMoonStone.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ObjMoonStone.cpp
@@ -18,9 +18,9 @@ void ObjMoonstone_DrawCustom(Actor* thisx, PlayState* play) {
     // When not in Astral Observatory, allow the item to convert and render with particles
     if (play->sceneId != SCENE_TENMON_DAI) {
         randoItemId = Rando::ConvertItem(randoSaveCheck.randoItemId, RC_ASTRAL_OBSERVATORY_MOON_TEAR);
-        Rando::DrawItem(randoItemId, thisx);
+        Rando::DrawItem(randoItemId, RC_ASTRAL_OBSERVATORY_MOON_TEAR, thisx);
     } else {
-        Rando::DrawItem(randoItemId);
+        Rando::DrawItem(randoItemId, RC_ASTRAL_OBSERVATORY_MOON_TEAR, thisx);
     }
 }
 

--- a/mm/2s2h/Rando/ActorBehavior/ObjSnowball.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ObjSnowball.cpp
@@ -213,7 +213,8 @@ void SpawnSnowballDrop(Vec3f pos, RandoCheckId randoCheckId) {
         [](Actor* actor, PlayState* play) {
             auto& randoSaveCheck = RANDO_SAVE_CHECKS[CUSTOM_ITEM_PARAM];
             Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
-            Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, (RandoCheckId)CUSTOM_ITEM_PARAM), actor);
+            Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, (RandoCheckId)CUSTOM_ITEM_PARAM),
+                            (RandoCheckId)CUSTOM_ITEM_PARAM, actor);
         });
 }
 

--- a/mm/2s2h/Rando/ActorBehavior/ObjTaru.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ObjTaru.cpp
@@ -150,7 +150,8 @@ void Rando::ActorBehavior::InitObjTaruBehavior() {
             [](Actor* actor, PlayState* play) {
                 auto& randoSaveCheck = RANDO_SAVE_CHECKS[CUSTOM_ITEM_PARAM];
                 Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
-                Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, (RandoCheckId)CUSTOM_ITEM_PARAM), actor);
+                Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, (RandoCheckId)CUSTOM_ITEM_PARAM),
+                                (RandoCheckId)CUSTOM_ITEM_PARAM, actor);
             });
     });
 }

--- a/mm/2s2h/Rando/ActorBehavior/ObjTsubo.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ObjTsubo.cpp
@@ -406,7 +406,8 @@ void Rando::ActorBehavior::InitObjTsuboBehavior() {
                 auto& randoSaveCheck = RANDO_SAVE_CHECKS[CUSTOM_ITEM_PARAM];
                 RandoItemId randoItemId = Rando::ConvertItem(randoSaveCheck.randoItemId);
                 Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
-                Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, (RandoCheckId)CUSTOM_ITEM_PARAM), actor);
+                Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, (RandoCheckId)CUSTOM_ITEM_PARAM),
+                                (RandoCheckId)CUSTOM_ITEM_PARAM, actor);
             });
         *should = false;
 

--- a/mm/2s2h/Rando/ConvertItem.cpp
+++ b/mm/2s2h/Rando/ConvertItem.cpp
@@ -2,6 +2,7 @@
 #include "Rando/ActorBehavior/Souls.h"
 #include "Rando/MiscBehavior/ClockShuffle.h"
 #include "2s2h/ShipUtils.h"
+#include "2s2h/ShipInit.hpp"
 #include <cassert>
 
 // Copied from z_player.c, we could instead move this to a header file, idk
@@ -51,9 +52,8 @@ extern GetItemEntry sGetItemTable[GI_MAX - 1];
 // obtain it. If not, we convert it to a junk item.
 //
 // Junk Items:
-// - The list of junk items is defined below. We attempt to roll a random junk item one time, based on the RC provided,
-// and if we fail, we return a blue rupee. This will still result in the "lots of blue rupees" problem, but it's better
-// than _always_ converting to a blue rupee.
+// - The list of junk items is defined below. Every 1.5 seconds we roll a random junk item, based on the RC provided and
+// the current obtainability status of all junk items. The user can also opt out of the timed cycling.
 
 static std::vector<RandoItemId> junkItems = {
     // Rupees
@@ -78,23 +78,94 @@ static std::vector<RandoItemId> junkItems = {
     RI_NONE,
 };
 
-// Pick a random junk item every second
-RandoItemId Rando::CurrentJunkItem() {
-    static RandoItemId lastJunkItem = RI_UNKNOWN;
-    static u32 lastChosenAt = 0;
-    if (gPlayState != NULL && ABS(gPlayState->gameplayFrames - lastChosenAt) > 20) {
-        lastChosenAt = gPlayState->gameplayFrames;
-        lastJunkItem = RI_UNKNOWN;
-    }
+static std::vector<RandoItemId> obtainableJunkItems;
+static std::vector<RandoItemId> obtainableTrapItems;
 
-    while (lastJunkItem == RI_UNKNOWN) {
-        RandoItemId randJunkItem = junkItems[rand() % junkItems.size()];
-        if (Rando::IsItemObtainable(randJunkItem)) {
-            lastJunkItem = randJunkItem;
+void RefreshObtainableJunkItems() {
+    obtainableJunkItems.clear();
+
+    for (RandoItemId junkItem : junkItems) {
+        if (Rando::IsItemObtainable(junkItem)) {
+            switch (junkItem) {
+                case RI_ARROWS_10:
+                    if (AMMO(ITEM_BOW) < CUR_CAPACITY(UPG_QUIVER)) {
+                        obtainableJunkItems.push_back(junkItem);
+                    }
+                    break;
+                case RI_BOMBCHU_5:
+                    if (AMMO(ITEM_BOMBCHU) < CUR_CAPACITY(UPG_BOMB_BAG)) {
+                        obtainableJunkItems.push_back(junkItem);
+                    }
+                    break;
+                case RI_BOMBS_5:
+                    if (AMMO(ITEM_BOMB) < CUR_CAPACITY(UPG_BOMB_BAG)) {
+                        obtainableJunkItems.push_back(junkItem);
+                    }
+                    break;
+                case RI_DEKU_NUTS_5:
+                    if (AMMO(ITEM_DEKU_NUT) < CUR_CAPACITY(UPG_DEKU_NUTS)) {
+                        obtainableJunkItems.push_back(junkItem);
+                    }
+                    break;
+                case RI_DEKU_STICKS_5:
+                    if (AMMO(ITEM_DEKU_STICK) < CUR_CAPACITY(UPG_DEKU_STICKS)) {
+                        obtainableJunkItems.push_back(junkItem);
+                    }
+                    break;
+                case RI_MAGIC_JAR_SMALL:
+                    if (gSaveContext.save.saveInfo.playerData.magic < gSaveContext.magicCapacity) {
+                        obtainableJunkItems.push_back(junkItem);
+                    }
+                    break;
+                default:
+                    obtainableJunkItems.push_back(junkItem);
+                    break;
+            }
         }
     }
+}
 
-    return lastJunkItem;
+void RefreshObtainableTrapItems() {
+    obtainableTrapItems.clear();
+
+    for (auto& [randoCheckId, _] : Rando::StaticData::Checks) {
+        RandoSaveCheck saveCheck = RANDO_SAVE_CHECKS[randoCheckId];
+        if (saveCheck.shuffled && !saveCheck.obtained &&
+            (Rando::StaticData::Items[saveCheck.randoItemId].randoItemType == RITYPE_MAJOR ||
+             Rando::StaticData::Items[saveCheck.randoItemId].randoItemType == RITYPE_MASK)) {
+            obtainableTrapItems.push_back(saveCheck.randoItemId);
+        }
+    }
+}
+
+static RegisterShipInitFunc refreshInitFunc(
+    []() {
+        COND_HOOK(OnSceneInit, IS_RANDO, [](s8 sceneId, s8 spawnNum) {
+            RefreshObtainableJunkItems();
+            RefreshObtainableTrapItems();
+        });
+    },
+    { "IS_RANDO" });
+
+RandoItemId Rando::CurrentJunkItem(RandoCheckId randoCheckId) {
+    if (CVarGetInteger("gRando.JunkItems", 0) == 0) {
+        Ship_Random_Seed(gSaveContext.save.shipSaveInfo.rando.finalSeed + randoCheckId +
+                         (gPlayState->gameplayFrames / 30));
+        return obtainableJunkItems[Ship_Random(0, obtainableJunkItems.size() - 1)];
+    } else {
+        Ship_Random_Seed(gSaveContext.save.shipSaveInfo.rando.finalSeed + randoCheckId);
+        return obtainableJunkItems[Ship_Random(0, obtainableJunkItems.size() - 1)];
+    }
+}
+
+RandoItemId Rando::CurrentTrapItem(RandoCheckId randoCheckId) {
+    if (obtainableTrapItems.size() == 0) {
+        return RI_RUPEE_SILVER;
+    }
+
+    Ship_Random_Seed(gSaveContext.save.shipSaveInfo.rando.finalSeed + randoCheckId);
+
+    return obtainableTrapItems[Ship_Random(0, obtainableTrapItems.size() - 1)];
 }
 
 bool Rando::IsItemObtainable(RandoItemId randoItemId, RandoCheckId randoCheckId) {

--- a/mm/2s2h/Rando/DrawItem.cpp
+++ b/mm/2s2h/Rando/DrawItem.cpp
@@ -311,52 +311,6 @@ void DrawTrapModel() {
     CLOSE_DISPS(gPlayState->state.gfxCtx);
 }
 
-void DrawRandomTrapModel(RandoItemId randoItemId, Actor* actor) {
-    uint32_t seed = gSaveContext.save.shipSaveInfo.rando.finalSeed / 100000;
-    int actorData = (int)gPlayState->sceneId + seed;
-
-    if (actor != NULL) {
-        actorData += abs(actor->home.pos.x + actor->home.pos.y + actor->params);
-    }
-
-    int drawRandoItemId = actorData % ((int)RI_MAX - 3);
-
-    if (drawRandoItemId == RI_UNKNOWN || drawRandoItemId >= RI_TRAP) {
-        drawRandoItemId++;
-    }
-
-    // Handle Progressive Items
-    switch (drawRandoItemId) {
-        case RI_BOMB_BAG_20:
-        case RI_BOMB_BAG_30:
-        case RI_BOMB_BAG_40:
-            drawRandoItemId = RI_PROGRESSIVE_BOMB_BAG;
-            break;
-        case RI_BOW:
-        case RI_QUIVER_40:
-        case RI_QUIVER_50:
-            drawRandoItemId = RI_PROGRESSIVE_BOW;
-            break;
-        case RI_SINGLE_MAGIC:
-        case RI_DOUBLE_MAGIC:
-            drawRandoItemId = RI_PROGRESSIVE_MAGIC;
-            break;
-        case RI_SWORD_GILDED:
-        case RI_SWORD_KOKIRI:
-        case RI_SWORD_RAZOR:
-            drawRandoItemId = RI_PROGRESSIVE_SWORD;
-            break;
-        case RI_WALLET_ADULT:
-        case RI_WALLET_GIANT:
-            drawRandoItemId = RI_PROGRESSIVE_WALLET;
-            break;
-        default:
-            break;
-    }
-
-    Rando::DrawItem((RandoItemId)drawRandoItemId, actor);
-}
-
 void DrawTriforcePiece(RandoItemId randoItemId) {
     Gfx* triforcePieceModels[3] = {
         (Gfx*)gTriforcePiece0DL,
@@ -505,7 +459,7 @@ void DrawSparkles(RandoItemId randoItemId, Actor* actor) {
     EffectSsKirakira_SpawnDispersed(gPlayState, &newPos, &sVelocity, &sAccel, &sPrimColor, &sEnvColor, 2000, 16);
 }
 
-void Rando::DrawItem(RandoItemId randoItemId, Actor* actor) {
+void Rando::DrawItem(RandoItemId randoItemId, RandoCheckId randoCheckId, Actor* actor) {
     // Apply hilites with actor world pos before drawing
     if (actor != NULL) {
         func_800B8118(actor, gPlayState, 0);
@@ -514,7 +468,7 @@ void Rando::DrawItem(RandoItemId randoItemId, Actor* actor) {
 
     switch (randoItemId) {
         case RI_JUNK:
-            Rando::DrawItem(Rando::CurrentJunkItem(), actor);
+            Rando::DrawItem(Rando::CurrentJunkItem(randoCheckId), randoCheckId, actor);
             break;
         case RI_GREAT_BAY_SMALL_KEY:
         case RI_SNOWHEAD_SMALL_KEY:
@@ -586,7 +540,7 @@ void Rando::DrawItem(RandoItemId randoItemId, Actor* actor) {
         case RI_PROGRESSIVE_BOMB_BAG:
         case RI_PROGRESSIVE_SWORD:
         case RI_PROGRESSIVE_WALLET:
-            Rando::DrawItem(Rando::ConvertItem(randoItemId), actor);
+            Rando::DrawItem(Rando::ConvertItem(randoItemId, randoCheckId), randoCheckId, actor);
             break;
         case RI_SOUL_ENEMY_ALIEN:
         case RI_SOUL_ENEMY_ARMOS:
@@ -666,7 +620,7 @@ void Rando::DrawItem(RandoItemId randoItemId, Actor* actor) {
             DrawTriforcePiece(randoItemId);
             break;
         case RI_TRAP:
-            DrawRandomTrapModel(randoItemId, actor);
+            Rando::DrawItem(Rando::CurrentTrapItem(randoCheckId), randoCheckId, actor);
             break;
         case RI_MAX_TRAP:
             DrawTrapModel();

--- a/mm/2s2h/Rando/Menu.cpp
+++ b/mm/2s2h/Rando/Menu.cpp
@@ -36,6 +36,11 @@ std::unordered_map<int32_t, const char*> accessTrialsOptions = {
     { RO_ACCESS_TRIALS_OPEN, "Open" },
 };
 
+std::unordered_map<int32_t, const char*> junkItemsOptions = {
+    { 0, "Default (Cycle)" },
+    { 1, "Static" },
+};
+
 // clang-format off
 std::vector<int32_t> incompatibleWithVanilla = {
     RO_SHUFFLE_BOSS_SOULS,
@@ -303,9 +308,19 @@ static void DrawGeneralTab() {
     }
 
     ImGui::SeparatorText("Enhancements");
-    UIWidgets::CVarCheckbox("Container Style Matches Contents", "gRando.CSMC");
-    UIWidgets::Tooltip("This will make the contents of a container match the container itself. This currently only "
-                       "applies to chests and pots.");
+    UIWidgets::CVarCheckbox(
+        "Container Style Matches Contents", "gRando.CSMC",
+        UIWidgets::CheckboxOptions().Tooltip("This will make the contents of a container match the container itself. "
+                                             "Eg chests, pots, crates, grass, etc."));
+    UIWidgets::CVarCombobox(
+        "Junk Items", "gRando.JunkItems", &junkItemsOptions,
+        UIWidgets::ComboboxOptions()
+            .ComponentAlignment(UIWidgets::ComponentAlignment::Right)
+            .LabelPosition(UIWidgets::LabelPosition::Near)
+            .Tooltip(
+                "Note: For both Options, junk items will be randomly rolled from a pool of obtainable "
+                "items.\n\nDefault (Cycle): Junk items will cycle every few seconds, allowing you to choose which item "
+                "to pick up\n\nStatic: Junk items will be static, only changing when obtainability status changes."));
     UIWidgets::WindowButton("Check Tracker", "gWindows.CheckTracker", BenGui::mRandoCheckTrackerWindow,
                             { .size = ImVec2((ImGui::GetContentRegionAvail().x - 48.0f), 40.0f) });
     ImGui::SameLine();
@@ -587,6 +602,16 @@ static void DrawItemsTab() {
     CVarCheckbox(
         "Time Traps", "gRando.Traps.Time",
         CheckboxOptions({ { .tooltip = "Advances Time 90 Minutes (Game Time).",
+                            .disabled = (bool)!CVarGetInteger(Rando::StaticData::Options[RO_SHUFFLE_TRAPS].cvar, 0),
+                            .disabledTooltip = "Shuffle Traps is disabled." } }));
+    CVarCheckbox(
+        "Fire Traps", "gRando.Traps.Fire",
+        CheckboxOptions({ { .tooltip = "Deals Fire to Link.",
+                            .disabled = (bool)!CVarGetInteger(Rando::StaticData::Options[RO_SHUFFLE_TRAPS].cvar, 0),
+                            .disabledTooltip = "Shuffle Traps is disabled." } }));
+    CVarCheckbox(
+        "Knockback Traps", "gRando.Traps.Knockback",
+        CheckboxOptions({ { .tooltip = "Knocks Link back.",
                             .disabled = (bool)!CVarGetInteger(Rando::StaticData::Options[RO_SHUFFLE_TRAPS].cvar, 0),
                             .disabledTooltip = "Shuffle Traps is disabled." } }));
     ImGui::EndChild();

--- a/mm/2s2h/Rando/MiscBehavior/CheckQueue.cpp
+++ b/mm/2s2h/Rando/MiscBehavior/CheckQueue.cpp
@@ -47,10 +47,11 @@ void Rando::MiscBehavior::CheckQueue() {
                         RandoItemId randoItemId =
                             Rando::ConvertItem(randoSaveCheck.randoItemId, (RandoCheckId)CUSTOM_ITEM_PARAM);
                         std::string prefix = "You found";
-                        std::string message = Rando::StaticData::GetItemName(randoItemId);
+                        std::string message =
+                            Rando::StaticData::GetItemName(randoItemId, true, (RandoCheckId)CUSTOM_ITEM_PARAM);
 
                         if (randoItemId == RI_JUNK) {
-                            randoItemId = Rando::CurrentJunkItem();
+                            randoItemId = Rando::CurrentJunkItem((RandoCheckId)CUSTOM_ITEM_PARAM);
                         }
                         if (randoItemId == RI_TRIFORCE_PIECE) {
                             if (gSaveContext.save.shipSaveInfo.rando.foundTriforcePieces + 1 >=
@@ -115,7 +116,7 @@ void Rando::MiscBehavior::CheckQueue() {
                         }
 
                         Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
-                        Rando::DrawItem(randoItemId);
+                        Rando::DrawItem(randoItemId, (RandoCheckId)CUSTOM_ITEM_PARAM, actor);
                     } });
             return;
         }

--- a/mm/2s2h/Rando/MiscBehavior/Traps.cpp
+++ b/mm/2s2h/Rando/MiscBehavior/Traps.cpp
@@ -20,10 +20,11 @@ int roll = TRAP_FREEZE;
 const u16 timeSkipInterval = 4000;
 
 std::map<TrapTypes, const char*> trapToCvarMap = {
-    { TRAP_FREEZE, "gRando.Traps.Freeze" }, { TRAP_BLAST, "gRando.Traps.Blast" },
-    { TRAP_SHOCK, "gRando.Traps.Shock" },   { TRAP_JINX, "gRando.Traps.Jinx" },
-    { TRAP_WALLET, "gRando.Traps.Wallet" }, { TRAP_ENEMY, "gRando.Traps.Enemy" },
-    { TRAP_TIME, "gRando.Traps.Time" },
+    { TRAP_FREEZE, "gRando.Traps.Freeze" },      { TRAP_BLAST, "gRando.Traps.Blast" },
+    { TRAP_SHOCK, "gRando.Traps.Shock" },        { TRAP_JINX, "gRando.Traps.Jinx" },
+    { TRAP_WALLET, "gRando.Traps.Wallet" },      { TRAP_ENEMY, "gRando.Traps.Enemy" },
+    { TRAP_TIME, "gRando.Traps.Time" },          { TRAP_FIRE, "gRando.Traps.Fire" },
+    { TRAP_KNOCKBACK, "gRando.Traps.Knockback" }
 };
 
 std::vector<TrapTypes> getEnabledTrapTypes() {
@@ -126,6 +127,8 @@ std::map<TrapTypes, std::vector<std::string>> trapMessageList = {
     { TRAP_WALLET, walletTrapMessages },
     { TRAP_ENEMY, enemyTrapMessages },
     { TRAP_TIME, timeTrapMessages },
+    { TRAP_FIRE, defaultTrapMessages },
+    { TRAP_KNOCKBACK, defaultTrapMessages },
 };
 // clang-format on
 
@@ -151,14 +154,52 @@ void Rando::MiscBehavior::OfferTrapItem() {
             break;
         case TRAP_BLAST:
             GameInteractor::Instance->events.emplace_back(GIEventTrap{ .action = []() {
+                GET_PLAYER(gPlayState)->actor.colChkInfo.damage = 16;
+                func_80833B18(gPlayState, GET_PLAYER(gPlayState), 2, 0, 0, 0, 0);
                 Actor_Spawn(&gPlayState->actorCtx, gPlayState, ACTOR_EN_BOM, GET_PLAYER(gPlayState)->actor.world.pos.x,
                             GET_PLAYER(gPlayState)->actor.world.pos.y, GET_PLAYER(gPlayState)->actor.world.pos.z, 1, 0,
                             0, 0);
             } });
             break;
         case TRAP_SHOCK:
-            GameInteractor::Instance->events.emplace_back(
-                GIEventTrap{ .action = []() { func_80833B18(gPlayState, GET_PLAYER(gPlayState), 4, 0, 0, 0, 0); } });
+            GameInteractor::Instance->events.emplace_back(GIEventTrap{ .action = []() {
+                GET_PLAYER(gPlayState)->actor.colChkInfo.damage = 16;
+                func_80833B18(gPlayState, GET_PLAYER(gPlayState), 4, 0, 0, 0, 0);
+            } });
+            break;
+        case TRAP_FIRE:
+            GameInteractor::Instance->events.emplace_back(GIEventTrap{ .action = []() {
+                Player* player = GET_PLAYER(gPlayState);
+                for (int i = 0; i < 18; i++) {
+                    player->bodyFlameTimers[i] = static_cast<uint8_t>(Rand_S16Offset(0, 200));
+                }
+                player->bodyIsBurning = true;
+                func_80833B18(gPlayState, player, 0, 0, 0, 0, 0);
+            } });
+            break;
+        case TRAP_KNOCKBACK:
+            GameInteractor::Instance->events.emplace_back(GIEventTrap{ .action = []() {
+                Player* player = GET_PLAYER(gPlayState);
+                float strength = 4;
+                func_800B8D98(gPlayState, &player->actor, strength * 5, player->actor.world.rot.y + 0x8000,
+                              strength * 5);
+
+                static HOOK_ID knockbackBounceHook = 0;
+                GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::OnActorUpdate>(knockbackBounceHook);
+                knockbackBounceHook = GameInteractor::Instance->RegisterGameHookForID<GameInteractor::OnActorUpdate>(
+                    ACTOR_PLAYER, [](Actor* actor) {
+                        Player* player = (Player*)actor;
+                        if (player->actor.bgCheckFlags & 0x08 && abs(player->speedXZ) > 15.0f) {
+                            player->yaw = ((player->actor.wallYaw - player->yaw) + player->actor.wallYaw) - 0x8000;
+                            Player_PlaySfx(player, NA_SE_PL_BODY_HIT);
+                        }
+
+                        if (player->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
+                            GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::OnActorUpdate>(
+                                knockbackBounceHook);
+                        }
+                    });
+            } });
             break;
         case TRAP_JINX:
             GameInteractor::Instance->events.emplace_back(GIEventTrap{ .action = []() {

--- a/mm/2s2h/Rando/MiscBehavior/Traps.h
+++ b/mm/2s2h/Rando/MiscBehavior/Traps.h
@@ -2,7 +2,18 @@
 #define RANDO_TRAP_H
 
 #include "Rando/Rando.h"
-typedef enum { TRAP_FREEZE, TRAP_BLAST, TRAP_SHOCK, TRAP_JINX, TRAP_WALLET, TRAP_ENEMY, TRAP_TIME, TRAP_MAX } TrapTypes;
+typedef enum {
+    TRAP_FREEZE,
+    TRAP_BLAST,
+    TRAP_SHOCK,
+    TRAP_JINX,
+    TRAP_WALLET,
+    TRAP_ENEMY,
+    TRAP_TIME,
+    TRAP_FIRE,
+    TRAP_KNOCKBACK,
+    TRAP_MAX
+} TrapTypes;
 
 extern int RollTrapType();
 extern std::string GetTrapMessage();

--- a/mm/2s2h/Rando/Rando.h
+++ b/mm/2s2h/Rando/Rando.h
@@ -13,10 +13,11 @@
 namespace Rando {
 
 void Init();
-void DrawItem(RandoItemId randoItemId, Actor* actor = nullptr);
+void DrawItem(RandoItemId randoItemId, RandoCheckId randoCheckId = RC_UNKNOWN, Actor* actor = nullptr);
 void GiveItem(RandoItemId randoItemId);
 void RemoveItem(RandoItemId randoItemId);
-RandoItemId CurrentJunkItem();
+RandoItemId CurrentJunkItem(RandoCheckId randoCheckId = RC_UNKNOWN);
+RandoItemId CurrentTrapItem(RandoCheckId randoCheckId = RC_UNKNOWN);
 bool IsItemObtainable(RandoItemId randoItemId, RandoCheckId randoCheckId = RC_UNKNOWN);
 RandoItemId ConvertItem(RandoItemId randoItemId, RandoCheckId randoCheckId = RC_UNKNOWN);
 RandoCheckId FindItemPlacement(RandoItemId randoItemId);

--- a/mm/2s2h/Rando/StaticData/Items.cpp
+++ b/mm/2s2h/Rando/StaticData/Items.cpp
@@ -520,7 +520,7 @@ bool ShouldShowGetItemCutscene(RandoItemId itemId) {
     }
 }
 
-std::string GetItemName(RandoItemId randoItemId, bool includeArticle) {
+std::string GetItemName(RandoItemId randoItemId, bool includeArticle, RandoCheckId randoCheckId) {
     std::string result;
 
     if (includeArticle && !Ship_IsCStringEmpty(Rando::StaticData::Items[randoItemId].article)) {
@@ -530,8 +530,28 @@ std::string GetItemName(RandoItemId randoItemId, bool includeArticle) {
 
     result += Rando::StaticData::Items[randoItemId].name;
 
-    if (randoItemId == RI_JUNK) {
-        result += std::string(" (") + Rando::StaticData::Items[Rando::CurrentJunkItem()].name + ")";
+    if (randoItemId == RI_JUNK && (randoCheckId == RC_UNKNOWN ||
+                                   (Rando::StaticData::Checks[randoCheckId].randoCheckType != RCTYPE_SHOP &&
+                                    Rando::StaticData::Checks[randoCheckId].randoCheckType != RCTYPE_TINGLE_SHOP))) {
+        result += std::string(" (") + Rando::StaticData::Items[Rando::CurrentJunkItem(randoCheckId)].name + ")";
+    }
+
+    if (randoItemId == RI_TRAP && randoCheckId != RC_UNKNOWN) {
+        // Get the name of the trapped item
+        RandoItemId trappedItemId = Rando::CurrentTrapItem(randoCheckId);
+        std::string fakeItemName = GetItemName(trappedItemId, false);
+        // Pick a random letter in the item name, and double it to fool the player
+        auto letterIndex = Ship_Random(0, fakeItemName.length() - 1);
+        char letterToDouble = fakeItemName[letterIndex];
+        fakeItemName.insert(letterIndex, 1, letterToDouble);
+        result.clear();
+
+        if (includeArticle && !Ship_IsCStringEmpty(Rando::StaticData::Items[randoItemId].article)) {
+            result += Rando::StaticData::Items[randoItemId].article;
+            result += " ";
+        }
+
+        result += fakeItemName;
     }
 
     return result;

--- a/mm/2s2h/Rando/StaticData/StaticData.h
+++ b/mm/2s2h/Rando/StaticData/StaticData.h
@@ -53,7 +53,7 @@ RandoItemId GetItemIdFromName(const char* name);
 u8 GetIconForZMessage(RandoItemId itemId);
 const char* GetIconTexturePath(RandoItemId itemId);
 bool ShouldShowGetItemCutscene(RandoItemId itemId);
-std::string GetItemName(RandoItemId randoItemId, bool includeArticle = true);
+std::string GetItemName(RandoItemId randoItemId, bool includeArticle = true, RandoCheckId randoCheckId = RC_UNKNOWN);
 std::string GetTrapMessage();
 
 struct RandoStaticOption {

--- a/mm/src/overlays/actors/ovl_Dm_Char05/z_dm_char05.c
+++ b/mm/src/overlays/actors/ovl_Dm_Char05/z_dm_char05.c
@@ -734,7 +734,7 @@ void func_80AADD9C(PlayState* play, DmChar05* this) {
         Matrix_Translate(this->unk_190.x, this->unk_190.y, this->unk_190.z, MTXMODE_NEW);
         Matrix_RotateZYX(0, play->gameplayFrames * 1000, 0, MTXMODE_APPLY);
         Matrix_Scale(0.2f, 0.2f, 0.2f, MTXMODE_APPLY);
-        if (GameInteractor_Should(VB_DRAW_ITEM_FROM_DMCHAR05, true, GID_MASK_GORON)) {
+        if (GameInteractor_Should(VB_DRAW_ITEM_FROM_DMCHAR05, true, GID_MASK_GORON, this)) {
             GetItem_Draw(play, GID_MASK_GORON);
         }
     }
@@ -749,7 +749,7 @@ void func_80AADE78(PlayState* play, DmChar05* this) {
         Matrix_Translate(this->unk_190.x, this->unk_190.y, this->unk_190.z, MTXMODE_NEW);
         Matrix_RotateZYX(0, play->gameplayFrames * 1000, 0, MTXMODE_APPLY);
         Matrix_Scale(0.2f, 0.2f, 0.2f, MTXMODE_APPLY);
-        if (GameInteractor_Should(VB_DRAW_ITEM_FROM_DMCHAR05, true, GID_MASK_ZORA)) {
+        if (GameInteractor_Should(VB_DRAW_ITEM_FROM_DMCHAR05, true, GID_MASK_ZORA, this)) {
             GetItem_Draw(play, GID_MASK_ZORA);
         }
     }
@@ -764,7 +764,7 @@ void func_80AADF54(PlayState* play, DmChar05* this) {
         Matrix_Translate(this->unk_190.x, this->unk_190.y, this->unk_190.z, MTXMODE_NEW);
         Matrix_RotateZYX(0, play->gameplayFrames * 1000, 0, MTXMODE_APPLY);
         Matrix_Scale(0.2f, 0.2f, 0.2f, MTXMODE_APPLY);
-        if (GameInteractor_Should(VB_DRAW_ITEM_FROM_DMCHAR05, true, GID_MASK_GIBDO)) {
+        if (GameInteractor_Should(VB_DRAW_ITEM_FROM_DMCHAR05, true, GID_MASK_GIBDO, this)) {
             GetItem_Draw(play, GID_MASK_GIBDO);
         }
     }
@@ -780,7 +780,7 @@ void func_80AAE030(PlayState* play, DmChar05* this) {
             Matrix_Translate(this->unk_190.x, this->unk_190.y, this->unk_190.z, MTXMODE_NEW);
             Matrix_RotateZYX(0, play->gameplayFrames * 1000, 0, MTXMODE_APPLY);
             Matrix_Scale(0.2f, 0.2f, 0.2f, MTXMODE_APPLY);
-            if (GameInteractor_Should(VB_DRAW_ITEM_FROM_DMCHAR05, true, GID_MASK_COUPLE)) {
+            if (GameInteractor_Should(VB_DRAW_ITEM_FROM_DMCHAR05, true, GID_MASK_COUPLE, this)) {
                 GetItem_Draw(play, GID_MASK_COUPLE);
             }
         }


### PR DESCRIPTION
I know these probably shouldn't have been grouped together, but I had to make lots of similar changes to pass additional information through for both (RCs).

## Junk Cycling:
This is a more simple alternative to #1326, while I do think some players would enjoy the granularity of the options that PR introduced, I felt it was a bit overwhelming, and most players would likely just get confused and leave the defaults. The approach I took here was to instead always limit the junk pool to the items the player needs, and just give the player two options: Cycle or Static, both options will deterministically roll an item from the pool, cycle will change every 1.5s, where static will only change when the players needs change. This solves two problems:
A) Players have complained the junk cycle includes stuff they don't need
B) Players have complained they didn't like the cycling at all, and would prefer them static.

## Traps:
This tweaks the traps to search through the current seed and look for Major or Mask items that the player has not obtained and fake as one of them. Additionally, within shops and messages, the item name will be the fake model's name but with a typo somewhere. 

The main drawback of this approach is that when the player obtains a major item or mask, all traps will effectively re-roll their chosen models. This may be fun to further confuse the player, but also some players may not like it.


Both of these changes are effectively proposals, and I'd like some minor playtesting to see what people think prior to merging.


<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5149485600.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5149533988.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5149994777.zip)
<!--- section:artifacts:end -->