### PR TITLE
Alt toggle support for models and skeletons

### DIFF
--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -998,8 +998,8 @@ extern "C" void Graph_ProcessGfxCommands(Gfx* commands) {
         prevAltAssets = curAltAssets;
         Ship::Context::GetInstance()->GetResourceManager()->SetAltAssetsEnabled(curAltAssets);
         gfx_texture_cache_clear();
-        // TODO: skeleton patch, hooks
-        // SOH::SkeletonPatcher::UpdateSkeletons();
+        PlayerCustomFlipbooks_Patch();
+        SOH::SkeletonPatcher::UpdateSkeletons();
         // GameInteractor::Instance->ExecuteHooks<GameInteractor::OnAssetAltChange>();
     }
 
@@ -1075,6 +1075,25 @@ extern "C" void ResourceMgr_LoadDirectory(const char* resName) {
 }
 extern "C" void ResourceMgr_DirtyDirectory(const char* resName) {
     Ship::Context::GetInstance()->GetResourceManager()->DirtyResources(resName);
+}
+
+extern "C" void ResourceMgr_UnloadResource(const char* resName) {
+    std::string path = resName;
+    if (path.starts_with("__OTR__")) {
+        path = path.substr(7);
+    }
+    Ship::Context::GetInstance()->GetResourceManager()->UnloadResource(path);
+}
+
+static void ResourceMgr_UnloadOriginalWhenAltExists(const char* resName) {
+    std::string path = resName;
+    if (path.starts_with("__OTR__")) {
+        path = path.substr(7);
+    }
+
+    if (ResourceMgr_IsAltAssetsEnabled() && ExtensionCache.contains(Ship::IResource::gAltAssetPrefix + path)) {
+        ResourceMgr_UnloadResource(path.c_str());
+    }
 }
 
 // OTRTODO: There is probably a more elegant way to go about this...
@@ -1207,6 +1226,8 @@ extern "C" void ResourceMgr_PushCurrentDirectory(char* path) {
 }
 
 extern "C" Gfx* ResourceMgr_LoadGfxByName(const char* path) {
+    ResourceMgr_UnloadOriginalWhenAltExists(path);
+
     auto res = std::static_pointer_cast<Fast::DisplayList>(GetResourceByName(path));
     return (Gfx*)&res->Instructions[0];
 }
@@ -1530,7 +1551,7 @@ extern "C" SkeletonHeader* ResourceMgr_LoadSkeletonByName(const char* path, Skel
     // Therefore we can take this opportunity to take note of the Skeleton that is created...
     if (skelAnime != nullptr) {
         auto stringPath = std::string(path);
-        // Ship::SkeletonPatcher::RegisterSkeleton(stringPath, skelAnime);
+        SOH::SkeletonPatcher::RegisterSkeleton(stringPath, skelAnime);
     }
 
     return skelHeader;
@@ -1541,9 +1562,8 @@ extern "C" void ResourceMgr_UnregisterSkeleton(SkelAnime* skelAnime) {
         SOH::SkeletonPatcher::UnregisterSkeleton(skelAnime);
 }
 
-extern "C" void ResourceMgr_ClearSkeletons(SkelAnime* skelAnime) {
-    if (skelAnime != nullptr)
-        SOH::SkeletonPatcher::ClearSkeletons();
+extern "C" void ResourceMgr_ClearSkeletons() {
+    SOH::SkeletonPatcher::ClearSkeletons();
 }
 
 extern "C" s32* ResourceMgr_LoadCSByName(const char* path) {

--- a/mm/2s2h/Enhancements/GfxPatcher/FierceDeitySheaths.cpp
+++ b/mm/2s2h/Enhancements/GfxPatcher/FierceDeitySheaths.cpp
@@ -3,9 +3,12 @@
 #include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
 #include "2s2h/ShipInit.hpp"
 
+#include <string>
+
 extern "C" {
 uint8_t ResourceMgr_FileExists(const char* resName);
 Gfx* ResourceMgr_LoadGfxByName(const char* path);
+bool ResourceMgr_IsAltAssetsEnabled();
 }
 
 static const char* sFierceDeitySwordInSheathDLPath = "__OTR__objects/object_link_boy/gLinkFierceDeitySwordInSheathDL";
@@ -13,14 +16,33 @@ static const char* sFierceDeitySwordSheathDLPath = "__OTR__objects/object_link_b
 static Gfx* sFierceDeitySwordInSheathDLs[2] = { nullptr, nullptr };
 static Gfx* sFierceDeitySwordSheathDLs[2] = { nullptr, nullptr };
 
-static bool sFierceDeitySheathChecked = false;
+static s32 sFierceDeitySheathAltState = -1;
+
+static bool ResourceMgr_DListExistsForCurrentAltState(const char* basePath) {
+    std::string resourcePath = basePath;
+    if (resourcePath.starts_with("__OTR__")) {
+        resourcePath = resourcePath.substr(7);
+    }
+
+    if (ResourceMgr_IsAltAssetsEnabled()) {
+        const std::string altPath = "__OTR__alt/" + resourcePath;
+        if (ResourceMgr_FileExists(altPath.c_str())) {
+            return true;
+        }
+    }
+
+    return ResourceMgr_FileExists(basePath);
+}
 
 static bool CustomFDSheath_LoadAssets() {
-    if (!sFierceDeitySheathChecked) {
-        sFierceDeitySheathChecked = true;
+    const s32 altState = ResourceMgr_IsAltAssetsEnabled() ? 1 : 0;
+    if (sFierceDeitySheathAltState != altState) {
+        sFierceDeitySheathAltState = altState;
+        sFierceDeitySwordInSheathDLs[0] = sFierceDeitySwordInSheathDLs[1] = nullptr;
+        sFierceDeitySwordSheathDLs[0] = sFierceDeitySwordSheathDLs[1] = nullptr;
 
-        if (ResourceMgr_FileExists(sFierceDeitySwordInSheathDLPath) &&
-            ResourceMgr_FileExists(sFierceDeitySwordSheathDLPath)) {
+        if (ResourceMgr_DListExistsForCurrentAltState(sFierceDeitySwordInSheathDLPath) &&
+            ResourceMgr_DListExistsForCurrentAltState(sFierceDeitySwordSheathDLPath)) {
             sFierceDeitySwordInSheathDLs[0] = sFierceDeitySwordInSheathDLs[1] =
                 ResourceMgr_LoadGfxByName(sFierceDeitySwordInSheathDLPath);
             sFierceDeitySwordSheathDLs[0] = sFierceDeitySwordSheathDLs[1] =

--- a/mm/2s2h/Enhancements/GfxPatcher/PlayerCustomFlipbooks.cpp
+++ b/mm/2s2h/Enhancements/GfxPatcher/PlayerCustomFlipbooks.cpp
@@ -1,11 +1,15 @@
 #include "PlayerCustomFlipbooks.h"
 #include "2s2h/BenPort.h"
 
+#include <array>
+#include <string>
+
 extern "C" {
 #include "z64player.h"
 extern TexturePtr sPlayerEyesTextures[PLAYER_FORM_MAX][PLAYER_EYES_MAX];
 extern TexturePtr sPlayerMouthTextures[PLAYER_FORM_MAX][PLAYER_MOUTH_MAX];
 uint8_t ResourceMgr_FileExists(const char* resName);
+bool ResourceMgr_IsAltAssetsEnabled();
 }
 
 static const char* sFDEyesTextures[PLAYER_EYES_MAX] = {
@@ -47,87 +51,84 @@ static const char* sGoronMouthTextures[PLAYER_MOUTH_MAX] = {
     "__OTR__objects/object_link_goron/gLinkGoronMouthSmileTex",
 };
 
-static s32 sFacePatchState = 0;
+static std::array<std::string, PLAYER_EYES_MAX> sResolvedFDEyesTextures;
+static std::array<std::string, PLAYER_MOUTH_MAX> sResolvedFDMouthTextures;
+static std::array<std::string, PLAYER_EYES_MAX> sResolvedDekuEyesTextures;
+static std::array<std::string, PLAYER_MOUTH_MAX> sResolvedDekuMouthTextures;
+static std::array<std::string, PLAYER_MOUTH_MAX> sResolvedGoronMouthTextures;
 
-static void PlayerCustomFlipbooks_PatchOnce(void) {
-    if (sFacePatchState != 0) {
-        return;
+static s32 sFacePatchAltState = -1;
+
+static bool ResolveTexturePath(const char* basePath, std::string& resolvedPath) {
+    std::string resourcePath = basePath;
+    if (resourcePath.starts_with("__OTR__")) {
+        resourcePath = resourcePath.substr(7);
     }
 
-    bool EyesPatch = true;
-    bool MouthPatch = true;
-    bool DekuEyesPatch = true;
-    bool DekuMouthPatch = true;
-    bool GoronMouthPatch = true;
+    if (ResourceMgr_IsAltAssetsEnabled()) {
+        const std::string altPath = "__OTR__alt/" + resourcePath;
+        if (ResourceMgr_FileExists(altPath.c_str())) {
+            resolvedPath = altPath;
+            return true;
+        }
+    }
 
+    if (ResourceMgr_FileExists(basePath)) {
+        resolvedPath = basePath;
+        return true;
+    }
+
+    return false;
+}
+
+template <size_t Count>
+static bool ResolveTextureSet(const char* const (&sourcePaths)[Count], std::array<std::string, Count>& resolvedPaths) {
+    for (size_t i = 0; i < Count; i++) {
+        if (!ResolveTexturePath(sourcePaths[i], resolvedPaths[i])) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static void ApplyEyesTextureSet(s32 form, const std::array<std::string, PLAYER_EYES_MAX>& resolvedPaths) {
     for (s32 i = 0; i < PLAYER_EYES_MAX; i++) {
-        if (!ResourceMgr_FileExists(sFDEyesTextures[i])) {
-            EyesPatch = false;
-            break;
-        }
+        sPlayerEyesTextures[form][i] = (TexturePtr)resolvedPaths[i].c_str();
     }
+}
 
+static void ApplyMouthTextureSet(s32 form, const std::array<std::string, PLAYER_MOUTH_MAX>& resolvedPaths) {
     for (s32 i = 0; i < PLAYER_MOUTH_MAX; i++) {
-        if (!ResourceMgr_FileExists(sFDMouthTextures[i])) {
-            MouthPatch = false;
-            break;
-        }
+        sPlayerMouthTextures[form][i] = (TexturePtr)resolvedPaths[i].c_str();
     }
-
-    for (s32 i = 0; i < PLAYER_EYES_MAX; i++) {
-        if (!ResourceMgr_FileExists(sDekuEyesTextures[i])) {
-            DekuEyesPatch = false;
-            break;
-        }
-    }
-
-    for (s32 i = 0; i < PLAYER_MOUTH_MAX; i++) {
-        if (!ResourceMgr_FileExists(sDekuMouthTextures[i])) {
-            DekuMouthPatch = false;
-            break;
-        }
-    }
-
-    for (s32 i = 0; i < PLAYER_MOUTH_MAX; i++) {
-        if (!ResourceMgr_FileExists(sGoronMouthTextures[i])) {
-            GoronMouthPatch = false;
-            break;
-        }
-    }
-
-    if (EyesPatch) {
-        for (s32 i = 0; i < PLAYER_EYES_MAX; i++) {
-            sPlayerEyesTextures[PLAYER_FORM_FIERCE_DEITY][i] = (TexturePtr)sFDEyesTextures[i];
-        }
-    }
-
-    if (MouthPatch) {
-        for (s32 i = 0; i < PLAYER_MOUTH_MAX; i++) {
-            sPlayerMouthTextures[PLAYER_FORM_FIERCE_DEITY][i] = (TexturePtr)sFDMouthTextures[i];
-        }
-    }
-
-    if (DekuEyesPatch) {
-        for (s32 i = 0; i < PLAYER_EYES_MAX; i++) {
-            sPlayerEyesTextures[PLAYER_FORM_DEKU][i] = (TexturePtr)sDekuEyesTextures[i];
-        }
-    }
-
-    if (DekuMouthPatch) {
-        for (s32 i = 0; i < PLAYER_MOUTH_MAX; i++) {
-            sPlayerMouthTextures[PLAYER_FORM_DEKU][i] = (TexturePtr)sDekuMouthTextures[i];
-        }
-    }
-
-    if (GoronMouthPatch) {
-        for (s32 i = 0; i < PLAYER_MOUTH_MAX; i++) {
-            sPlayerMouthTextures[PLAYER_FORM_GORON][i] = (TexturePtr)sGoronMouthTextures[i];
-        }
-    }
-
-    sFacePatchState = 1;
 }
 
 void PlayerCustomFlipbooks_Patch(void) {
-    PlayerCustomFlipbooks_PatchOnce();
+    const s32 altState = ResourceMgr_IsAltAssetsEnabled() ? 1 : 0;
+    if (sFacePatchAltState == altState) {
+        return;
+    }
+
+    sFacePatchAltState = altState;
+
+    if (ResolveTextureSet(sFDEyesTextures, sResolvedFDEyesTextures)) {
+        ApplyEyesTextureSet(PLAYER_FORM_FIERCE_DEITY, sResolvedFDEyesTextures);
+    }
+
+    if (ResolveTextureSet(sFDMouthTextures, sResolvedFDMouthTextures)) {
+        ApplyMouthTextureSet(PLAYER_FORM_FIERCE_DEITY, sResolvedFDMouthTextures);
+    }
+
+    if (ResolveTextureSet(sDekuEyesTextures, sResolvedDekuEyesTextures)) {
+        ApplyEyesTextureSet(PLAYER_FORM_DEKU, sResolvedDekuEyesTextures);
+    }
+
+    if (ResolveTextureSet(sDekuMouthTextures, sResolvedDekuMouthTextures)) {
+        ApplyMouthTextureSet(PLAYER_FORM_DEKU, sResolvedDekuMouthTextures);
+    }
+
+    if (ResolveTextureSet(sGoronMouthTextures, sResolvedGoronMouthTextures)) {
+        ApplyMouthTextureSet(PLAYER_FORM_GORON, sResolvedGoronMouthTextures);
+    }
 }

--- a/mm/2s2h/resource/type/Skeleton.cpp
+++ b/mm/2s2h/resource/type/Skeleton.cpp
@@ -62,18 +62,27 @@ void SkeletonPatcher::ClearSkeletons() {
 
 void SkeletonPatcher::UpdateSkeletons() {
     auto resourceMgr = Ship::Context::GetInstance()->GetResourceManager();
-    bool isHD = resourceMgr->IsAltAssetsEnabled();
-    for (auto skel : skeletons) {
-        Skeleton* newSkel =
-            (Skeleton*)resourceMgr
-                ->LoadResource((isHD ? Ship::IResource::gAltAssetPrefix : "") + skel.vanillaSkeletonPath, true)
-                .get();
+    bool isAlt = resourceMgr->IsAltAssetsEnabled();
 
-        if (newSkel != nullptr) {
-            skel.skelAnime->skeleton = newSkel->skeletonData.skeletonHeader.segment;
-            uintptr_t skelPtr = (uintptr_t)newSkel->GetPointer();
-            memcpy(&skel.skelAnime->skeleton, &skelPtr,
-                   sizeof(uintptr_t)); // Dumb thing that needs to be done because cast is not cooperating
+    for (const auto& skel : skeletons) {
+        auto newSkel = std::static_pointer_cast<Skeleton>(resourceMgr->LoadResource(
+            (isAlt ? Ship::IResource::gAltAssetPrefix : "") + skel.vanillaSkeletonPath, true));
+
+        if (newSkel == nullptr || skel.skelAnime == nullptr) {
+            continue;
+        }
+
+        switch (newSkel->type) {
+            case SkeletonType::Flex:
+                skel.skelAnime->skeleton = newSkel->skeletonData.flexSkeletonHeader.sh.segment;
+                skel.skelAnime->dListCount = newSkel->skeletonData.flexSkeletonHeader.dListCount;
+                break;
+            case SkeletonType::Normal:
+                skel.skelAnime->skeleton = newSkel->skeletonData.skeletonHeader.segment;
+                break;
+            case SkeletonType::Curve:
+                skel.skelAnime->skeleton = reinterpret_cast<void**>(newSkel->skeletonData.skelCurveLimbList.limbs);
+                break;
         }
     }
 }


### PR DESCRIPTION
Adds proper alt toggling support for custom models and skeletons so we can hopefully make this a requirement for 2ship mods as well, better for compatibility and mod support.

I had to make some changes in the custom flipbooks and fd sheaths code bc i originally built those around not having alt toggle, so thats what those changes in there are for

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/6202145169.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/6201944649.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/6201728125.zip)
<!--- section:artifacts:end -->