### PR TITLE
Format strings before printing

### DIFF
--- a/mm/2s2h/BenGui/UIWidgets.cpp
+++ b/mm/2s2h/BenGui/UIWidgets.cpp
@@ -1177,7 +1177,7 @@ void DrawFlagArray32(const std::string& name, uint32_t& flags, Colors color) {
         }
         if (ImGui::IsItemHovered()) {
             std::string label = fmt::format("0x{:02X} ({})", flagIndex, flagIndex);
-            ImGui::SetTooltip(label.c_str());
+            ImGui::SetTooltip("%s", label.c_str());
         }
         ImGui::PopStyleVar();
         PopStyleCheckbox();
@@ -1207,7 +1207,7 @@ void DrawFlagArray16(const std::string& name, uint16_t& flags, Colors color) {
         }
         if (ImGui::IsItemHovered()) {
             std::string label = fmt::format("0x{:02X} ({})", flagIndex, flagIndex);
-            ImGui::SetTooltip(label.c_str());
+            ImGui::SetTooltip("%s", label.c_str());
         }
         ImGui::PopStyleVar();
         PopStyleCheckbox();
@@ -1241,7 +1241,7 @@ void DrawFlagTableArray16(const FlagTable& flagTable, uint16_t& flags) {
             if (!label.size()) {
                 label = fmt::format("0x{:02X} ({})", flagIndex, flagIndex);
             }
-            ImGui::SetTooltip(label.c_str());
+            ImGui::SetTooltip("%s", label.c_str());
         }
         ImGui::PopStyleVar();
         PopStyleCheckbox();
@@ -1275,7 +1275,7 @@ void DrawFlagTableArray8(const FlagTable& flagTable, uint16_t row, uint8_t& flag
             if (!label.size()) {
                 label = fmt::format("0x{:02X} ({})", flagIndex, flagIndex);
             }
-            ImGui::SetTooltip(label.c_str());
+            ImGui::SetTooltip("%s", label.c_str());
         }
         ImGui::PopStyleVar();
         PopStyleCheckbox();
@@ -1307,7 +1307,7 @@ void DrawFlagTableArray8Mask(const FlagTable& flagTable, uint16_t row, uint8_t& 
         if (ImGui::IsItemHovered()) {
             std::string label = WrappedText(flagEntry.description, 60).c_str();
             label += fmt::format("{}0x{:02X} ({})", label.size() ? "\n" : "", bitMask, flagIndex);
-            ImGui::SetTooltip(label.c_str());
+            ImGui::SetTooltip("%s", label.c_str());
         }
         ImGui::PopStyleVar();
         PopStyleCheckbox();

--- a/mm/2s2h/DeveloperTools/DLViewer.cpp
+++ b/mm/2s2h/DeveloperTools/DLViewer.cpp
@@ -343,7 +343,7 @@ void DrawColorEditor(uint8_t& r, uint8_t& g, uint8_t& b, uint8_t& a, const std::
         }
 
         ImGui::SameLine();
-        ImGui::Text(letter);
+        ImGui::Text("%s", letter);
         ImGui::SameLine();
     };
 

--- a/mm/2s2h/DeveloperTools/SaveEditor.cpp
+++ b/mm/2s2h/DeveloperTools/SaveEditor.cpp
@@ -2318,7 +2318,7 @@ void DrawRandoTab() {
         ImGui::TableNextColumn();
         ImGui::TextColored(randoSaveCheck.obtained ? UIWidgets::ColorValues.at(UIWidgets::Colors::Green)
                                                    : UIWidgets::ColorValues.at(UIWidgets::Colors::White),
-                           randoStaticCheck.name);
+                           "%s", randoStaticCheck.name);
         ImGui::TableNextColumn();
         UIWidgets::ComboboxWithSearch((hiddenName + "reward").c_str(), &randoSaveCheck.randoItemId,
                                       &randoItemIdComboboxMap, { .labelPosition = UIWidgets::LabelPosition::None });

--- a/mm/2s2h/Enhancements/Trackers/ItemTracker/ItemTracker.cpp
+++ b/mm/2s2h/Enhancements/Trackers/ItemTracker/ItemTracker.cpp
@@ -275,7 +275,7 @@ void DrawItemCounts(TrackerItemType itemType, u32 itemId, ImVec2 textureSize, fl
         ImVec2(currentPos.x + textureSize.x - textSize.x - 2.0f, currentPos.y + textureSize.y - textSize.y - 2.0f);
     ImGui::SetCursorPos(textPos);
     ImGui::SetWindowFontScale(scale);
-    ImGui::Text(itemCount.c_str());
+    ImGui::Text("%s", itemCount.c_str());
 }
 
 bool DrawItemTrackerSlot(TrackerItemType itemType, u32 itemId, float scale, bool clickable) {

--- a/mm/2s2h/Enhancements/Trackers/TimeSplits/Timesplits.cpp
+++ b/mm/2s2h/Enhancements/Trackers/TimeSplits/Timesplits.cpp
@@ -139,7 +139,7 @@ void TableCellCenteredText(ImVec4 color, const char* text) {
     float textHeight = ImGui::GetTextLineHeight();
     float offsetY = (32.0f - textHeight + 10.0f) * 0.5f;
     ImGui::SetCursorPosY(ImGui::GetCursorPosY() + offsetY);
-    ImGui::TextColored(color, text);
+    ImGui::TextColored(color, "%s", text);
 }
 
 void SplitsPushImageButtonStyle() {
@@ -227,6 +227,7 @@ void DrawSplitsList(bool isMain) {
                     : i < comparisonList.size()
                         ? ImGui::TextColored(
                               GetComparisonTimeTextDisplay(splitList[i], comparisonList[i]).colorDisplay,
+                              "%s",
                               Ship_FormatTimeDisplay(
                                   GetComparisonTimeTextDisplay(splitList[i], comparisonList[i]).timeDisplay)
                                   .c_str())
@@ -237,7 +238,7 @@ void DrawSplitsList(bool isMain) {
                 ImGui::TableNextColumn();
                 TableCellCenteredText(COLOR_WHITE, Ship_FormatTimeDisplay(splitList[i].splitPreviousBest).c_str());
                 if (CVarGetInteger("gSettings.TimeSplits.Compare", 0) && comparisonList.size() != 0) {
-                    ImGui::TextColored(COLOR_GREY,
+                    ImGui::TextColored(COLOR_GREY, "%s",
                                        i < comparisonList.size()
                                            ? Ship_FormatTimeDisplay(comparisonList[i].splitPreviousBest).c_str()
                                            : "No Data");

--- a/mm/2s2h/Enhancements/Trackers/TimeSplits/Timesplits.cpp
+++ b/mm/2s2h/Enhancements/Trackers/TimeSplits/Timesplits.cpp
@@ -226,8 +226,7 @@ void DrawSplitsList(bool isMain) {
                     !gPlayState ? ImGui::TextColored(COLOR_WHITE, BLANK_SPLIT)
                     : i < comparisonList.size()
                         ? ImGui::TextColored(
-                              GetComparisonTimeTextDisplay(splitList[i], comparisonList[i]).colorDisplay,
-                              "%s",
+                              GetComparisonTimeTextDisplay(splitList[i], comparisonList[i]).colorDisplay, "%s",
                               Ship_FormatTimeDisplay(
                                   GetComparisonTimeTextDisplay(splitList[i], comparisonList[i]).timeDisplay)
                                   .c_str())


### PR DESCRIPTION
When compiling SoH on NixOS, my compiler `clang` was failing due to not formatting strings before printing. This PR fixes that.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/6413380109.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/6413220399.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/6413047742.zip)
<!--- section:artifacts:end -->