### PR TITLE
Freeze the player when encountering the music box house cutscene

### DIFF
--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipIkanaCurseCutscenes.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipIkanaCurseCutscenes.cpp
@@ -56,6 +56,10 @@ void RegisterSkipIkanaCurseCutscenes() {
                 hgDoor->rotation = otherDoor->rotation = 0x5555;  // Open the doors
                 hgDoor->dyna.actor.parent->colChkInfo.health = 1; // The Gibdo dad moves once this is set
                 *should = false;
+
+                Player* player = GET_PLAYER(gPlayState);
+                player->speedXZ = 0.0f;
+                player->actor.freezeTimer = 20;
             } else if (*csId == 10 || *csId == 12) { // Failed to heal Pamela's father
                 /*
                  * The WEEKEVENTREG_61_02 flag marks that the player has failed to heal Pamela's father this cycle.


### PR DESCRIPTION
People often accidentally run towards this encounter, which due to the cutscene causes them to immediately be kicked out. This will freeze them for 1 second and stop their momentum so that they have more of a chance to react.

This is likely just a temporary measure until we find a better more long term solution

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5602407128.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5602441392.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5602579403.zip)
<!--- section:artifacts:end -->