### PR TITLE
[Fix] Fix Button Env Color

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1496,10 +1496,11 @@ void BenMenu::AddEnhancements() {
                               "- Owl Warp menu crash when moving the cursor with Index-Warp active\n"
                               "- Remote Hookshot Hookslide crashes when over voids in Great Bay Temple")
                      .DefaultValue(true));
-    AddWidget(path, "Fix Ammo Count Color", WIDGET_CVAR_CHECKBOX)
-        .CVar("gFixes.FixAmmoCountEnvColor")
-        .Options(CheckboxOptions().Tooltip("Fixes a missing gDPSetEnvColor, which causes the ammo count to be "
-                                           "the wrong color prior to obtaining magic or other conditions."));
+    AddWidget(path, "Fix Button Env Color", WIDGET_CVAR_CHECKBOX)
+        .CVar("gFixes.FixButtonEnvColor")
+        .Options(CheckboxOptions().Tooltip(
+            "Fixes a missing gDPSetEnvColor, which causes ammo counts and B button "
+            "action labels to be the wrong color prior to obtaining magic or other conditions."));
     AddWidget(path, "Fix Epona stealing Sword", WIDGET_CVAR_CHECKBOX)
         .CVar("gFixes.FixEponaStealingSword")
         .Options(CheckboxOptions().Tooltip(

--- a/mm/2s2h/Enhancements/Fixes/FixButtonEnvColor.cpp
+++ b/mm/2s2h/Enhancements/Fixes/FixButtonEnvColor.cpp
@@ -1,0 +1,17 @@
+#include <libultraship/bridge/consolevariablebridge.h>
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
+#include "2s2h/ShipInit.hpp"
+
+#define CVAR_NAME "gFixes.FixButtonEnvColor"
+#define CVAR CVarGetInteger(CVAR_NAME, 0)
+
+void RegisterFixButtonEnvColor() {
+    COND_VB_SHOULD(VB_SET_BUTTON_ENV_COLOR, CVAR, {
+        OPEN_DISPS(gPlayState->state.gfxCtx);
+        gDPSetEnvColor(OVERLAY_DISP++, 0, 0, 0, 255);
+        CLOSE_DISPS(gPlayState->state.gfxCtx);
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterFixButtonEnvColor, { CVAR_NAME });

--- a/mm/2s2h/GameInteractor/GameInteractor_VanillaBehavior.h
+++ b/mm/2s2h/GameInteractor/GameInteractor_VanillaBehavior.h
@@ -1794,6 +1794,14 @@ typedef enum {
 
     // #### `result`
     // ```c
+    // false
+    // ```
+    // #### `args`
+    // - None
+    VB_SET_BUTTON_ENV_COLOR,
+
+    // #### `result`
+    // ```c
     // true
     // ```
     // #### `args`

--- a/mm/2s2h/PresetManager/PresetManager.cpp
+++ b/mm/2s2h/PresetManager/PresetManager.cpp
@@ -200,7 +200,7 @@ nlohmann::json curatedPresetJ = R"(
             }
         },
         "gFixes": {
-            "FixAmmoCountEnvColor": 1,
+            "FixButtonEnvColor": 1,
             "FixEponaStealingSword": 1,
             "FixIkanaGreatFairyFountainColor": 1
         },

--- a/mm/src/code/z_parameter.c
+++ b/mm/src/code/z_parameter.c
@@ -6289,9 +6289,7 @@ void Interface_DrawAmmoCount(PlayState* play, s16 button, s16 alpha) {
         //! but prior to that, when certain conditions are met, the color will have last been set by the wallet icon
         //! causing the ammo count to be drawn incorrectly. This is most obvious when you get deku nuts early on, and
         //! the ammo count is drawn with a shade of green.
-        if (CVarGetInteger("gFixes.FixAmmoCountEnvColor", 0)) {
-            gDPSetEnvColor(OVERLAY_DISP++, 0, 0, 0, 255);
-        }
+        GameInteractor_Should(VB_SET_BUTTON_ENV_COLOR, false);
 
         if ((button == EQUIP_SLOT_B) && (gSaveContext.minigameStatus == MINIGAME_STATUS_ACTIVE)) {
             ammo = play->interfaceCtx.minigameAmmo;
@@ -6368,6 +6366,9 @@ void Interface_DrawBButtonIcons(PlayState* play) {
                     gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE,
                                       0, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
 
+                    //! @bug Same missing gDPSetEnvColor as in Interface_DrawAmmoCount. The B button ammo count
+                    //! will be drawn with the last env color set prior to obtaining magic.
+                    GameInteractor_Should(VB_SET_BUTTON_ENV_COLOR, false);
                     if ((play->sceneId != SCENE_SYATEKI_MIZU) && (play->sceneId != SCENE_SYATEKI_MORI) &&
                         (play->sceneId != SCENE_BOWLING) &&
                         ((gSaveContext.minigameStatus != MINIGAME_STATUS_ACTIVE) ||
@@ -6383,6 +6384,10 @@ void Interface_DrawBButtonIcons(PlayState* play) {
         gDPPipeSync(OVERLAY_DISP++);
         gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0,
                           PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
+        //! @bug Same missing gDPSetEnvColor as in Interface_DrawAmmoCount. The B button action label
+        //! uses ENVIRONMENT in its combine mode and will be drawn with the last env color set (e.g. green
+        //! from the wallet icon) prior to obtaining magic.
+        GameInteractor_Should(VB_SET_BUTTON_ENV_COLOR, false);
         gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, interfaceCtx->bAlpha);
         gDPLoadTextureBlock_4b(OVERLAY_DISP++, interfaceCtx->doActionSegment[DO_ACTION_SEG_B].mainTex, G_IM_FMT_IA,
                                DO_ACTION_TEX_WIDTH, DO_ACTION_TEX_HEIGHT, 0, G_TX_NOMIRROR | G_TX_WRAP,
@@ -6426,6 +6431,10 @@ void Interface_DrawBButtonIcons(PlayState* play) {
         gDPPipeSync(OVERLAY_DISP++);
         gDPSetCombineLERP(OVERLAY_DISP++, PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0,
                           PRIMITIVE, ENVIRONMENT, TEXEL0, ENVIRONMENT, TEXEL0, 0, PRIMITIVE, 0);
+        //! @bug Same missing gDPSetEnvColor as in Interface_DrawAmmoCount. The B button action label
+        //! uses ENVIRONMENT in its combine mode and will be drawn with the last env color set (e.g. green
+        //! from the wallet icon) prior to obtaining magic.
+        GameInteractor_Should(VB_SET_BUTTON_ENV_COLOR, false);
         gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, interfaceCtx->bAlpha);
         gDPLoadTextureBlock_4b(OVERLAY_DISP++, interfaceCtx->doActionSegment[DO_ACTION_SEG_B].subTex, G_IM_FMT_IA,
                                DO_ACTION_TEX_WIDTH, DO_ACTION_TEX_HEIGHT, 0, G_TX_NOMIRROR | G_TX_WRAP,


### PR DESCRIPTION
The original fix only covered the ammo count digits, but the same missing `gDPSetEnvColor` bug shows up in a few other spots in `Interface_DrawBButtonIcons`. I hookified it (`VB_SET_BUTTON_ENV_COLOR`) and expanded the fix to cover all the affected call sites with bug documentation. The fix has been renamed to 'FixButtonEnvColor' and the tooltip updated accordingly.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5926929405.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5926733640.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5926690459.zip)
<!--- section:artifacts:end -->