### PR TITLE
Award red potion and gold dust refills on first attempt

### DIFF
--- a/mm/2s2h/Rando/ActorBehavior/EnGk.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnGk.cpp
@@ -16,10 +16,16 @@ void Rando::ActorBehavior::InitEnGKBehavior() {
 
         switch (actor->id) {
             case ACTOR_EN_GK:
-                if (RANDO_SAVE_CHECKS[RC_GORON_RACETRACK_GOLD_DUST].cycleObtained) {
+                // In either case here, WEEKEVENTREG_RECEIVED_GORON_RACE_BOTTLE will be set and trigger the rando
+                // check to be queued.
+
+                // If they have an empty bottle, force item to gold dust refill and let vanilla item get continue
+                if (Inventory_HasEmptyBottle()) {
+                    *item = GI_GOLD_DUST_2;
                     return;
                 }
 
+                // Otherwise bypass item get entirely
                 *should = false;
                 actor->parent = &player->actor;
                 player->talkActor = actor;

--- a/mm/2s2h/Rando/ActorBehavior/EnTrt.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnTrt.cpp
@@ -27,17 +27,28 @@ void Rando::ActorBehavior::InitEnTrtBehavior() {
         Actor* actor = va_arg(args, Actor*);
         Player* player = GET_PLAYER(gPlayState);
 
-        if (actor->id != ACTOR_EN_TRT && actor->id != ACTOR_EN_TRT2) {
-            return;
-        }
-        if (!RANDO_SAVE_CHECKS[RC_HAGS_POTION_SHOP_KOTAKE].shuffled ||
-            RANDO_SAVE_CHECKS[RC_HAGS_POTION_SHOP_KOTAKE].cycleObtained ||
+        // Let vanilla item give continue
+        if ((actor->id != ACTOR_EN_TRT && actor->id != ACTOR_EN_TRT2) ||
+            !RANDO_SAVE_CHECKS[RC_HAGS_POTION_SHOP_KOTAKE].shuffled ||
             (*item != GI_POTION_RED_BOTTLE && *item != GI_POTION_RED)) {
             return;
         }
 
-        SET_WEEKEVENTREG(WEEKEVENTREG_RECEIVED_KOTAKE_BOTTLE);
-        SET_WEEKEVENTREG(WEEKEVENTREG_RECEIVED_RED_POTION_FOR_KOUME);
+        if (!RANDO_SAVE_CHECKS[RC_HAGS_POTION_SHOP_KOTAKE].cycleObtained) {
+            SET_WEEKEVENTREG(WEEKEVENTREG_RECEIVED_KOTAKE_BOTTLE);
+            SET_WEEKEVENTREG(WEEKEVENTREG_RECEIVED_RED_POTION_FOR_KOUME);
+        }
+
+        // In either case here, WEEKEVENTREG_RECEIVED_KOTAKE_BOTTLE will be set and trigger the rando
+        // check to be queued.
+
+        // If they have an empty bottle, force item to red potion and let vanilla item get continue
+        if (Inventory_HasEmptyBottle()) {
+            *item = GI_POTION_RED;
+            return;
+        }
+
+        // Otherwise bypass item get entirely
         *should = false;
 
         actor->parent = &player->actor;


### PR DESCRIPTION
This is to make it more apparent to players that we grant red potion refill and gold dust refill at their vanilla locations, prior to this change, the player would have to do the action twice, first to receive the check then again to get the refill.

This makes it to where if they have an empty bottle we will always attempt to give the refill, even on the first go.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5602874836.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5602910483.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5603098308.zip)
<!--- section:artifacts:end -->