### PR TITLE
Exclude some tatl text for glitches

### DIFF
--- a/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipTatlInterrupts.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/MiscInteractions/SkipTatlInterrupts.cpp
@@ -61,8 +61,8 @@ void RegisterSkipTatlInterrupts() {
 
     // General interupt (6) (the flags were directly copied from the original code)
     COND_VB_SHOULD(VB_TATL_INTERRUPT_MSG6, CVAR, {
-        if (*should) {
-            Actor* actor = va_arg(args, Actor*);
+        Actor* actor = va_arg(args, Actor*);
+        if (*should && actor->csId != -1 && actor->csId != 124) {
             *should = false;
             switch (actor->textId) {
                 case 0x224:


### PR DESCRIPTION
If there's an obvious way I'd like to only skip the tatl events that actually interrupt gameplay, leaving the ones that are opt-in with C-up. But this works for now.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5605153515.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5605185427.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5605295486.zip)
<!--- section:artifacts:end -->