### PR TITLE
[Rando] Make more checks repeatable

### DIFF
--- a/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipGiantsChamber.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/StoryCutscenes/SkipGiantsChamber.cpp
@@ -96,29 +96,27 @@ void handleGiantsCheck(SceneId sceneId) {
     }
 
     // The Oath to Order check only occurs when freeing a Giant for the first time.
-    if (gSaveContext.save.saveInfo.unk_EA8[1] == 1) {
-        if (IS_RANDO) {
+    if (IS_RANDO) {
+        if (!RANDO_SAVE_CHECKS[RC_GIANTS_CHAMBER_OATH_TO_ORDER].cycleObtained) {
             RANDO_SAVE_CHECKS[RC_GIANTS_CHAMBER_OATH_TO_ORDER].eligible = true;
-        } else {
-            GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
-                .showGetItemCutscene = !CVarGetInteger("gEnhancements.Cutscenes.SkipGetItemCutscenes", 0),
-                .giveItem =
-                    [](Actor* actor, PlayState* play) {
-                        if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
-                            CustomMessage::SetActiveCustomMessage("You learned the Oath to Order!",
-                                                                  { .textboxType = 2 });
-                        } else {
-                            CustomMessage::StartTextbox("You learned the Oath to Order!\x1C\x02\x10",
-                                                        { .textboxType = 2 });
-                        }
-                        Item_Give(gPlayState, ITEM_SONG_OATH);
-                    },
-                .drawItem =
-                    [](Actor* actor, PlayState* play) {
-                        Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
-                        Rando::DrawItem(RI_SONG_OATH);
-                    } });
         }
+    } else if (gSaveContext.save.saveInfo.unk_EA8[1] == 1) {
+        GameInteractor::Instance->events.emplace_back(GIEventGiveItem{
+            .showGetItemCutscene = !CVarGetInteger("gEnhancements.Cutscenes.SkipGetItemCutscenes", 0),
+            .giveItem =
+                [](Actor* actor, PlayState* play) {
+                    if (CUSTOM_ITEM_FLAGS & CustomItem::GIVE_ITEM_CUTSCENE) {
+                        CustomMessage::SetActiveCustomMessage("You learned the Oath to Order!", { .textboxType = 2 });
+                    } else {
+                        CustomMessage::StartTextbox("You learned the Oath to Order!\x1C\x02\x10", { .textboxType = 2 });
+                    }
+                    Item_Give(gPlayState, ITEM_SONG_OATH);
+                },
+            .drawItem =
+                [](Actor* actor, PlayState* play) {
+                    Matrix_Scale(30.0f, 30.0f, 30.0f, MTXMODE_APPLY);
+                    Rando::DrawItem(RI_SONG_OATH);
+                } });
     }
 }
 

--- a/mm/2s2h/Rando/ActorBehavior/DmHina.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/DmHina.cpp
@@ -23,8 +23,7 @@ void Rando::ActorBehavior::InitDmHinaBehavior() {
         *should = false;
 
         auto randoSaveCheck = RANDO_SAVE_CHECKS[checkId];
-        // Do not display if already obtained (i.e. for repeat visits)
-        if (!randoSaveCheck.obtained) {
+        if (!randoSaveCheck.cycleObtained) {
             Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, checkId), checkId, actor);
         }
     });

--- a/mm/2s2h/Rando/ActorBehavior/DoorWarp1.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/DoorWarp1.cpp
@@ -15,19 +15,20 @@ void Rando::ActorBehavior::InitDoorWarp1VBehavior() {
      */
     COND_VB_SHOULD(VB_SPAWN_BOSS_REMAINS, IS_RANDO, {
         s32* ret = va_arg(args, s32*);
-        if ((gPlayState->sceneId == SCENE_MITURIN_BS) && !RANDO_SAVE_CHECKS[RC_WOODFALL_TEMPLE_BOSS_WARP].obtained) {
+        if ((gPlayState->sceneId == SCENE_MITURIN_BS) &&
+            !RANDO_SAVE_CHECKS[RC_WOODFALL_TEMPLE_BOSS_WARP].cycleObtained) {
             // Odolwa's Lair
             *ret = 1;
         } else if ((gPlayState->sceneId == SCENE_HAKUGIN_BS) &&
-                   !RANDO_SAVE_CHECKS[RC_SNOWHEAD_TEMPLE_BOSS_WARP].obtained) {
+                   !RANDO_SAVE_CHECKS[RC_SNOWHEAD_TEMPLE_BOSS_WARP].cycleObtained) {
             // Goht's Lair
             *ret = 2;
         } else if ((gPlayState->sceneId == SCENE_SEA_BS) &&
-                   !RANDO_SAVE_CHECKS[RC_GREAT_BAY_TEMPLE_BOSS_WARP].obtained) {
+                   !RANDO_SAVE_CHECKS[RC_GREAT_BAY_TEMPLE_BOSS_WARP].cycleObtained) {
             // Gyorg's Lair
             *ret = 3;
         } else if ((gPlayState->sceneId == SCENE_INISIE_BS) &&
-                   !RANDO_SAVE_CHECKS[RC_STONE_TOWER_TEMPLE_INVERTED_BOSS_WARP].obtained) {
+                   !RANDO_SAVE_CHECKS[RC_STONE_TOWER_TEMPLE_INVERTED_BOSS_WARP].cycleObtained) {
             // Twinmold's Lair
             *ret = 4;
         }
@@ -59,8 +60,7 @@ void Rando::ActorBehavior::InitDoorWarp1VBehavior() {
                     checkId = RC_STONE_TOWER_TEMPLE_INVERTED_BOSS_WARP;
                     break;
             }
-            // Cannot get each boss remains check more than once
-            RANDO_SAVE_CHECKS[checkId].eligible = !RANDO_SAVE_CHECKS[checkId].obtained;
+            RANDO_SAVE_CHECKS[checkId].eligible = !RANDO_SAVE_CHECKS[checkId].cycleObtained;
             // Transform back to human Link and warp away without waiting for a textbox to close as normal
             Player_SetCsActionWithHaltedActors(gPlayState, &doorWarp1->dyna.actor, PLAYER_CSACTION_9);
             player->unk_3A0.x = doorWarp1->dyna.actor.world.pos.x;

--- a/mm/2s2h/Rando/ActorBehavior/EnGg.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnGg.cpp
@@ -3,5 +3,5 @@
 // This accounts for both EnGg and EnGg2, both of which act as Darmani's ghost.
 void Rando::ActorBehavior::InitEnGgBehavior() {
     COND_VB_SHOULD(VB_CONSIDER_DARMANI_HEALED, IS_RANDO,
-                   { *should = RANDO_SAVE_CHECKS[RC_GORON_GRAVEYARD_DARMANI].obtained; });
+                   { *should = RANDO_SAVE_CHECKS[RC_GORON_GRAVEYARD_DARMANI].cycleObtained; });
 }

--- a/mm/2s2h/Rando/ActorBehavior/EnGirlA.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnGirlA.cpp
@@ -29,10 +29,11 @@ void EnGirlA_RandoDrawFunc(Actor* actor, PlayState* play) {
     EnGirlA* enGirlA = (EnGirlA*)actor;
 
     auto randoSaveCheck = RANDO_SAVE_CHECKS[actor->world.rot.z];
+    RandoCheckId randoCheckId = (RandoCheckId)actor->world.rot.z;
 
     Matrix_RotateYS(enGirlA->rotY, MTXMODE_APPLY);
 
-    Rando::DrawItem(randoSaveCheck.randoItemId, (RandoCheckId)actor->world.rot.z, actor);
+    Rando::DrawItem(Rando::ConvertItem(randoSaveCheck.randoItemId, randoCheckId), randoCheckId, actor);
 }
 
 void EnGirlA_RandoBought(PlayState* play, EnGirlA* enGirlA) {
@@ -42,8 +43,9 @@ void EnGirlA_RandoBought(PlayState* play, EnGirlA* enGirlA) {
 
 void EnGirlA_RandoRestock(PlayState* play, EnGirlA* enGirlA) {
     auto randoSaveCheck = RANDO_SAVE_CHECKS[enGirlA->actor.world.rot.z];
+    RandoCheckId randoCheckId = (RandoCheckId)enGirlA->actor.world.rot.z;
 
-    if (Rando::IsItemObtainable(randoSaveCheck.randoItemId, (RandoCheckId)enGirlA->actor.world.rot.z)) {
+    if (Rando::IsItemObtainable(Rando::ConvertItem(randoSaveCheck.randoItemId, randoCheckId), randoCheckId)) {
         enGirlA->isOutOfStock = false;
         enGirlA->actor.draw = EnGirlA_RandoDrawFunc;
     }
@@ -55,8 +57,9 @@ s32 EnGirlA_RandoCanBuyFunc(PlayState* play, EnGirlA* enGirlA) {
     }
 
     auto randoSaveCheck = RANDO_SAVE_CHECKS[enGirlA->actor.world.rot.z];
+    RandoCheckId randoCheckId = (RandoCheckId)enGirlA->actor.world.rot.z;
 
-    if (!Rando::IsItemObtainable(randoSaveCheck.randoItemId, (RandoCheckId)enGirlA->actor.world.rot.z)) {
+    if (!Rando::IsItemObtainable(Rando::ConvertItem(randoSaveCheck.randoItemId, randoCheckId), randoCheckId)) {
         return CANBUY_RESULT_CANNOT_GET_NOW;
     }
 
@@ -103,9 +106,10 @@ void EnGirlA_RandoInit(EnGirlA* enGirlA, PlayState* play) {
     enGirlA->initialRotY = enGirlA->actor.shape.rot.y;
 
     auto randoSaveCheck = RANDO_SAVE_CHECKS[enGirlA->actor.world.rot.z];
+    RandoCheckId randoCheckId = (RandoCheckId)enGirlA->actor.world.rot.z;
 
-    if (!Rando::IsItemObtainable(randoSaveCheck.randoItemId, (RandoCheckId)enGirlA->actor.world.rot.z) &&
-        randoSaveCheck.obtained) {
+    if (!Rando::IsItemObtainable(Rando::ConvertItem(randoSaveCheck.randoItemId, randoCheckId), randoCheckId) &&
+        randoSaveCheck.cycleObtained) {
         enGirlA->isOutOfStock = true;
         enGirlA->actor.draw = NULL;
     } else {
@@ -115,25 +119,27 @@ void EnGirlA_RandoInit(EnGirlA* enGirlA, PlayState* play) {
 }
 
 void renameStolenBombBag(u16* textId, bool* loadFromMessageTable) {
-    auto randoSaveCheck = RANDO_SAVE_CHECKS[RC_BOMB_SHOP_ITEM_04_OR_CURIOSITY_SHOP_ITEM];
+    RandoCheckId randoCheckId = RC_BOMB_SHOP_ITEM_04_OR_CURIOSITY_SHOP_ITEM;
+    auto randoSaveCheck = RANDO_SAVE_CHECKS[randoCheckId];
     auto randoStaticItem = Rando::StaticData::Items[randoSaveCheck.randoItemId];
     auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
     entry.msg = "Tonight's special, stolen from the Bomb Shop: %r{{itemName}}%w. Check it out!\x19\xA8";
-    CustomMessage::Replace(
-        &entry.msg, "{{itemName}}",
-        Rando::StaticData::GetItemName(randoSaveCheck.randoItemId, false, RC_BOMB_SHOP_ITEM_04_OR_CURIOSITY_SHOP_ITEM));
+    CustomMessage::Replace(&entry.msg, "{{itemName}}",
+                           Rando::StaticData::GetItemName(Rando::ConvertItem(randoSaveCheck.randoItemId, randoCheckId),
+                                                          false, randoCheckId));
     CustomMessage::LoadCustomMessageIntoFont(entry);
     *loadFromMessageTable = false;
 }
 
 void renameSpecialBargain(u16* textId, bool* loadFromMessageTable) {
-    auto randoSaveCheck = RANDO_SAVE_CHECKS[RC_CURIOSITY_SHOP_SPECIAL_ITEM];
+    RandoCheckId randoCheckId = RC_CURIOSITY_SHOP_SPECIAL_ITEM;
+    auto randoSaveCheck = RANDO_SAVE_CHECKS[randoCheckId];
     auto randoStaticItem = Rando::StaticData::Items[randoSaveCheck.randoItemId];
     auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
     entry.msg = "Tonight's bargain: %r{{itemName}}%w. Check it out!\x19\xA8";
-    CustomMessage::Replace(
-        &entry.msg, "{{itemName}}",
-        Rando::StaticData::GetItemName(randoSaveCheck.randoItemId, false, RC_CURIOSITY_SHOP_SPECIAL_ITEM));
+    CustomMessage::Replace(&entry.msg, "{{itemName}}",
+                           Rando::StaticData::GetItemName(Rando::ConvertItem(randoSaveCheck.randoItemId, randoCheckId),
+                                                          false, randoCheckId));
     CustomMessage::LoadCustomMessageIntoFont(entry);
     *loadFromMessageTable = false;
 }
@@ -289,7 +295,7 @@ void Rando::ActorBehavior::InitEnGirlABehavior() {
         }
 
         auto randoSaveCheck = RANDO_SAVE_CHECKS[randoCheckId];
-        auto randoStaticItem = Rando::StaticData::Items[randoSaveCheck.randoItemId];
+        RandoItemId randoItemId = Rando::ConvertItem(randoSaveCheck.randoItemId, randoCheckId);
 
         auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
         // Not using formatting here, to ensure the item name and price stay on one line
@@ -297,10 +303,10 @@ void Rando::ActorBehavior::InitEnGirlABehavior() {
         entry.msg = "\x01{{itemName}}: {{rupees}} Rupees\x11\x00";
         entry.msg += '\x00';
         CustomMessage::Replace(&entry.msg, "{{itemName}}",
-                               Rando::StaticData::GetItemName(randoSaveCheck.randoItemId, false, randoCheckId));
+                               Rando::StaticData::GetItemName(randoItemId, false, randoCheckId));
         CustomMessage::Replace(&entry.msg, "{{rupees}}", std::to_string(randoSaveCheck.price));
 
-        if (!Rando::IsItemObtainable(randoSaveCheck.randoItemId, randoCheckId) && randoSaveCheck.obtained) {
+        if (!Rando::IsItemObtainable(randoItemId, randoCheckId) && randoSaveCheck.cycleObtained) {
             entry.msg += "Out of Stock";
         } else {
             entry.msg += flavorTexts[rand() % flavorTexts.size()];
@@ -320,7 +326,6 @@ void Rando::ActorBehavior::InitEnGirlABehavior() {
         }
 
         auto randoSaveCheck = RANDO_SAVE_CHECKS[randoCheckId];
-        auto randoStaticItem = Rando::StaticData::Items[randoSaveCheck.randoItemId];
 
         auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
         // Not using formatting here, to ensure the item name and price stay on one line
@@ -328,7 +333,8 @@ void Rando::ActorBehavior::InitEnGirlABehavior() {
         entry.firstItemCost = randoSaveCheck.price;
         entry.msg = "\x01{{itemName}}: {{rupees}} Rupees\x02\x11\xC2I'll buy it\x11No thanks\xBF";
         CustomMessage::Replace(&entry.msg, "{{itemName}}",
-                               Rando::StaticData::GetItemName(randoSaveCheck.randoItemId, false, randoCheckId));
+                               Rando::StaticData::GetItemName(
+                                   Rando::ConvertItem(randoSaveCheck.randoItemId, randoCheckId), false, randoCheckId));
         CustomMessage::Replace(&entry.msg, "{{rupees}}", std::to_string(randoSaveCheck.price));
 
         CustomMessage::LoadCustomMessageIntoFont(entry);
@@ -344,7 +350,6 @@ void Rando::ActorBehavior::InitEnGirlABehavior() {
         }
 
         auto randoSaveCheck = RANDO_SAVE_CHECKS[randoCheckId];
-        auto randoStaticItem = Rando::StaticData::Items[randoSaveCheck.randoItemId];
 
         auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
         // Not using formatting here, to ensure the item name and price stay on one line
@@ -354,7 +359,8 @@ void Rando::ActorBehavior::InitEnGirlABehavior() {
         entry.msg += '\x00';
         entry.msg += "I need a mushroom to make this.\x1A";
         CustomMessage::Replace(&entry.msg, "{{itemName}}",
-                               Rando::StaticData::GetItemName(randoSaveCheck.randoItemId, false, randoCheckId));
+                               Rando::StaticData::GetItemName(
+                                   Rando::ConvertItem(randoSaveCheck.randoItemId, randoCheckId), false, randoCheckId));
         CustomMessage::Replace(&entry.msg, "{{itemPrice}}", std::to_string(randoSaveCheck.price));
         CustomMessage::LoadCustomMessageIntoFont(entry);
         *loadFromMessageTable = false;
@@ -372,7 +378,8 @@ void Rando::ActorBehavior::InitEnGirlABehavior() {
         auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
         entry.msg = "I used this to make %r{{itemName}}%w, take it!\x19";
         CustomMessage::Replace(&entry.msg, "{{itemName}}",
-                               Rando::StaticData::GetItemName(randoSaveCheck.randoItemId, true, randoCheckId));
+                               Rando::StaticData::GetItemName(
+                                   Rando::ConvertItem(randoSaveCheck.randoItemId, randoCheckId), true, randoCheckId));
 
         // Mark the item as eligible for purchase
         randoSaveCheck.eligible = true;
@@ -393,39 +400,42 @@ void Rando::ActorBehavior::InitEnGirlABehavior() {
 
     // Bomb Shop "We're expecting new stock" (hint)
     COND_ID_HOOK(OnOpenText, 0x648, IS_RANDO, [](u16* textId, bool* loadFromMessageTable) {
-        auto randoSaveCheck = RANDO_SAVE_CHECKS[RC_BOMB_SHOP_ITEM_04_OR_CURIOSITY_SHOP_ITEM];
+        RandoCheckId randoCheckId = RC_BOMB_SHOP_ITEM_04_OR_CURIOSITY_SHOP_ITEM;
+        auto randoSaveCheck = RANDO_SAVE_CHECKS[randoCheckId];
         auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
         entry.msg =
             "If nothing devastating happens to Mommy tonight, we should be able to sell %r{{itemName}}%w.\x19\xA8";
         CustomMessage::Replace(&entry.msg, "{{itemName}}",
-                               Rando::StaticData::GetItemName(randoSaveCheck.randoItemId, true,
-                                                              RC_BOMB_SHOP_ITEM_04_OR_CURIOSITY_SHOP_ITEM));
+                               Rando::StaticData::GetItemName(
+                                   Rando::ConvertItem(randoSaveCheck.randoItemId, randoCheckId), true, randoCheckId));
         CustomMessage::LoadCustomMessageIntoFont(entry);
         *loadFromMessageTable = false;
     });
 
     // Bomb Shop "We should have had..."
     COND_ID_HOOK(OnOpenText, 0x64A, IS_RANDO, [](u16* textId, bool* loadFromMessageTable) {
-        auto randoSaveCheck = RANDO_SAVE_CHECKS[RC_BOMB_SHOP_ITEM_04_OR_CURIOSITY_SHOP_ITEM];
+        RandoCheckId randoCheckId = RC_BOMB_SHOP_ITEM_04_OR_CURIOSITY_SHOP_ITEM;
+        auto randoSaveCheck = RANDO_SAVE_CHECKS[randoCheckId];
         auto randoStaticItem = Rando::StaticData::Items[randoSaveCheck.randoItemId];
         auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
         entry.msg = "Thanks to a mishap, we did not receive our %r{{itemName}}%w stock. Maybe next time...\x19\xA8";
         CustomMessage::Replace(&entry.msg, "{{itemName}}",
-                               Rando::StaticData::GetItemName(randoSaveCheck.randoItemId, true,
-                                                              RC_BOMB_SHOP_ITEM_04_OR_CURIOSITY_SHOP_ITEM));
+                               Rando::StaticData::GetItemName(
+                                   Rando::ConvertItem(randoSaveCheck.randoItemId, randoCheckId), true, randoCheckId));
         CustomMessage::LoadCustomMessageIntoFont(entry);
         *loadFromMessageTable = false;
     });
 
     // Bomb Shop "I thought we could finally sell"
     COND_ID_HOOK(OnOpenText, 0x660, IS_RANDO, [](u16* textId, bool* loadFromMessageTable) {
-        auto randoSaveCheck = RANDO_SAVE_CHECKS[RC_BOMB_SHOP_ITEM_04_OR_CURIOSITY_SHOP_ITEM];
+        RandoCheckId randoCheckId = RC_BOMB_SHOP_ITEM_04_OR_CURIOSITY_SHOP_ITEM;
+        auto randoSaveCheck = RANDO_SAVE_CHECKS[randoCheckId];
 
         auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
         entry.msg = "It's over... Now we'll never sell %r{{itemName}}%w...\x19\xA8";
         CustomMessage::Replace(&entry.msg, "{{itemName}}",
-                               Rando::StaticData::GetItemName(randoSaveCheck.randoItemId, true,
-                                                              RC_BOMB_SHOP_ITEM_04_OR_CURIOSITY_SHOP_ITEM));
+                               Rando::StaticData::GetItemName(
+                                   Rando::ConvertItem(randoSaveCheck.randoItemId, randoCheckId), true, randoCheckId));
 
         CustomMessage::LoadCustomMessageIntoFont(entry);
         *loadFromMessageTable = false;
@@ -433,14 +443,15 @@ void Rando::ActorBehavior::InitEnGirlABehavior() {
 
     // Bomb Shop "We just got a larger bomb bag in stock"
     COND_ID_HOOK(OnOpenText, 0x649, IS_RANDO, [](u16* textId, bool* loadFromMessageTable) {
-        auto randoSaveCheck = RANDO_SAVE_CHECKS[RC_BOMB_SHOP_ITEM_04_OR_CURIOSITY_SHOP_ITEM];
+        RandoCheckId randoCheckId = RC_BOMB_SHOP_ITEM_04_OR_CURIOSITY_SHOP_ITEM;
+        auto randoSaveCheck = RANDO_SAVE_CHECKS[randoCheckId];
         auto randoStaticItem = Rando::StaticData::Items[randoSaveCheck.randoItemId];
 
         auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
         entry.msg = "We just got some new stock: %r{{itemName}}%w.\x19\xA8";
         CustomMessage::Replace(&entry.msg, "{{itemName}}",
-                               Rando::StaticData::GetItemName(randoSaveCheck.randoItemId, true,
-                                                              RC_BOMB_SHOP_ITEM_04_OR_CURIOSITY_SHOP_ITEM));
+                               Rando::StaticData::GetItemName(
+                                   Rando::ConvertItem(randoSaveCheck.randoItemId, randoCheckId), true, randoCheckId));
 
         CustomMessage::LoadCustomMessageIntoFont(entry);
         *loadFromMessageTable = false;

--- a/mm/2s2h/Rando/ActorBehavior/EnZog.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnZog.cpp
@@ -7,14 +7,14 @@
 void Rando::ActorBehavior::InitEnZogBehavior() {
     COND_VB_SHOULD(VB_CONSIDER_MIKAU_HEALED, IS_RANDO, {
         int shouldIfMikauIsGone = va_arg(args, int);
-        // Check both eligible and obtained flags to account for both cutscene skips and scene reloads
+        // Check both eligible and cycleObtained flags to account for both cutscene skips and scene reloads
         if (shouldIfMikauIsGone) {
             *should = (RANDO_SAVE_CHECKS[RC_GREAT_BAY_COAST_MIKAU].eligible ||
-                       RANDO_SAVE_CHECKS[RC_GREAT_BAY_COAST_MIKAU].obtained);
+                       RANDO_SAVE_CHECKS[RC_GREAT_BAY_COAST_MIKAU].cycleObtained);
         } else {
             // Only if Mikau is still present, i.e. kill his gravestone's actor
             *should = !(RANDO_SAVE_CHECKS[RC_GREAT_BAY_COAST_MIKAU].eligible ||
-                        RANDO_SAVE_CHECKS[RC_GREAT_BAY_COAST_MIKAU].obtained);
+                        RANDO_SAVE_CHECKS[RC_GREAT_BAY_COAST_MIKAU].cycleObtained);
         }
     });
 }

--- a/mm/2s2h/Rando/ActorBehavior/ObjWarpstone.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ObjWarpstone.cpp
@@ -40,7 +40,7 @@ void Rando::ActorBehavior::InitObjWarpstoneBehavior() {
         RandoCheckId randoCheckId = Identify_Statue(warpstoneId);
 
         if (randoCheckId != RC_UNKNOWN && RANDO_SAVE_CHECKS[randoCheckId].shuffled) {
-            if (!RANDO_SAVE_CHECKS[randoCheckId].obtained) {
+            if (!RANDO_SAVE_CHECKS[randoCheckId].cycleObtained) {
                 RANDO_SAVE_CHECKS[randoCheckId].eligible = true;
             }
             *should = false;
@@ -52,7 +52,7 @@ void Rando::ActorBehavior::InitObjWarpstoneBehavior() {
         RandoCheckId randoCheckId = Identify_Statue(warpstoneId);
 
         if (randoCheckId != RC_UNKNOWN && RANDO_SAVE_CHECKS[randoCheckId].shuffled) {
-            *should = RANDO_SAVE_CHECKS[randoCheckId].obtained;
+            *should = RANDO_SAVE_CHECKS[randoCheckId].cycleObtained;
         }
     });
 }


### PR DESCRIPTION
Makes the following checks repeatable each cycle:

- Giants Chamber Oath to Order (first boss warp in a cycle)
- Boss warp/remains
- Darmani and Mikau
- Shops, also makes refillable checks able to be purchased multiple times in a cycle
- Owl statues

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/6272548008.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/6272514413.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/6272473426.zip)
<!--- section:artifacts:end -->