### PR TITLE
swap forms from fd mask

### DIFF
--- a/mm/2s2h/Enhancements/Masks/3DSMaskEquipping.cpp
+++ b/mm/2s2h/Enhancements/Masks/3DSMaskEquipping.cpp
@@ -8,8 +8,7 @@ static PlayerMask sPendingMask = PLAYER_MASK_NONE;
 static HOOK_ID sPlayerUpdateHookId = 0;
 
 static bool IsTransformationMask(PlayerMask mask) {
-    return mask == PLAYER_MASK_DEKU || mask == PLAYER_MASK_GORON || mask == PLAYER_MASK_ZORA ||
-           mask == PLAYER_MASK_FIERCE_DEITY;
+    return mask <= PLAYER_MASK_DEKU && mask >= PLAYER_MASK_FIERCE_DEITY;
 }
 
 static bool IsMask(ItemId itemId) {

--- a/mm/2s2h/Enhancements/Masks/3DSMaskEquipping.cpp
+++ b/mm/2s2h/Enhancements/Masks/3DSMaskEquipping.cpp
@@ -1,4 +1,3 @@
-#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 
@@ -8,8 +7,20 @@
 static PlayerMask sPendingMask = PLAYER_MASK_NONE;
 static HOOK_ID sPlayerUpdateHookId = 0;
 
+static bool IsTransformationMask(PlayerMask mask) {
+    return mask == PLAYER_MASK_DEKU || mask == PLAYER_MASK_GORON || mask == PLAYER_MASK_ZORA ||
+           mask == PLAYER_MASK_FIERCE_DEITY;
+}
+
 static bool IsMask(ItemId itemId) {
-    return (itemId >= ITEM_MASK_TRUTH) && (itemId <= ITEM_MASK_SCENTS);
+    if ((itemId >= ITEM_MASK_TRUTH) && (itemId <= ITEM_MASK_SCENTS)) {
+        return true;
+    }
+    Player* player = GET_PLAYER(gPlayState);
+    if ((player != NULL) && (player->transformation == PLAYER_FORM_FIERCE_DEITY)) {
+        return (itemId == ITEM_MASK_GORON) || (itemId == ITEM_MASK_ZORA) || (itemId == ITEM_MASK_DEKU);
+    }
+    return false;
 }
 
 static bool IsMaskAction(PlayerItemAction itemAction) {
@@ -26,23 +37,22 @@ static void UnregisterMaskSwap() {
 static void OnTransform(Actor* actor) {
     Player* player = (Player*)actor;
 
-    if ((player->stateFlags1 & PLAYER_STATE1_2) && player->transformation == PLAYER_FORM_HUMAN &&
-        player->currentMask != sPendingMask) {
-        player->currentMask = sPendingMask;
-        gSaveContext.save.equippedMask = sPendingMask;
-    } else if (player->transformation == PLAYER_FORM_HUMAN) {
+    if (player->transformation == PLAYER_FORM_HUMAN) {
+        if (sPendingMask != PLAYER_MASK_NONE && !IsTransformationMask(sPendingMask) &&
+            player->currentMask != sPendingMask) {
+            player->currentMask = sPendingMask;
+            gSaveContext.save.equippedMask = sPendingMask;
+        }
         sPendingMask = PLAYER_MASK_NONE;
         UnregisterMaskSwap();
     }
 }
 
 static void RegisterMaskSwap() {
-    if (sPlayerUpdateHookId != 0) {
-        return;
+    if (sPlayerUpdateHookId == 0) {
+        sPlayerUpdateHookId =
+            GameInteractor::Instance->RegisterGameHookForID<GameInteractor::OnActorUpdate>(ACTOR_PLAYER, OnTransform);
     }
-
-    sPlayerUpdateHookId =
-        GameInteractor::Instance->RegisterGameHookForID<GameInteractor::OnActorUpdate>(ACTOR_PLAYER, OnTransform);
 }
 
 static void AllowMask(ItemId* itemId, bool* should) {
@@ -61,9 +71,12 @@ void RegisterMaskSwapHooks() {
         PlayerItemAction* itemAction = va_arg(args, PlayerItemAction*);
         Player* player = GET_PLAYER(gPlayState);
         if (player != NULL && player->transformation != PLAYER_FORM_HUMAN && IsMaskAction(*itemAction)) {
-            sPendingMask = static_cast<PlayerMask>(GET_MASK_FROM_IA(*itemAction));
-            gSaveContext.save.equippedMask = sPendingMask;
-            RegisterMaskSwap();
+            PlayerMask mask = static_cast<PlayerMask>(GET_MASK_FROM_IA(*itemAction));
+            if (!IsTransformationMask(mask)) { // don't queue transformation masks
+                sPendingMask = mask;
+                gSaveContext.save.equippedMask = sPendingMask;
+                RegisterMaskSwap();
+            }
         }
     });
 }

--- a/mm/2s2h/Enhancements/Masks/3DSMaskEquipping.cpp
+++ b/mm/2s2h/Enhancements/Masks/3DSMaskEquipping.cpp
@@ -16,6 +16,8 @@ static bool IsMask(ItemId itemId) {
     if ((itemId >= ITEM_MASK_TRUTH) && (itemId <= ITEM_MASK_SCENTS)) {
         return true;
     }
+
+    // Transformation masks
     Player* player = GET_PLAYER(gPlayState);
     if ((player != NULL) && (player->transformation == PLAYER_FORM_FIERCE_DEITY)) {
         return itemId >= ITEM_MASK_DEKU && itemId <= ITEM_MASK_ZORA;

--- a/mm/2s2h/Enhancements/Masks/3DSMaskEquipping.cpp
+++ b/mm/2s2h/Enhancements/Masks/3DSMaskEquipping.cpp
@@ -12,6 +12,7 @@ static bool IsTransformationMask(PlayerMask mask) {
 }
 
 static bool IsMask(ItemId itemId) {
+    // Non-transformation masks
     if ((itemId >= ITEM_MASK_TRUTH) && (itemId <= ITEM_MASK_SCENTS)) {
         return true;
     }

--- a/mm/2s2h/Enhancements/Masks/3DSMaskEquipping.cpp
+++ b/mm/2s2h/Enhancements/Masks/3DSMaskEquipping.cpp
@@ -17,7 +17,7 @@ static bool IsMask(ItemId itemId) {
     }
     Player* player = GET_PLAYER(gPlayState);
     if ((player != NULL) && (player->transformation == PLAYER_FORM_FIERCE_DEITY)) {
-        return (itemId == ITEM_MASK_GORON) || (itemId == ITEM_MASK_ZORA) || (itemId == ITEM_MASK_DEKU);
+        return itemId >= ITEM_MASK_DEKU && itemId <= ITEM_MASK_ZORA;
     }
     return false;
 }


### PR DESCRIPTION
extension to #1455
realised i forgot to allow fd to use other transformation masks, this is a feature in mm3d so im just adding it to this enhancement. initially caused a softlock when switching from fd, and then to human, so i had to rewrite some stuff to fix that. also renamed the cpp bc i forgot to when i first did the name change on the enhancement so the cpp now matches what its actually for

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5425534510.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5425575803.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5425631724.zip)
<!--- section:artifacts:end -->