### PR TITLE
Add EnOt reset function

### DIFF
--- a/mm/src/overlays/actors/ovl_En_Ot/z_en_ot.c
+++ b/mm/src/overlays/actors/ovl_En_Ot/z_en_ot.c
@@ -14,6 +14,7 @@ void EnOt_Init(Actor* thisx, PlayState* play);
 void EnOt_Destroy(Actor* thisx, PlayState* play);
 void EnOt_Update(Actor* thisx, PlayState* play);
 void EnOt_Draw(Actor* thisx, PlayState* play);
+void EnOt_Reset(void);
 
 void func_80B5BDA8(EnOt* this, PlayState* play);
 void func_80B5BE04(EnOt* this, PlayState* play);
@@ -70,6 +71,7 @@ ActorProfile En_Ot_Profile = {
     /**/ EnOt_Destroy,
     /**/ EnOt_Update,
     /**/ EnOt_Draw,
+    /**/ EnOt_Reset,
 };
 
 static ColliderCylinderInit sCylinderInit = {
@@ -1199,4 +1201,10 @@ void func_80B5E1D8(PlayState* play, EnOtUnkStruct* arg1, s32 arg2) {
     }
 
     CLOSE_DISPS(play->state.gfxCtx);
+}
+
+void EnOt_Reset(void) {
+    D_80B5E880 = NULL;
+    D_80B5E884 = NULL;
+    D_80B5E888 = NULL;
 }


### PR DESCRIPTION
Fixes a bug where the seahorse could only be unbottled once per runtime

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5146319149.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5146424156.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5146973580.zip)
<!--- section:artifacts:end -->