### PR TITLE
Arrow buyback at full price, always

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1086,7 +1086,8 @@ void BenMenu::AddEnhancements() {
                               "to the Curiosity Shop owner for Rupees.\n"
                               "-Vanilla: Ammo items cannot be sold\n"
                               "-Full Price: Sell at full value\n"
-                              "-Half Price: Sell at half value (rounded up)")
+                              "-Half Price: Sell at half value (rounded up)"
+                              "Arrows will always be sold back at Full Price.")
                      .ComboVec(&ammoBuybackOptions));
     AddWidget(path, "Curiosity Shop Refills", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Shops.CuriosityShopRefills")

--- a/mm/2s2h/Enhancements/Items/AmmoBuyback.cpp
+++ b/mm/2s2h/Enhancements/Items/AmmoBuyback.cpp
@@ -87,7 +87,7 @@ static const char* GetNameForDialogue(ItemId itemId) {
 
 static s16 GetSalePrice(ItemId itemId, s16 count) {
     s16 totalPrice = count * GetPricePerUnit(itemId);
-    if (CVAR == AMMO_BUYBACK_HALF_PRICE) {
+    if (CVAR == AMMO_BUYBACK_HALF_PRICE && itemId != ITEM_BOW) {
         totalPrice = (totalPrice + 1) / 2;
     }
     return totalPrice;


### PR DESCRIPTION
I decided to make a tweak to the Ammo Buyback hook, making the Arrows always be sold at full price, even at the Half Price option. Otherwise, players might either sell their arrows one at a time just to maximize Rupee gains, or switch to Full Price just for arrows.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5548475910.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5548557190.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5548632153.zip)
<!--- section:artifacts:end -->