### PR TITLE
[Enhancement] Save Game on Moon Crash

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1132,6 +1132,11 @@ void BenMenu::AddEnhancements() {
         })
         .Options(IntSliderOptions().Tooltip("Sets the interval between Autosaves.").Min(1).Max(60).DefaultValue(5));
     AddWidget(path, "Time Cycle", WIDGET_SEPARATOR_TEXT);
+    AddWidget(path, "Save Game on Moon Crash", WIDGET_CVAR_CHECKBOX)
+        .CVar("gEnhancements.Cycle.SaveOnMoonCrash")
+        .Options(CheckboxOptions().Tooltip("Moon Crashes will save game data similar to the Song of Time,\n"
+                                           "instead of wiping owl save data. Automatically enabled in glitchless \n"
+                                           "rando seeds."));
     AddWidget(path, "Do not reset Bottle content", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Cycle.DoNotResetBottleContent")
         .Options(CheckboxOptions().Tooltip("Playing the Song of Time will not reset the bottles' content."));

--- a/mm/2s2h/Enhancements/Cycle/MoonCrashSave.cpp
+++ b/mm/2s2h/Enhancements/Cycle/MoonCrashSave.cpp
@@ -1,0 +1,30 @@
+#include <libultraship/bridge/consolevariablebridge.h>
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/ShipInit.hpp"
+#include "2s2h/Enhancements/Saving/SavingEnhancements.h"
+#include "2s2h/Rando/Rando.h"
+
+extern "C" {
+#include "variables.h"
+}
+
+#define CVAR_NAME "gEnhancements.Cycle.SaveOnMoonCrash"
+#define CVAR CVarGetInteger(CVAR_NAME, 0)
+
+void RegisterMoonCrashSave() {
+    COND_HOOK(BeforeMoonCrashSaveReset, CVAR || IS_RANDO, []() {
+        if (CVAR || (IS_RANDO && RANDO_SAVE_OPTIONS[RO_LOGIC] == RO_LOGIC_GLITCHLESS)) {
+            SavingEnhancements_AdvancePlaytime();
+            Sram_SaveEndOfCycle(gPlayState);
+            func_8014546C(&gPlayState->sramCtx);
+            if (gSaveContext.fileNum != 0xFF) {
+                Sram_SetFlashPagesDefault(&gPlayState->sramCtx,
+                                          gFlashSaveStartPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER],
+                                          gFlashSpecialSaveNumPages[gSaveContext.fileNum * FLASH_SAVE_MAIN_MULTIPLIER]);
+                Sram_StartWriteToFlashDefault(&gPlayState->sramCtx);
+            }
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterMoonCrashSave, { CVAR_NAME, "IS_RANDO" });

--- a/mm/2s2h/Rando/Menu.cpp
+++ b/mm/2s2h/Rando/Menu.cpp
@@ -333,7 +333,7 @@ static void DrawLogicConditionsTab() {
     }
     UIWidgets::Tooltip(
         "Glitchless - The items are shuffled in a way that guarantees the seed is beatable without "
-        "glitches.\n\n"
+        "glitches. With this setting, \"Save Game on Moon Crash\" is automatically enabled.\n\n"
         "No Logic - The items are shuffled completely randomly, this can result in unbeatable seeds, and "
         "will require heavy use of glitches.\n\n"
         "Nearly No Logic - The items are shuffled completely randomly, with the following exceptions:\n"


### PR DESCRIPTION
With this enabled, game data will be SoT-saved on moon crash instead of having owl data wiped. In this first iteration, this will always be enabled for glitchless seeds since it will help ensure beatability for in seeds where SoT, Ocarina, and/or Ocarina buttons are shuffled. It can be toggled at will for vanilla or other logic settings.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5196079496.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5196165207.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5196273927.zip)
<!--- section:artifacts:end -->