### PR TITLE
Add slower swim speed for Zora Link

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -63,6 +63,12 @@ static const std::vector<const char*> ammoBuybackOptions = {
     "Half Price", // AMMO_BUYBACK_HALF_PRICE
 };
 
+static const std::vector<const char*> slowZoraSwimOptions = {
+    "Off",              // SLOW_ZORA_SWIM_OFF
+    "Hold to slow",     // SLOW_ZORA_SWIM_HOLD_SLOW
+    "Hold to speed up", // SLOW_ZORA_SWIM_HOLD_FAST
+};
+
 static const std::vector<const char*> gibdoTradeSequenceOptions = {
     "Vanilla",  // GIBDO_TRADE_SEQUENCE_VANILLA
     "MM3D",     // GIBDO_TRADE_SEQUENCE_MM3D
@@ -965,6 +971,14 @@ void BenMenu::AddEnhancements() {
     path = { "Enhancements", "Gameplay", SECTION_COLUMN_1 };
     AddSidebarEntry("Enhancements", "Gameplay", 3);
     AddWidget(path, "Player", WIDGET_SEPARATOR_TEXT);
+    AddWidget(path, "Zora Swims Slowly By Holding Z", WIDGET_CVAR_COMBOBOX)
+        .CVar("gEnhancements.Player.SlowZoraSwim")
+        .Options(ComboboxOptions()
+                     .Tooltip("Allows slowing down Zora Link's swimming speed by holding down the Z button.\n"
+                              "-Off: disabled\n"
+                              "-Hold to slow: speed is normal by default\n"
+                              "-Hold to speed up: speed is slow by default")
+                     .ComboVec(&slowZoraSwimOptions));
     AddWidget(path, "Fast Deku Flower Launch", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Player.FastFlowerLaunch")
         .Options(CheckboxOptions().Tooltip("Speeds up the time it takes to be able to get maximum height from"

--- a/mm/2s2h/Enhancements/Enhancements.h
+++ b/mm/2s2h/Enhancements/Enhancements.h
@@ -31,6 +31,12 @@ enum AmmoBuybackOptions {
     AMMO_BUYBACK_HALF_PRICE,
 };
 
+enum SlowZoraSwimOptions {
+    SLOW_ZORA_SWIM_OFF,
+    SLOW_ZORA_SWIM_HOLD_SLOW,
+    SLOW_ZORA_SWIM_HOLD_FAST,
+};
+
 enum GibdoTradeSequenceOptions {
     GIBDO_TRADE_SEQUENCE_VANILLA,
     GIBDO_TRADE_SEQUENCE_MM3D,

--- a/mm/2s2h/Enhancements/Player/SlowZoraSwim.cpp
+++ b/mm/2s2h/Enhancements/Player/SlowZoraSwim.cpp
@@ -1,0 +1,28 @@
+#include <libultraship/bridge/consolevariablebridge.h>
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/ShipInit.hpp"
+#include "2s2h/Enhancements/Enhancements.h"
+
+#define CVAR_NAME "gEnhancements.Player.SlowZoraSwim"
+#define CVAR CVarGetInteger(CVAR_NAME, SLOW_ZORA_SWIM_OFF)
+
+static void HandleSlowZoraSwim(f32* speed, f32* speedTarget) {
+    bool isZPressed = CHECK_BTN_ALL(gPlayState->state.input[0].cur.button, BTN_Z);
+    bool shouldSwimSlow = (CVAR == SLOW_ZORA_SWIM_HOLD_SLOW) ? isZPressed : !isZPressed;
+    if (shouldSwimSlow) {
+        if (*speed == 16.0f) {
+            *speed = 8.0f;
+        }
+        *speedTarget = 6.0f;
+    }
+}
+
+static void RegisterSlowZoraSwim() {
+    COND_VB_SHOULD(VB_ZORA_LINK_SWIM_SLOWLY, CVAR, {
+        f32* speed = va_arg(args, f32*);
+        f32* speedTarget = va_arg(args, f32*);
+        HandleSlowZoraSwim(speed, speedTarget);
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterSlowZoraSwim, { CVAR_NAME });

--- a/mm/2s2h/GameInteractor/GameInteractor_VanillaBehavior.h
+++ b/mm/2s2h/GameInteractor/GameInteractor_VanillaBehavior.h
@@ -2211,6 +2211,15 @@ typedef enum {
     // ```
     // #### `args`
     // - `*f32` (speed)
+    // - `*f32` (target speed)
+    VB_ZORA_LINK_SWIM_SLOWLY,
+
+    // #### `result`
+    // ```c
+    // false
+    // ```
+    // #### `args`
+    // - `*f32` (speed)
     VB_ZTARGET_SPEED_CHECK,
 } GIVanillaBehavior;
 

--- a/mm/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/mm/src/overlays/actors/ovl_player_actor/z_player.c
@@ -17450,6 +17450,7 @@ void Player_Action_56(Player* this, PlayState* play) {
         Player_PlaySfx(this, NA_SE_PL_BODY_BOUND);
     }
 
+    GameInteractor_Should(VB_ZORA_LINK_SWIM_SLOWLY, false, &this->unk_B48, &speedTarget);
     func_80850BF8(this, speedTarget);
     func_80850BA8(this);
 }


### PR DESCRIPTION
Closes #1557

The idea was to help players not bang their heads so much when trying to swim in confined spaces (e.g. Great Bay Temple), but the game gives you better control than that; you can just tilt the stick and Zora Link will swim in that direction. Still, it might be an appreciated feature.

Anyway, you can now slow down Zora Link's swim speed using the Z button.

<img width="990" height="207" alt="zora-slow-swim" src="https://github.com/user-attachments/assets/5d97e427-5bba-4268-b557-a2b1fb5a771c" />

Let's compare. Using the side stroke method, Zora Link swims past this platform in a bit over 3 seconds:

https://github.com/user-attachments/assets/0834af79-f93a-4a5d-be2f-30d74916cb09

When dash swimming at his normal speed, he clocks in at around 1.3 seconds:

https://github.com/user-attachments/assets/6c72745c-cde3-4109-bc58-b2f3f6af5d98

And at the reduced swim speed, he's a bit over 2 seconds, right in the middle:

https://github.com/user-attachments/assets/512fe39c-7e6d-4646-a222-d1f9b35fcc65


<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5612394749.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5612463145.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5613222341.zip)
<!--- section:artifacts:end -->