### PR TITLE
Surround sound support

### DIFF
--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -37,7 +37,7 @@
 #endif
 #include "Extractor/Extract.h"
 // OTRTODO
-//#include <functions.h>
+// #include <functions.h>
 #include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
 
 #ifdef ENABLE_CROWD_CONTROL
@@ -211,10 +211,10 @@ OTRGlobals::OTRGlobals() {
     overlay->LoadFont("Fipps", 32.0f, "fonts/Fipps-Regular.otf");
     overlay->SetCurrentFont(CVarGetString(CVAR_GAME_OVERLAY_FONT, "Press Start 2P"));
 
-    // Read audio channel setting from CVar (audioMatrix51 = 1)
-    AudioChannelsSetting channelSetting = 
+    AudioChannelsSetting channelSetting =
         static_cast<AudioChannelsSetting>(CVarGetInteger("gAudioChannelsSetting", audioStereo));
-    context->InitAudio({ .SampleRate = 32000, .SampleLength = 1024, .DesiredBuffered = 1680, .ChannelSetting = channelSetting });
+    context->InitAudio(
+        { .SampleRate = 32000, .SampleLength = 1024, .DesiredBuffered = 1680, .ChannelSetting = channelSetting });
 
     SPDLOG_INFO("Starting 2 Ship 2 Harkinian version {} (Branch: {} | Commit: {})", (char*)gBuildVersion,
                 (char*)gGitBranch, (char*)gGitCommitHash);

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -211,7 +211,10 @@ OTRGlobals::OTRGlobals() {
     overlay->LoadFont("Fipps", 32.0f, "fonts/Fipps-Regular.otf");
     overlay->SetCurrentFont(CVarGetString(CVAR_GAME_OVERLAY_FONT, "Press Start 2P"));
 
-    context->InitAudio({ .SampleRate = 32000, .SampleLength = 1024, .DesiredBuffered = 1680 });
+    // Read audio channel setting from CVar (audioMatrix51 = 1)
+    AudioChannelsSetting channelSetting = 
+        static_cast<AudioChannelsSetting>(CVarGetInteger("gAudioChannelsSetting", audioStereo));
+    context->InitAudio({ .SampleRate = 32000, .SampleLength = 1024, .DesiredBuffered = 1680, .ChannelSetting = channelSetting });
 
     SPDLOG_INFO("Starting 2 Ship 2 Harkinian version {} (Branch: {} | Commit: {})", (char*)gBuildVersion,
                 (char*)gGitBranch, (char*)gGitCommitHash);

--- a/mm/src/audio/code_8019AF00.c
+++ b/mm/src/audio/code_8019AF00.c
@@ -4,6 +4,7 @@
 #include "GameInteractor/GameInteractor.h"
 #include "2s2h/Enhancements/Audio/AudioEditor.h"
 #include <libultraship/bridge/consolevariablebridge.h>
+#include <libultraship/bridge/audiobridge.h>
 
 typedef struct {
     /* 0x0 */ s8 x;

--- a/mm/src/audio/code_8019AF00.c
+++ b/mm/src/audio/code_8019AF00.c
@@ -6115,6 +6115,10 @@ void Audio_SetFileSelectSettings(s8 audioSetting) {
     // Dynamically switch audio backend between stereo and 5.1 surround
     SetAudioChannels(channelsSetting);
 
+    // Save audio channel setting so it persists across game launches
+    CVarSetInteger("gAudioChannelsSetting", channelsSetting);
+    CVarSave();
+
     SEQCMD_SET_SOUND_MODE(soundMode);
 }
 

--- a/mm/src/audio/code_8019AF00.c
+++ b/mm/src/audio/code_8019AF00.c
@@ -6080,31 +6080,39 @@ void Audio_PlaySfx_SurroundSoundTest(void) {
 
 void Audio_SetFileSelectSettings(s8 audioSetting) {
     s8 soundMode;
+    AudioChannelsSetting channelsSetting = audioStereo;
 
     switch (audioSetting) {
         case SAVE_AUDIO_STEREO:
             soundMode = SOUNDMODE_STEREO;
             sSoundMode = SOUNDMODE_STEREO;
+            channelsSetting = audioStereo;
             break;
 
         case SAVE_AUDIO_MONO:
             soundMode = SOUNDMODE_MONO;
             sSoundMode = SOUNDMODE_MONO;
+            channelsSetting = audioStereo;
             break;
 
         case SAVE_AUDIO_HEADSET:
             soundMode = SOUNDMODE_HEADSET;
             sSoundMode = SOUNDMODE_HEADSET;
+            channelsSetting = audioStereo;
             break;
 
         case SAVE_AUDIO_SURROUND:
             soundMode = SOUNDMODE_SURROUND;
             sSoundMode = SOUNDMODE_SURROUND_EXTERNAL;
+            channelsSetting = audioMatrix51;
             break;
 
         default:
             break;
     }
+
+    // Dynamically switch audio backend between stereo and 5.1 surround
+    SetAudioChannels(channelsSetting);
 
     SEQCMD_SET_SOUND_MODE(soundMode);
 }

--- a/mm/src/audio/lib/synthesis.c
+++ b/mm/src/audio/lib/synthesis.c
@@ -1484,13 +1484,32 @@ Acmd* AudioSynth_ApplySurroundEffect(Acmd* cmd, NoteSampleState* sampleState, No
     } else {
         aLoadBuffer(cmd++, synthState->synthesisBuffers->surroundEffectState, dmem,
                     sizeof(synthState->synthesisBuffers->surroundEffectState));
-        aMix(cmd++, (numSamplesPerUpdate * (s32)SAMPLE_SIZE) >> 4, dryGain, dmem, DMEM_LEFT_CH);
-        aMix(cmd++, (numSamplesPerUpdate * (s32)SAMPLE_SIZE) >> 4, (dryGain ^ 0xFFFF), dmem, DMEM_RIGHT_CH);
+
+        // === Pro Logic II encoding: steer surround to RL or RR based on pan ===
+        // Calculate pan position: 0.0 = full left, 0.5 = center, 1.0 = full right
+        f32 sumVol = sampleState->targetVolLeft + sampleState->targetVolRight;
+        f32 panPosition = 0.5f; // default: center (mono surround)
+        if (sumVol > 0.0f) {
+            panPosition = (f32)sampleState->targetVolRight / sumVol;
+        }
+
+        // For PLII decoding, the L/R balance determines RL vs RR steering:
+        // - L dominant (leftGain > rightGain): surround goes more to Rear Left
+        // - R dominant (rightGain > leftGain): surround goes more to Rear Right
+        // - Equal: mono surround to both (like Pro Logic I)
+        s16 leftGain = (s16)(dryGain * (1.0f - panPosition));
+        s16 rightGain = (s16)(dryGain * panPosition);
+
+        aMix(cmd++, (numSamplesPerUpdate * (s32)SAMPLE_SIZE) >> 4, leftGain, dmem, DMEM_LEFT_CH);
+        aMix(cmd++, (numSamplesPerUpdate * (s32)SAMPLE_SIZE) >> 4, (rightGain ^ 0xFFFF), dmem, DMEM_RIGHT_CH);
 
         wetGain = (dryGain * synthState->curReverbVol) >> 7;
+        s16 wetLeftGain = (s16)(wetGain * (1.0f - panPosition));
+        s16 wetRightGain = (s16)(wetGain * panPosition);
 
-        aMix(cmd++, (numSamplesPerUpdate * (s32)SAMPLE_SIZE) >> 4, wetGain, dmem, DMEM_WET_LEFT_CH);
-        aMix(cmd++, (numSamplesPerUpdate * (s32)SAMPLE_SIZE) >> 4, (wetGain ^ 0xFFFF), dmem, DMEM_WET_RIGHT_CH);
+        aMix(cmd++, (numSamplesPerUpdate * (s32)SAMPLE_SIZE) >> 4, wetLeftGain, dmem, DMEM_WET_LEFT_CH);
+        aMix(cmd++, (numSamplesPerUpdate * (s32)SAMPLE_SIZE) >> 4, (wetRightGain ^ 0xFFFF), dmem, DMEM_WET_RIGHT_CH);
+        // === End Pro Logic II encoding ===
     }
 
     aSaveBuffer(cmd++, DMEM_SURROUND_TEMP + (numSamplesPerUpdate * SAMPLE_SIZE),

--- a/mm/src/audio/lib/synthesis.c
+++ b/mm/src/audio/lib/synthesis.c
@@ -1485,7 +1485,7 @@ Acmd* AudioSynth_ApplySurroundEffect(Acmd* cmd, NoteSampleState* sampleState, No
         aLoadBuffer(cmd++, synthState->synthesisBuffers->surroundEffectState, dmem,
                     sizeof(synthState->synthesisBuffers->surroundEffectState));
 
-        // === Pro Logic II encoding: steer surround to RL or RR based on pan ===
+        // === Matrix surround encoding: steer surround to RL or RR based on pan ===
         // Calculate pan position: 0.0 = full left, 0.5 = center, 1.0 = full right
         f32 sumVol = sampleState->targetVolLeft + sampleState->targetVolRight;
         f32 panPosition = 0.5f; // default: center (mono surround)
@@ -1493,10 +1493,10 @@ Acmd* AudioSynth_ApplySurroundEffect(Acmd* cmd, NoteSampleState* sampleState, No
             panPosition = (f32)sampleState->targetVolRight / sumVol;
         }
 
-        // For PLII decoding, the L/R balance determines RL vs RR steering:
+        // The L/R balance determines RL vs RR steering:
         // - L dominant (leftGain > rightGain): surround goes more to Rear Left
         // - R dominant (rightGain > leftGain): surround goes more to Rear Right
-        // - Equal: mono surround to both (like Pro Logic I)
+        // - Equal: mono surround to both
         s16 leftGain = (s16)(dryGain * (1.0f - panPosition));
         s16 rightGain = (s16)(dryGain * panPosition);
 
@@ -1509,7 +1509,7 @@ Acmd* AudioSynth_ApplySurroundEffect(Acmd* cmd, NoteSampleState* sampleState, No
 
         aMix(cmd++, (numSamplesPerUpdate * (s32)SAMPLE_SIZE) >> 4, wetLeftGain, dmem, DMEM_WET_LEFT_CH);
         aMix(cmd++, (numSamplesPerUpdate * (s32)SAMPLE_SIZE) >> 4, (wetRightGain ^ 0xFFFF), dmem, DMEM_WET_RIGHT_CH);
-        // === End Pro Logic II encoding ===
+        // === End matrix surround encoding ===
     }
 
     aSaveBuffer(cmd++, DMEM_SURROUND_TEMP + (numSamplesPerUpdate * SAMPLE_SIZE),

--- a/mm/src/code/z_common_data.c
+++ b/mm/src/code/z_common_data.c
@@ -6,6 +6,7 @@
 #include "z64environment.h"
 #include "z64transition.h"
 #include <string.h>
+#include <libultraship/bridge/audiobridge.h>
 
 SaveContext gSaveContext ALIGNED(16);
 
@@ -26,6 +27,6 @@ void SaveContext_Init(void) {
     gSaveContext.prevHudVisibility = HUD_VISIBILITY_ALL;
 
     gSaveContext.options.language = LANGUAGE_ENG;
-    gSaveContext.options.audioSetting = SAVE_AUDIO_STEREO;
+    gSaveContext.options.audioSetting = (GetAudioChannels() == audioMatrix51) ? SAVE_AUDIO_SURROUND : SAVE_AUDIO_STEREO;
     gSaveContext.options.zTargetSetting = 0;
 }

--- a/mm/src/code/z_sram_NES.c
+++ b/mm/src/code/z_sram_NES.c
@@ -8,6 +8,7 @@
 #include "2s2h/Enhancements/Saving/SavingEnhancements.h"
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include <libultraship/bridge/consolevariablebridge.h>
+#include <libultraship/bridge/audiobridge.h>
 
 void Sram_SyncWriteToFlash(SramContext* sramCtx, s32 curPage, s32 numPages);
 void func_80147414(SramContext* sramCtx, s32 fileNum, s32 arg2);
@@ -1774,10 +1775,13 @@ void func_801457CC(GameState* gameState, SramContext* sramCtx) {
                                           gFlashSaveNumPages[sp64 + FLASH_SAVE_BACKUP_OFFSET]);
                 }
             } else {
+                // Get default audio setting from config
+                s8 defaultAudioSetting = (GetAudioChannels() == audioMatrix51) ? SAVE_AUDIO_SURROUND : SAVE_AUDIO_STEREO;
+
                 if (phi_s2) {
                     gSaveContext.options.optionId = 0xA51D;
                     gSaveContext.options.language = LANGUAGE_ENG;
-                    gSaveContext.options.audioSetting = SAVE_AUDIO_STEREO;
+                    gSaveContext.options.audioSetting = defaultAudioSetting;
                     gSaveContext.options.languageSetting = 0;
                     gSaveContext.options.zTargetSetting = 0;
                 } else {
@@ -1785,7 +1789,7 @@ void func_801457CC(GameState* gameState, SramContext* sramCtx) {
                     if (gSaveContext.options.optionId != 0xA51D) {
                         gSaveContext.options.optionId = 0xA51D;
                         gSaveContext.options.language = LANGUAGE_ENG;
-                        gSaveContext.options.audioSetting = SAVE_AUDIO_STEREO;
+                        gSaveContext.options.audioSetting = defaultAudioSetting;
                         gSaveContext.options.languageSetting = 0;
                         gSaveContext.options.zTargetSetting = 0;
                     }

--- a/mm/src/code/z_sram_NES.c
+++ b/mm/src/code/z_sram_NES.c
@@ -1776,7 +1776,8 @@ void func_801457CC(GameState* gameState, SramContext* sramCtx) {
                 }
             } else {
                 // Get default audio setting from config
-                s8 defaultAudioSetting = (GetAudioChannels() == audioMatrix51) ? SAVE_AUDIO_SURROUND : SAVE_AUDIO_STEREO;
+                s8 defaultAudioSetting =
+                    (GetAudioChannels() == audioMatrix51) ? SAVE_AUDIO_SURROUND : SAVE_AUDIO_STEREO;
 
                 if (phi_s2) {
                     gSaveContext.options.optionId = 0xA51D;


### PR DESCRIPTION
This PR enables Majora's Mask Surround Matrix sound support when 5.1 speakers are available.

- The saved settings are not loaded until the savefile select screen, which caused the initial effect of the mask being loaded potentially in Stereo even if the game would be configured in Surround. To bypass that, a CVAR is used to save / load the settings prior to loading the sound engine.
- This PR updates the version of LUS to the one supporting surround matrix decoder, and selects that upon changing the audio to surround.
- I also added a small improvement to the Surround effect to make use of the RL / RR separation which the surround matrix sound decoder is capable of.

Requires https://github.com/Kenix3/libultraship/pull/986.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5286001243.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5286003525.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5286100069.zip)
<!--- section:artifacts:end -->