### PR TITLE
Changed bomb arrow HUD visual

### DIFF
--- a/mm/2s2h/Enhancements/Equipment/ArrowCycle.cpp
+++ b/mm/2s2h/Enhancements/Equipment/ArrowCycle.cpp
@@ -326,6 +326,11 @@ void ArrowCycleMain() {
             Magic_Add(gPlayState, sMagicArrowCosts[ARROW_GET_MAGIC_FROM_TYPE(heldArrow->actor.params)]);
         }
 
+        // If the held arrow has a bomb attached, then we should return the bomb.
+        if (IsBombArrowButton(player)) {
+            Inventory_ChangeAmmo(ITEM_BOMB, 1);
+        }
+
         CycleToNextArrow(gPlayState, player);
         // Track that we just cycled for 2 frames to prevent held R input from triggering the shield action when in
         // Z-Target mode as the arrow is respawned (Player_UpperAction_8)

--- a/mm/2s2h/Enhancements/Equipment/ArrowCycle.cpp
+++ b/mm/2s2h/Enhancements/Equipment/ArrowCycle.cpp
@@ -326,11 +326,6 @@ void ArrowCycleMain() {
             Magic_Add(gPlayState, sMagicArrowCosts[ARROW_GET_MAGIC_FROM_TYPE(heldArrow->actor.params)]);
         }
 
-        // If the held arrow has a bomb attached, then we should return the bomb.
-        if (IsBombArrowButton(player)) {
-            Inventory_ChangeAmmo(ITEM_BOMB, 1);
-        }
-
         CycleToNextArrow(gPlayState, player);
         // Track that we just cycled for 2 frames to prevent held R input from triggering the shield action when in
         // Z-Target mode as the arrow is respawned (Player_UpperAction_8)

--- a/mm/2s2h/Enhancements/Equipment/BombArrows.cpp
+++ b/mm/2s2h/Enhancements/Equipment/BombArrows.cpp
@@ -519,7 +519,7 @@ static void HandleEquipCleanup(PauseContext* pauseCtx) {
     }
 }
 
-static void DrawBombArrowAmmoCount(PlayState* play, s16 button, s16 alpha, bool isDpad) {
+static void DrawBombArrowAmmoCount(PlayState* play, s16 button, s16 alpha, bool isDpad, bool has_bombs) {
     if (!IsBombArrowButton(button, isDpad)) {
         return;
     }
@@ -531,9 +531,17 @@ static void DrawBombArrowAmmoCount(PlayState* play, s16 button, s16 alpha, bool 
 
     s16 effectiveAmmo = (arrows < bombs) ? arrows : bombs;
     s16 effectiveMax = (maxArrows < maxBombs) ? maxArrows : maxBombs;
+    s16 ammo;
+    bool turnGreen;
 
-    s16 ammo = effectiveAmmo;
-    bool turnGreen = (effectiveAmmo == effectiveMax);
+    // When out of bombs displays arrow count instead
+    if (has_bombs) {
+        ammo = effectiveAmmo;
+        turnGreen = (effectiveAmmo == effectiveMax);
+    } else {
+        ammo = arrows;
+        turnGreen = (arrows == maxArrows);
+    }
 
     OPEN_DISPS(play->state.gfxCtx);
 
@@ -980,10 +988,16 @@ static void OnDrawHudAmmoCount(bool* should, va_list args) {
     s16 button = (s16)va_arg(args, int);
     s16 alpha = (s16)va_arg(args, int);
     bool isDpad = (bool)va_arg(args, int);
+    bool has_bombs = (AMMO(ITEM_BOMB) > 0);
 
     if (IsBombArrowButton(button, isDpad)) {
         *should = false;
-        DrawBombArrowAmmoCount(gPlayState, button, alpha, isDpad);
+        DrawBombArrowAmmoCount(gPlayState, button, alpha, isDpad, has_bombs);
+
+        // When bombs is 0, reduce alpha for bomb texture.
+        if (!has_bombs) {
+            alpha /= 2;
+        }
 
         // Draw the bomb overlay here so it shares the same render order as the C/D-button icons.
         if (isDpad) {


### PR DESCRIPTION
Was also gonna try to fix the issue where bombs are consumed on cycling but figured it made sense to do it separately.

When out of bombs...

1. The bomb texture is now transparent. (Whatever alpha value it would display as is halved)

2. It will display the arrow count instead, while accounting for the arrows being maxed(Green text)

Pause menu display is unaltered.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/6880489462.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/6880300236.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/6880129433.zip)
<!--- section:artifacts:end -->