### PR TITLE
[Enhancement] Require only one bug to spawn a Soft Soil Skulltula

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1545,6 +1545,11 @@ void BenMenu::AddEnhancements() {
         .CVar("gEnhancements.Restorations.BonkCollision")
         .Options(
             CheckboxOptions().Tooltip("Corrects rolls to allow bonking trees near the end of the roll, as in OoT."));
+    AddWidget(path, "Soft Soil Skulltulas only require one bug", WIDGET_CVAR_CHECKBOX)
+        .CVar("gEnhancements.Restorations.OneBugSoftSoil")
+        .Options(CheckboxOptions().Tooltip(
+            "Soft Soil Golden Skulltulas only require one bug to spawn, matching OoT behavior.\n\n"
+            "This allows rebottling one of the bugs while still spawning the Skulltula."));
     AddWidget(path, "Simulated Input Lag", WIDGET_CVAR_SLIDER_INT)
         .CVar(CVAR_SIMULATED_INPUT_LAG)
         .Options(IntSliderOptions()

--- a/mm/src/overlays/actors/ovl_En_Mushi2/z_en_mushi2.c
+++ b/mm/src/overlays/actors/ovl_En_Mushi2/z_en_mushi2.c
@@ -6,6 +6,7 @@
 
 #include "overlays/actors/ovl_Obj_Bean/z_obj_bean.h"
 #include "z_en_mushi2.h"
+#include <libultraship/bridge/consolevariablebridge.h>
 
 #define FLAGS (ACTOR_FLAG_UPDATE_CULLING_DISABLED)
 

--- a/mm/src/overlays/actors/ovl_En_Mushi2/z_en_mushi2.c
+++ b/mm/src/overlays/actors/ovl_En_Mushi2/z_en_mushi2.c
@@ -722,6 +722,12 @@ s32 func_80A6A094(EnMushi2* this) {
         ObjBean* bean = this->unk_34C;
 
         if ((bean->unk_1E4 == 2) || (bean->unk_1E4 == 1)) {
+            if (CVarGetInteger("gEnhancements.Restorations.OneBugSoftSoil", 0)) {
+                if (bean->unk_1E4 == 2 && bean->unk_1E0 < 2) {
+                    bean->unk_1E0 = 2;
+                }
+                return false;
+            }
             bean->unk_1E4 = 4;
             return true;
         }


### PR DESCRIPTION
Only require one bug, instead of all three, to have to burrow into a soft soil patch to spawn the Golden Skulltula, which matches the behavior in OoT. This allows for quickly rebottling one of the three bugs dropped, so you don't have to keep getting new ones.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5338506287.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5338557746.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5338625426.zip)
<!--- section:artifacts:end -->