### PR TITLE
[Enhancement] Extra Powder Kegs

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1089,6 +1089,10 @@ void BenMenu::AddEnhancements() {
                               "-Half Price: Sell at half value (rounded up)"
                               "Arrows will always be sold back at Full Price.")
                      .ComboVec(&ammoBuybackOptions));
+    AddWidget(path, "Extra Powder Kegs", WIDGET_CVAR_CHECKBOX)
+        .CVar("gEnhancements.Items.ExtraPowderKegs")
+        .Options(CheckboxOptions().Tooltip(
+            "Allows carrying up to 3 Powder Kegs at once instead of the vanilla limit of 1."));
     AddWidget(path, "Curiosity Shop Refills", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Shops.CuriosityShopRefills")
         .Options(CheckboxOptions().Tooltip(

--- a/mm/2s2h/Enhancements/Items/ExtraPowderKegs.cpp
+++ b/mm/2s2h/Enhancements/Items/ExtraPowderKegs.cpp
@@ -1,0 +1,59 @@
+#include <libultraship/bridge/consolevariablebridge.h>
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/CustomMessage/CustomMessage.h"
+#include "2s2h/ShipInit.hpp"
+
+#define CVAR_NAME "gEnhancements.Items.ExtraPowderKegs"
+#define CVAR CVarGetInteger(CVAR_NAME, 0)
+#define MAX_POWDER_KEGS 3
+
+void RegisterExtraPowderKegs() {
+    // When giving a powder keg, increment ammo instead of setting to 1
+    COND_VB_SHOULD(VB_POWDER_KEG_SET_AMMO_ON_GIVE, CVAR, {
+        *should = false;
+        if (AMMO(ITEM_POWDER_KEG) < MAX_POWDER_KEGS) {
+            AMMO(ITEM_POWDER_KEG)++;
+        }
+    });
+
+    // When clamping ammo, use our max instead of 1
+    COND_VB_SHOULD(VB_POWDER_KEG_CAP_AMMO, CVAR, {
+        *should = false;
+        if (AMMO(ITEM_POWDER_KEG) > MAX_POWDER_KEGS) {
+            AMMO(ITEM_POWDER_KEG) = MAX_POWDER_KEGS;
+        } else if (AMMO(ITEM_POWDER_KEG) < 0) {
+            AMMO(ITEM_POWDER_KEG) = 0;
+        }
+    });
+
+    // Allow buying more kegs if below max
+    COND_VB_SHOULD(VB_POWDER_KEG_CHECK_HAS, CVAR, {
+        *should = (AMMO(ITEM_POWDER_KEG) >= MAX_POWDER_KEGS) || (gPlayState->actorCtx.flags & ACTORCTX_FLAG_0);
+    });
+
+    // Show green ammo text only when at max capacity (3), not at 1
+    COND_VB_SHOULD(VB_POWDER_KEG_AMMO_AT_CAPACITY, CVAR, { *should = (AMMO(ITEM_POWDER_KEG) >= MAX_POWDER_KEGS); });
+
+    // Update Goron dialogue to say "three" instead of "one"
+    COND_ID_HOOK(OnOpenText, 0x0C87, CVAR, [](u16* textId, bool* loadFromMessageTable) {
+        auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
+        CustomMessage::Replace(&entry.msg, "one", "three");
+        CustomMessage::LoadCustomMessageIntoFont(entry);
+        *loadFromMessageTable = false;
+    });
+    COND_ID_HOOK(OnOpenText, 0x0C8B, CVAR, [](u16* textId, bool* loadFromMessageTable) {
+        auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
+        CustomMessage::Replace(&entry.msg, "one", "three");
+        CustomMessage::Replace(&entry.msg, "Keg", "Kegs");
+        CustomMessage::LoadCustomMessageIntoFont(entry);
+        *loadFromMessageTable = false;
+    });
+    COND_ID_HOOK(OnOpenText, 0x0673, CVAR, [](u16* textId, bool* loadFromMessageTable) {
+        auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
+        CustomMessage::Replace(&entry.msg, "one", "three");
+        CustomMessage::LoadCustomMessageIntoFont(entry);
+        *loadFromMessageTable = false;
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterExtraPowderKegs, { CVAR_NAME });

--- a/mm/2s2h/Enhancements/Items/ExtraPowderKegs.cpp
+++ b/mm/2s2h/Enhancements/Items/ExtraPowderKegs.cpp
@@ -35,51 +35,33 @@ void RegisterExtraPowderKegs() {
     COND_VB_SHOULD(VB_POWDER_KEG_AMMO_AT_CAPACITY, CVAR, { *should = (AMMO(ITEM_POWDER_KEG) >= MAX_POWDER_KEGS); });
 
     // Update Goron dialogue to reflect the higher max carry count
+    // '\x1e\x3a\xbb' Goron (Oh) (Mono) SFX
+    // '\x1e\x38\xfc' Goron (Oh?) (Pitched) SFX
+    // '\x12' Box Break II
     COND_ID_HOOK(OnOpenText, 0x0C87, CVAR, [](u16*, bool* loadFromMessageTable) {
         CustomMessage::Entry entry;
-        entry.autoFormat = false;
-        entry.msg = "\x1e:\xbb\x01Powder Kegs";
-        entry.msg += '\x00';
-        entry.msg += " are\x11highly unstable! Carry only \x01";
-        entry.msg += std::to_string(MAX_POWDER_KEGS);
-        entry.msg += '\x11';
-        entry.msg += '\x00';
-        entry.msg += "at a time.\x11\x12Strike one with an \x01"
-                     "arrow";
-        entry.msg += '\x00';
-        entry.msg += " and it'll\x11"
-                     "detonate \x01"
-                     "on impact";
-        entry.msg += '\x00';
-        entry.msg += ". Watch out!\xbf";
+        entry.msg = "\x1e\x3a\xbb%rPowder Kegs%w are extremely\n"
+                    "dangerous. You are limited to carrying\n"
+                    "%rthree%w at any given time.\n"
+                    "\x12If an %rarrow%w hits one, it will %rexplode%w\n"
+                    "on the spot, so use caution.";
         CustomMessage::LoadCustomMessageIntoFont(entry);
         *loadFromMessageTable = false;
     });
     COND_ID_HOOK(OnOpenText, 0x0C8B, CVAR, [](u16*, bool* loadFromMessageTable) {
         CustomMessage::Entry entry;
-        entry.autoFormat = false;
-        entry.msg = "Your limit is \x01";
-        entry.msg += std::to_string(MAX_POWDER_KEGS);
-        entry.msg += " Powder\x11Kegs";
-        entry.msg += '\x00';
-        entry.msg += " at a time. Use some up\x11"
-                     "and then come back.\xbf";
+        entry.msg = "You are only allowed to take %rthree\n"
+                    "Powder Kegs%w with you. After they've\n"
+                    "been used, come back and get more.";
         CustomMessage::LoadCustomMessageIntoFont(entry);
         *loadFromMessageTable = false;
     });
     COND_ID_HOOK(OnOpenText, 0x0673, CVAR, [](u16*, bool* loadFromMessageTable) {
         CustomMessage::Entry entry;
-        entry.autoFormat = false;
-        entry.msg = "\x1e\x38\xfc\x17Whoa, you're already\x11"
-                    "carrying \x01";
-        entry.msg += std::to_string(MAX_POWDER_KEGS);
-        entry.msg += '\x00';
-        entry.msg += "!\x18\x11\x13\x13\x12\x01Powder Kegs";
-        entry.msg += '\x00';
-        entry.msg += " are serious\x11hazards. The limit is \x01";
-        entry.msg += std::to_string(MAX_POWDER_KEGS);
-        entry.msg += '\x00';
-        entry.msg += " at a time!\xbf";
+        entry.msg = "\x1e\x38\xfcHold on, you already got %rthree%w!\n"
+                    "\x12%rPowder Kegs%w are hazardous\n"
+                    "explosives, so you may carry only\n"
+                    "%rthree%w at a time!";
         CustomMessage::LoadCustomMessageIntoFont(entry);
         *loadFromMessageTable = false;
     });

--- a/mm/2s2h/Enhancements/Items/ExtraPowderKegs.cpp
+++ b/mm/2s2h/Enhancements/Items/ExtraPowderKegs.cpp
@@ -40,41 +40,43 @@ void RegisterExtraPowderKegs() {
         entry.autoFormat = false;
         entry.msg = "\x1e:\xbb\x01Powder Kegs";
         entry.msg += '\x00';
-        entry.msg += " are very\x11volatile, so you can carry only \x01";
+        entry.msg += " are\x11highly unstable! Carry only \x01";
         entry.msg += std::to_string(MAX_POWDER_KEGS);
         entry.msg += '\x11';
         entry.msg += '\x00';
-        entry.msg += "at a time.\x11\x12If you shoot them with an \x01"
+        entry.msg += "at a time.\x11\x12Strike one with an \x01"
                      "arrow";
         entry.msg += '\x00';
-        entry.msg += ",\x11they'll \x01"
-                     "explode ";
+        entry.msg += " and it'll\x11"
+                     "detonate \x01"
+                     "on impact";
         entry.msg += '\x00';
-        entry.msg += "as soon as they're\x11hit, so be careful.\xbf";
+        entry.msg += ". Watch out!\xbf";
         CustomMessage::LoadCustomMessageIntoFont(entry);
         *loadFromMessageTable = false;
     });
     COND_ID_HOOK(OnOpenText, 0x0C8B, CVAR, [](u16*, bool* loadFromMessageTable) {
         CustomMessage::Entry entry;
         entry.autoFormat = false;
-        entry.msg = "You can carry only \x01";
+        entry.msg = "Your limit is \x01";
         entry.msg += std::to_string(MAX_POWDER_KEGS);
         entry.msg += " Powder\x11Kegs";
         entry.msg += '\x00';
-        entry.msg += " at a time. Once you've used\x11them, come back.\xbf";
+        entry.msg += " at a time. Use some up\x11"
+                     "and then come back.\xbf";
         CustomMessage::LoadCustomMessageIntoFont(entry);
         *loadFromMessageTable = false;
     });
     COND_ID_HOOK(OnOpenText, 0x0673, CVAR, [](u16*, bool* loadFromMessageTable) {
         CustomMessage::Entry entry;
         entry.autoFormat = false;
-        entry.msg = "\x1e\x38\xfc\x17Oh, but you already have \x01";
+        entry.msg = "\x1e\x38\xfc\x17Whoa, you're already\x11"
+                    "carrying \x01";
         entry.msg += std::to_string(MAX_POWDER_KEGS);
         entry.msg += '\x00';
-        entry.msg += ".\x18\x11\x13\x13\x12\x01Powder Kegs";
+        entry.msg += "!\x18\x11\x13\x13\x12\x01Powder Kegs";
         entry.msg += '\x00';
-        entry.msg += " are dangerous\x11"
-                     "explosives, so you can carry only\x11\x01";
+        entry.msg += " are serious\x11hazards. The limit is \x01";
         entry.msg += std::to_string(MAX_POWDER_KEGS);
         entry.msg += '\x00';
         entry.msg += " at a time!\xbf";

--- a/mm/2s2h/Enhancements/Items/ExtraPowderKegs.cpp
+++ b/mm/2s2h/Enhancements/Items/ExtraPowderKegs.cpp
@@ -34,23 +34,50 @@ void RegisterExtraPowderKegs() {
     // Show green ammo text only when at max capacity (3), not at 1
     COND_VB_SHOULD(VB_POWDER_KEG_AMMO_AT_CAPACITY, CVAR, { *should = (AMMO(ITEM_POWDER_KEG) >= MAX_POWDER_KEGS); });
 
-    // Update Goron dialogue to say "three" instead of "one"
-    COND_ID_HOOK(OnOpenText, 0x0C87, CVAR, [](u16* textId, bool* loadFromMessageTable) {
-        auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
-        CustomMessage::Replace(&entry.msg, "one", "three");
+    // Update Goron dialogue to reflect the higher max carry count
+    COND_ID_HOOK(OnOpenText, 0x0C87, CVAR, [](u16*, bool* loadFromMessageTable) {
+        CustomMessage::Entry entry;
+        entry.autoFormat = false;
+        entry.msg = "\x1e:\xbb\x01Powder Kegs";
+        entry.msg += '\x00';
+        entry.msg += " are very\x11volatile, so you can carry only \x01";
+        entry.msg += std::to_string(MAX_POWDER_KEGS);
+        entry.msg += '\x11';
+        entry.msg += '\x00';
+        entry.msg += "at a time.\x11\x12If you shoot them with an \x01"
+                     "arrow";
+        entry.msg += '\x00';
+        entry.msg += ",\x11they'll \x01"
+                     "explode ";
+        entry.msg += '\x00';
+        entry.msg += "as soon as they're\x11hit, so be careful.\xbf";
         CustomMessage::LoadCustomMessageIntoFont(entry);
         *loadFromMessageTable = false;
     });
-    COND_ID_HOOK(OnOpenText, 0x0C8B, CVAR, [](u16* textId, bool* loadFromMessageTable) {
-        auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
-        CustomMessage::Replace(&entry.msg, "one", "three");
-        CustomMessage::Replace(&entry.msg, "Keg", "Kegs");
+    COND_ID_HOOK(OnOpenText, 0x0C8B, CVAR, [](u16*, bool* loadFromMessageTable) {
+        CustomMessage::Entry entry;
+        entry.autoFormat = false;
+        entry.msg = "You can carry only \x01";
+        entry.msg += std::to_string(MAX_POWDER_KEGS);
+        entry.msg += " Powder\x11Kegs";
+        entry.msg += '\x00';
+        entry.msg += " at a time. Once you've used\x11them, come back.\xbf";
         CustomMessage::LoadCustomMessageIntoFont(entry);
         *loadFromMessageTable = false;
     });
-    COND_ID_HOOK(OnOpenText, 0x0673, CVAR, [](u16* textId, bool* loadFromMessageTable) {
-        auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
-        CustomMessage::Replace(&entry.msg, "one", "three");
+    COND_ID_HOOK(OnOpenText, 0x0673, CVAR, [](u16*, bool* loadFromMessageTable) {
+        CustomMessage::Entry entry;
+        entry.autoFormat = false;
+        entry.msg = "\x1e\x38\xfc\x17Oh, but you already have \x01";
+        entry.msg += std::to_string(MAX_POWDER_KEGS);
+        entry.msg += '\x00';
+        entry.msg += ".\x18\x11\x13\x13\x12\x01Powder Kegs";
+        entry.msg += '\x00';
+        entry.msg += " are dangerous\x11"
+                     "explosives, so you can carry only\x11\x01";
+        entry.msg += std::to_string(MAX_POWDER_KEGS);
+        entry.msg += '\x00';
+        entry.msg += " at a time!\xbf";
         CustomMessage::LoadCustomMessageIntoFont(entry);
         *loadFromMessageTable = false;
     });

--- a/mm/2s2h/GameInteractor/GameInteractor_VanillaBehavior.h
+++ b/mm/2s2h/GameInteractor/GameInteractor_VanillaBehavior.h
@@ -1666,6 +1666,38 @@ typedef enum {
 
     // #### `result`
     // ```c
+    // ammo == 1
+    // ```
+    // #### `args`
+    // - None
+    VB_POWDER_KEG_AMMO_AT_CAPACITY,
+
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
+    // - None
+    VB_POWDER_KEG_CAP_AMMO,
+
+    // #### `result`
+    // ```c
+    // (AMMO(ITEM_POWDER_KEG) != 0) || (play->actorCtx.flags & ACTORCTX_FLAG_0)
+    // ```
+    // #### `args`
+    // - None
+    VB_POWDER_KEG_CHECK_HAS,
+
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
+    // - None
+    VB_POWDER_KEG_SET_AMMO_ON_GIVE,
+
+    // #### `result`
+    // ```c
     // false
     // ```
     // #### `args`

--- a/mm/src/code/z_msgevent.c
+++ b/mm/src/code/z_msgevent.c
@@ -865,7 +865,8 @@ s32 MsgEvent_CheckHasPowderKeg(Actor* actor, PlayState* play, u8** script, MsgSc
     MsgScriptCmdCheckHasPowderKeg* cmd = (MsgScriptCmdCheckHasPowderKeg*)*script;
     s16 skip = SCRIPT_PACK_16(cmd->offsetH, cmd->offsetL);
 
-    if ((AMMO(ITEM_POWDER_KEG) != 0) || (play->actorCtx.flags & ACTORCTX_FLAG_0)) {
+    if (GameInteractor_Should(VB_POWDER_KEG_CHECK_HAS,
+                              (AMMO(ITEM_POWDER_KEG) != 0) || (play->actorCtx.flags & ACTORCTX_FLAG_0))) {
         *script += skip;
     }
     return false;

--- a/mm/src/code/z_parameter.c
+++ b/mm/src/code/z_parameter.c
@@ -4357,7 +4357,9 @@ u8 Item_GiveImpl(PlayState* play, u8 item) {
             INV_CONTENT(ITEM_POWDER_KEG) = ITEM_POWDER_KEG;
         }
 
-        AMMO(ITEM_POWDER_KEG) = 1;
+        if (GameInteractor_Should(VB_POWDER_KEG_SET_AMMO_ON_GIVE, true)) {
+            AMMO(ITEM_POWDER_KEG) = 1;
+        }
         return ITEM_NONE;
 
     } else if (item == ITEM_BOMB) {
@@ -5214,10 +5216,12 @@ void Inventory_ChangeAmmo(s16 item, s16 ammoChange) {
 
     } else if (item == ITEM_POWDER_KEG) {
         AMMO(ITEM_POWDER_KEG) += ammoChange;
-        if (AMMO(ITEM_POWDER_KEG) >= 1) {
-            AMMO(ITEM_POWDER_KEG) = 1;
-        } else if (AMMO(ITEM_POWDER_KEG) < 0) {
-            AMMO(ITEM_POWDER_KEG) = 0;
+        if (GameInteractor_Should(VB_POWDER_KEG_CAP_AMMO, true)) {
+            if (AMMO(ITEM_POWDER_KEG) >= 1) {
+                AMMO(ITEM_POWDER_KEG) = 1;
+            } else if (AMMO(ITEM_POWDER_KEG) < 0) {
+                AMMO(ITEM_POWDER_KEG) = 0;
+            }
         }
     }
 }
@@ -6179,8 +6183,8 @@ void Interface_Dpad_DrawAmmoCount(PlayState* play, s16 button, s16 alpha) {
             ((i == ITEM_DEKU_STICK) && (AMMO(i) == CUR_CAPACITY(UPG_DEKU_STICKS))) ||
             ((i == ITEM_DEKU_NUT) && (AMMO(i) == CUR_CAPACITY(UPG_DEKU_NUTS))) ||
             ((i == ITEM_BOMBCHU) && (AMMO(i) == CUR_CAPACITY(UPG_BOMB_BAG))) ||
-            ((i == ITEM_POWDER_KEG) && (ammo == 1)) || ((i == ITEM_PICTOGRAPH_BOX) && (ammo == 1)) ||
-            ((i == ITEM_MAGIC_BEANS) && (ammo == 20))) {
+            ((i == ITEM_POWDER_KEG) && GameInteractor_Should(VB_POWDER_KEG_AMMO_AT_CAPACITY, ammo == 1)) ||
+            ((i == ITEM_PICTOGRAPH_BOX) && (ammo == 1)) || ((i == ITEM_MAGIC_BEANS) && (ammo == 20))) {
             gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 120, 255, 0, alpha);
         }
 
@@ -6302,8 +6306,8 @@ void Interface_DrawAmmoCount(PlayState* play, s16 button, s16 alpha) {
                    ((i == ITEM_DEKU_STICK) && (AMMO(i) == CUR_CAPACITY(UPG_DEKU_STICKS))) ||
                    ((i == ITEM_DEKU_NUT) && (AMMO(i) == CUR_CAPACITY(UPG_DEKU_NUTS))) ||
                    ((i == ITEM_BOMBCHU) && (AMMO(i) == CUR_CAPACITY(UPG_BOMB_BAG))) ||
-                   ((i == ITEM_POWDER_KEG) && (ammo == 1)) || ((i == ITEM_PICTOGRAPH_BOX) && (ammo == 1)) ||
-                   ((i == ITEM_MAGIC_BEANS) && (ammo == 20))) {
+                   ((i == ITEM_POWDER_KEG) && GameInteractor_Should(VB_POWDER_KEG_AMMO_AT_CAPACITY, ammo == 1)) ||
+                   ((i == ITEM_PICTOGRAPH_BOX) && (ammo == 1)) || ((i == ITEM_MAGIC_BEANS) && (ammo == 20))) {
             gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 120, 255, 0, alpha);
         }
 

--- a/mm/src/overlays/actors/ovl_En_S_Goro/z_en_s_goro.c
+++ b/mm/src/overlays/actors/ovl_En_S_Goro/z_en_s_goro.c
@@ -32,6 +32,7 @@ Week Event Flags:
 */
 
 #include "z_en_s_goro.h"
+#include "2s2h/GameInteractor/GameInteractor.h"
 #include "overlays/actors/ovl_En_Gk/z_en_gk.h" // Goron Elder's Son
 #include "overlays/actors/ovl_En_Jg/z_en_jg.h" // Goron Elder
 #include "objects/object_taisou/object_taisou.h"
@@ -674,7 +675,7 @@ u16 EnSGoro_BombshopGoron_NextTextId(EnSGoro* this, PlayState* play) {
 
         case 0x670:
             if (this->bombbuyFlags & EN_S_GORO_BOMBBUYFLAG_YESBUY) {
-                if (AMMO(ITEM_POWDER_KEG) != 0) {
+                if (GameInteractor_Should(VB_POWDER_KEG_CHECK_HAS, AMMO(ITEM_POWDER_KEG) != 0)) {
                     this->actionFlags |= EN_S_GORO_ACTIONFLAG_LASTMESSAGE;
                     Audio_PlaySfx(NA_SE_SY_ERROR);
                     return 0x673;

--- a/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_item.c
+++ b/mm/src/overlays/kaleido_scope/ovl_kaleido_scope/z_kaleido_item.c
@@ -213,8 +213,8 @@ void KaleidoScope_DrawAmmoCount(PauseContext* pauseCtx, GraphicsContext* gfxCtx,
                    ((item == ITEM_DEKU_STICK) && (AMMO(item) == CUR_CAPACITY(UPG_DEKU_STICKS))) ||
                    ((item == ITEM_DEKU_NUT) && (AMMO(item) == CUR_CAPACITY(UPG_DEKU_NUTS))) ||
                    ((item == ITEM_BOMBCHU) && (AMMO(item) == CUR_CAPACITY(UPG_BOMB_BAG))) ||
-                   ((item == ITEM_POWDER_KEG) && (ammo == 1)) || ((item == ITEM_PICTOGRAPH_BOX) && (ammo == 1)) ||
-                   ((item == ITEM_MAGIC_BEANS) && (ammo == 20))) {
+                   ((item == ITEM_POWDER_KEG) && GameInteractor_Should(VB_POWDER_KEG_AMMO_AT_CAPACITY, ammo == 1)) ||
+                   ((item == ITEM_PICTOGRAPH_BOX) && (ammo == 1)) || ((item == ITEM_MAGIC_BEANS) && (ammo == 20))) {
             // Ammo at capacity
             gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 120, 255, 0, pauseCtx->alpha);
         }


### PR DESCRIPTION
Allows the player to carry up to 3 powder kegs in total. NPC Dialogue will reflect the new max.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/6085407104.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/6085349519.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/6085276857.zip)
<!--- section:artifacts:end -->