### PR TITLE
Change Seahorse Requirement for Curiosity Shop Refills

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1089,7 +1089,7 @@ void BenMenu::AddEnhancements() {
         .CVar("gEnhancements.Shops.CuriosityShopRefills")
         .Options(CheckboxOptions().Tooltip(
             "Adds refillable bottles to the Curiosity Shop after completing certain prerequisites:\\n"
-            "- Seahorse: After reuniting the seahorses at Pinnacle Rock\\n"
+            "- Seahorse: After obtaining a Bottle, Zora Mask, Pictograph Box & (Rando Only) Swim Ability\\n"
             "- Gold Dust: After obtaining the Gold Dust bottle\\n"
             "- Chateau Romani: After obtaining Chateau Romani"));
     AddWidget(path, "Accessibility", WIDGET_SEPARATOR_TEXT);

--- a/mm/2s2h/Enhancements/Items/AmmoBuyback.cpp
+++ b/mm/2s2h/Enhancements/Items/AmmoBuyback.cpp
@@ -55,6 +55,8 @@ static s16 GetPricePerUnit(ItemId itemId) {
             return 10;
         case ITEM_POWDER_KEG:
             return 50;
+        case ITEM_SEAHORSE:
+            return 50;
         default:
             return 0;
     }
@@ -76,6 +78,8 @@ static const char* GetNameForDialogue(ItemId itemId) {
             return "%rMagic Beans%w";
         case ITEM_POWDER_KEG:
             return "%rPowder Kegs%w";
+        case ITEM_SEAHORSE:
+            return "%rSeahorse%w";
         default:
             return "%ritems%w";
     }
@@ -95,6 +99,9 @@ static bool IsItemAvailable(ItemId itemId) {
     }
     if (itemId == ITEM_MAGIC_BEANS) {
         return INV_CONTENT(ITEM_MAGIC_BEANS) == ITEM_MAGIC_BEANS && AMMO(ITEM_MAGIC_BEANS) > 0;
+    }
+    if (itemId == ITEM_SEAHORSE) {
+        return true;
     }
     return Item_CheckObtainability(itemId) != ITEM_NONE;
 }
@@ -150,13 +157,14 @@ static void HandleStart(EnFsn* enFsn, PlayState* play) {
                                      ? DPAD_GET_CUR_FORM_BTN_ITEM(HELD_ITEM_TO_DPAD(player->heldItemButton))
                                      : GET_CUR_FORM_BTN_ITEM(player->heldItemButton));
 
-    if (GetPricePerUnit(buttonItem) > 0 && IsItemAvailable(buttonItem) && AMMO(buttonItem) > 0) {
+    if (GetPricePerUnit(buttonItem) > 0 && IsItemAvailable(buttonItem) &&
+        (buttonItem == ITEM_SEAHORSE || AMMO(buttonItem) > 0)) {
         sAmmoSale.actor = enFsn;
         sAmmoSale.itemId = buttonItem;
         sAmmoSale.lastRupeesSelected = 10; // Default for input mode
 
         // If player only has 1, skip inputs
-        s16 maxAllowed = MIN(AMMO(buttonItem), MAX_AMMO_SELL_QUANTITY);
+        s16 maxAllowed = (buttonItem == ITEM_SEAHORSE) ? 1 : MIN(AMMO(buttonItem), MAX_AMMO_SELL_QUANTITY);
 
         if (maxAllowed == 1) {
             sAmmoSale.quantity = 1;
@@ -191,7 +199,7 @@ static void HandleInput(EnFsn* enFsn, PlayState* play) {
 
     s16 currentQuantity = (s16)(msgCtx->rupeesSelected / 10);
     s16 newQuantity = currentQuantity;
-    s16 maxAllowed = MIN(AMMO(sAmmoSale.itemId), MAX_AMMO_SELL_QUANTITY);
+    s16 maxAllowed = (sAmmoSale.itemId == ITEM_SEAHORSE) ? 1 : MIN(AMMO(sAmmoSale.itemId), MAX_AMMO_SELL_QUANTITY);
 
     // Enforce cursor on visible digits (0=Tens, 1=Units)
     if (msgCtx->unk120C2 > 1)
@@ -268,7 +276,11 @@ static void Resolve(EnFsn* enFsn, bool* shouldGiveItem) {
     if (enFsn->actionFunc == EnFsn_GiveItem) {
         *shouldGiveItem = false;
 
-        Inventory_ChangeAmmo(sAmmoSale.itemId, -sAmmoSale.quantity);
+        if (sAmmoSale.itemId == ITEM_SEAHORSE) {
+            Inventory_ReplaceItem(gPlayState, ITEM_SEAHORSE, ITEM_BOTTLE);
+        } else {
+            Inventory_ChangeAmmo(sAmmoSale.itemId, -sAmmoSale.quantity);
+        }
         Rupees_ChangeBy(sAmmoSale.price);
 
         enFsn->actor.parent = nullptr;

--- a/mm/2s2h/Enhancements/Timesavers/CuriosityShopRefills.cpp
+++ b/mm/2s2h/Enhancements/Timesavers/CuriosityShopRefills.cpp
@@ -56,17 +56,30 @@ static const RefillItem* GetRefillItem(s16 shopId) {
     return &sRefillItems[shopId];
 }
 
-static bool HasAnyBottle() {
-    for (int i = SLOT_BOTTLE_1; i <= SLOT_BOTTLE_6; i++) {
-        if (gSaveContext.save.saveInfo.inventory.items[i] != ITEM_NONE) {
+static bool HasAccessToGreatBay() {
+    if (gSaveContext.save.saveInfo.inventory.items[SLOT_OCARINA] == ITEM_NONE) {
+        return false;
+    }
+
+    if (CHECK_QUEST_ITEM(QUEST_SONG_EPONA)) {
+        return true;
+    }
+
+    if (CHECK_QUEST_ITEM(QUEST_SONG_SOARING)) {
+        if (GET_OWL_STATUE_ACTIVATED(OWL_WARP_GREAT_BAY_COAST)) {
+            return true;
+        }
+
+        if (GET_OWL_STATUE_ACTIVATED(OWL_WARP_ZORA_CAPE)) {
             return true;
         }
     }
     return false;
 }
 
+// Note: IsRefillAvailable checks for bottle availibility. We don't need to do that here.
 static bool HasSeahorseRequirements() {
-    if (!HasAnyBottle()) {
+    if (!HasAccessToGreatBay()) {
         return false;
     }
 

--- a/mm/2s2h/Enhancements/Timesavers/CuriosityShopRefills.cpp
+++ b/mm/2s2h/Enhancements/Timesavers/CuriosityShopRefills.cpp
@@ -56,19 +56,49 @@ static const RefillItem* GetRefillItem(s16 shopId) {
     return &sRefillItems[shopId];
 }
 
+static bool HasAnyBottle() {
+    for (int i = SLOT_BOTTLE_1; i <= SLOT_BOTTLE_6; i++) {
+        if (gSaveContext.save.saveInfo.inventory.items[i] != ITEM_NONE) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool HasSeahorseRequirements() {
+    if (!HasAnyBottle()) {
+        return false;
+    }
+
+    if (gSaveContext.save.saveInfo.inventory.items[SLOT_MASK_ZORA] == ITEM_NONE) {
+        return false;
+    }
+
+    if (gSaveContext.save.saveInfo.inventory.items[SLOT_PICTOGRAPH_BOX] == ITEM_NONE) {
+        return false;
+    }
+
+    if (IS_RANDO && RANDO_SAVE_OPTIONS[RO_SHUFFLE_SWIM] && !Flags_GetRandoInf(RANDO_INF_OBTAINED_SWIM)) {
+        return false;
+    }
+
+    return true;
+}
+
 static bool IsRefillAvailable(const RefillItem& item) {
     // If they got it in their inventory don't even offer the thing for sale
     if (Inventory_HasItemInBottle(item.itemId)) {
         return false;
     }
 
+    if (item.itemId == ITEM_SEAHORSE) {
+        return HasSeahorseRequirements();
+    }
+
     if (IS_RANDO) {
         if (item.randoItem != RI_NONE) {
             RandoCheckId itemPlacement = Rando::FindItemPlacement(item.randoItem);
             return itemPlacement != RC_UNKNOWN && RANDO_SAVE_CHECKS[itemPlacement].obtained;
-        } else if (item.itemId == ITEM_SEAHORSE) {
-            // Seahorse doesn't have a rando item, check week event flag directly
-            return CHECK_WEEKEVENTREG(WEEKEVENTREG_RECEIVED_SEAHORSE_HEART_PIECE);
         }
     }
 


### PR DESCRIPTION
Changes:
- Owns at least one bottle
- Has Zora’s Mask
- Has the Pictograph
- Has the swim ability (Randomizer only)
- AmmoBuyback supports selling the Seahorse back to the shopkeeper

Pricing:
- Purchase price: 100 Rupees (Unchanged)
- Buyback price: 50 Rupees

Yes, the margin is intentional. The shopkeeper is not open to negotiation.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5309274671.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5309363185.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5309472936.zip)
<!--- section:artifacts:end -->