### PR TITLE
Check/Item Tracker improvements

### DIFF
--- a/mm/2s2h/Enhancements/Trackers/ItemTracker/ItemTracker.cpp
+++ b/mm/2s2h/Enhancements/Trackers/ItemTracker/ItemTracker.cpp
@@ -5,7 +5,7 @@
 #include "Rando/Rando.h"
 #include "Rando/ActorBehavior/Souls.h"
 #include "Rando/MiscBehavior/ClockShuffle.h"
-
+#include "2s2h/BenPort.h"
 #include "2s2h/ShipUtils.h"
 #include <spdlog/fmt/fmt.h>
 
@@ -25,7 +25,13 @@ extern std::shared_ptr<ItemTrackerWindow> mItemTrackerWindow;
 
 #define FORMAT_COUNT "{}/{}"
 
+#define CVAR_NAME_VISIBILITY_MODE "gSettings.ItemTracker.VisibilityMode"
+#define CVAR_NAME_VISIBILITY_BTN "gSettings.ItemTracker.VisibilityBtn"
+#define CVAR_VISIBILITY_MODE CVarGetInteger(CVAR_NAME_VISIBILITY_MODE, ITEM_TRACKER_VISIBILITY_MODE_ALWAYS)
+#define CVAR_VISIBILITY_BTN CVarGetInteger(CVAR_NAME_VISIBILITY_BTN, BTN_CUSTOM_MODIFIER1)
+
 std::vector<TrackerGroup> itemTrackerGroups;
+static bool sItemTrackerBtnState = false;
 
 TrackerImageObject GetImageObject(TrackerItemType itemType, u32 itemId) {
     bool isSaveLoaded = gPlayState != NULL && gSaveContext.gameMode == GAMEMODE_NORMAL;
@@ -79,8 +85,11 @@ TrackerImageObject GetImageObject(TrackerItemType itemType, u32 itemId) {
             }
 
             trackerImageObject.textureColor = Ship_GetRandoItemColorTint(randoItemId);
-            trackerImageObject.textureId = Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName(
-                Rando::StaticData::GetIconTexturePath(randoItemId));
+            const char* texturePath = Rando::StaticData::GetIconTexturePath(randoItemId);
+            if (texturePath != nullptr) {
+                trackerImageObject.textureId =
+                    Ship::Context::GetInstance()->GetWindow()->GetGui()->GetTextureByName(texturePath);
+            }
             if (randoItemId >= RI_OWL_CLOCK_TOWN_SOUTH && randoItemId <= RI_OWL_ZORA_CAPE) {
                 trackerImageObject.textureDimensions.y = 24.0f;
             } else if (randoItemId >= RI_SONG_DOUBLE_TIME && randoItemId <= RI_SONG_TIME) {
@@ -90,7 +99,7 @@ TrackerImageObject GetImageObject(TrackerItemType itemType, u32 itemId) {
         case TRACKER_ITEM_SLOT: {
             itemObtained = gSaveContext.save.saveInfo.inventory.items[itemId] != ITEM_NONE;
             auto vanillaItemId = isSaveLoaded ? gSaveContext.save.saveInfo.inventory.items[itemId] : ITEM_NONE;
-            if (vanillaItemId == ITEM_NONE) {
+            if (vanillaItemId == ITEM_NONE || vanillaItemId >= ITEM_RECOVERY_HEART) {
                 vanillaItemId = safeItemsForInventorySlot[itemId][0];
             }
 
@@ -339,8 +348,10 @@ bool DrawItemTrackerSlot(TrackerItemType itemType, u32 itemId, float scale, bool
                                              ImGui::GetColorU32(tintColor));
     }
 
-    ImGui::GetWindowDrawList()->AddImage(imageObject.textureId, p0 + offset, p0 + offset + drawSize, ImVec2(0, 0),
-                                         ImVec2(1, 1), ImGui::GetColorU32(imageObject.textureColor));
+    if (imageObject.textureId != nullptr) {
+        ImGui::GetWindowDrawList()->AddImage(imageObject.textureId, p0 + offset, p0 + offset + drawSize, ImVec2(0, 0),
+                                             ImVec2(1, 1), ImGui::GetColorU32(imageObject.textureColor));
+    }
     auto itemName = GetItemTrackerItemName(itemType, itemId);
     if (!itemName.empty()) {
         UIWidgets::Tooltip(itemName.c_str());
@@ -385,6 +396,17 @@ void DrawItemTrackerGroup(TrackerGroup& trackerGroup) {
 
 void ItemTrackerWindow::Draw() {
     if (!IsVisible()) {
+        return;
+    }
+
+    if (CVAR_VISIBILITY_MODE == ITEM_TRACKER_VISIBILITY_MODE_ONLY_ON_PAUSE_MENU &&
+        (!gPlayState || !gPlayState->pauseCtx.state)) {
+        return;
+    }
+
+    if ((CVAR_VISIBILITY_MODE == ITEM_TRACKER_VISIBILITY_MODE_BUTTON_TOGGLE ||
+         CVAR_VISIBILITY_MODE == ITEM_TRACKER_VISIBILITY_MODE_BUTTON_HOLD) &&
+        !sItemTrackerBtnState) {
         return;
     }
 
@@ -452,3 +474,24 @@ void ItemTrackerWindow::InitElement() {
 
 void ItemTrackerWindow::DrawElement() {
 }
+
+static RegisterShipInitFunc initFunc(
+    []() {
+        COND_HOOK(OnGameStateMainStart, CVAR_VISIBILITY_MODE >= ITEM_TRACKER_VISIBILITY_MODE_BUTTON_TOGGLE, []() {
+            Input* input = CONTROLLER1(gGameState);
+
+            if (CVAR_VISIBILITY_MODE == ITEM_TRACKER_VISIBILITY_MODE_BUTTON_HOLD) {
+                if (CHECK_BTN_ALL(input->cur.button, CVAR_VISIBILITY_BTN)) {
+                    sItemTrackerBtnState = true;
+                } else {
+                    sItemTrackerBtnState = false;
+                }
+            } else {
+                if (CHECK_BTN_ALL(input->cur.button, CVAR_VISIBILITY_BTN) &&
+                    CHECK_BTN_ANY(input->press.button, CVAR_VISIBILITY_BTN)) {
+                    sItemTrackerBtnState = !sItemTrackerBtnState;
+                }
+            }
+        });
+    },
+    { CVAR_NAME_VISIBILITY_MODE });

--- a/mm/2s2h/Enhancements/Trackers/ItemTracker/ItemTracker.h
+++ b/mm/2s2h/Enhancements/Trackers/ItemTracker/ItemTracker.h
@@ -13,6 +13,13 @@ typedef enum {
     TRACKER_ITEM_MAGIC,
 } TrackerItemType;
 
+typedef enum {
+    ITEM_TRACKER_VISIBILITY_MODE_ALWAYS,
+    ITEM_TRACKER_VISIBILITY_MODE_ONLY_ON_PAUSE_MENU,
+    ITEM_TRACKER_VISIBILITY_MODE_BUTTON_TOGGLE,
+    ITEM_TRACKER_VISIBILITY_MODE_BUTTON_HOLD,
+} ItemTrackerVisibilityMode;
+
 typedef struct {
     ImTextureID textureId;
     ImVec4 textureColor;

--- a/mm/2s2h/Enhancements/Trackers/ItemTracker/ItemTrackerSettings.cpp
+++ b/mm/2s2h/Enhancements/Trackers/ItemTracker/ItemTrackerSettings.cpp
@@ -4,6 +4,7 @@
 #include "ShipUtils.h"
 #include "ship/config/Config.h"
 #include "2s2h/ShipInit.hpp"
+#include "2s2h/BenPort.h"
 
 namespace BenGui {
 extern std::shared_ptr<ItemTrackerWindow> mItemTrackerWindow;
@@ -13,8 +14,19 @@ void ItemTrackerSettingsWindow::UpdateElement() {
 }
 
 #define WIDGET_COLOR UIWidgets::Colors(CVarGetInteger("gSettings.Menu.Theme", 5))
+#define CVAR_NAME_VISIBILITY_MODE "gSettings.ItemTracker.VisibilityMode"
+#define CVAR_NAME_VISIBILITY_BTN "gSettings.ItemTracker.VisibilityBtn"
+#define CVAR_VISIBILITY_MODE CVarGetInteger(CVAR_NAME_VISIBILITY_MODE, ITEM_TRACKER_VISIBILITY_MODE_ALWAYS)
+#define CVAR_VISIBILITY_BTN CVarGetInteger(CVAR_NAME_VISIBILITY_BTN, BTN_CUSTOM_MODIFIER1)
 
 static const char* windowTypes[2] = { "Floating", "Window" };
+
+static std::unordered_map<int32_t, const char*> sItemTrackerVisibilityModes = {
+    { ITEM_TRACKER_VISIBILITY_MODE_ALWAYS, "Always" },
+    { ITEM_TRACKER_VISIBILITY_MODE_ONLY_ON_PAUSE_MENU, "Only on Pause Menu" },
+    { ITEM_TRACKER_VISIBILITY_MODE_BUTTON_TOGGLE, "Button Toggle" },
+    { ITEM_TRACKER_VISIBILITY_MODE_BUTTON_HOLD, "Button Hold" },
+};
 
 std::vector<TrackerGroup> itemTrackerGroupsAvailable;
 void SaveItemTrackerLayout();
@@ -493,7 +505,7 @@ void LoadItemTrackerConfig() {
 }
 
 void DrawTrackerOptions() {
-    if (ImGui::BeginTable("OptionsTable", 2)) {
+    if (ImGui::BeginTable("OptionsTable", 3)) {
         ImGui::TableNextColumn();
         if (CVarGetInteger("gWindows.ItemTracker", 0)) {
             UIWidgets::WindowButton("Disable Item Tracker", "gWindows.ItemTracker", BenGui::mItemTrackerWindow,
@@ -503,13 +515,26 @@ void DrawTrackerOptions() {
                                     { .size = UIWidgets::Sizes::Inline, .color = UIWidgets::Colors::Green });
         }
 
-        UIWidgets::CVarCombobox("Window Type", "gSettings.ItemTracker.WindowType", windowTypes,
-                                { .alignment = UIWidgets::ComponentAlignment::Right,
-                                  .labelPosition = UIWidgets::LabelPosition::Near,
-                                  .color = WIDGET_COLOR });
         UIWidgets::CVarCheckbox("Split Window Groups", "gSettings.ItemTracker.WindowGroup");
         UIWidgets::CVarCheckbox("Show Item Counts", "gSettings.ItemTracker.ItemCounts",
                                 UIWidgets::CheckboxOptions().DefaultValue(true));
+        ImGui::TableNextColumn();
+
+        UIWidgets::CVarCombobox("Window Type", "gSettings.ItemTracker.WindowType", windowTypes,
+                                UIWidgets::ComboboxOptions()
+                                    .ComponentAlignment(UIWidgets::ComponentAlignment::Right)
+                                    .LabelPosition(UIWidgets::LabelPosition::Far));
+        UIWidgets::CVarCombobox("Visibility", CVAR_NAME_VISIBILITY_MODE, &sItemTrackerVisibilityModes,
+                                UIWidgets::ComboboxOptions()
+                                    .DefaultIndex(ITEM_TRACKER_VISIBILITY_MODE_ALWAYS)
+                                    .ComponentAlignment(UIWidgets::ComponentAlignment::Right)
+                                    .LabelPosition(UIWidgets::LabelPosition::Far));
+        if (CVAR_VISIBILITY_MODE == ITEM_TRACKER_VISIBILITY_MODE_BUTTON_TOGGLE ||
+            CVAR_VISIBILITY_MODE == ITEM_TRACKER_VISIBILITY_MODE_BUTTON_HOLD) {
+            UIWidgets::CVarBtnSelector("Button Combination:", CVAR_NAME_VISIBILITY_BTN,
+                                       UIWidgets::BtnSelectorOptions().DefaultValue(BTN_CUSTOM_MODIFIER1));
+        }
+
         ImGui::TableNextColumn();
 
         if (UIWidgets::Button("Restore Default Groups", { .color = UIWidgets::Colors::Gray })) {

--- a/mm/2s2h/Rando/CheckTracker/CheckTracker.cpp
+++ b/mm/2s2h/Rando/CheckTracker/CheckTracker.cpp
@@ -4,6 +4,7 @@
 #include "2s2h/ShipUtils.h"
 #include "2s2h/BenGui/UIWidgets.hpp"
 #include "2s2h/Rando/StaticData/StaticData.h"
+#include "2s2h/BenPort.h"
 #include <cstring>
 
 // Image Icons
@@ -51,7 +52,25 @@ static std::unordered_map<int32_t, const char*> sCheckModes = {
     { CHECK_MODE_HIDDEN, "Hidden" },
 };
 
+typedef enum {
+    CHECK_TRACKER_VISIBILITY_MODE_ALWAYS,
+    CHECK_TRACKER_VISIBILITY_MODE_ONLY_ON_PAUSE_MENU,
+    CHECK_TRACKER_VISIBILITY_MODE_BUTTON_TOGGLE,
+    CHECK_TRACKER_VISIBILITY_MODE_BUTTON_HOLD,
+} CheckTrackerVisibilityMode;
+
+static std::unordered_map<int32_t, const char*> sCheckVisibilityModes = {
+    { CHECK_TRACKER_VISIBILITY_MODE_ALWAYS, "Always" },
+    { CHECK_TRACKER_VISIBILITY_MODE_ONLY_ON_PAUSE_MENU, "Only on Pause Menu" },
+    { CHECK_TRACKER_VISIBILITY_MODE_BUTTON_TOGGLE, "Button Toggle" },
+    { CHECK_TRACKER_VISIBILITY_MODE_BUTTON_HOLD, "Button Hold" },
+};
+
+static bool sCheckTrackerBtnState = false;
+
 #define CVAR_NAME_SHOW_CHECK_TRACKER "gWindows.CheckTracker"
+#define CVAR_NAME_VISIBILITY_MODE "gRando.CheckTracker.VisibilityMode"
+#define CVAR_NAME_VISIBILITY_BTN "gRando.CheckTracker.VisibilityBtn"
 #define CVAR_NAME_OUT_OF_LOGIC_MODE "gRando.CheckTracker.OutOfLogicMode"
 #define CVAR_NAME_OUT_OF_LOGIC_COLOR "gRando.CheckTracker.OutOfLogicColor"
 #define CVAR_NAME_COLLECTED_MODE "gRando.CheckTracker.CollectedMode"
@@ -65,6 +84,8 @@ static std::unordered_map<int32_t, const char*> sCheckModes = {
 #define CVAR_NAME_SHOW_CHECK_TYPE_FILTER "gRando.CheckTracker.ShowCheckTypeFilter"
 #define CVAR_NAME_SHOW_SEARCH "gRando.CheckTracker.ShowSearch"
 #define CVAR_SHOW_CHECK_TRACKER CVarGetInteger(CVAR_NAME_SHOW_CHECK_TRACKER, 0)
+#define CVAR_VISIBILITY_MODE CVarGetInteger(CVAR_NAME_VISIBILITY_MODE, CHECK_TRACKER_VISIBILITY_MODE_ALWAYS)
+#define CVAR_VISIBILITY_BTN CVarGetInteger(CVAR_NAME_VISIBILITY_BTN, BTN_CUSTOM_MODIFIER1)
 #define CVAR_OUT_OF_LOGIC_MODE CVarGetInteger(CVAR_NAME_OUT_OF_LOGIC_MODE, CHECK_MODE_COLORED)
 #define CVAR_OUT_OF_LOGIC_COLOR CVarGetColor(CVAR_NAME_OUT_OF_LOGIC_COLOR ".Value", { 255, 255, 255, 100 })
 #define CVAR_COLLECTED_MODE CVarGetInteger(CVAR_NAME_COLLECTED_MODE, CHECK_MODE_HIDDEN)
@@ -351,15 +372,15 @@ void CheckTrackerDrawNonLogicalList() {
             continue;
         }
 
-        if (!CVAR_SHOW_CURRENT_SCENE && CVAR_SCROLL_TO_SCENE && sScrollToTargetScene != -1 &&
-            sScrollToTargetScene == sceneId) {
+        ImGui::PushID(sceneId);
+        ImGui::Separator();
+
+        // Auto-scroll to current scene - called after Separator to ensure stable positioning
+        if (!CVAR_SHOW_CURRENT_SCENE && sScrollToTargetScene != -1 && sScrollToTargetScene == sceneId) {
             ImGui::SetScrollHereY(0.0f);
             sScrollToTargetScene = -1;
             sScrollToTargetEntrance = -1;
         }
-
-        ImGui::PushID(sceneId);
-        ImGui::Separator();
         ImGui::PushStyleColor(ImGuiCol_Header, ImVec4(0, 0, 0, 0));
         std::string headerText = Ship_GetSceneName(sceneId);
         headerText += " (" + std::to_string(obtainedCheckSum) + "/" + std::to_string(unfilteredChecks.size()) + ")";
@@ -456,6 +477,17 @@ void CheckTrackerWindow::Draw() {
         return;
     }
 
+    if (CVAR_VISIBILITY_MODE == CHECK_TRACKER_VISIBILITY_MODE_ONLY_ON_PAUSE_MENU &&
+        (!gPlayState || !gPlayState->pauseCtx.state)) {
+        return;
+    }
+
+    if ((CVAR_VISIBILITY_MODE == CHECK_TRACKER_VISIBILITY_MODE_BUTTON_TOGGLE ||
+         CVAR_VISIBILITY_MODE == CHECK_TRACKER_VISIBILITY_MODE_BUTTON_HOLD) &&
+        !sCheckTrackerBtnState) {
+        return;
+    }
+
     ImGui::PushStyleColor(ImGuiCol_TitleBgActive, trackerBG);
     ImGui::PushStyleColor(ImGuiCol_TitleBg, trackerBG);
     ImGui::PushStyleColor(ImGuiCol_WindowBg, trackerBG);
@@ -483,12 +515,32 @@ void CheckTrackerWindow::Draw() {
         bool sameLine = !(ImGui::GetContentRegionAvail().x <= 300.0f * trackerScale);
         auto totalCheckCount = GetTotalCheckCount();
 
-        UIWidgets::PushStyleCombobox();
+        UIWidgets::PushStyleInput();
         sCheckTrackerFilter.Draw("##filter", (ImGui::GetContentRegionAvail().x -
                                               (sameLine ? (ImGui::CalcTextSize("Total: ").x +
-                                                           ImGui::CalcTextSize(totalCheckCount.c_str()).x + 15.0f)
-                                                        : 0)));
-        UIWidgets::PopStyleCombobox();
+                                                           ImGui::CalcTextSize(totalCheckCount.c_str()).x + 60.0f)
+                                                        : 40.0f)));
+        UIWidgets::PopStyleInput();
+
+        ImGui::SameLine();
+        if (!sCheckTrackerFilter.IsActive()) {
+            if (UIWidgets::Button(ICON_FA_ARROWS_V, UIWidgets::ButtonOptions().Size(UIWidgets::Sizes::Inline))) {
+                if (gPlayState) {
+                    sScrollToTargetScene = Play_GetOriginalSceneId(gPlayState->sceneId);
+                    sScrollToTargetEntrance = gSaveContext.save.entrance;
+                }
+            }
+            UIWidgets::Tooltip("Scroll to Current Scene");
+        } else {
+            if (UIWidgets::Button(ICON_FA_TIMES, UIWidgets::ButtonOptions().Size(UIWidgets::Sizes::Inline))) {
+                sCheckTrackerFilter.Clear();
+                if (gPlayState) {
+                    sScrollToTargetScene = Play_GetOriginalSceneId(gPlayState->sceneId);
+                    sScrollToTargetEntrance = gSaveContext.save.entrance;
+                }
+            }
+        }
+
         if (!sCheckTrackerFilter.IsActive()) {
             ImGui::SameLine(18.0f);
             ImGui::Text("Search");
@@ -521,15 +573,22 @@ void CheckTrackerWindow::Draw() {
                 } else if (randoCheckType == RCTYPE_SONG) {
                     ImGui::SetCursorPosX(ImGui::GetCursorPosX() + 4.0f);
                 }
-                if (ImGui::ImageButton(
-                        std::to_string(randoCheckType).c_str(), textureId,
-                        ImVec2((randoCheckType == RCTYPE_SONG ? 18.0f : 24.0f) * trackerScale,
-                               (randoCheckType == RCTYPE_OWL ? 12.0f * trackerScale : 24.0f * trackerScale) *
-                                   trackerScale),
-                        ImVec2(0, 0), ImVec2(1, 1), ImVec4(0, 0, 0, 0),
-                        randoCheckType == RCTYPE_UNKNOWN        ? ImVec4(1, 0, 0, 1)
-                        : randoCheckType == RCTYPE_FREESTANDING ? ImVec4(0.78f, 1, 0.39f, 1)
-                                                                : ImVec4(1, 1, 1, 1))) {
+
+                ImVec2 size = ImVec2(24.0f * trackerScale, 24.0f * trackerScale);
+                if (randoCheckType == RCTYPE_SONG) {
+                    size.x = 18.0f * trackerScale;
+                } else if (randoCheckType == RCTYPE_OWL) {
+                    size.y = 12.0f * trackerScale;
+                }
+                ImVec4 tint = ImVec4(1, 1, 1, 1);
+                if (randoCheckType == RCTYPE_FREESTANDING) {
+                    tint = ImVec4(0.78f, 1, 0.39f, 1);
+                } else if (randoCheckType == RCTYPE_UNKNOWN) {
+                    tint = ImVec4(1, 0, 0, 1);
+                }
+
+                if (ImGui::ImageButton(std::to_string(randoCheckType).c_str(), textureId, size, ImVec2(0, 0),
+                                       ImVec2(1, 1), ImVec4(0, 0, 0, 0), tint)) {
                     if (randoCheckType == RCTYPE_UNKNOWN) {
                         checkTypeFilter.clear();
                     } else {
@@ -607,6 +666,16 @@ void SettingsWindow::DrawElement() {
 
         ImGui::TableNextColumn();
         ImGui::SeparatorText("Window Settings");
+        UIWidgets::CVarCombobox("Visibility", CVAR_NAME_VISIBILITY_MODE, &sCheckVisibilityModes,
+                                UIWidgets::ComboboxOptions()
+                                    .DefaultIndex(CHECK_TRACKER_VISIBILITY_MODE_ALWAYS)
+                                    .ComponentAlignment(UIWidgets::ComponentAlignment::Right)
+                                    .LabelPosition(UIWidgets::LabelPosition::Far));
+        if (CVAR_VISIBILITY_MODE == CHECK_TRACKER_VISIBILITY_MODE_BUTTON_TOGGLE ||
+            CVAR_VISIBILITY_MODE == CHECK_TRACKER_VISIBILITY_MODE_BUTTON_HOLD) {
+            UIWidgets::CVarBtnSelector("Button Combination:", CVAR_NAME_VISIBILITY_BTN,
+                                       UIWidgets::BtnSelectorOptions().DefaultValue(BTN_CUSTOM_MODIFIER1));
+        }
         UIWidgets::CVarCheckbox("Show Search", CVAR_NAME_SHOW_SEARCH, UIWidgets::CheckboxOptions().DefaultValue(true));
         UIWidgets::CVarCheckbox("Show Check Type Filters", CVAR_NAME_SHOW_CHECK_TYPE_FILTER);
 
@@ -653,6 +722,27 @@ void Init() {
     trackerBG = { 0, 0, 0, CVAR_TRACKER_OPACITY };
     trackerScale = CVAR_TRACKER_SCALE;
 }
+
+static RegisterShipInitFunc initFunc(
+    []() {
+        COND_HOOK(OnGameStateMainStart, CVAR_VISIBILITY_MODE >= CHECK_TRACKER_VISIBILITY_MODE_BUTTON_TOGGLE, []() {
+            Input* input = CONTROLLER1(gGameState);
+
+            if (CVAR_VISIBILITY_MODE == CHECK_TRACKER_VISIBILITY_MODE_BUTTON_HOLD) {
+                if (CHECK_BTN_ALL(input->cur.button, CVAR_VISIBILITY_BTN)) {
+                    sCheckTrackerBtnState = true;
+                } else {
+                    sCheckTrackerBtnState = false;
+                }
+            } else {
+                if (CHECK_BTN_ALL(input->cur.button, CVAR_VISIBILITY_BTN) &&
+                    CHECK_BTN_ANY(input->press.button, CVAR_VISIBILITY_BTN)) {
+                    sCheckTrackerBtnState = !sCheckTrackerBtnState;
+                }
+            }
+        });
+    },
+    { CVAR_NAME_VISIBILITY_MODE });
 
 void OnFileLoad() {
     if (!IS_RANDO) {

--- a/mm/2s2h/Rando/ConvertItem.cpp
+++ b/mm/2s2h/Rando/ConvertItem.cpp
@@ -322,7 +322,6 @@ bool Rando::IsItemObtainable(RandoItemId randoItemId, RandoCheckId randoCheckId)
         case RI_SNOWHEAD_SMALL_KEY:
         case RI_GREAT_BAY_SMALL_KEY:
         case RI_STONE_TOWER_SMALL_KEY:
-        case RI_CLOCK_TOWN_STRAY_FAIRY:
         case RI_WOODFALL_STRAY_FAIRY:
         case RI_SNOWHEAD_STRAY_FAIRY:
         case RI_GREAT_BAY_STRAY_FAIRY:
@@ -334,6 +333,8 @@ bool Rando::IsItemObtainable(RandoItemId randoItemId, RandoCheckId randoCheckId)
                 return false;
             }
             return true;
+        case RI_CLOCK_TOWN_STRAY_FAIRY:
+            return !CHECK_WEEKEVENTREG(WEEKEVENTREG_08_80);
         case RI_HEART_PIECE:
         case RI_HEART_CONTAINER:
             if (hasObtainedCheck) {


### PR DESCRIPTION
- Add visibility options for both trackers
  - Only on Pause Menu
  - Button combo hold
  - Button combo toggle
- Fix clock town stray fairy not showing as collected
- Fix some invalid access for textures (maybe affecting linux?)
- Add scroll to current scene button on Check tracker
- Fix scroll to current scene (mostly)

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5225742120.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5225840957.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5225930307.zip)
<!--- section:artifacts:end -->