### PR TITLE
Add Reset function to enRailSkb

### DIFF
--- a/mm/src/overlays/actors/ovl_En_Rail_Skb/z_en_rail_skb.c
+++ b/mm/src/overlays/actors/ovl_En_Rail_Skb/z_en_rail_skb.c
@@ -14,6 +14,7 @@ void EnRailSkb_Init(Actor* thisx, PlayState* play);
 void EnRailSkb_Destroy(Actor* thisx, PlayState* play);
 void EnRailSkb_Update(Actor* thisx, PlayState* play);
 void EnRailSkb_Draw(Actor* thisx, PlayState* play);
+void EnRailSkb_Reset(void);
 
 void func_80B70FA0(EnRailSkb* this);
 void func_80B70FF8(EnRailSkb* this, PlayState* play);
@@ -58,6 +59,7 @@ ActorProfile En_Rail_Skb_Profile = {
     /**/ EnRailSkb_Destroy,
     /**/ EnRailSkb_Update,
     /**/ EnRailSkb_Draw,
+    /**/ EnRailSkb_Reset,
 };
 
 typedef enum EnRailSkbAnimation {
@@ -169,8 +171,10 @@ static DamageTable sDamageTable = {
     /* Powder Keg     */ DMG_ENTRY(1, 0xF),
 };
 
+// 2S2H [Port] Moved this variable out of func_80B708C0 so reset function can access
+static s32 D_80B7348C = 0;
+
 void func_80B708C0(EnRailSkb* this, PlayState* play) {
-    static s32 D_80B7348C = 0;
     Path* path = &play->setupPathList[ENRAILSKB_GET_PATH_INDEX(&this->actor)];
     Vec3f sp70;
     s32 phi_a3;
@@ -1181,4 +1185,8 @@ void EnRailSkb_Draw(Actor* thisx, PlayState* play) {
     if ((this->unk_402 & 0x40) && !(this->unk_402 & 0x80)) {
         this->unk_402 |= 0x80;
     }
+}
+
+void EnRailSkb_Reset(void) {
+    D_80B7348C = 0;
 }


### PR DESCRIPTION
There is a static variable in enRailSkb that facilitates spawning the three circling stalchildren. This looks like it should always be reset to 0 normally, but there have been reports of softlocks occurring because only one stalchild is spawning. 

I was able to replicate the softlock by artificially preventing the variable from resetting. 

This PR adds a Reset function to the actor to ensure this variable is always reset to 0. While I haven't been to naturally replicate, I'm confident this will prevent the softlock.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5792775985.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5792655538.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5792563014.zip)
<!--- section:artifacts:end -->