### PR TITLE
fix free cam collision slide

### DIFF
--- a/mm/2s2h/Enhancements/Camera/FreeLook.cpp
+++ b/mm/2s2h/Enhancements/Camera/FreeLook.cpp
@@ -127,9 +127,19 @@ bool Camera_FreeLook(Camera* camera) {
     *eyeNext = OLib_AddVecGeoToVec3f(at, &eyeAdjustment);
     // Apply new camera angle only when camera active
     if (camera->status == CAM_STATUS_ACTIVE) {
-        *eye = *eyeNext;
-        // Adjust camera for collision with floors, walls and ceilings.
-        func_800CBFA4(camera, at, eye, 0);
+        CameraCollision camCollision = {};
+        camCollision.pos = *eyeNext;
+
+        if (Camera_BgCheckInfo(camera, at, &camCollision)) {
+            f32 collDist = Math3D_Vec3f_DistXYZ(at, &camCollision.pos);
+            eyeAdjustment.r = collDist - 3.0f;
+            *eye = OLib_AddVecGeoToVec3f(at, &eyeAdjustment);
+        } else {
+            *eye = *eyeNext;
+        }
+
+        camera->dist = Math3D_Vec3f_DistXYZ(at, eye);
+        camera->eyeNext = *eye;
     }
 
     // 65.0f based on value from SoH


### PR DESCRIPTION
its always bothered me how the free look cam slides off walls when the camera is positioned against them, and ive heard a few others complain about it too, i assume it wasnt intentional since soh's free look cam doesnt do this, so this mimics the soh cam and no longer slides off walls

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5244758872.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5244785898.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5244815756.zip)
<!--- section:artifacts:end -->