### PR TITLE
[RANDO] Seed gen fix + commented out trick connection

### DIFF
--- a/mm/2s2h/Rando/Logic/Regions/GreatBayTemple.cpp
+++ b/mm/2s2h/Rando/Logic/Regions/GreatBayTemple.cpp
@@ -117,7 +117,7 @@ static RegisterShipInitFunc initFunc([]() {
         },
         .connections = {
             CONNECTION(RR_GREAT_BAY_TEMPLE_BABA_CHEST_ROOM,                   true),
-            CONNECTION(RR_GREAT_BAY_TEMPLE_COMPASS_ROOM_WITH_BOSS_KEY_CHEST,  CAN_BE_ZORA && CAN_USE_MAGIC_ARROW(ICE)), // TODO : Decide if this should be considered a trick
+            //CONNECTION(RR_GREAT_BAY_TEMPLE_COMPASS_ROOM_WITH_BOSS_KEY_CHEST,  CAN_BE_ZORA && CAN_USE_MAGIC_ARROW(ICE)), // Implement as trick later.
             CONNECTION(RR_GREAT_BAY_TEMPLE_GEKKO,                             CAN_USE_MAGIC_ARROW(ICE) && CAN_USE_MAGIC_ARROW(FIRE)),
             CONNECTION(RR_GREAT_BAY_TEMPLE_COMPASS_ROOM_TUNNEL, CAN_USE_ABILITY(SWIM))
         },

--- a/mm/2s2h/Rando/Logic/Regions/South.cpp
+++ b/mm/2s2h/Rando/Logic/Regions/South.cpp
@@ -150,6 +150,7 @@ static RegisterShipInitFunc initFunc([]() {
         },
         .connections = {
             CONNECTION(RR_DEKU_PALACE_OUTSIDE, CanKillEnemy(ACTOR_EN_DEKUNUTS) && CAN_BE_DEKU),
+            CONNECTION(RR_DEKU_PALACE_INSIDE_UPPER_MIDDLE, CanKillEnemy(ACTOR_EN_DEKUNUTS) && CAN_BE_DEKU),
             CONNECTION(RR_DEKU_PALACE_INSIDE_LOWER, true),
         }
     };


### PR DESCRIPTION
Deku palace was missing a connection causing failed seed gen.

And Boss Key connection in GBT was left over when it was intended to be done as a trick(my bad) Commented it out for now until trick menu is implemented.

Also found another issue related to Day 1 Under the RR_BENEATH_THE_GRAVEYARD_NIGHT_1_GRAVE and some Ranch checks but have not isolated them yet, if I find a fix ill include it in another PR.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/6676017540.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/6675080114.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/6675010154.zip)
<!--- section:artifacts:end -->