### PR TITLE
[Enhancement] Color Pictograph

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1018,6 +1018,9 @@ void BenMenu::AddEnhancements() {
         })
         .Options(CheckboxOptions().Tooltip("Mirrors the world horizontally."));
     AddWidget(path, "Other", WIDGET_SEPARATOR_TEXT);
+    AddWidget(path, "Color Picto", WIDGET_CVAR_CHECKBOX)
+        .CVar("gEnhancements.Items.ColorPictograph")
+        .Options(CheckboxOptions().Tooltip("Color Picto."));
     AddWidget(path, "Milk Run Reward Options", WIDGET_CVAR_COMBOBOX)
         .CVar("gEnhancements.Minigames.CremiaHugs")
         .Options(ComboboxOptions()

--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1018,9 +1018,6 @@ void BenMenu::AddEnhancements() {
         })
         .Options(CheckboxOptions().Tooltip("Mirrors the world horizontally."));
     AddWidget(path, "Other", WIDGET_SEPARATOR_TEXT);
-    AddWidget(path, "Color Picto", WIDGET_CVAR_CHECKBOX)
-        .CVar("gEnhancements.Items.ColorPictograph")
-        .Options(CheckboxOptions().Tooltip("Color Picto."));
     AddWidget(path, "Milk Run Reward Options", WIDGET_CVAR_COMBOBOX)
         .CVar("gEnhancements.Minigames.CremiaHugs")
         .Options(ComboboxOptions()
@@ -1298,6 +1295,13 @@ void BenMenu::AddEnhancements() {
     AddWidget(path, "Skip Soaring cutscene", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Songs.SkipSoaringCutscene")
         .Options(CheckboxOptions().Tooltip("Skips the cutscene when using the Song of Soaring to warp."));
+
+    // Item Enhancements
+    path.column = SECTION_COLUMN_3;
+    AddWidget(path, "Items", WIDGET_SEPARATOR_TEXT);
+    AddWidget(path, "Color Pictograph", WIDGET_CVAR_CHECKBOX)
+        .CVar("gEnhancements.Items.ColorPictograph")
+        .Options(CheckboxOptions().Tooltip("Will take and display pictographs in color."));
 
     // Time Savers
     path = { "Enhancements", "Time Savers", SECTION_COLUMN_1 };

--- a/mm/2s2h/Enhancements/Items/ColorPictograph.cpp
+++ b/mm/2s2h/Enhancements/Items/ColorPictograph.cpp
@@ -170,9 +170,12 @@ void RegisterColorPictograph() {
         }
     });
 
-    COND_HOOK(OnSaveLoad, true, [](s16 fileNum) {
-        fileNumber = fileNum + 1;
-        LoadPictoPNG();
+    COND_HOOK(OnSaveLoad, true, [](s16 fileNum) { fileNumber = fileNum + 1; });
+
+    COND_VB_SHOULD(VB_PICTO_ACTIVATE, CVAR, {
+        if (*should) {
+            LoadPictoPNG();
+        }
     });
 }
 

--- a/mm/2s2h/Enhancements/Items/ColorPictograph.cpp
+++ b/mm/2s2h/Enhancements/Items/ColorPictograph.cpp
@@ -17,6 +17,7 @@ extern "C" {
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 static s16 fileNumber = 1;
+static u16 pictoPhotoRGBABuffer[PICTO_PHOTO_SIZE];
 
 void SavePictoPng() {
     const int width = PICTO_PHOTO_WIDTH;
@@ -51,11 +52,8 @@ void SavePictoPng() {
     std::vector<uint8_t> buffer(width * height * 4);
 
     for (int i = 0; i < width * height; ++i) {
-        uint16_t px = gSaveContext.shipSaveContext.pictoPhotoRGBA[i];
-
-        // fix endianness so png looks good
+        uint16_t px = pictoPhotoRGBABuffer[i];
         px = (px >> 8) | (px << 8);
-
         buffer[i * 4 + 0] = ((px >> 11) & 0x1F) << 3; // R
         buffer[i * 4 + 1] = ((px >> 6) & 0x1F) << 3;  // G
         buffer[i * 4 + 2] = ((px >> 1) & 0x1F) << 3;  // B
@@ -79,8 +77,7 @@ void LoadPictoPNG() {
 
     FILE* fp = fopen(path.c_str(), "rb");
     if (!fp) {
-        std::memset(gSaveContext.shipSaveContext.pictoPhotoRGBA, 0,
-                    sizeof(gSaveContext.shipSaveContext.pictoPhotoRGBA));
+        std::memset(pictoPhotoRGBABuffer, 0, sizeof(pictoPhotoRGBABuffer));
         return;
     }
 
@@ -118,10 +115,8 @@ void LoadPictoPNG() {
         uint8_t g = buffer[i * 4 + 1] >> 3;
         uint8_t b = buffer[i * 4 + 2] >> 3;
         uint8_t a = buffer[i * 4 + 3] ? 1 : 0;
-
-        // More endianness stuff to check
         uint16_t px = (r << 11) | (g << 6) | (b << 1) | a;
-        gSaveContext.shipSaveContext.pictoPhotoRGBA[i] = (px >> 8) | (px << 8);
+        pictoPhotoRGBABuffer[i] = (px >> 8) | (px << 8);
     }
 
     png_destroy_read_struct(&png, &info, nullptr);
@@ -130,9 +125,6 @@ void LoadPictoPNG() {
 
 void ConvertImage(u16* destI, u16* srcRgba16, s32 rgba16Width, s32 pixelLeft, s32 pixelTop, s32 pixelRight,
                   s32 pixelBottom) {
-
-    // not sure if best way to do this
-    // also not sure if/how endianness needs to be handled for cross-platform
     for (int i = pixelTop; i <= pixelBottom; i++) {
         for (int j = pixelLeft; j <= pixelRight; j++) {
             u16 px = srcRgba16[i * rgba16Width + j];
@@ -140,7 +132,6 @@ void ConvertImage(u16* destI, u16* srcRgba16, s32 rgba16Width, s32 pixelLeft, s3
             destI[(i - pixelTop) * PICTO_PHOTO_WIDTH + (j - pixelLeft)] = px;
         }
     }
-
 
     // Probably don't need to do this everytime, just on Save (specifically owl save)
     SavePictoPng();
@@ -153,11 +144,10 @@ void DrawPicto(s16 sp2CC) {
     // Get rid of Sepia tone from prior gDPSetPrimColor call
     gDPSetCombineMode(OVERLAY_DISP++, G_CC_DECALRGBA, G_CC_DECALRGBA);
 
-    // Calling invalidate twice because I couldn't cast as a u16*
-    gSPInvalidateTexCache(OVERLAY_DISP++, (uintptr_t)(gSaveContext.shipSaveContext.pictoPhotoRGBA) + (0xA00 * sp2CC));
-    gDPLoadTextureBlock(OVERLAY_DISP++, (u16*)(gSaveContext.shipSaveContext.pictoPhotoRGBA) + (0x500 * sp2CC),
-                        G_IM_FMT_RGBA, G_IM_SIZ_16b, PICTO_PHOTO_WIDTH, 8, 0, G_TX_NOMIRROR | G_TX_WRAP,
-                        G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
+    gSPInvalidateTexCache(OVERLAY_DISP++, (uintptr_t)(pictoPhotoRGBABuffer) + (0xA00 * sp2CC));
+    gDPLoadTextureBlock(OVERLAY_DISP++, (u16*)(pictoPhotoRGBABuffer) + (0x500 * sp2CC), G_IM_FMT_RGBA, G_IM_SIZ_16b,
+                        PICTO_PHOTO_WIDTH, 8, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK,
+                        G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
 
     CLOSE_DISPS(gPlayState->state.gfxCtx);
 }
@@ -165,8 +155,8 @@ void DrawPicto(s16 sp2CC) {
 void RegisterColorPictograph() {
     COND_VB_SHOULD(VB_PICTO_TAKE, true /*maybe cvar?*/, {
         PreRender* prerender = va_arg(args, PreRender*);
-        ConvertImage(gSaveContext.shipSaveContext.pictoPhotoRGBA, prerender->fbufSave, SCREEN_WIDTH,
-                     PICTO_PHOTO_TOPLEFT_X, PICTO_PHOTO_TOPLEFT_Y, (PICTO_PHOTO_TOPLEFT_X + PICTO_PHOTO_WIDTH) - 1,
+        ConvertImage(pictoPhotoRGBABuffer, prerender->fbufSave, SCREEN_WIDTH, PICTO_PHOTO_TOPLEFT_X,
+                     PICTO_PHOTO_TOPLEFT_Y, (PICTO_PHOTO_TOPLEFT_X + PICTO_PHOTO_WIDTH) - 1,
                      (PICTO_PHOTO_TOPLEFT_Y + PICTO_PHOTO_HEIGHT) - 1);
     });
 
@@ -174,7 +164,7 @@ void RegisterColorPictograph() {
         s16 sp2CC = va_arg(args, s16);
 
         // might need something better to check for existance
-        if (gSaveContext.shipSaveContext.pictoPhotoRGBA[0] != 0) {
+        if (pictoPhotoRGBABuffer[0] != 0) {
             DrawPicto(sp2CC);
             *should = false;
         }

--- a/mm/2s2h/Enhancements/Items/ColorPictograph.cpp
+++ b/mm/2s2h/Enhancements/Items/ColorPictograph.cpp
@@ -141,11 +141,6 @@ void ConvertImage(u16* destI, u16* srcRgba16, s32 rgba16Width, s32 pixelLeft, s3
         }
     }
 
-    nlohmann::json image = nlohmann::json::array();
-
-    for (auto i = 0; i < std::size(gSaveContext.shipSaveContext.pictoPhotoRGBA); i++) {
-        image.push_back(gSaveContext.shipSaveContext.pictoPhotoRGBA[i]);
-    }
 
     // Probably don't need to do this everytime, just on Save (specifically owl save)
     SavePictoPng();

--- a/mm/2s2h/Enhancements/Items/ColorPictograph.cpp
+++ b/mm/2s2h/Enhancements/Items/ColorPictograph.cpp
@@ -1,0 +1,59 @@
+#include <libultraship/bridge/consolevariablebridge.h>
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/ShipInit.hpp"
+#include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
+
+#define CVAR_NAME "gEnhancements.Items.ColorPictograph"
+#define CVAR CVarGetInteger(CVAR_NAME, 0)
+
+void convertImage(u16* destI, u16* srcRgba16, s32 rgba16Width, s32 pixelLeft, s32 pixelTop, s32 pixelRight,
+                  s32 pixelBottom) {
+
+    for (int i = pixelTop; i <= pixelBottom; i++) {
+        for (int j = pixelLeft; j <= pixelRight; j++) {
+            u16 px = srcRgba16[i * rgba16Width + j];
+            px |= 1;
+            px = (px >> 8) | (px << 8);
+            destI[(i - pixelTop) * PICTO_PHOTO_WIDTH + (j - pixelLeft)] = px;
+        }
+    }
+}
+
+void drawPicto(s16 sp2CC) {
+
+    OPEN_DISPS(gPlayState->state.gfxCtx);
+
+    // Get rid of Sepia tone from prior gDPSetPrimColor call
+    gDPSetCombineMode(OVERLAY_DISP++, G_CC_DECALRGBA, G_CC_DECALRGBA);
+
+    // Calling twice because I couldn't cast as a u16*
+    gSPInvalidateTexCache(OVERLAY_DISP++, (uintptr_t)(gSaveContext.shipSaveContext.pictoPhotoRGBA) + (0x500 * sp2CC));
+    gSPInvalidateTexCache(OVERLAY_DISP++, (uintptr_t)(gSaveContext.shipSaveContext.pictoPhotoRGBA) + (0xA00 * sp2CC));
+    gDPLoadTextureBlock(OVERLAY_DISP++, (u16*)(gSaveContext.shipSaveContext.pictoPhotoRGBA) + (0x500 * sp2CC),
+                        G_IM_FMT_RGBA, G_IM_SIZ_16b, PICTO_PHOTO_WIDTH, 8, 0, G_TX_NOMIRROR | G_TX_WRAP,
+                        G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
+
+    CLOSE_DISPS(gPlayState->state.gfxCtx);
+}
+
+void RegisterColorPictograph() {
+
+    COND_VB_SHOULD(VB_PICTO_TAKE, true /*maybe cvar?*/, {
+        PreRender* prerender = va_arg(args, PreRender*);
+        // 320came from SCREEN_WIDTH
+        convertImage(gSaveContext.shipSaveContext.pictoPhotoRGBA, prerender->fbufSave, 320, PICTO_PHOTO_TOPLEFT_X,
+                     PICTO_PHOTO_TOPLEFT_Y, (PICTO_PHOTO_TOPLEFT_X + PICTO_PHOTO_WIDTH) - 1,
+                     (PICTO_PHOTO_TOPLEFT_Y + PICTO_PHOTO_HEIGHT) - 1);
+    });
+
+    COND_VB_SHOULD(VB_PICTO_DISPLAY, CVAR, {
+        s16 sp2CC = va_arg(args, s16);
+
+        if (gSaveContext.shipSaveContext.pictoPhotoRGBA[0] != 0) {
+            drawPicto(sp2CC);
+            *should = false;
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterColorPictograph, { CVAR_NAME });

--- a/mm/2s2h/Enhancements/Items/ColorPictograph.cpp
+++ b/mm/2s2h/Enhancements/Items/ColorPictograph.cpp
@@ -132,9 +132,6 @@ void ConvertImage(u16* destI, u16* srcRgba16, s32 rgba16Width, s32 pixelLeft, s3
             destI[(i - pixelTop) * PICTO_PHOTO_WIDTH + (j - pixelLeft)] = px;
         }
     }
-
-    // Probably don't need to do this everytime, just on Save (specifically owl save)
-    SavePictoPng();
 }
 
 void DrawPicto(s16 sp2CC) {
@@ -153,11 +150,14 @@ void DrawPicto(s16 sp2CC) {
 }
 
 void RegisterColorPictograph() {
-    COND_VB_SHOULD(VB_PICTO_TAKE, true /*maybe cvar?*/, {
+    COND_VB_SHOULD(VB_PICTO_TAKE, true, {
         PreRender* prerender = va_arg(args, PreRender*);
         ConvertImage(pictoPhotoRGBABuffer, prerender->fbufSave, SCREEN_WIDTH, PICTO_PHOTO_TOPLEFT_X,
                      PICTO_PHOTO_TOPLEFT_Y, (PICTO_PHOTO_TOPLEFT_X + PICTO_PHOTO_WIDTH) - 1,
                      (PICTO_PHOTO_TOPLEFT_Y + PICTO_PHOTO_HEIGHT) - 1);
+        
+        // Probably don't need to do this everytime, just on Save (specifically owl save)
+        SavePictoPng();
     });
 
     COND_VB_SHOULD(VB_PICTO_DISPLAY, CVAR, {
@@ -172,7 +172,7 @@ void RegisterColorPictograph() {
 
     COND_HOOK(OnSaveLoad, true, [](s16 fileNum) { fileNumber = fileNum + 1; });
 
-    COND_VB_SHOULD(VB_PICTO_ACTIVATE, CVAR, {
+    COND_VB_SHOULD(VB_PICTO_ACTIVATE, true, {
         if (*should) {
             LoadPictoPNG();
         }

--- a/mm/2s2h/Enhancements/Items/ColorPictograph.cpp
+++ b/mm/2s2h/Enhancements/Items/ColorPictograph.cpp
@@ -155,7 +155,7 @@ void RegisterColorPictograph() {
         ConvertImage(pictoPhotoRGBABuffer, prerender->fbufSave, SCREEN_WIDTH, PICTO_PHOTO_TOPLEFT_X,
                      PICTO_PHOTO_TOPLEFT_Y, (PICTO_PHOTO_TOPLEFT_X + PICTO_PHOTO_WIDTH) - 1,
                      (PICTO_PHOTO_TOPLEFT_Y + PICTO_PHOTO_HEIGHT) - 1);
-        
+
         // Probably don't need to do this everytime, just on Save (specifically owl save)
         SavePictoPng();
     });

--- a/mm/2s2h/Enhancements/Items/ColorPictograph.cpp
+++ b/mm/2s2h/Enhancements/Items/ColorPictograph.cpp
@@ -5,6 +5,7 @@
 #include <fstream>
 #include <filesystem>
 #include <cstring>
+#include <png.h>
 
 using json = nlohmann::json;
 
@@ -15,73 +16,114 @@ extern "C" {
 #define CVAR_NAME "gEnhancements.Items.ColorPictograph"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
-static s16 fileNumber = 0;
+static s16 fileNumber = 1;
 
-// currently saving in root
-std::string pictoFilePath = "picto.json";
+void SavePictoPng() {
+    const int width = PICTO_PHOTO_WIDTH;
+    const int height = PICTO_PHOTO_HEIGHT;
 
-// convert to msgpack or .png or some other format?
-void SavePictoToFile(const nlohmann::json& image) {
-    std::string filePath = Ship::Context::GetPathRelativeToAppDirectory(pictoFilePath);
-    nlohmann::json picto = nlohmann::json::object();
+    std::string path =
+        Ship::Context::GetPathRelativeToAppDirectory("saves/picto" + std::to_string(fileNumber) + ".png");
 
-    std::ifstream fileStream(filePath);
-    if (fileStream.is_open()) {
-        try {
-            fileStream >> picto;
-        } catch (nlohmann::json::exception& e) {
-            throw std::runtime_error("Failed to parse picto file: " + std::string(e.what()));
-        }
+    FILE* fp = fopen(path.c_str(), "wb");
+    if (!fp)
+        throw std::runtime_error("Failed to open PNG file for write");
+
+    png_structp png = png_create_write_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
+    if (!png)
+        throw std::runtime_error("png_create_write_struct failed");
+
+    png_infop info = png_create_info_struct(png);
+    if (!info)
+        throw std::runtime_error("png_create_info_struct failed");
+
+    if (setjmp(png_jmpbuf(png)))
+        throw std::runtime_error("libpng write error");
+
+    png_init_io(png, fp);
+
+    png_set_IHDR(png, info, width, height, 8, PNG_COLOR_TYPE_RGBA, PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_BASE,
+                 PNG_FILTER_TYPE_BASE);
+
+    png_write_info(png, info);
+
+    // RGBA8 buffer
+    std::vector<uint8_t> buffer(width * height * 4);
+
+    for (int i = 0; i < width * height; ++i) {
+        uint16_t px = gSaveContext.shipSaveContext.pictoPhotoRGBA[i];
+
+        // fix endianness so png looks good
+        px = (px >> 8) | (px << 8);
+
+        buffer[i * 4 + 0] = ((px >> 11) & 0x1F) << 3; // R
+        buffer[i * 4 + 1] = ((px >> 6) & 0x1F) << 3;  // G
+        buffer[i * 4 + 2] = ((px >> 1) & 0x1F) << 3;  // B
+        buffer[i * 4 + 3] = (px & 1) ? 255 : 0;       // A
     }
 
-    std::string fileKey = "file" + std::to_string(fileNumber);
-    picto[fileKey]["image"] = image;
+    std::vector<png_bytep> rows(height);
+    for (int y = 0; y < height; ++y)
+        rows[y] = &buffer[y * width * 4];
 
-    std::ofstream out(filePath);
-    if (!out) {
-        throw std::runtime_error("Failed to write picto file");
-    }
-    out << picto.dump(4);
+    png_write_image(png, rows.data());
+    png_write_end(png, nullptr);
+
+    png_destroy_write_struct(&png, &info);
+    fclose(fp);
 }
 
-void LoadPictoFromFile(s16 fileNum) {
-    std::string filePath = Ship::Context::GetPathRelativeToAppDirectory(pictoFilePath);
-    std::ifstream fileStream(filePath);
-    if (!fileStream.is_open()) {
-        throw std::runtime_error("Failed to open picto file");
-    }
+void LoadPictoPNG() {
+    std::string path =
+        Ship::Context::GetPathRelativeToAppDirectory("saves/picto" + std::to_string(fileNumber) + ".png");
 
-    nlohmann::json picto;
-    try {
-        fileStream >> picto;
-    } catch (nlohmann::json::exception& e) {
-        throw std::runtime_error("Failed to parse picto file: " + std::string(e.what()));
-    }
-
-    std::string fileKey = "file" + std::to_string(fileNum);
-
-    if (!picto.contains(fileKey)) {
+    FILE* fp = fopen(path.c_str(), "rb");
+    if (!fp) {
         std::memset(gSaveContext.shipSaveContext.pictoPhotoRGBA, 0,
                     sizeof(gSaveContext.shipSaveContext.pictoPhotoRGBA));
         return;
     }
 
-    if (!picto[fileKey].contains("image")) {
-        std::memset(gSaveContext.shipSaveContext.pictoPhotoRGBA, 0,
-                    sizeof(gSaveContext.shipSaveContext.pictoPhotoRGBA));
-        return;
+    png_structp png = png_create_read_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
+    png_infop info = png_create_info_struct(png);
+
+    if (setjmp(png_jmpbuf(png)))
+        throw std::runtime_error("libpng read error");
+
+    png_init_io(png, fp);
+    png_read_info(png, info);
+
+    png_uint_32 width, height;
+    int depth, color;
+    png_get_IHDR(png, info, &width, &height, &depth, &color, nullptr, nullptr, nullptr);
+
+    if (width != PICTO_PHOTO_WIDTH || height != PICTO_PHOTO_HEIGHT)
+        throw std::runtime_error("PNG dimensions mismatch");
+
+    png_set_expand(png);
+    png_set_strip_16(png);
+    png_set_add_alpha(png, 0xFF, PNG_FILLER_AFTER);
+    png_read_update_info(png, info);
+
+    std::vector<uint8_t> buffer(width * height * 4);
+    std::vector<png_bytep> rows(height);
+
+    for (size_t y = 0; y < height; ++y)
+        rows[y] = &buffer[y * width * 4];
+
+    png_read_image(png, rows.data());
+
+    for (size_t i = 0; i < width * height; ++i) {
+        uint8_t r = buffer[i * 4 + 0] >> 3;
+        uint8_t g = buffer[i * 4 + 1] >> 3;
+        uint8_t b = buffer[i * 4 + 2] >> 3;
+        uint8_t a = buffer[i * 4 + 3] ? 1 : 0;
+
+        gSaveContext.shipSaveContext.pictoPhotoRGBA[i] = (r << 11) | (g << 6) | (b << 1) | a;
     }
 
-    if (!picto[fileKey]["image"].is_array() ||
-        picto[fileKey]["image"].size() < std::size(gSaveContext.shipSaveContext.pictoPhotoRGBA)) {
-        std::memset(gSaveContext.shipSaveContext.pictoPhotoRGBA, 0,
-                    sizeof(gSaveContext.shipSaveContext.pictoPhotoRGBA));
-        return;
-    }
-
-    for (auto i = 0; i < std::size(gSaveContext.shipSaveContext.pictoPhotoRGBA); i++) {
-        gSaveContext.shipSaveContext.pictoPhotoRGBA[i] = picto[fileKey]["image"].at(i).get<uint16_t>();
-    }
+    png_destroy_read_struct(&png, &info, nullptr);
+    fclose(fp);
 }
 
 void ConvertImage(u16* destI, u16* srcRgba16, s32 rgba16Width, s32 pixelLeft, s32 pixelTop, s32 pixelRight,
@@ -103,7 +145,8 @@ void ConvertImage(u16* destI, u16* srcRgba16, s32 rgba16Width, s32 pixelLeft, s3
         image.push_back(gSaveContext.shipSaveContext.pictoPhotoRGBA[i]);
     }
 
-    SavePictoToFile(image);
+    // Probably don't need to do this everytime, just on Save (specifically owl save)
+    SavePictoPng();
 }
 
 void DrawPicto(s16 sp2CC) {
@@ -124,13 +167,6 @@ void DrawPicto(s16 sp2CC) {
 }
 
 void RegisterColorPictograph() {
-    if (!std::filesystem::exists(Ship::Context::GetPathRelativeToAppDirectory(pictoFilePath))) {
-        json initFile;
-        std::ofstream file(Ship::Context::GetPathRelativeToAppDirectory(pictoFilePath));
-        file << initFile.dump(4);
-        file.close();
-    }
-
     COND_VB_SHOULD(VB_PICTO_TAKE, true /*maybe cvar?*/, {
         PreRender* prerender = va_arg(args, PreRender*);
         ConvertImage(gSaveContext.shipSaveContext.pictoPhotoRGBA, prerender->fbufSave, SCREEN_WIDTH,
@@ -149,8 +185,8 @@ void RegisterColorPictograph() {
     });
 
     COND_HOOK(OnSaveLoad, true, [](s16 fileNum) {
-        fileNumber = fileNum;
-        LoadPictoFromFile(fileNum);
+        fileNumber = fileNum + 1;
+        LoadPictoPNG();
     });
 }
 

--- a/mm/2s2h/Enhancements/Items/ColorPictograph.cpp
+++ b/mm/2s2h/Enhancements/Items/ColorPictograph.cpp
@@ -161,11 +161,11 @@ void RegisterColorPictograph() {
     });
 
     COND_VB_SHOULD(VB_PICTO_DISPLAY, CVAR, {
-        s16 sp2CC = va_arg(args, s16);
+        s16* sp2CC = va_arg(args, s16*);
 
         // might need something better to check for existance
         if (pictoPhotoRGBABuffer[0] != 0) {
-            DrawPicto(sp2CC);
+            DrawPicto(*sp2CC);
             *should = false;
         }
     });

--- a/mm/2s2h/Enhancements/Items/ColorPictograph.cpp
+++ b/mm/2s2h/Enhancements/Items/ColorPictograph.cpp
@@ -119,7 +119,9 @@ void LoadPictoPNG() {
         uint8_t b = buffer[i * 4 + 2] >> 3;
         uint8_t a = buffer[i * 4 + 3] ? 1 : 0;
 
-        gSaveContext.shipSaveContext.pictoPhotoRGBA[i] = (r << 11) | (g << 6) | (b << 1) | a;
+        // More endianness stuff to check
+        uint16_t px = (r << 11) | (g << 6) | (b << 1) | a;
+        gSaveContext.shipSaveContext.pictoPhotoRGBA[i] = (px >> 8) | (px << 8);
     }
 
     png_destroy_read_struct(&png, &info, nullptr);

--- a/mm/2s2h/Enhancements/Items/ColorPictograph.cpp
+++ b/mm/2s2h/Enhancements/Items/ColorPictograph.cpp
@@ -154,7 +154,6 @@ void DrawPicto(s16 sp2CC) {
     gDPSetCombineMode(OVERLAY_DISP++, G_CC_DECALRGBA, G_CC_DECALRGBA);
 
     // Calling invalidate twice because I couldn't cast as a u16*
-    gSPInvalidateTexCache(OVERLAY_DISP++, (uintptr_t)(gSaveContext.shipSaveContext.pictoPhotoRGBA) + (0x500 * sp2CC));
     gSPInvalidateTexCache(OVERLAY_DISP++, (uintptr_t)(gSaveContext.shipSaveContext.pictoPhotoRGBA) + (0xA00 * sp2CC));
     gDPLoadTextureBlock(OVERLAY_DISP++, (u16*)(gSaveContext.shipSaveContext.pictoPhotoRGBA) + (0x500 * sp2CC),
                         G_IM_FMT_RGBA, G_IM_SIZ_16b, PICTO_PHOTO_WIDTH, 8, 0, G_TX_NOMIRROR | G_TX_WRAP,

--- a/mm/2s2h/Enhancements/Items/ColorPictograph.cpp
+++ b/mm/2s2h/Enhancements/Items/ColorPictograph.cpp
@@ -4,6 +4,7 @@
 #include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
 #include <fstream>
 #include <filesystem>
+#include <cstring>
 
 using json = nlohmann::json;
 
@@ -16,19 +17,35 @@ extern "C" {
 
 static s16 fileNumber = 0;
 
-void SavePictoToFile(nlohmann::json picto) {
-    // where to save and format
-    std::string filePath = Ship::Context::GetPathRelativeToAppDirectory("picto.json");
-    std::ofstream fileStream(filePath);
-    if (!fileStream.is_open()) {
-        throw std::runtime_error("Failed to open picto file");
+// currently saving in root
+std::string pictoFilePath = "picto.json";
+
+// convert to msgpack or .png or some other format?
+void SavePictoToFile(const nlohmann::json& image) {
+    std::string filePath = Ship::Context::GetPathRelativeToAppDirectory(pictoFilePath);
+    nlohmann::json picto = nlohmann::json::object();
+
+    std::ifstream fileStream(filePath);
+    if (fileStream.is_open()) {
+        try {
+            fileStream >> picto;
+        } catch (nlohmann::json::exception& e) {
+            throw std::runtime_error("Failed to parse picto file: " + std::string(e.what()));
+        }
     }
 
-    fileStream << picto.dump(4);
+    std::string fileKey = "file" + std::to_string(fileNumber);
+    picto[fileKey]["image"] = image;
+
+    std::ofstream out(filePath);
+    if (!out) {
+        throw std::runtime_error("Failed to write picto file");
+    }
+    out << picto.dump(4);
 }
 
 void LoadPictoFromFile(s16 fileNum) {
-    std::string filePath = Ship::Context::GetPathRelativeToAppDirectory("picto.json");
+    std::string filePath = Ship::Context::GetPathRelativeToAppDirectory(pictoFilePath);
     std::ifstream fileStream(filePath);
     if (!fileStream.is_open()) {
         throw std::runtime_error("Failed to open picto file");
@@ -55,6 +72,13 @@ void LoadPictoFromFile(s16 fileNum) {
         return;
     }
 
+    if (!picto[fileKey]["image"].is_array() ||
+        picto[fileKey]["image"].size() < std::size(gSaveContext.shipSaveContext.pictoPhotoRGBA)) {
+        std::memset(gSaveContext.shipSaveContext.pictoPhotoRGBA, 0,
+                    sizeof(gSaveContext.shipSaveContext.pictoPhotoRGBA));
+        return;
+    }
+
     for (auto i = 0; i < std::size(gSaveContext.shipSaveContext.pictoPhotoRGBA); i++) {
         gSaveContext.shipSaveContext.pictoPhotoRGBA[i] = picto[fileKey]["image"].at(i).get<uint16_t>();
     }
@@ -64,38 +88,22 @@ void ConvertImage(u16* destI, u16* srcRgba16, s32 rgba16Width, s32 pixelLeft, s3
                   s32 pixelBottom) {
 
     // not sure if best way to do this
-    // also not sure how endianness needs to be handled for cross-platform
+    // also not sure if/how endianness needs to be handled for cross-platform
     for (int i = pixelTop; i <= pixelBottom; i++) {
         for (int j = pixelLeft; j <= pixelRight; j++) {
             u16 px = srcRgba16[i * rgba16Width + j];
-            px |= 1;
             px = (px >> 8) | (px << 8);
             destI[(i - pixelTop) * PICTO_PHOTO_WIDTH + (j - pixelLeft)] = px;
         }
     }
 
-    // below should probably be moved to SavePictoToFile()
-    std::string filePath = Ship::Context::GetPathRelativeToAppDirectory("picto.json");
-    std::ifstream fileStream(filePath);
-    if (!fileStream.is_open()) {
-        throw std::runtime_error("Failed to open picto file");
-    }
-
-    nlohmann::json picto;
-    try {
-        fileStream >> picto;
-    } catch (nlohmann::json::exception& e) {
-        throw std::runtime_error("Failed to parse picto file: " + std::string(e.what()));
-    }
-
-    std::string fileKey = "file" + std::to_string(fileNumber);
-
-    picto[fileKey]["image"] = nlohmann::json::array();
+    nlohmann::json image = nlohmann::json::array();
 
     for (auto i = 0; i < std::size(gSaveContext.shipSaveContext.pictoPhotoRGBA); i++) {
-        picto[fileKey]["image"].push_back(gSaveContext.shipSaveContext.pictoPhotoRGBA[i]);
+        image.push_back(gSaveContext.shipSaveContext.pictoPhotoRGBA[i]);
     }
-    SavePictoToFile(picto);
+
+    SavePictoToFile(image);
 }
 
 void DrawPicto(s16 sp2CC) {
@@ -116,21 +124,17 @@ void DrawPicto(s16 sp2CC) {
 }
 
 void RegisterColorPictograph() {
-    // where to put file?
-    // have file for each save file, or three objects in one file?
-    // convert to .png?
-    if (!std::filesystem::exists(Ship::Context::GetPathRelativeToAppDirectory("picto.json"))) {
+    if (!std::filesystem::exists(Ship::Context::GetPathRelativeToAppDirectory(pictoFilePath))) {
         json initFile;
-        std::ofstream file(Ship::Context::GetPathRelativeToAppDirectory("picto.json"));
+        std::ofstream file(Ship::Context::GetPathRelativeToAppDirectory(pictoFilePath));
         file << initFile.dump(4);
         file.close();
     }
 
     COND_VB_SHOULD(VB_PICTO_TAKE, true /*maybe cvar?*/, {
         PreRender* prerender = va_arg(args, PreRender*);
-        // 320 came from SCREEN_WIDTH which is undefined here
-        ConvertImage(gSaveContext.shipSaveContext.pictoPhotoRGBA, prerender->fbufSave, 320, PICTO_PHOTO_TOPLEFT_X,
-                     PICTO_PHOTO_TOPLEFT_Y, (PICTO_PHOTO_TOPLEFT_X + PICTO_PHOTO_WIDTH) - 1,
+        ConvertImage(gSaveContext.shipSaveContext.pictoPhotoRGBA, prerender->fbufSave, SCREEN_WIDTH,
+                     PICTO_PHOTO_TOPLEFT_X, PICTO_PHOTO_TOPLEFT_Y, (PICTO_PHOTO_TOPLEFT_X + PICTO_PHOTO_WIDTH) - 1,
                      (PICTO_PHOTO_TOPLEFT_Y + PICTO_PHOTO_HEIGHT) - 1);
     });
 

--- a/mm/2s2h/Enhancements/Items/ColorPictograph.cpp
+++ b/mm/2s2h/Enhancements/Items/ColorPictograph.cpp
@@ -2,13 +2,69 @@
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 #include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
+#include <fstream>
+#include <filesystem>
+
+using json = nlohmann::json;
+
+extern "C" {
+#include "variables.h"
+}
 
 #define CVAR_NAME "gEnhancements.Items.ColorPictograph"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)
 
-void convertImage(u16* destI, u16* srcRgba16, s32 rgba16Width, s32 pixelLeft, s32 pixelTop, s32 pixelRight,
+static s16 fileNumber = 0;
+
+void SavePictoToFile(nlohmann::json picto) {
+    // where to save and format
+    std::string filePath = Ship::Context::GetPathRelativeToAppDirectory("picto.json");
+    std::ofstream fileStream(filePath);
+    if (!fileStream.is_open()) {
+        throw std::runtime_error("Failed to open picto file");
+    }
+
+    fileStream << picto.dump(4);
+}
+
+void LoadPictoFromFile(s16 fileNum) {
+    std::string filePath = Ship::Context::GetPathRelativeToAppDirectory("picto.json");
+    std::ifstream fileStream(filePath);
+    if (!fileStream.is_open()) {
+        throw std::runtime_error("Failed to open picto file");
+    }
+
+    nlohmann::json picto;
+    try {
+        fileStream >> picto;
+    } catch (nlohmann::json::exception& e) {
+        throw std::runtime_error("Failed to parse picto file: " + std::string(e.what()));
+    }
+
+    std::string fileKey = "file" + std::to_string(fileNum);
+
+    if (!picto.contains(fileKey)) {
+        std::memset(gSaveContext.shipSaveContext.pictoPhotoRGBA, 0,
+                    sizeof(gSaveContext.shipSaveContext.pictoPhotoRGBA));
+        return;
+    }
+
+    if (!picto[fileKey].contains("image")) {
+        std::memset(gSaveContext.shipSaveContext.pictoPhotoRGBA, 0,
+                    sizeof(gSaveContext.shipSaveContext.pictoPhotoRGBA));
+        return;
+    }
+
+    for (auto i = 0; i < std::size(gSaveContext.shipSaveContext.pictoPhotoRGBA); i++) {
+        gSaveContext.shipSaveContext.pictoPhotoRGBA[i] = picto[fileKey]["image"].at(i).get<uint16_t>();
+    }
+}
+
+void ConvertImage(u16* destI, u16* srcRgba16, s32 rgba16Width, s32 pixelLeft, s32 pixelTop, s32 pixelRight,
                   s32 pixelBottom) {
 
+    // not sure if best way to do this
+    // also not sure how endianness needs to be handled for cross-platform
     for (int i = pixelTop; i <= pixelBottom; i++) {
         for (int j = pixelLeft; j <= pixelRight; j++) {
             u16 px = srcRgba16[i * rgba16Width + j];
@@ -17,16 +73,39 @@ void convertImage(u16* destI, u16* srcRgba16, s32 rgba16Width, s32 pixelLeft, s3
             destI[(i - pixelTop) * PICTO_PHOTO_WIDTH + (j - pixelLeft)] = px;
         }
     }
+
+    // below should probably be moved to SavePictoToFile()
+    std::string filePath = Ship::Context::GetPathRelativeToAppDirectory("picto.json");
+    std::ifstream fileStream(filePath);
+    if (!fileStream.is_open()) {
+        throw std::runtime_error("Failed to open picto file");
+    }
+
+    nlohmann::json picto;
+    try {
+        fileStream >> picto;
+    } catch (nlohmann::json::exception& e) {
+        throw std::runtime_error("Failed to parse picto file: " + std::string(e.what()));
+    }
+
+    std::string fileKey = "file" + std::to_string(fileNumber);
+
+    picto[fileKey]["image"] = nlohmann::json::array();
+
+    for (auto i = 0; i < std::size(gSaveContext.shipSaveContext.pictoPhotoRGBA); i++) {
+        picto[fileKey]["image"].push_back(gSaveContext.shipSaveContext.pictoPhotoRGBA[i]);
+    }
+    SavePictoToFile(picto);
 }
 
-void drawPicto(s16 sp2CC) {
+void DrawPicto(s16 sp2CC) {
 
     OPEN_DISPS(gPlayState->state.gfxCtx);
 
     // Get rid of Sepia tone from prior gDPSetPrimColor call
     gDPSetCombineMode(OVERLAY_DISP++, G_CC_DECALRGBA, G_CC_DECALRGBA);
 
-    // Calling twice because I couldn't cast as a u16*
+    // Calling invalidate twice because I couldn't cast as a u16*
     gSPInvalidateTexCache(OVERLAY_DISP++, (uintptr_t)(gSaveContext.shipSaveContext.pictoPhotoRGBA) + (0x500 * sp2CC));
     gSPInvalidateTexCache(OVERLAY_DISP++, (uintptr_t)(gSaveContext.shipSaveContext.pictoPhotoRGBA) + (0xA00 * sp2CC));
     gDPLoadTextureBlock(OVERLAY_DISP++, (u16*)(gSaveContext.shipSaveContext.pictoPhotoRGBA) + (0x500 * sp2CC),
@@ -37,11 +116,20 @@ void drawPicto(s16 sp2CC) {
 }
 
 void RegisterColorPictograph() {
+    // where to put file?
+    // have file for each save file, or three objects in one file?
+    // convert to .png?
+    if (!std::filesystem::exists(Ship::Context::GetPathRelativeToAppDirectory("picto.json"))) {
+        json initFile;
+        std::ofstream file(Ship::Context::GetPathRelativeToAppDirectory("picto.json"));
+        file << initFile.dump(4);
+        file.close();
+    }
 
     COND_VB_SHOULD(VB_PICTO_TAKE, true /*maybe cvar?*/, {
         PreRender* prerender = va_arg(args, PreRender*);
-        // 320came from SCREEN_WIDTH
-        convertImage(gSaveContext.shipSaveContext.pictoPhotoRGBA, prerender->fbufSave, 320, PICTO_PHOTO_TOPLEFT_X,
+        // 320 came from SCREEN_WIDTH which is undefined here
+        ConvertImage(gSaveContext.shipSaveContext.pictoPhotoRGBA, prerender->fbufSave, 320, PICTO_PHOTO_TOPLEFT_X,
                      PICTO_PHOTO_TOPLEFT_Y, (PICTO_PHOTO_TOPLEFT_X + PICTO_PHOTO_WIDTH) - 1,
                      (PICTO_PHOTO_TOPLEFT_Y + PICTO_PHOTO_HEIGHT) - 1);
     });
@@ -49,10 +137,16 @@ void RegisterColorPictograph() {
     COND_VB_SHOULD(VB_PICTO_DISPLAY, CVAR, {
         s16 sp2CC = va_arg(args, s16);
 
+        // might need something better to check for existance
         if (gSaveContext.shipSaveContext.pictoPhotoRGBA[0] != 0) {
-            drawPicto(sp2CC);
+            DrawPicto(sp2CC);
             *should = false;
         }
+    });
+
+    COND_HOOK(OnSaveLoad, true, [](s16 fileNum) {
+        fileNumber = fileNum;
+        LoadPictoFromFile(fileNum);
     });
 }
 

--- a/mm/2s2h/GameInteractor/GameInteractor_VanillaBehavior.h
+++ b/mm/2s2h/GameInteractor/GameInteractor_VanillaBehavior.h
@@ -1421,6 +1421,22 @@ typedef enum {
 
     // #### `result`
     // ```c
+    // true
+    // ```
+    // #### `args`
+    // - None
+    VB_PICTO_DISPLAY,
+
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
+    // - `*PreRender` (prerender)
+    VB_PICTO_TAKE,
+
+    // #### `result`
+    // ```c
     // Rand_Next() & 0x80
     // ```
     // #### `args`

--- a/mm/2s2h/GameInteractor/GameInteractor_VanillaBehavior.h
+++ b/mm/2s2h/GameInteractor/GameInteractor_VanillaBehavior.h
@@ -1421,6 +1421,14 @@ typedef enum {
 
     // #### `result`
     // ```c
+    // play->actorCtx.flags & ACTORCTX_FLAG_PICTO_BOX_ON
+    // ```
+    // #### `args`
+    // - None
+    VB_PICTO_ACTIVATE,
+
+    // #### `result`
+    // ```c
     // true
     // ```
     // #### `args`

--- a/mm/include/z64save.h
+++ b/mm/include/z64save.h
@@ -402,6 +402,7 @@ typedef struct ShipSaveInfo {
     RespawnData respawn[RESPAWN_MODE_MAX];
     char commitHash[8];
     RandoSaveInfo rando;
+    // u16 pictoPhotoRGBA[PICTO_PHOTO_SIZE];
 } ShipSaveInfo;
 // #endregion
 
@@ -436,6 +437,7 @@ typedef struct DpadSaveContext {
 typedef struct ShipSaveContext {
     DpadSaveContext dpad;
     uint64_t lastTimeLog;
+    u16 pictoPhotoRGBA[PICTO_PHOTO_SIZE] ALIGNED(64);
 } ShipSaveContext;
 // #endregion
 

--- a/mm/include/z64save.h
+++ b/mm/include/z64save.h
@@ -436,7 +436,6 @@ typedef struct DpadSaveContext {
 typedef struct ShipSaveContext {
     DpadSaveContext dpad;
     uint64_t lastTimeLog;
-    u16 pictoPhotoRGBA[PICTO_PHOTO_SIZE];
 } ShipSaveContext;
 // #endregion
 

--- a/mm/include/z64save.h
+++ b/mm/include/z64save.h
@@ -436,7 +436,7 @@ typedef struct DpadSaveContext {
 typedef struct ShipSaveContext {
     DpadSaveContext dpad;
     uint64_t lastTimeLog;
-    u16 pictoPhotoRGBA[PICTO_PHOTO_SIZE] ALIGNED(64);
+    u16 pictoPhotoRGBA[PICTO_PHOTO_SIZE];
 } ShipSaveContext;
 // #endregion
 

--- a/mm/include/z64save.h
+++ b/mm/include/z64save.h
@@ -402,7 +402,6 @@ typedef struct ShipSaveInfo {
     RespawnData respawn[RESPAWN_MODE_MAX];
     char commitHash[8];
     RandoSaveInfo rando;
-    // u16 pictoPhotoRGBA[PICTO_PHOTO_SIZE];
 } ShipSaveInfo;
 // #endregion
 

--- a/mm/src/code/z_parameter.c
+++ b/mm/src/code/z_parameter.c
@@ -9429,7 +9429,7 @@ void Interface_Draw(PlayState* play) {
             for (sp2CC = 0; sp2CC < (PICTO_PHOTO_HEIGHT / 8); sp2CC++, pictoRectTop += 8) {
                 pictoRectLeft = PICTO_PHOTO_TOPLEFT_X;
 
-                if (GameInteractor_Should(VB_PICTO_DISPLAY, true, sp2CC)) {
+                if (GameInteractor_Should(VB_PICTO_DISPLAY, true, &sp2CC)) {
                     // 2S2H [Port] Invalidate each section. This could probably be optimized to only be done once each
                     // pic
                     gSPInvalidateTexCache(OVERLAY_DISP++,

--- a/mm/src/code/z_parameter.c
+++ b/mm/src/code/z_parameter.c
@@ -3956,7 +3956,7 @@ void Interface_UpdateButtonsPart1(PlayState* play) {
             gSaveContext.shipSaveContext.dpad.status[EQUIP_SLOT_D_UP] = BTN_DISABLED;
             // #endregion
             Interface_SetHudVisibility(HUD_VISIBILITY_A_B_HEARTS_MAGIC_MINIMAP);
-        } else if (play->actorCtx.flags & ACTORCTX_FLAG_PICTO_BOX_ON) {
+        } else if (GameInteractor_Should(VB_PICTO_ACTIVATE, play->actorCtx.flags & ACTORCTX_FLAG_PICTO_BOX_ON)) {
             // Related to pictograph
             if (!CHECK_QUEST_ITEM(QUEST_PICTOGRAPH)) {
                 Interface_SetBButtonInterfaceDoAction(play, DO_ACTION_STOP);

--- a/mm/src/code/z_parameter.c
+++ b/mm/src/code/z_parameter.c
@@ -9428,16 +9428,19 @@ void Interface_Draw(PlayState* play) {
             pictoRectTop = PICTO_PHOTO_TOPLEFT_Y - 33;
             for (sp2CC = 0; sp2CC < (PICTO_PHOTO_HEIGHT / 8); sp2CC++, pictoRectTop += 8) {
                 pictoRectLeft = PICTO_PHOTO_TOPLEFT_X;
-                // 2S2H [Port] Invalidate each section. This could probably be optimized to only be done once each pic
-                gSPInvalidateTexCache(OVERLAY_DISP++,
-                                      (u8*)((play->pictoPhotoI8 != NULL) ? play->pictoPhotoI8 : gWorkBuffer) +
-                                          (0x500 * sp2CC));
-                gDPLoadTextureBlock(OVERLAY_DISP++,
-                                    (u8*)((play->pictoPhotoI8 != NULL) ? play->pictoPhotoI8 : gWorkBuffer) +
-                                        (0x500 * sp2CC),
-                                    G_IM_FMT_I, G_IM_SIZ_8b, PICTO_PHOTO_WIDTH, 8, 0, G_TX_NOMIRROR | G_TX_WRAP,
-                                    G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
 
+                if (GameInteractor_Should(VB_PICTO_DISPLAY, true, sp2CC)) {
+                    // 2S2H [Port] Invalidate each section. This could probably be optimized to only be done once each
+                    // pic
+                    gSPInvalidateTexCache(OVERLAY_DISP++,
+                                          (u8*)((play->pictoPhotoI8 != NULL) ? play->pictoPhotoI8 : gWorkBuffer) +
+                                              (0x500 * sp2CC));
+                    gDPLoadTextureBlock(OVERLAY_DISP++,
+                                        (u8*)((play->pictoPhotoI8 != NULL) ? play->pictoPhotoI8 : gWorkBuffer) +
+                                            (0x500 * sp2CC),
+                                        G_IM_FMT_I, G_IM_SIZ_8b, PICTO_PHOTO_WIDTH, 8, 0, G_TX_NOMIRROR | G_TX_WRAP,
+                                        G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
+                }
                 gSPTextureRectangle(OVERLAY_DISP++, pictoRectLeft << 2, pictoRectTop << 2,
                                     (pictoRectLeft + PICTO_PHOTO_WIDTH) << 2, (pictoRectTop << 2) + (8 << 2),
                                     G_TX_RENDERTILE, 0, 0, 1 << 10, 1 << 10);

--- a/mm/src/code/z_play.c
+++ b/mm/src/code/z_play.c
@@ -291,6 +291,7 @@ void Play_TakePictoPhoto(PreRender* prerender) {
     Play_ConvertRgba16ToIntensityImage(gHiBuffer.pictoPhotoI8, prerender->fbufSave, SCREEN_WIDTH, PICTO_PHOTO_TOPLEFT_X,
                                        PICTO_PHOTO_TOPLEFT_Y, (PICTO_PHOTO_TOPLEFT_X + PICTO_PHOTO_WIDTH) - 1,
                                        (PICTO_PHOTO_TOPLEFT_Y + PICTO_PHOTO_HEIGHT) - 1, 8);
+    GameInteractor_Should(VB_PICTO_TAKE, true, prerender);
 }
 
 s32 Play_ChooseDynamicTransition(PlayState* this, s32 transitionType) {


### PR DESCRIPTION
This adds an option to have color pictographs. When enabled, your pictograph will display in color, if the data is available.

The color pictograph saves as a .png in the saves folder. One .png per file. 

<img width="741" height="563" alt="image" src="https://github.com/user-attachments/assets/2bca16ae-d3d2-4d6c-bc39-aa3ca2ff72bf" />


<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/6020289196.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/6020220031.zip)
<!--- section:artifacts:end -->