### PR TITLE
Gracefully handle old starting items config & allow empty starting items

### DIFF
--- a/mm/2s2h/Rando/StartingItems.cpp
+++ b/mm/2s2h/Rando/StartingItems.cpp
@@ -139,16 +139,23 @@ std::vector<RandoItemId> GetStartingItemsFromConfig() {
     // Verify that the config has CVars.gRando.StartingItems and its an array
     if (allConfig.find("CVars") != allConfig.end() && allConfig["CVars"].is_object() &&
         allConfig["CVars"].find("gRando") != allConfig["CVars"].end() && allConfig["CVars"]["gRando"].is_object() &&
-        allConfig["CVars"]["gRando"].find("StartingItems") != allConfig["CVars"]["gRando"].end() &&
-        allConfig["CVars"]["gRando"]["StartingItems"].is_array()) {
-        startingItems.clear();
+        allConfig["CVars"]["gRando"].find("StartingItems") != allConfig["CVars"]["gRando"].end()) {
 
-        auto startingItemsStrings = allConfig["CVars"]["gRando"]["StartingItems"].get<std::vector<std::string>>();
-        for (auto& itemName : startingItemsStrings) {
-            auto randoItemId = Rando::StaticData::GetItemIdFromName(itemName.c_str());
-            if (randoItemId > RI_UNKNOWN && randoItemId < RI_MAX) {
-                startingItems.push_back(randoItemId);
+        if (allConfig["CVars"]["gRando"]["StartingItems"].is_array()) {
+            startingItems.clear();
+
+            auto startingItemsStrings = allConfig["CVars"]["gRando"]["StartingItems"].get<std::vector<std::string>>();
+            for (auto& itemName : startingItemsStrings) {
+                auto randoItemId = Rando::StaticData::GetItemIdFromName(itemName.c_str());
+                if (randoItemId > RI_UNKNOWN && randoItemId < RI_MAX) {
+                    startingItems.push_back(randoItemId);
+                }
             }
+        } else if (allConfig["CVars"]["gRando"]["StartingItems"].is_string()) {
+            CVarClear("gRando.StartingItems");
+            Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
+        } else if (allConfig["CVars"]["gRando"]["StartingItems"].is_null()) {
+            startingItems.clear();
         }
     }
 


### PR DESCRIPTION
Old starting items string was causing a crash and clearing JSONs, bad stuff

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5184716466.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5184771171.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5184823589.zip)
<!--- section:artifacts:end -->