### PR TITLE
[Fix] Swordless GFS with B

### DIFF
--- a/mm/src/code/z_player_lib.c
+++ b/mm/src/code/z_player_lib.c
@@ -772,6 +772,8 @@ ItemId Player_GetItemOnButton(PlayState* play, Player* player, EquipSlot slot) {
     if (slot == EQUIP_SLOT_B) {
         ItemId item = Inventory_GetBtnBItem(play);
 
+        GameInteractor_Should(VB_GET_ITEM_ON_BUTTON, item, slot, &item);
+
         if (item >= ITEM_FD) {
             return item;
         }
@@ -790,8 +792,6 @@ ItemId Player_GetItemOnButton(PlayState* play, Player* player, EquipSlot slot) {
             (play->interfaceCtx.bButtonPlayerDoAction == DO_ACTION_DANCE)) {
             return ITEM_F2;
         }
-
-        GameInteractor_Should(VB_GET_ITEM_ON_BUTTON, item, slot, &item);
 
         return item;
     }


### PR DESCRIPTION
Moved `VB_GET_ITEM_ON_BUTTON ` before the `>= ITEM_FD` guard. When swordless, `Player_GetItemOnButton` returns early, so the VB call was not being reached.