### PR TITLE
Adjust dialogue after failing boat archery with custom health setting

### DIFF
--- a/mm/2s2h/Enhancements/Minigames/Archery.cpp
+++ b/mm/2s2h/Enhancements/Minigames/Archery.cpp
@@ -1,4 +1,5 @@
 #include <libultraship/bridge/consolevariablebridge.h>
+#include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
 
@@ -19,6 +20,8 @@ void EnSyatekiMan_Town_RunGame(EnSyatekiMan* enSyatekiMan, PlayState* play);
 #define BOAT_HEALTH_CVAR CVarGetInteger(BOAT_HEALTH_CVAR_NAME, 10)
 #define BOAT_NO_DAMAGE_CVAR_NAME "gEnhancements.Minigames.BoatArcheryInvincible"
 #define BOAT_NO_DAMAGE_CVAR CVarGetInteger(BOAT_NO_DAMAGE_CVAR_NAME, 0)
+
+static constexpr u16 TEXT_BOAT_ARCHERY_FAIL = 0x877;
 
 static void RegisterSwampArchery() {
     COND_ID_HOOK(ShouldActorUpdate, ACTOR_EN_SYATEKI_MAN, SWAMP_CVAR != 2180, [](Actor* actor, bool* should) {
@@ -73,8 +76,18 @@ static bool ShouldFailBoatArchery() {
     return gSaveContext.minigameHiddenScore >= BOAT_HEALTH_CVAR;
 }
 
+static void ModifyHitCount(u16* textId, bool* loadFromMessageTable) {
+    auto entry = CustomMessage::LoadVanillaMessageTableEntry(*textId);
+    u16 hits = gSaveContext.minigameHiddenScore;
+    CustomMessage::Replace(&entry.msg, "10 times", std::to_string(hits) + " time" + (hits == 1 ? "" : "s"));
+    CustomMessage::LoadCustomMessageIntoFont(entry);
+    *loadFromMessageTable = false;
+}
+
 static void RegisterKoumeHealth() {
-    COND_VB_SHOULD(VB_FAIL_BOAT_ARCHERY, BOAT_HEALTH_CVAR != 10, { *should = ShouldFailBoatArchery(); });
+    bool isHealthChanged = BOAT_HEALTH_CVAR != 10;
+    COND_VB_SHOULD(VB_FAIL_BOAT_ARCHERY, isHealthChanged, { *should = ShouldFailBoatArchery(); });
+    COND_ID_HOOK(OnOpenText, TEXT_BOAT_ARCHERY_FAIL, isHealthChanged, ModifyHitCount);
 }
 
 static void RegisterKoumeInvincible() {


### PR DESCRIPTION
The boat archery health hook now tweaks the number of times Koume says she hit you (she always said 10 before) to be correct to the actual number of hits.

One hit (singular, edge case):
<img width="1920" height="1080" alt="2026-04-07 (3)" src="https://github.com/user-attachments/assets/8a9d8814-be7d-40c4-8550-693e0d00c39b" />

Between 1 and 10 hits:
<img width="1920" height="1080" alt="2026-04-07 (4)" src="https://github.com/user-attachments/assets/d2333b9d-a8cb-475c-b2c9-6e6150483a50" />

More than 10 hits (maxed out to 30 in this case):
<img width="1920" height="1080" alt="2026-04-07 (5)" src="https://github.com/user-attachments/assets/fde940da-b257-4b50-86b6-b480dbf92ebb" />

Sorry for the torture, Koume, but it had to be done.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/6313659262.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/6313468851.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/6313325945.zip)
<!--- section:artifacts:end -->