### PR TITLE
[Rando] Blacklist Epona's Song from cow checks in NNL

### DIFF
--- a/mm/2s2h/Rando/Logic/NearlyNoLogic.cpp
+++ b/mm/2s2h/Rando/Logic/NearlyNoLogic.cpp
@@ -51,6 +51,29 @@ void ApplyNearlyNoLogicToSaveContext(std::vector<RandoCheckId>& checkPool, std::
             RC_GREAT_BAY_COAST_COW_FRONT } }
     };
 
+    auto IsSafeScene = [&](SceneId sceneId) {
+        return sceneId != SCENE_MITURIN &&    // Woodfall Temple
+               sceneId != SCENE_MITURIN_BS && // Woodfall Temple Boss
+               sceneId != SCENE_SEA &&        // Great Bay Temple
+               sceneId != SCENE_SEA_BS &&     // Great Bay Temple Boss
+               sceneId != SCENE_LAST_DEKU &&  // Moon Deku
+               sceneId != SCENE_LAST_GORON && // Moon Goron
+               sceneId != SCENE_LAST_ZORA &&  // Moon Goron
+               sceneId != SCENE_LAST_LINK &&  // Moon Human
+               sceneId != SCENE_SOUGEN &&     // Moon
+               sceneId != SCENE_LAST_BS;      // Moon Boss
+    };
+
+    auto IsSafeCheck = [&](RandoCheckId randoCheckId) {
+        return randoCheckId != RC_BENEATH_THE_WELL_COW && randoCheckId != RC_ROMANI_RANCH_BARN_COW_LEFT &&
+               randoCheckId != RC_ROMANI_RANCH_BARN_COW_MIDDLE && randoCheckId != RC_ROMANI_RANCH_BARN_COW_RIGHT &&
+               randoCheckId != RC_ROMANI_RANCH_FIELD_COW_ENTRANCE &&
+               randoCheckId != RC_ROMANI_RANCH_FIELD_COW_NEAR_HOUSE_BACK &&
+               randoCheckId != RC_ROMANI_RANCH_FIELD_COW_NEAR_HOUSE_FRONT &&
+               randoCheckId != RC_TERMINA_FIELD_COW_BACK && randoCheckId != RC_TERMINA_FIELD_COW_FRONT &&
+               randoCheckId != RC_GREAT_BAY_COAST_COW_BACK && randoCheckId != RC_GREAT_BAY_COAST_COW_FRONT;
+    };
+
     for (auto& randoCheckId : checkPool) {
         if (randoCheckId == RC_UNKNOWN) {
             continue;
@@ -67,17 +90,7 @@ void ApplyNearlyNoLogicToSaveContext(std::vector<RandoCheckId>& checkPool, std::
         if (itemToSceneBlacklist.find(randoItemId) != itemToSceneBlacklist.end() ||
             itemToCheckBlacklist.find(randoItemId) != itemToCheckBlacklist.end()) {
             importantItems[randoItemId] = randoCheckId;
-        } else if (randoStaticCheck.sceneId != SCENE_MITURIN &&    // Woodfall Temple
-                   randoStaticCheck.sceneId != SCENE_MITURIN_BS && // Woodfall Temple Boss
-                   randoStaticCheck.sceneId != SCENE_SEA &&        // Great Bay Temple
-                   randoStaticCheck.sceneId != SCENE_SEA_BS &&     // Great Bay Temple Boss
-                   randoStaticCheck.sceneId != SCENE_LAST_DEKU &&  // Moon Deku
-                   randoStaticCheck.sceneId != SCENE_LAST_GORON && // Moon Goron
-                   randoStaticCheck.sceneId != SCENE_LAST_ZORA &&  // Moon Goron
-                   randoStaticCheck.sceneId != SCENE_LAST_LINK &&  // Moon Human
-                   randoStaticCheck.sceneId != SCENE_SOUGEN &&     // Moon
-                   randoStaticCheck.sceneId != SCENE_LAST_BS       // Moon Boss
-        ) {
+        } else if (IsSafeScene(randoStaticCheck.sceneId) && IsSafeCheck(randoStaticCheck.randoCheckId)) {
             safeChecks.push_back(randoCheckId);
         }
     }

--- a/mm/2s2h/Rando/Logic/NearlyNoLogic.cpp
+++ b/mm/2s2h/Rando/Logic/NearlyNoLogic.cpp
@@ -42,14 +42,7 @@ void ApplyNearlyNoLogicToSaveContext(std::vector<RandoCheckId>& checkPool, std::
           { SCENE_LAST_DEKU, SCENE_LAST_GORON, SCENE_LAST_ZORA, SCENE_LAST_LINK, SCENE_SOUGEN, SCENE_LAST_BS } },
     };
 
-    std::map<RandoItemId, std::vector<RandoCheckId>> itemToCheckBlacklist = {
-        { RI_SONG_EPONA,
-          { RC_BENEATH_THE_WELL_COW, RC_ROMANI_RANCH_BARN_COW_LEFT, RC_ROMANI_RANCH_BARN_COW_MIDDLE,
-            RC_ROMANI_RANCH_BARN_COW_RIGHT, RC_ROMANI_RANCH_FIELD_COW_ENTRANCE,
-            RC_ROMANI_RANCH_FIELD_COW_NEAR_HOUSE_BACK, RC_ROMANI_RANCH_FIELD_COW_NEAR_HOUSE_FRONT,
-            RC_TERMINA_FIELD_COW_BACK, RC_TERMINA_FIELD_COW_FRONT, RC_GREAT_BAY_COAST_COW_BACK,
-            RC_GREAT_BAY_COAST_COW_FRONT } }
-    };
+    std::map<RandoItemId, RandoCheckType> itemToCheckTypeBlacklist = { { RI_SONG_EPONA, RCTYPE_COW } };
 
     auto IsSafeScene = [&](SceneId sceneId) {
         return sceneId != SCENE_MITURIN &&    // Woodfall Temple
@@ -64,15 +57,7 @@ void ApplyNearlyNoLogicToSaveContext(std::vector<RandoCheckId>& checkPool, std::
                sceneId != SCENE_LAST_BS;      // Moon Boss
     };
 
-    auto IsSafeCheck = [&](RandoCheckId randoCheckId) {
-        return randoCheckId != RC_BENEATH_THE_WELL_COW && randoCheckId != RC_ROMANI_RANCH_BARN_COW_LEFT &&
-               randoCheckId != RC_ROMANI_RANCH_BARN_COW_MIDDLE && randoCheckId != RC_ROMANI_RANCH_BARN_COW_RIGHT &&
-               randoCheckId != RC_ROMANI_RANCH_FIELD_COW_ENTRANCE &&
-               randoCheckId != RC_ROMANI_RANCH_FIELD_COW_NEAR_HOUSE_BACK &&
-               randoCheckId != RC_ROMANI_RANCH_FIELD_COW_NEAR_HOUSE_FRONT &&
-               randoCheckId != RC_TERMINA_FIELD_COW_BACK && randoCheckId != RC_TERMINA_FIELD_COW_FRONT &&
-               randoCheckId != RC_GREAT_BAY_COAST_COW_BACK && randoCheckId != RC_GREAT_BAY_COAST_COW_FRONT;
-    };
+    auto IsSafeCheckType = [&](RandoCheckType randoCheckType) { return randoCheckType != RCTYPE_COW; };
 
     for (auto& randoCheckId : checkPool) {
         if (randoCheckId == RC_UNKNOWN) {
@@ -88,9 +73,9 @@ void ApplyNearlyNoLogicToSaveContext(std::vector<RandoCheckId>& checkPool, std::
         auto randoStaticCheck = Rando::StaticData::Checks[randoCheckId];
 
         if (itemToSceneBlacklist.find(randoItemId) != itemToSceneBlacklist.end() ||
-            itemToCheckBlacklist.find(randoItemId) != itemToCheckBlacklist.end()) {
+            itemToCheckTypeBlacklist.find(randoItemId) != itemToCheckTypeBlacklist.end()) {
             importantItems[randoItemId] = randoCheckId;
-        } else if (IsSafeScene(randoStaticCheck.sceneId) && IsSafeCheck(randoStaticCheck.randoCheckId)) {
+        } else if (IsSafeScene(randoStaticCheck.sceneId) && IsSafeCheckType(randoStaticCheck.randoCheckType)) {
             safeChecks.push_back(randoCheckId);
         }
     }
@@ -114,12 +99,12 @@ void ApplyNearlyNoLogicToSaveContext(std::vector<RandoCheckId>& checkPool, std::
         }
     }
 
-    for (auto& [randoItemId, blackListedChecks] : itemToCheckBlacklist) {
+    for (auto& [randoItemId, blackListedChecks] : itemToCheckTypeBlacklist) {
         if (importantItems.find(randoItemId) != importantItems.end()) {
             auto randoStaticCheck = Rando::StaticData::Checks[importantItems.at(randoItemId)];
-            const auto& blacklist = itemToCheckBlacklist.at(randoItemId);
-            // This item is blacklisted from this check, so replace it
-            if (std::find(blacklist.begin(), blacklist.end(), randoStaticCheck.randoCheckId) != blacklist.end()) {
+            const auto& blacklistedRandoCheckType = itemToCheckTypeBlacklist.at(randoItemId);
+            // This item is blacklisted from this check type, so replace it
+            if (randoStaticCheck.randoCheckType == blacklistedRandoCheckType) {
                 PerformBlacklistReplacement(randoItemId);
             }
         }

--- a/mm/2s2h/Rando/Logic/NearlyNoLogic.cpp
+++ b/mm/2s2h/Rando/Logic/NearlyNoLogic.cpp
@@ -42,6 +42,15 @@ void ApplyNearlyNoLogicToSaveContext(std::vector<RandoCheckId>& checkPool, std::
           { SCENE_LAST_DEKU, SCENE_LAST_GORON, SCENE_LAST_ZORA, SCENE_LAST_LINK, SCENE_SOUGEN, SCENE_LAST_BS } },
     };
 
+    std::map<RandoItemId, std::vector<RandoCheckId>> itemToCheckBlacklist = {
+        { RI_SONG_EPONA,
+          { RC_BENEATH_THE_WELL_COW, RC_ROMANI_RANCH_BARN_COW_LEFT, RC_ROMANI_RANCH_BARN_COW_MIDDLE,
+            RC_ROMANI_RANCH_BARN_COW_RIGHT, RC_ROMANI_RANCH_FIELD_COW_ENTRANCE,
+            RC_ROMANI_RANCH_FIELD_COW_NEAR_HOUSE_BACK, RC_ROMANI_RANCH_FIELD_COW_NEAR_HOUSE_FRONT,
+            RC_TERMINA_FIELD_COW_BACK, RC_TERMINA_FIELD_COW_FRONT, RC_GREAT_BAY_COAST_COW_BACK,
+            RC_GREAT_BAY_COAST_COW_FRONT } }
+    };
+
     for (auto& randoCheckId : checkPool) {
         if (randoCheckId == RC_UNKNOWN) {
             continue;
@@ -55,7 +64,8 @@ void ApplyNearlyNoLogicToSaveContext(std::vector<RandoCheckId>& checkPool, std::
 
         auto randoStaticCheck = Rando::StaticData::Checks[randoCheckId];
 
-        if (itemToSceneBlacklist.find(randoItemId) != itemToSceneBlacklist.end()) {
+        if (itemToSceneBlacklist.find(randoItemId) != itemToSceneBlacklist.end() ||
+            itemToCheckBlacklist.find(randoItemId) != itemToCheckBlacklist.end()) {
             importantItems[randoItemId] = randoCheckId;
         } else if (randoStaticCheck.sceneId != SCENE_MITURIN &&    // Woodfall Temple
                    randoStaticCheck.sceneId != SCENE_MITURIN_BS && // Woodfall Temple Boss
@@ -72,17 +82,32 @@ void ApplyNearlyNoLogicToSaveContext(std::vector<RandoCheckId>& checkPool, std::
         }
     }
 
+    auto PerformBlacklistReplacement = [&](RandoItemId randoItemId) {
+        auto otherCheckIndex = Ship_Random(0, safeChecks.size() - 1);
+        RANDO_SAVE_CHECKS[importantItems[randoItemId]].randoItemId =
+            RANDO_SAVE_CHECKS[safeChecks[otherCheckIndex]].randoItemId;
+        RANDO_SAVE_CHECKS[safeChecks[otherCheckIndex]].randoItemId = randoItemId;
+        safeChecks.erase(safeChecks.begin() + otherCheckIndex);
+    };
+
     for (auto& [randoItemId, blacklistedScenes] : itemToSceneBlacklist) {
         if (importantItems.find(randoItemId) != importantItems.end()) {
             auto randoStaticCheck = Rando::StaticData::Checks[importantItems.at(randoItemId)];
             const auto& blacklist = itemToSceneBlacklist.at(randoItemId);
-
+            // This item is blacklisted from this scene, so replace it
             if (std::find(blacklist.begin(), blacklist.end(), randoStaticCheck.sceneId) != blacklist.end()) {
-                auto otherCheckIndex = Ship_Random(0, safeChecks.size() - 1);
-                RANDO_SAVE_CHECKS[importantItems[randoItemId]].randoItemId =
-                    RANDO_SAVE_CHECKS[safeChecks[otherCheckIndex]].randoItemId;
-                RANDO_SAVE_CHECKS[safeChecks[otherCheckIndex]].randoItemId = randoItemId;
-                safeChecks.erase(safeChecks.begin() + otherCheckIndex);
+                PerformBlacklistReplacement(randoItemId);
+            }
+        }
+    }
+
+    for (auto& [randoItemId, blackListedChecks] : itemToCheckBlacklist) {
+        if (importantItems.find(randoItemId) != importantItems.end()) {
+            auto randoStaticCheck = Rando::StaticData::Checks[importantItems.at(randoItemId)];
+            const auto& blacklist = itemToCheckBlacklist.at(randoItemId);
+            // This item is blacklisted from this check, so replace it
+            if (std::find(blacklist.begin(), blacklist.end(), randoStaticCheck.randoCheckId) != blacklist.end()) {
+                PerformBlacklistReplacement(randoItemId);
             }
         }
     }


### PR DESCRIPTION
Adds general handling for blacklisting items from specific check types in NNL, should we need more than just Epona's Song on cows. I generated several seeds where Epona's Song was going to be on a cow and got replaced appropriately. Additional seed gen testing is always welcome; I recommend using boot to file warp and resetting for sanity's sake.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7099818038.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7099705049.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7099604738.zip)
<!--- section:artifacts:end -->