### PR TITLE
[Enhancement] Faster Rupee Accumulator 

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1490,6 +1490,9 @@ void BenMenu::AddEnhancements() {
             "Automatically deposits excess Rupees into your bank account when your wallet is full. "
             "Deposits stop when the bank reaches maximum capacity. "
             "Bank rewards are granted automatically. Notifications display deposit amount and new balance."));
+    AddWidget(path, "Faster Rupee Accumulator", WIDGET_CVAR_CHECKBOX)
+        .CVar("gEnhancements.Timesavers.FasterRupeeAccumulator")
+        .Options(CheckboxOptions().Tooltip("Causes your Wallet to fill and empty faster when you gain or lose money."));
 
     // Fixes
     path = { "Enhancements", "Fixes", SECTION_COLUMN_1 };

--- a/mm/2s2h/Enhancements/Timesavers/FasterRupeeAccumulator.cpp
+++ b/mm/2s2h/Enhancements/Timesavers/FasterRupeeAccumulator.cpp
@@ -1,0 +1,41 @@
+#include <libultraship/bridge/consolevariablebridge.h>
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/ShipInit.hpp"
+
+#define CVAR_NAME "gEnhancements.Timesavers.FasterRupeeAccumulator"
+#define CVAR CVarGetInteger(CVAR_NAME, 0)
+
+void RegisterFasterRupeeAccumulator() {
+    COND_HOOK(OnGameStateUpdate, CVAR, []() {
+        if (!gPlayState) {
+            return;
+        }
+
+        if (gSaveContext.rupeeAccumulator == 0) {
+            return;
+        }
+
+        s16 capacity = (s16)CUR_CAPACITY(UPG_WALLET);
+        s16 step = capacity / 50;
+
+        // Gaining rupees - add extra per frame on top of vanilla's 1/frame
+        if (gSaveContext.rupeeAccumulator > 0) {
+            s16 amount = MIN(step, MIN(gSaveContext.rupeeAccumulator,
+                                       (s16)(capacity - gSaveContext.save.saveInfo.playerData.rupees)));
+            if (amount > 0) {
+                gSaveContext.rupeeAccumulator -= amount;
+                gSaveContext.save.saveInfo.playerData.rupees += amount;
+            }
+            // Losing rupees - add extra per frame on top of vanilla's handling
+        } else {
+            s16 amount =
+                MIN(step, MIN((s16)(-gSaveContext.rupeeAccumulator), gSaveContext.save.saveInfo.playerData.rupees));
+            if (amount > 0) {
+                gSaveContext.rupeeAccumulator += amount;
+                gSaveContext.save.saveInfo.playerData.rupees -= amount;
+            }
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterFasterRupeeAccumulator, { CVAR_NAME });

--- a/mm/2s2h/Rando/GiveItem.cpp
+++ b/mm/2s2h/Rando/GiveItem.cpp
@@ -143,7 +143,8 @@ void Rando::GiveItem(RandoItemId randoItemId) {
         case RI_WALLET_GIANT:
             Item_Give(gPlayState, Rando::StaticData::Items[randoItemId].itemId);
             // Fill Rupees to max, this may be opt-in later
-            gSaveContext.rupeeAccumulator = CUR_CAPACITY(UPG_WALLET);
+            // Use remaining space rather than full capacity to avoid excess in the accumulator.
+            gSaveContext.rupeeAccumulator = CUR_CAPACITY(UPG_WALLET) - gSaveContext.save.saveInfo.playerData.rupees;
             break;
         case RI_GS_TOKEN_SWAMP:
             // Set QUEST_QUIVER to match bug mentioned in z_parameter.c

--- a/mm/2s2h/Rando/StartingItems.cpp
+++ b/mm/2s2h/Rando/StartingItems.cpp
@@ -99,6 +99,8 @@ void GrantStartingItems() {
 
     if (RANDO_SAVE_OPTIONS[RO_STARTING_RUPEES]) {
         gSaveContext.save.saveInfo.playerData.rupees = CUR_CAPACITY(UPG_WALLET);
+        // Clear any accumulator from starting wallet items since rupees are set directly.
+        gSaveContext.rupeeAccumulator = 0;
     }
 }
 


### PR DESCRIPTION
Unlike the SoH version which uses a fixed step of 10, I scaled the step proportionally to wallet capacity (`CUR_CAPACITY / 50`) and always transfer`MIN(step, remaining)` per frame. This keeps fill time consistent regardless of wallet size. 

While working on this I also ran into two pre-existing bugs that had to be fixed in order to ship this cleanly:

`GiveItem.cpp` was setting `rupeeAccumulator = CUR_CAPACITY(UPG_WALLET)` (full capacity) instead of the remaining space when giving wallet upgrades. If you already had rupees, the excess accumulator would overflow into Auto Bank Deposit. Changed to `CUR_CAPACITY - current rupees`.

Starting a rando save with wallet starting items + Wallet Full enabled caused an immediate bank deposit. `GiveItem` sets the accumulator when granting starting wallets, but `StartingItems` then sets rupees directly, That leaves a stale accumulator that triggered `VB_DISCARD_EXCESS_RUPEES` on the first frame. Fixed by clearing the accumulator after the direct assignment.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5977401553.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5977320406.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/5977229827.zip)
<!--- section:artifacts:end -->