### PR TITLE
Erase warning from Owl Save message when persistent option is on

### DIFF
--- a/mm/2s2h/Enhancements/Dialogue/SkipOwlSaveWarning.cpp
+++ b/mm/2s2h/Enhancements/Dialogue/SkipOwlSaveWarning.cpp
@@ -1,7 +1,8 @@
 #include <libultraship/bridge/consolevariablebridge.h>
-#include "2s2h/GameInteractor/GameInteractor.h"
-#include "2s2h/ShipInit.hpp"
 #include "2s2h/CustomMessage/CustomMessage.h"
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/BenPort.hpp"
+#include "2s2h/ShipInit.hpp"
 
 #define CVAR_NAME "gEnhancements.Saving.PersistentOwlSaves"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)

--- a/mm/2s2h/Enhancements/Dialogue/SkipOwlSaveWarning.cpp
+++ b/mm/2s2h/Enhancements/Dialogue/SkipOwlSaveWarning.cpp
@@ -1,0 +1,28 @@
+#include <libultraship/bridge/consolevariablebridge.h>
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/ShipInit.hpp"
+#include "2s2h/CustomMessage/CustomMessage.h"
+
+#define CVAR_NAME "gEnhancements.Saving.PersistentOwlSaves"
+#define CVAR CVarGetInteger(CVAR_NAME, 0)
+
+// "You can save your progress and quit here."
+static constexpr u16 TEXT_ID_OWL_SAVE = 0xC01;
+
+// "Warning: If you reopen this Owl File, then reset without saving..."
+static constexpr size_t TEXT_WARNING_BEGIN = 258;
+static constexpr size_t TEXT_WARNING_LENGTH = 261;
+
+static void ModifySaveExplanation(u16* textId, bool* loadFromMessageTable) {
+    // Get original message
+    auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
+    entry.msg.erase(TEXT_WARNING_BEGIN, TEXT_WARNING_LENGTH);
+    CustomMessage::LoadCustomMessageIntoFont(entry);
+    *loadFromMessageTable = false;
+}
+
+static void RegisterSkipOwlSaveWarning() {
+    COND_ID_HOOK(OnOpenText, TEXT_ID_OWL_SAVE, CVAR, ModifySaveExplanation);
+}
+
+static RegisterShipInitFunc initFunc(RegisterSkipOwlSaveWarning, { CVAR_NAME });

--- a/mm/2s2h/Enhancements/Dialogue/SkipOwlSaveWarning.cpp
+++ b/mm/2s2h/Enhancements/Dialogue/SkipOwlSaveWarning.cpp
@@ -9,6 +9,10 @@
 // "You can save your progress and quit here."
 static constexpr u16 TEXT_ID_OWL_SAVE = 0xC01;
 
+// "Warning: If you reopen this Owl File, then reset without saving..."
+static constexpr size_t TEXT_WARNING_BEGIN_NTSC = 258;
+static constexpr size_t TEXT_WARNING_LENGTH_NTSC = 261;
+
 static void ModifySaveExplanation(u16* textId, bool* loadFromMessageTable) {
     size_t warningStart;
     size_t warningLength;
@@ -17,9 +21,8 @@ static void ModifySaveExplanation(u16* textId, bool* loadFromMessageTable) {
     switch (ResourceMgr_GetGameVersion(0)) {
         case MM_NTSC_US_10:
         case MM_NTSC_US_GC:
-            // "Warning: If you reopen this Owl File, then reset without saving..."
-            warningStart = 258;
-            warningLength = 261;
+            warningStart = TEXT_WARNING_BEGIN_NTSC;
+            warningLength = TEXT_WARNING_LENGTH_NTSC;
             break;
         default:
             // Unknown region, don't modify the message

--- a/mm/2s2h/Enhancements/Dialogue/SkipOwlSaveWarning.cpp
+++ b/mm/2s2h/Enhancements/Dialogue/SkipOwlSaveWarning.cpp
@@ -4,7 +4,8 @@
 #include "2s2h/ShipInit.hpp"
 
 extern "C" {
-#include "2s2h/BenPort.h"
+#include "BenPort.h"
+uint32_t ResourceMgr_GetGameVersion(int index);
 }
 
 #define CVAR_NAME "gEnhancements.Saving.PersistentOwlSaves"

--- a/mm/2s2h/Enhancements/Dialogue/SkipOwlSaveWarning.cpp
+++ b/mm/2s2h/Enhancements/Dialogue/SkipOwlSaveWarning.cpp
@@ -9,14 +9,25 @@
 // "You can save your progress and quit here."
 static constexpr u16 TEXT_ID_OWL_SAVE = 0xC01;
 
-// "Warning: If you reopen this Owl File, then reset without saving..."
-static constexpr size_t TEXT_WARNING_BEGIN = 258;
-static constexpr size_t TEXT_WARNING_LENGTH = 261;
-
 static void ModifySaveExplanation(u16* textId, bool* loadFromMessageTable) {
-    // Get original message
+    size_t warningStart;
+    size_t warningLength;
+
+    // TODO: Add different cases when other versions are supported
+    switch (ResourceMgr_GetGameVersion(0)) {
+        case MM_NTSC_US_10:
+        case MM_NTSC_US_GC:
+            // "Warning: If you reopen this Owl File, then reset without saving..."
+            warningStart = 258;
+            warningLength = 261;
+            break;
+        default:
+            // Unknown region, don't modify the message
+            return;
+    }
+
     auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
-    entry.msg.erase(TEXT_WARNING_BEGIN, TEXT_WARNING_LENGTH);
+    entry.msg.erase(warningStart, warningLength);
     CustomMessage::LoadCustomMessageIntoFont(entry);
     *loadFromMessageTable = false;
 }

--- a/mm/2s2h/Enhancements/Dialogue/SkipOwlSaveWarning.cpp
+++ b/mm/2s2h/Enhancements/Dialogue/SkipOwlSaveWarning.cpp
@@ -1,7 +1,7 @@
 #include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/GameInteractor/GameInteractor.h"
-#include "2s2h/BenPort.hpp"
+#include "2s2h/BenPort.h"
 #include "2s2h/ShipInit.hpp"
 
 #define CVAR_NAME "gEnhancements.Saving.PersistentOwlSaves"

--- a/mm/2s2h/Enhancements/Dialogue/SkipOwlSaveWarning.cpp
+++ b/mm/2s2h/Enhancements/Dialogue/SkipOwlSaveWarning.cpp
@@ -1,8 +1,11 @@
 #include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/GameInteractor/GameInteractor.h"
-#include "2s2h/BenPort.h"
 #include "2s2h/ShipInit.hpp"
+
+extern "C" {
+#include "2s2h/BenPort.h"
+}
 
 #define CVAR_NAME "gEnhancements.Saving.PersistentOwlSaves"
 #define CVAR CVarGetInteger(CVAR_NAME, 0)


### PR DESCRIPTION
Closes #1630

This warning now gets skipped when "Persistent Owl Saves" is turned on:

<img width="1920" height="1080" alt="2026-04-07 (1)" src="https://github.com/user-attachments/assets/fea551e9-bb86-4354-a050-9437d8edb33d" />
<img width="1920" height="1080" alt="2026-04-07 (2)" src="https://github.com/user-attachments/assets/728c763f-4108-4e29-a118-b5ab04a33f89" />

https://github.com/user-attachments/assets/8ca5ed5a-60b0-4514-8cce-35698ad3b854

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/6385898206.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/6385858053.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/6385819871.zip)
<!--- section:artifacts:end -->