### PR TITLE
Use computed starting items for pool removal

### DIFF
--- a/mm/2s2h/Rando/Logic/GeneratePools.cpp
+++ b/mm/2s2h/Rando/Logic/GeneratePools.cpp
@@ -14,19 +14,8 @@ namespace Logic {
 
 void GeneratePools(RandoSaveInfo& saveInfo, std::vector<RandoCheckId>& checkPool, std::vector<RandoItemId>& itemPool) {
     std::vector<RandoItemId> startingItems = Rando::GetStartingItemsFromSave(saveInfo);
-
-    if (saveInfo.randoSaveOptions[RO_STARTING_MAPS_AND_COMPASSES]) {
-        std::vector<RandoItemId> MapsAndCompasses = {
-            RI_GREAT_BAY_COMPASS,       RI_GREAT_BAY_MAP,       RI_SNOWHEAD_COMPASS,       RI_SNOWHEAD_MAP,
-            RI_STONE_TOWER_COMPASS,     RI_STONE_TOWER_MAP,     RI_TINGLE_MAP_CLOCK_TOWN,  RI_TINGLE_MAP_GREAT_BAY,
-            RI_TINGLE_MAP_ROMANI_RANCH, RI_TINGLE_MAP_SNOWHEAD, RI_TINGLE_MAP_STONE_TOWER, RI_TINGLE_MAP_WOODFALL,
-            RI_WOODFALL_COMPASS,        RI_WOODFALL_MAP,
-        };
-
-        for (RandoItemId itemId : MapsAndCompasses) {
-            startingItems.push_back(itemId);
-        }
-    }
+    std::vector<RandoItemId> computedStartingItems = Rando::GetComputedStartingItems(saveInfo);
+    startingItems.insert(startingItems.end(), computedStartingItems.begin(), computedStartingItems.end());
 
     std::vector<RandoCheckId> excludedChecks;
     std::string excludedChecksList = CVarGetString("gRando.ExcludedChecks", "");

--- a/mm/2s2h/Rando/Rando.h
+++ b/mm/2s2h/Rando/Rando.h
@@ -23,6 +23,7 @@ RandoItemId ConvertItem(RandoItemId randoItemId, RandoCheckId randoCheckId = RC_
 RandoCheckId FindItemPlacement(RandoItemId randoItemId);
 void RegisterMenu();
 
+std::vector<RandoItemId> GetComputedStartingItems(RandoSaveInfo& randoSaveInfo);
 void GrantStartingItems();
 std::vector<RandoItemId> GetStartingItemsFromSpoiler(nlohmann::json& spoiler);
 void SetStartingItemsInSpoiler(nlohmann::json& spoiler, std::vector<RandoItemId>& startingItems);

--- a/mm/2s2h/Rando/StartingItems.cpp
+++ b/mm/2s2h/Rando/StartingItems.cpp
@@ -12,10 +12,10 @@
 
 namespace Rando {
 
-void GrantStartingItems() {
-    std::vector<RandoItemId> startingItems = Rando::GetStartingItemsFromSave(gSaveContext.save.shipSaveInfo.rando);
+std::vector<RandoItemId> GetComputedStartingItems(RandoSaveInfo& randoSaveInfo) {
+    std::vector<RandoItemId> startingItems;
 
-    if (RANDO_SAVE_OPTIONS[RO_STARTING_MAPS_AND_COMPASSES]) {
+    if (randoSaveInfo.randoSaveOptions[RO_STARTING_MAPS_AND_COMPASSES]) {
         std::vector<RandoItemId> MapsAndCompasses = {
             RI_GREAT_BAY_COMPASS,       RI_GREAT_BAY_MAP,       RI_SNOWHEAD_COMPASS,       RI_SNOWHEAD_MAP,
             RI_STONE_TOWER_COMPASS,     RI_STONE_TOWER_MAP,     RI_TINGLE_MAP_CLOCK_TOWN,  RI_TINGLE_MAP_GREAT_BAY,
@@ -28,24 +28,24 @@ void GrantStartingItems() {
         }
     }
 
-    if (RANDO_SAVE_OPTIONS[RO_SHUFFLE_SWIM] != RO_GENERIC_YES) {
+    if (randoSaveInfo.randoSaveOptions[RO_SHUFFLE_SWIM] != RO_GENERIC_YES) {
         startingItems.push_back(RI_ABILITY_SWIM);
     }
 
-    if (RANDO_SAVE_OPTIONS[RO_SHUFFLE_ENEMY_SOULS] != RO_GENERIC_YES) {
+    if (randoSaveInfo.randoSaveOptions[RO_SHUFFLE_ENEMY_SOULS] != RO_GENERIC_YES) {
         for (int i = RI_SOUL_ENEMY_ALIEN; i <= RI_SOUL_ENEMY_WOLFOS; i++) {
             startingItems.push_back((RandoItemId)i);
         }
     }
 
-    if (RANDO_SAVE_OPTIONS[RO_SHUFFLE_OCARINA_BUTTONS] != RO_GENERIC_YES) {
+    if (randoSaveInfo.randoSaveOptions[RO_SHUFFLE_OCARINA_BUTTONS] != RO_GENERIC_YES) {
         for (int i = RI_OCARINA_BUTTON_A; i <= RI_OCARINA_BUTTON_C_UP; i++) {
             startingItems.push_back((RandoItemId)i);
         }
     }
 
     // When shuffling time, if the player did not choose any starting time items, we need to give them at least one.
-    if (RANDO_SAVE_OPTIONS[RO_CLOCK_SHUFFLE] == RO_GENERIC_YES) {
+    if (randoSaveInfo.randoSaveOptions[RO_CLOCK_SHUFFLE] == RO_GENERIC_YES) {
         bool hasTimeItem = false;
         for (RandoItemId randoItemId : startingItems) {
             if (randoItemId >= RI_TIME_DAY_1 && randoItemId <= RI_TIME_PROGRESSIVE) {
@@ -54,14 +54,23 @@ void GrantStartingItems() {
             }
         }
         if (!hasTimeItem) {
-            if (RANDO_SAVE_OPTIONS[RO_CLOCK_SHUFFLE_PROGRESSIVE] == RO_CLOCK_SHUFFLE_RANDOM) {
-                Ship_Random_Seed(gSaveContext.save.shipSaveInfo.rando.finalSeed);
+            if (randoSaveInfo.randoSaveOptions[RO_CLOCK_SHUFFLE_PROGRESSIVE] == RO_CLOCK_SHUFFLE_RANDOM) {
+                Ship_Random_Seed(randoSaveInfo.finalSeed);
                 startingItems.push_back((RandoItemId)(RI_TIME_DAY_1 + Ship_Random(0, 5)));
             } else {
                 startingItems.push_back(RI_TIME_PROGRESSIVE);
             }
         }
     }
+
+    return startingItems;
+}
+
+void GrantStartingItems() {
+    std::vector<RandoItemId> startingItems = Rando::GetStartingItemsFromSave(gSaveContext.save.shipSaveInfo.rando);
+    std::vector<RandoItemId> computedStartingItems =
+        Rando::GetComputedStartingItems(gSaveContext.save.shipSaveInfo.rando);
+    startingItems.insert(startingItems.end(), computedStartingItems.begin(), computedStartingItems.end());
 
     for (RandoItemId startingItem : startingItems) {
         Rando::GiveItem(Rando::ConvertItem(startingItem));


### PR DESCRIPTION
This ensures all starting items (both user defined and computed) are removed from the item pool properly.

Shuffle time's random starting time was not being removed from the pool, causing issues once it was granted then removed in a playthrough.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5184407313.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5184460117.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5184901770.zip)
<!--- section:artifacts:end -->