### PR TITLE
Tweaks to speed modifier cheat

### DIFF
--- a/mm/2s2h/BenGui/BenInputEditorWindow.cpp
+++ b/mm/2s2h/BenGui/BenInputEditorWindow.cpp
@@ -15,6 +15,8 @@
 
 using namespace UIWidgets;
 
+static s32 heldInputs = 0;
+
 BenInputEditorWindow::~BenInputEditorWindow() {
 }
 
@@ -447,6 +449,9 @@ void BenInputEditorWindow::DrawButtonLine(const char* buttonName, uint8_t port, 
                                           ImVec4 color = CHIP_COLOR_N64_GREY) {
     ImGui::NewLine();
     ImGui::SameLine(SCALE_IMGUI_SIZE(32.0f));
+    if (heldInputs & bitmask) {
+        color.w = 0.5f;
+    }
     DrawInputChip(buttonName, color);
     ImGui::SameLine(SCALE_IMGUI_SIZE(86.0f));
     for (auto id : mBitmaskToMappingIds[port][bitmask]) {
@@ -1201,65 +1206,6 @@ void BenInputEditorWindow::DrawGyroSection(uint8_t port) {
     }
 }
 
-void BenInputEditorWindow::DrawModifierButtonsSection(uint8_t port) {
-    DrawButtonLine("M1", port, BTN_CUSTOM_MODIFIER1);
-    DrawButtonLine("M2", port, BTN_CUSTOM_MODIFIER2);
-
-    ImGui::BeginDisabled(CVarGetInteger("gSettings.DisableChanges", 0));
-    CVarCheckbox("Enable Speed Modifiers", "gSettings.SpeedModifier.Enable",
-                 CheckboxOptions()
-                     .Color(THEME_COLOR)
-                     .Tooltip("Hold the assigned button to change the maximum walking or swimming speed."));
-    if (CVarGetInteger("gSettings.SpeedModifier.Enable", 0)) {
-        UIWidgets::Spacer(5);
-        Ship::GuiWindow::BeginGroupPanel("Speed Modifier", ImGui::GetContentRegionAvail());
-        CVarCheckbox("Toggle modifier instead of holding", "gSettings.SpeedModifier.Toggle",
-                     CheckboxOptions().Color(THEME_COLOR));
-        Ship::GuiWindow::BeginGroupPanel("Walk Modifier", ImGui::GetContentRegionAvail());
-        CVarCheckbox("Enable Walk Speed Modifier", "gSettings.SpeedModifier.WalkEnable",
-                     CheckboxOptions().Color(THEME_COLOR));
-        CVarSliderFloat("Walk Modifier 1: %.0f %%", "gSettings.SpeedModifier.WalkMapping1",
-                        FloatSliderOptions()
-                            .Color(THEME_COLOR)
-                            .IsPercentage()
-                            .Min(0.0f)
-                            .Max(15.0f)
-                            .DefaultValue(1.0f)
-                            .ShowAdjustmentButtons(true));
-        CVarSliderFloat("Walk Modifier 2: %.0f %%", "gSettings.SpeedModifier.WalkMapping2",
-                        FloatSliderOptions()
-                            .Color(THEME_COLOR)
-                            .IsPercentage()
-                            .Min(0.0f)
-                            .Max(15.0f)
-                            .DefaultValue(1.0f)
-                            .ShowAdjustmentButtons(true));
-        Ship::GuiWindow::EndGroupPanel(0);
-        Ship::GuiWindow::BeginGroupPanel("Swim Modifier", ImGui::GetContentRegionAvail());
-        CVarCheckbox("Enable Swim Speed Modifier", "gSettings.SpeedModifier.SwimEnable",
-                     CheckboxOptions().Color(THEME_COLOR));
-        CVarSliderFloat("Swim Modifier 1: %.0f %%", "gSettings.SpeedModifier.SwimMapping1",
-                        FloatSliderOptions()
-                            .Color(THEME_COLOR)
-                            .IsPercentage()
-                            .Min(0.0f)
-                            .Max(8.75f)
-                            .DefaultValue(1.0f)
-                            .ShowAdjustmentButtons(true));
-        CVarSliderFloat("Swim Modifier 2: %.0f %%", "gSettings.SpeedModifier.SwimMapping2",
-                        FloatSliderOptions()
-                            .Color(THEME_COLOR)
-                            .IsPercentage()
-                            .Min(0.0f)
-                            .Max(8.75f)
-                            .DefaultValue(1.0f)
-                            .ShowAdjustmentButtons(true));
-        Ship::GuiWindow::EndGroupPanel(0);
-        Ship::GuiWindow::EndGroupPanel(0);
-    }
-    ImGui::EndDisabled();
-}
-
 const ImGuiTableFlags PANEL_TABLE_FLAGS = ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV;
 const ImGuiTableColumnFlags PANEL_TABLE_COLUMN_FLAGS =
     ImGuiTableColumnFlags_IndentEnable | ImGuiTableColumnFlags_NoSort;
@@ -1440,6 +1386,13 @@ void BenInputEditorWindow::DrawPortTabContents(uint8_t portIndex) {
         DrawButtonLine(StringHelper::Sprintf("%s##DPad", ICON_FA_ARROW_RIGHT).c_str(), portIndex, BTN_DRIGHT);
     }
 
+    if (ImGui::CollapsingHeader("Modifier Buttons", NULL, ImGuiTreeNodeFlags_DefaultOpen)) {
+        ImGui::TextWrapped("These can be bound to physical buttons and be selected for use in various\nenhancements, "
+                           "but otherwise have no use on their own.");
+        DrawButtonLine("M1", portIndex, BTN_CUSTOM_MODIFIER1);
+        DrawButtonLine("M2", portIndex, BTN_CUSTOM_MODIFIER2);
+    }
+
     if (ImGui::CollapsingHeader("Analog Stick", NULL, ImGuiTreeNodeFlags_DefaultOpen)) {
         DrawStickSection(portIndex, Ship::LEFT);
     }
@@ -1458,10 +1411,6 @@ void BenInputEditorWindow::DrawPortTabContents(uint8_t portIndex) {
 
     if (ImGui::CollapsingHeader("LEDs")) {
         DrawLEDSection(portIndex);
-    }
-
-    if (ImGui::CollapsingHeader("Modifier Buttons")) {
-        DrawModifierButtonsSection(portIndex);
     }
 
     ImGui::PopStyleColor();
@@ -1561,3 +1510,12 @@ void BenInputEditorWindow::OffsetMappingPopup() {
     pos.x += HORIZONTAL_OFFSET;
     ImGui::SetNextWindowPos(pos);
 }
+
+static RegisterShipInitFunc initFunc(
+    []() {
+        COND_HOOK(OnGameStateMainStart, true, []() {
+            Input* input = CONTROLLER1(gGameState);
+            heldInputs = input->cur.button;
+        });
+    },
+    {});

--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -114,6 +114,13 @@ static const std::vector<const char*> timeStopOptions = {
     "Temples + Mini Dungeons", // TIME_STOP_TEMPLES_DUNGEONS
 };
 
+static const std::vector<const char*> speedModifierModeOptions = {
+    "Off",
+    "On",
+    "Hold Buttons",
+    "Toggle Buttons",
+};
+
 static const std::vector<const char*> notificationPosition = {
     "Top Left", "Top Right", "Bottom Left", "Bottom Right", "Hidden",
 };
@@ -880,7 +887,7 @@ void BenMenu::AddEnhancements() {
                      .Max(3.0f));
 
     path = { "Enhancements", "Cheats", SECTION_COLUMN_1 };
-    AddSidebarEntry("Enhancements", "Cheats", 3);
+    AddSidebarEntry("Enhancements", "Cheats", 2);
     AddWidget(path, "Infinite Health", WIDGET_CVAR_CHECKBOX)
         .CVar("gCheats.InfiniteHealth")
         .Options(CheckboxOptions().Tooltip("Always have full Hearts."));
@@ -933,6 +940,19 @@ void BenMenu::AddEnhancements() {
                          "- Temples + Mini Dungeons: In addition to the above temples, stops time in both Spider "
                          "Houses, Pirate's Fortress, Beneath the Well, Ancient Castle of Ikana, and Secret Shrine.")
                 .ComboVec(&timeStopOptions));
+
+    path.column = SECTION_COLUMN_2;
+    AddWidget(path, "Speed Modifier", WIDGET_SEPARATOR_TEXT);
+    AddWidget(path, "Speed Modifier Mode", WIDGET_CVAR_COMBOBOX)
+        .CVar("gCheats.SpeedModifier.Mode")
+        .Options(ComboboxOptions().ComboVec(&speedModifierModeOptions).LabelPosition(LabelPosition::None));
+    AddWidget(path, "Multiplier:", WIDGET_CVAR_SLIDER_FLOAT)
+        .CVar("gCheats.SpeedModifier.Value")
+        .PreFunc([](WidgetInfo& info) { info.isHidden = !CVarGetInteger("gCheats.SpeedModifier.Mode", 0); })
+        .Options(FloatSliderOptions().Format("%.1fx").Min(0.0f).Max(6.0f).DefaultValue(1.0f));
+    AddWidget(path, "Button Combination:", WIDGET_CVAR_BTN_SELECTOR)
+        .CVar("gCheats.SpeedModifier.Btn")
+        .PreFunc([](WidgetInfo& info) { info.isHidden = CVarGetInteger("gCheats.SpeedModifier.Mode", 0) < 2; });
 
     //// Gameplay Enhancements
     path = { "Enhancements", "Gameplay", SECTION_COLUMN_1 };

--- a/mm/2s2h/BenGui/Menu.cpp
+++ b/mm/2s2h/BenGui/Menu.cpp
@@ -441,6 +441,13 @@ void Menu::MenuDrawItem(WidgetInfo& widget, uint32_t width, UIWidgets::Colors me
                     }
                 }
             } break;
+            case WIDGET_CVAR_BTN_SELECTOR: {
+                if (UIWidgets::CVarBtnSelector(widget.name.c_str(), widget.cVar)) {
+                    if (widget.callback != nullptr) {
+                        widget.callback(widget);
+                    }
+                }
+            } break;
             case WIDGET_BUTTON: {
                 auto options = std::static_pointer_cast<UIWidgets::ButtonOptions>(widget.options);
                 options->color = menuThemeIndex;

--- a/mm/2s2h/BenGui/MenuTypes.h
+++ b/mm/2s2h/BenGui/MenuTypes.h
@@ -50,6 +50,7 @@ typedef enum {
     WIDGET_CVAR_COMBOBOX,
     WIDGET_CVAR_SLIDER_INT,
     WIDGET_CVAR_SLIDER_FLOAT,
+    WIDGET_CVAR_BTN_SELECTOR,
     WIDGET_BUTTON,
     WIDGET_COLOR_24, // color picker without alpha
     WIDGET_COLOR_32, // color picker with alpha

--- a/mm/2s2h/BenGui/UIWidgets.cpp
+++ b/mm/2s2h/BenGui/UIWidgets.cpp
@@ -6,6 +6,7 @@
 #include <unordered_map>
 #include "2s2h/ShipUtils.h"
 #include <spdlog/fmt/fmt.h>
+#include "2s2h/BenPort.h"
 
 namespace UIWidgets {
 
@@ -1314,6 +1315,95 @@ void DrawFlagTableArray8Mask(const FlagTable& flagTable, uint16_t row, uint8_t& 
     }
     ImGui::PopID();
 }
+
+std::map<std::string, int32_t> buttonMap = {
+    { "A", BTN_A },
+    { "B", BTN_B },
+    { "Z", BTN_Z },
+    { "START", BTN_START },
+    { "D-Up", BTN_DUP },
+    { "D-Down", BTN_DDOWN },
+    { "D-Left", BTN_DLEFT },
+    { "D-Right", BTN_DRIGHT },
+    { "L", BTN_L },
+    { "R", BTN_R },
+    { "C-Up", BTN_CUP },
+    { "C-Down", BTN_CDOWN },
+    { "C-Left", BTN_CLEFT },
+    { "C-Right", BTN_CRIGHT },
+    { "Modifier 1", BTN_CUSTOM_MODIFIER1 },
+    { "Modifier 2", BTN_CUSTOM_MODIFIER2 },
+};
+bool BtnSelector(const char* label, int32_t* value) {
+    bool dirty = false;
+    ImGui::PushID(label);
+    ImGui::BeginGroup();
+    ImGui::AlignTextToFramePadding();
+    ImGui::Text("%s", label);
+    ImGui::BeginDisabled(false);
+    PushStyleCombobox(UIWidgets::Colors::DarkGray);
+    ImGui::BeginGroup();
+    int32_t currentValue = *value;
+    int index = 0;
+    for (const auto& [buttonName, buttonMask] : buttonMap) {
+        if (currentValue & buttonMask) {
+            ImGui::PushID(buttonName.c_str());
+            if (index++ > 0) {
+                ImGui::Text("+");
+                ImGui::SameLine();
+            }
+            if (UIWidgets::Button(buttonName.c_str(), UIWidgets::ButtonOptions()
+                                                          .Tooltip("Remove this button from the combination")
+                                                          .Color(UIWidgets::Colors::Gray)
+                                                          .Size(UIWidgets::Sizes::Inline))) {
+                currentValue &= ~buttonMask;
+                dirty = true;
+            }
+            ImGui::PopID();
+            ImGui::SameLine();
+        }
+    }
+    if (UIWidgets::Button("+", UIWidgets::ButtonOptions({ { .tooltip = "Add a button to the combination" } })
+                                   .Size(UIWidgets::Sizes::Inline))) {
+        ImGui::OpenPopup("Add Button");
+    }
+    if (ImGui::BeginPopup("Add Button")) {
+        UIWidgets::PushStyleMenuItem();
+        for (const auto& [buttonName, buttonMask] : buttonMap) {
+            if (!(currentValue & buttonMask)) {
+                if (ImGui::MenuItem(buttonName.c_str())) {
+                    currentValue |= buttonMask;
+                    dirty = true;
+                }
+            }
+        }
+        UIWidgets::PopStyleMenuItem();
+        ImGui::EndPopup();
+    }
+    ImGui::EndGroup();
+    PopStyleCombobox();
+    ImGui::EndDisabled();
+    ImGui::EndGroup();
+    ImGui::PopID();
+
+    if (dirty) {
+        *value = currentValue;
+    }
+    return dirty;
+}
+
+bool CVarBtnSelector(const char* label, const char* cvarName) {
+    bool dirty = false;
+    int32_t value = CVarGetInteger(cvarName, 0);
+    if (BtnSelector(label, &value)) {
+        CVarSetInteger(cvarName, value);
+        Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
+        ShipInit::Init(cvarName);
+        dirty = true;
+    }
+    return dirty;
+}
+
 } // namespace UIWidgets
 
 ImVec4 GetRandomValue() {

--- a/mm/2s2h/BenGui/UIWidgets.hpp
+++ b/mm/2s2h/BenGui/UIWidgets.hpp
@@ -1159,6 +1159,8 @@ void DrawFlagArray16(const std::string& name, uint16_t& flags, Colors color = Co
 void DrawFlagTableArray16(const FlagTable& flagTable, uint16_t& flags);
 void DrawFlagTableArray8(const FlagTable& flagTable, uint16_t row, uint8_t& flags);
 void DrawFlagTableArray8Mask(const FlagTable& flagTable, uint16_t row, uint8_t& flags);
+bool BtnSelector(const char* label, int32_t* value);
+bool CVarBtnSelector(const char* label, const char* cvarName);
 } // namespace UIWidgets
 ImVec4 GetRandomValue();
 

--- a/mm/2s2h/Enhancements/Player/LinkSpeedModifier.cpp
+++ b/mm/2s2h/Enhancements/Player/LinkSpeedModifier.cpp
@@ -8,87 +8,63 @@ extern "C" {
 extern Input* sPlayerControlInput;
 }
 
-#define CVAR_SPEED_MODIFIER_NAME "gSettings.SpeedModifier.Enable"
-#define CVAR_SPEED_MODIFIER_TOGGLE "gSettings.SpeedModifier.Toggle"
-#define CVAR_WALK_MODIFIER_NAME "gSettings.SpeedModifier.WalkEnable"
-#define CVAR_SWIM_MODIFIER_NAME "gSettings.SpeedModifier.SwimEnable"
-#define CVAR_SPEED CVarGetInteger(CVAR_SPEED_MODIFIER_NAME, 0)
-#define CVAR_SPEED_TOGGLE CVarGetInteger(CVAR_SPEED_MODIFIER_TOGGLE, 0)
-#define CVAR_WALK CVarGetInteger(CVAR_WALK_MODIFIER_NAME, 0)
-#define CVAR_SWIM CVarGetInteger(CVAR_SWIM_MODIFIER_NAME, 0)
+#define CVAR_SPEED_MODIFIER_MODE_NAME "gCheats.SpeedModifier.Mode"
+#define CVAR_SPEED_MODIFIER_TOGGLE_NAME "gCheats.SpeedModifier.Toggle"
+#define CVAR_SPEED_MODIFIER_VALUE_NAME "gCheats.SpeedModifier.Value"
+#define CVAR_SPEED_MODIFIER_BTN_NAME "gCheats.SpeedModifier.Btn"
+#define CVAR_SPEED_MODIFIER_MODE CVarGetInteger(CVAR_SPEED_MODIFIER_MODE_NAME, 0)
+#define CVAR_SPEED_MODIFIER_TOGGLE CVarGetInteger(CVAR_SPEED_MODIFIER_TOGGLE_NAME, 0)
+#define CVAR_SPEED_MODIFIER_VALUE CVarGetFloat(CVAR_SPEED_MODIFIER_VALUE_NAME, 1.0f)
+#define CVAR_SPEED_MODIFIER_BTN CVarGetInteger(CVAR_SPEED_MODIFIER_BTN_NAME, 0)
 
-bool speedToggle1;
-bool speedToggle2;
+bool btnHeldOrToggled = false;
 
 void RegisterLinkSpeedModifier() {
+    // Reset in case they disabled while toggled
+    btnHeldOrToggled = false;
 
-    COND_VB_SHOULD(VB_SPEED_MODIFIER_WALK, CVAR_WALK && CVAR_SPEED, {
+    COND_VB_SHOULD(VB_SPEED_MODIFIER_WALK, CVAR_SPEED_MODIFIER_MODE, {
         f32* speedTarget = va_arg(args, f32*);
 
-        if (CVAR_SPEED_TOGGLE) {
-            if (speedToggle1) {
-                *speedTarget *= CVarGetFloat("gSettings.SpeedModifier.WalkMapping1", 1.0f);
-            } else if (speedToggle2) {
-                *speedTarget *= CVarGetFloat("gSettings.SpeedModifier.WalkMapping2", 1.0f);
-            }
-        } else {
-            if (CHECK_BTN_ALL(sPlayerControlInput->cur.button, BTN_CUSTOM_MODIFIER1)) {
-                *speedTarget *= CVarGetFloat("gSettings.SpeedModifier.WalkMapping1", 1.0f);
-            } else if (CHECK_BTN_ALL(sPlayerControlInput->cur.button, BTN_CUSTOM_MODIFIER2)) {
-                *speedTarget *= CVarGetFloat("gSettings.SpeedModifier.WalkMapping2", 1.0f);
-            }
+        if (CVAR_SPEED_MODIFIER_MODE == 1 || btnHeldOrToggled) {
+            *speedTarget *= CVAR_SPEED_MODIFIER_VALUE;
         }
     });
 
-    COND_VB_SHOULD(VB_SPEED_MODIFIER_SWIM, CVAR_SWIM && CVAR_SPEED, {
-        *should = false;
+    COND_VB_SHOULD(VB_SPEED_MODIFIER_SWIM, CVAR_SPEED_MODIFIER_MODE, {
         f32* incrStep = va_arg(args, f32*);
         f32* maxSpeed = va_arg(args, f32*);
         f32* speed = va_arg(args, f32*);
         f32* speedTarget = va_arg(args, f32*);
         f32 swimMod = 1.0f;
 
-        if (CVAR_SPEED_TOGGLE) {
-            if (speedToggle1) {
-                swimMod *= CVarGetFloat("gSettings.SpeedModifier.SwimMapping1", 1.0f);
-            } else if (speedToggle2) {
-                swimMod *= CVarGetFloat("gSettings.SpeedModifier.SwimMapping2", 1.0f);
-            }
-
-            // sControlInput is NULL to prevent inputs while surfacing after obtaining an underwater item so we want
-            // to ignore it for that case
-        } else if (sPlayerControlInput != NULL) {
-            if (CHECK_BTN_ALL(sPlayerControlInput->cur.button, BTN_CUSTOM_MODIFIER1)) {
-                swimMod *= CVarGetFloat("gSettings.SpeedModifier.SwimMapping1", 1.0f);
-            } else if (CHECK_BTN_ALL(sPlayerControlInput->cur.button, BTN_CUSTOM_MODIFIER2)) {
-                swimMod *= CVarGetFloat("gSettings.SpeedModifier.SwimMapping2", 1.0f);
-            }
+        // sControlInput is NULL to prevent inputs while surfacing after obtaining an underwater item so we want
+        // to ignore it for that case
+        if (sPlayerControlInput == NULL) {
+            return;
         }
 
-        *maxSpeed *= swimMod;
-
-        Math_AsymStepToF(speed, *speedTarget * 0.8f * swimMod, *incrStep, (fabsf(*speed) * 0.02f) + 0.05f);
-    });
-
-    COND_HOOK(OnPassPlayerInputs, CVAR_SPEED && (CVAR_WALK || CVAR_SWIM), [](Input* input) {
-        if (CVAR_SPEED_TOGGLE) {
-
-            if (CHECK_BTN_ALL(input->press.button, BTN_CUSTOM_MODIFIER1)) {
-                speedToggle1 = !speedToggle1;
-                speedToggle2 = false;
-            }
-            if (CHECK_BTN_ALL(input->press.button, BTN_CUSTOM_MODIFIER2)) {
-                speedToggle2 = !speedToggle2;
-                speedToggle1 = false;
-            }
+        if (CVAR_SPEED_MODIFIER_MODE == 1 || btnHeldOrToggled) {
+            swimMod *= CVAR_SPEED_MODIFIER_VALUE;
+            *maxSpeed *= swimMod;
+            Math_AsymStepToF(speed, *speedTarget * 0.8f * swimMod, *incrStep, (fabsf(*speed) * 0.02f) + 0.05f);
+            *should = false;
         }
     });
 
-    COND_HOOK(OnConsoleLogoUpdate, CVAR_SPEED && (CVAR_WALK || CVAR_SWIM), []() {
-        speedToggle1 = false;
-        speedToggle2 = false;
+    COND_HOOK(OnPassPlayerInputs, CVAR_SPEED_MODIFIER_MODE >= 2, [](Input* input) {
+        if (CVAR_SPEED_MODIFIER_MODE == 2) {
+            if (CHECK_BTN_ALL(input->cur.button, CVAR_SPEED_MODIFIER_BTN)) {
+                btnHeldOrToggled = true;
+            } else {
+                btnHeldOrToggled = false;
+            }
+        } else {
+            if (CHECK_BTN_ALL(input->press.button, CVAR_SPEED_MODIFIER_BTN)) {
+                btnHeldOrToggled = !btnHeldOrToggled;
+            }
+        }
     });
 }
 
-static RegisterShipInitFunc initFunc(RegisterLinkSpeedModifier, { CVAR_SPEED_MODIFIER_NAME, CVAR_SPEED_MODIFIER_TOGGLE,
-                                                                  CVAR_WALK_MODIFIER_NAME, CVAR_SWIM_MODIFIER_NAME });
+static RegisterShipInitFunc initFunc(RegisterLinkSpeedModifier, { CVAR_SPEED_MODIFIER_MODE_NAME });


### PR DESCRIPTION
- Simplified Movement speed cheat, combined swim & walk speed and just made it one modifier instead of two
- Moved to cheats menu (removed from controller menu)
- On controller menu pressed inputs will now darken to indicate they are pressed

Notably, I added a BtnSelector UIWidget and am using this PR to set the stage for other custom bindings that I will be introducing in the future using the same interface, eg
- Hide/Show item tracker
- Customize debug binds (debug warp and noclip)
- Reset binding (no more CTRL+R accidentally refreshing discord)

<img width="1485" height="1013" alt="Screenshot 2026-01-17 at 12 06 38 PM" src="https://github.com/user-attachments/assets/76278118-3c73-418f-966e-22fca6d0206d" />





https://github.com/user-attachments/assets/fdcb6bcb-5081-4e54-9120-b05ad864e18b



<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5165056244.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5165075538.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5165102822.zip)
<!--- section:artifacts:end -->