### PR TITLE
Python script to compare source files with decomp

### DIFF
--- a/decomp_diff.py
+++ b/decomp_diff.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""
+Generate a git-style patch that shows changes in decompilation between 2Ship (new)
+and the official decomp repo (old).
+"""
+import difflib
+import os
+import sys
+
+ZELDARET_URL = "https://raw.githubusercontent.com/zeldaret/mm/master/"
+
+OLD_DISPLAY = "zeldaret/mm"
+NEW_DISPLAY = "2Ship"
+
+try:
+    # Prefer requests if available for nicer error handling
+    import requests
+except Exception:
+    requests = None
+    import urllib.request
+
+def read_file(path):
+    with open(path, "r", encoding="utf-8", errors="surrogateescape") as f:
+        return f.read().splitlines(keepends=False)
+
+def fetch_url(url):
+    if requests:
+        r = requests.get(url)
+        r.raise_for_status()
+        return r.text.splitlines(keepends=False)
+    else:
+        with urllib.request.urlopen(url) as resp:
+            data = resp.read()
+            # decode with utf-8 fallback
+            text = data.decode("utf-8", errors="surrogateescape")
+            return text.splitlines(keepends=False)
+
+def to_display_path(fullpath, repo_root):
+    """Return path for patch header (relative to repo root) or basename fallback."""
+    if repo_root and os.path.commonpath([os.path.abspath(fullpath), repo_root]) == repo_root:
+        return os.path.relpath(fullpath, repo_root).replace("\\", "/")
+    return os.path.basename(fullpath).replace("\\", "/")
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python decomp_diff.py <local_file> [decomp_relative_path]", file=sys.stderr)
+        sys.exit(2)
+
+    local_path = sys.argv[1]
+    if not os.path.exists(local_path):
+        print(f"Local file not found: {local_path}", file=sys.stderr)
+        sys.exit(2)
+
+    if not local_path.endswith((".c", ".h")):
+        print("Can only compare .c and .h files", file=sys.stderr)
+        sys.exit(2)
+
+    # Read local file (new)
+    local_path = os.path.abspath(local_path)
+    new_lines = read_file(local_path)
+
+    repo_path = os.path.join(os.path.dirname(__file__), "mm")
+    relative_path = os.path.relpath(local_path, repo_path)
+
+    if len(sys.argv) > 2:
+        decomp_url = sys.argv[2]
+    else:
+        decomp_url = None
+
+    print(f"Comparing '{relative_path}' to{f" '{decomp_url}' in" if decomp_url else ""} zeldaret's decomp...")
+
+    if not decomp_url:
+        decomp_url = relative_path.replace("\\", "/")
+
+    # Read zeldaret file (old)
+    try:
+        old_lines = fetch_url(ZELDARET_URL + decomp_url)
+    except Exception as e:
+        print(f"Failed to fetch URL {ZELDARET_URL + decomp_url}: {e}", file=sys.stderr)
+        sys.exit(3)
+
+    # produce unified diff (old -> new)
+    patch_lines = list(difflib.unified_diff(old_lines, new_lines,
+                                   fromfile=f"{OLD_DISPLAY} ({decomp_url})",
+                                   tofile=f"{NEW_DISPLAY} ({relative_path})",
+                                   lineterm=""))
+
+    # append --- and +++ lines are already present in unified diff output; but ensure they exist
+    # if unified_diff returned an empty list and files are identical, print nothing
+    if not patch_lines:
+        print("No differences found.")
+        return
+
+    out_text = "\n".join(patch_lines) + "\n"
+    sys.stdout.write(out_text)
+
+if __name__ == "__main__":
+    main()

--- a/decomp_diff.py
+++ b/decomp_diff.py
@@ -35,12 +35,6 @@ def fetch_url(url):
             text = data.decode("utf-8", errors="surrogateescape")
             return text.splitlines(keepends=False)
 
-def to_display_path(fullpath, repo_root):
-    """Return path for patch header (relative to repo root) or basename fallback."""
-    if repo_root and os.path.commonpath([os.path.abspath(fullpath), repo_root]) == repo_root:
-        return os.path.relpath(fullpath, repo_root).replace("\\", "/")
-    return os.path.basename(fullpath).replace("\\", "/")
-
 def main():
     if len(sys.argv) < 2:
         print("Usage: python decomp_diff.py <local_file> [decomp_relative_path]", file=sys.stderr)


### PR DESCRIPTION
Motivated by the desire to find incongruities between 2Ship's version of decomp and the "official" decomp. Some names might be different, especially as decomp receives more and more updates, but some things might also have been renamed in 2Ship for convenience, in ways that don't align with the official decomp. Ideally, we want them to match as closely as possible. I know SoH has several incongruities, and I plan to implement this script there as well.

```
Usage: python decomp_diff.py <local_file> [decomp_relative_path]
```

It can only compare one file at a time, because the number of changes that are specific to 2Ship's functionality (e.g. `GameInteractor` hooks) are too numerous, some files may have different names, and comparing each file all at once to its proper decomp counterpart while excluding 2Ship-specific code files would be way too complicated. The idea is to look at one file, look through the differences and identify which ones are differences come from decomp, like names of functions and constants. In case a file has been renamed, there's an optional argument to specify its path in decomp.

Sample output (now that zeldaret/mm#1838 has merged):
```
>python decomp_diff.py mm\src\overlays\actors\ovl_En_Kendo_Js\z_en_kendo_js.h
Comparing 'src\overlays\actors\ovl_En_Kendo_Js\z_en_kendo_js.h' to zeldaret's decomp...
--- zeldaret/mm (src/overlays/actors/ovl_En_Kendo_Js/z_en_kendo_js.h)
+++ 2Ship (src\overlays\actors\ovl_En_Kendo_Js\z_en_kendo_js.h)
@@ -2,16 +2,16 @@
 #define Z_EN_KENDO_JS_H

 #include "global.h"
-#include "assets/objects/object_js/object_js.h"
+#include "objects/object_js/object_js.h"

 struct EnKendoJs;

 typedef void (*EnKendoJsActionFunc)(struct EnKendoJs*, PlayState*);

-#define ENKENDOJS_GET_LOCATION(thisx) ((thisx)->params & 0xFF)
+#define ENKENDOJS_GET_FF(thisx) ((thisx)->params & 0xFF)
 #define ENKENDOJS_GET_PATH_INDEX(thisx) (((thisx)->params & 0xFF00) >> 8)

-#define ENKENDOJS_IN_BACK_ROOM 1
+#define ENKENDOJS_FF_1 1

 typedef struct EnKendoJs {
     /* 0x000 */ Actor actor;
@@ -23,17 +23,14 @@
     /* 0x274 */ Vec3s* pathPoints;
     /* 0x278 */ Vec3s headRot;
     /* 0x27E */ Vec3s torsoRot;
-    /* 0x284 */ union {
-        s16 noviceRound;
-        s16 expertRound;
-    } minigameRound;
-    /* 0x286 */ s16 courseState;
-    /* 0x288 */ s16 curTextId;
-    /* 0x28A */ s16 hasSpoken;
-    /* 0x28C */ s16 numLogs;
-    /* 0x28E */ s16 isSlashingLog;
-    /* 0x290 */ s16 timer;
-    /* 0x292 */ u8 isPlayerLockedOn;
+    /* 0x284 */ s16 unk_284;
+    /* 0x286 */ s16 unk_286;
+    /* 0x288 */ s16 unk_288;
+    /* 0x28A */ s16 unk_28A;
+    /* 0x28C */ s16 unk_28C;
+    /* 0x28E */ s16 unk_28E;
+    /* 0x290 */ s16 unk_290;
+    /* 0x292 */ u8 unk_292;
 } EnKendoJs; // size = 0x294

 #endif // Z_EN_KENDO_JS_H
```

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/6329497374.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/6329321346.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/6329147949.zip)
<!--- section:artifacts:end -->