### PR TITLE
[Mod] Port bomb billboard and grotto rotation from SoH

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1191,6 +1191,16 @@ void BenMenu::AddEnhancements() {
         .Options(CheckboxOptions().Tooltip(
             "Toggle between standard assets and alternate assets. Usually mods will indicate if "
             "this setting has to be used or not."));
+    AddWidget(path, "Disable Bomb Billboarding", WIDGET_CVAR_CHECKBOX)
+        .CVar("gEnhancements.Mods.DisableBombBillboarding")
+        .Options(CheckboxOptions().Tooltip(
+            "Disables bombs always rotating to face the camera. To be used in conjunction with mods that want "
+            "to replace bombs with 3D objects."));
+    AddWidget(path, "Disable Grotto Fixed Rotation", WIDGET_CVAR_CHECKBOX)
+        .CVar("gEnhancements.Mods.DisableGrottoRotation")
+        .Options(CheckboxOptions().Tooltip(
+            "Disables Grottos rotating with the Camera. To be used in conjuction with mods that want to "
+            "replace grottos with 3D objects."));
     AddWidget(path, "Motion Blur", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Motion Blur Mode", WIDGET_CVAR_COMBOBOX)
         .CVar("gEnhancements.Graphics.MotionBlur.Mode")

--- a/mm/2s2h/Enhancements/Graphics/DisableBombBillboarding.cpp
+++ b/mm/2s2h/Enhancements/Graphics/DisableBombBillboarding.cpp
@@ -1,0 +1,12 @@
+#include <libultraship/bridge/consolevariablebridge.h>
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/ShipInit.hpp"
+
+#define CVAR_NAME "gEnhancements.Mods.DisableBombBillboarding"
+#define CVAR CVarGetInteger(CVAR_NAME, 0)
+
+void RegisterDisableBombBillboarding() {
+    COND_VB_SHOULD(VB_APPLY_BOMB_BILLBOARDING, CVAR, { *should = false; });
+}
+
+static RegisterShipInitFunc initFunc(RegisterDisableBombBillboarding, { CVAR_NAME });

--- a/mm/2s2h/Enhancements/Graphics/DisableGrottoRotation.cpp
+++ b/mm/2s2h/Enhancements/Graphics/DisableGrottoRotation.cpp
@@ -1,0 +1,12 @@
+#include <libultraship/bridge/consolevariablebridge.h>
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/ShipInit.hpp"
+
+#define CVAR_NAME "gEnhancements.Mods.DisableGrottoRotation"
+#define CVAR CVarGetInteger(CVAR_NAME, 0)
+
+void RegisterDisableGrottoRotation() {
+    COND_VB_SHOULD(VB_ROTATE_GROTTO_ENTRANCE, CVAR, { *should = false; });
+}
+
+static RegisterShipInitFunc initFunc(RegisterDisableGrottoRotation, { CVAR_NAME });

--- a/mm/2s2h/GameInteractor/GameInteractor_VanillaBehavior.h
+++ b/mm/2s2h/GameInteractor/GameInteractor_VanillaBehavior.h
@@ -73,6 +73,14 @@ typedef enum {
 
     // #### `result`
     // ```c
+    // true
+    // ```
+    // #### `args`
+    // - None
+    VB_APPLY_BOMB_BILLBOARDING,
+
+    // #### `result`
+    // ```c
     // cylinderOc != NULL
     // ```
     // #### `args`
@@ -1711,6 +1719,14 @@ typedef enum {
     // #### `args`
     // - `bool` (unused)
     VB_ROMANI_CONSIDER_EPONA_SONG_GIVEN,
+
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
+    // - None
+    VB_ROTATE_GROTTO_ENTRANCE,
 
     // #### `result`
     // ```c

--- a/mm/src/overlays/actors/ovl_Door_Ana/z_door_ana.c
+++ b/mm/src/overlays/actors/ovl_Door_Ana/z_door_ana.c
@@ -7,6 +7,8 @@
 #include "z_door_ana.h"
 #include "objects/gameplay_field_keep/gameplay_field_keep.h"
 
+#include "2s2h/GameInteractor/GameInteractor.h"
+
 #define FLAGS (ACTOR_FLAG_UPDATE_DURING_OCARINA)
 
 void DoorAna_Init(Actor* thisx, PlayState* play);
@@ -193,7 +195,9 @@ void DoorAna_Update(Actor* thisx, PlayState* play) {
     DoorAna* this = (DoorAna*)thisx;
 
     this->actionFunc(this, play);
-    this->actor.shape.rot.y = BINANG_ROT180(Camera_GetCamDirYaw(GET_ACTIVE_CAM(play)));
+    if (GameInteractor_Should(VB_ROTATE_GROTTO_ENTRANCE, true)) {
+        this->actor.shape.rot.y = BINANG_ROT180(Camera_GetCamDirYaw(GET_ACTIVE_CAM(play)));
+    }
 }
 
 void DoorAna_Draw(Actor* thisx, PlayState* play) {

--- a/mm/src/overlays/actors/ovl_En_Bom/z_en_bom.c
+++ b/mm/src/overlays/actors/ovl_En_Bom/z_en_bom.c
@@ -9,6 +9,8 @@
 #include "overlays/actors/ovl_En_Clear_Tag/z_en_clear_tag.h"
 #include "objects/gameplay_keep/gameplay_keep.h"
 
+#include "2s2h/GameInteractor/GameInteractor.h"
+
 #define FLAGS (ACTOR_FLAG_UPDATE_CULLING_DISABLED | ACTOR_FLAG_DRAW_CULLING_DISABLED)
 
 void EnBom_Init(Actor* thisx, PlayState* play);
@@ -629,7 +631,9 @@ void EnBom_Draw(Actor* thisx, PlayState* play) {
             MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, play->state.gfxCtx);
             gSPDisplayList(POLY_OPA_DISP++, gBombCapDL);
 
-            Matrix_ReplaceRotation(&play->billboardMtxF);
+            if (GameInteractor_Should(VB_APPLY_BOMB_BILLBOARDING, true, this->actor.id)) {
+                Matrix_ReplaceRotation(&play->billboardMtxF);
+            }
             Matrix_RotateXS(0x4000, MTXMODE_APPLY);
 
             MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, play->state.gfxCtx);


### PR DESCRIPTION
Ports the mod settings for disabling bomb billboarding and grotto rotation from SoH, for use with 3D assets instead of 2D sprites.

Will need testing from 3D mods. I've only confirmed that the sprite billboarding and rotation themselves are disabled, but I don't have 3D mods to replace them with.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5251695270.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5251741155.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5252137896.zip)
<!--- section:artifacts:end -->