### PR TITLE
Fix weirdness with playing a restricted song

### DIFF
--- a/mm/2s2h/Rando/MiscBehavior/SariasSongHint.cpp
+++ b/mm/2s2h/Rando/MiscBehavior/SariasSongHint.cpp
@@ -125,6 +125,8 @@ void Rando::MiscBehavior::SariasSongHint() {
             }
 
             playedSariasSongState = 0;
+        } else if (playedSariasSongState == 0) {
+            return;
         }
 
         CustomMessage::LoadCustomMessageIntoFont(entry);


### PR DESCRIPTION
Playing a restricted song when Saria's song is shuffled (ie Song of Soaring inside the clock tower) has been reported as causing some weird textbox stuff a few times. When attempted in a debug build, I was getting crashes. 

This adds a condition to skip the CustomMessage stuff in the Saria's Song OnOpenText hook, when we want the vanilla text for playing a restricted song.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5314421076.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5314470866.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5314537234.zip)
<!--- section:artifacts:end -->