### PR TITLE
Revert changes to original Gfx_TexScroll & Gfx_TwoTexScroll

### DIFF
--- a/mm/2s2h/Rando/DrawFuncs.cpp
+++ b/mm/2s2h/Rando/DrawFuncs.cpp
@@ -573,8 +573,8 @@ extern void DrawFreezard() {
     Gfx_SetupDL25_Xlu(gPlayState->state.gfxCtx);
 
     gSPSegment(POLY_XLU_DISP++, 0x08,
-               (uintptr_t)Gfx_TwoTexScroll(gPlayState->state.gfxCtx, 0, 0, gPlayState->state.frames % 128, 0x20, 0x20,
-                                           1, 0, (gPlayState->state.frames * 2) % 128, 0x20, 0x20));
+               (uintptr_t)Gfx_TwoTexScrollEx(gPlayState->state.gfxCtx, 0, 0, gPlayState->state.frames % 128, 0x20, 0x20,
+                                             1, 0, (gPlayState->state.frames * 2) % 128, 0x20, 0x20, 0, 1, 0, 2));
     MATRIX_FINALIZE_AND_LOAD(POLY_XLU_DISP++, gPlayState->state.gfxCtx);
     gDPSetCombineLERP(POLY_XLU_DISP++, TEXEL1, PRIMITIVE, PRIM_LOD_FRAC, TEXEL0, TEXEL1, TEXEL0, PRIMITIVE, TEXEL0,
                       PRIMITIVE, ENVIRONMENT, COMBINED, ENVIRONMENT, COMBINED, 0, ENVIRONMENT, 0);
@@ -796,8 +796,9 @@ extern void DrawLikeLike() {
 
     gSPSegment(POLY_OPA_DISP++, 0x0C, (uintptr_t)mtx);
     gSPSegment(POLY_OPA_DISP++, 0x08,
-               (uintptr_t)Gfx_TwoTexScroll(gPlayState->state.gfxCtx, 0, 0, 0, 0x20, 0x10, 1, (textureScroll * 0) & 0x3F,
-                                           (textureScroll * -6) & 0x7F, 0x20, 0x10));
+               (uintptr_t)Gfx_TwoTexScrollEx(gPlayState->state.gfxCtx, 0, (textureScroll * 0) & 0x7F,
+                                             (textureScroll * 0) & 0x3F, 0x20, 0x10, 1, (textureScroll * 0) & 0x3F,
+                                             (textureScroll * -6) & 0x7F, 0x20, 0x10, 0, 0, 0, -6));
 
     Matrix_Push();
     Matrix_Scale((1.0f + segments[0].unk_10) * segments[0].unk_08, 1.0f,

--- a/mm/src/code/z_rcp.c
+++ b/mm/src/code/z_rcp.c
@@ -1409,7 +1409,16 @@ Gfx* Gfx_TexScrollEx(GraphicsContext* gfxCtx, u32 x, u32 y, s32 width, s32 heigh
 }
 
 Gfx* Gfx_TexScroll(GraphicsContext* gfxCtx, u32 x, u32 y, s32 width, s32 height) {
-    Gfx_TexScrollEx(gfxCtx, x, y, width, height, 0, 0);
+    Gfx* gfx = GRAPH_ALLOC(gfxCtx, 3 * sizeof(Gfx));
+
+    x %= 2048;
+    y %= 2048;
+
+    gDPTileSync(&gfx[0]);
+    gDPSetTileSize(&gfx[1], 0, x, y, (x + ((width - 1) << 2)), (y + ((height - 1) << 2)));
+    gSPEndDisplayList(&gfx[2]);
+
+    return gfx;
 }
 
 Gfx* Gfx_TwoTexScrollEx(GraphicsContext* gfxCtx, s32 tile1, u32 x1, u32 y1, s32 width1, s32 height1, s32 tile2, u32 x2,
@@ -1460,7 +1469,20 @@ Gfx* Gfx_TwoTexScrollEx(GraphicsContext* gfxCtx, s32 tile1, u32 x1, u32 y1, s32 
 
 Gfx* Gfx_TwoTexScroll(GraphicsContext* gfxCtx, s32 tile1, u32 x1, u32 y1, s32 width1, s32 height1, s32 tile2, u32 x2,
                       u32 y2, s32 width2, s32 height2) {
-    Gfx_TwoTexScrollEx(gfxCtx, tile1, x1, y1, width1, height1, tile2, x2, y2, width2, height2, 0, 0, 0, 0);
+    Gfx* gfx = GRAPH_ALLOC(gfxCtx, 5 * sizeof(Gfx));
+
+    x1 %= 2048;
+    y1 %= 2048;
+    x2 %= 2048;
+    y2 %= 2048;
+
+    gDPTileSync(&gfx[0]);
+    gDPSetTileSize(&gfx[1], tile1, x1, y1, (x1 + ((width1 - 1) << 2)), (y1 + ((height1 - 1) << 2)));
+    gDPTileSync(&gfx[2]);
+    gDPSetTileSize(&gfx[3], tile2, x2, y2, (x2 + ((width2 - 1) << 2)), (y2 + ((height2 - 1) << 2)));
+    gSPEndDisplayList(&gfx[4]);
+
+    return gfx;
 }
 
 Gfx* Gfx_TwoTexScrollEnvColor(GraphicsContext* gfxCtx, s32 tile1, u32 x1, u32 y1, s32 width1, s32 height1, s32 tile2,


### PR DESCRIPTION
All interpolated textures were already changed to use the `Ex` versions anyway, so the only things that were calling these functions weren't being interpolated, so we're just going to revert them to their original source.

Also fixes two souls draws that were likely added after the interpolation PR work was done

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5206896988.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5207015955.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5207150398.zip)
<!--- section:artifacts:end -->