### PR TITLE
[Fix] Timer Mode Resetting After Restart

### DIFF
--- a/mm/2s2h/BenGui/BenGui.cpp
+++ b/mm/2s2h/BenGui/BenGui.cpp
@@ -154,6 +154,7 @@ void SetupGuiElements() {
                                                                              "Item Tracker Settings", ImVec2(800, 400));
     gui->AddGuiWindow(mItemTrackerSettingsWindow);
 
+    DisplayOverlay_Init();
     mDisplayOverlayWindow = std::make_shared<DisplayOverlayWindow>("gWindows.DisplayOverlay", "Display Overlay");
     gui->AddGuiWindow(mDisplayOverlayWindow);
 
@@ -220,6 +221,19 @@ void Destroy() {
 void RegisterPopup(std::string title, std::string message, std::string button1, std::string button2,
                    std::function<void()> button1callback, std::function<void()> button2callback) {
     mModalWindow->RegisterPopup(title, message, button1, button2, button1callback, button2callback);
+}
+
+void SetDisplayOverlayVisibility(bool visible) {
+    if (mDisplayOverlayWindow != nullptr) {
+        if (visible) {
+            mDisplayOverlayWindow->Show();
+        } else {
+            mDisplayOverlayWindow->Hide();
+        }
+    } else {
+        CVarSetInteger("gWindows.DisplayOverlay", visible ? 1 : 0);
+    }
+    Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
 }
 
 } // namespace BenGui

--- a/mm/2s2h/BenGui/BenGui.cpp
+++ b/mm/2s2h/BenGui/BenGui.cpp
@@ -154,7 +154,6 @@ void SetupGuiElements() {
                                                                              "Item Tracker Settings", ImVec2(800, 400));
     gui->AddGuiWindow(mItemTrackerSettingsWindow);
 
-    DisplayOverlay_Init();
     mDisplayOverlayWindow = std::make_shared<DisplayOverlayWindow>("gWindows.DisplayOverlay", "Display Overlay");
     gui->AddGuiWindow(mDisplayOverlayWindow);
 

--- a/mm/2s2h/BenGui/BenGui.hpp
+++ b/mm/2s2h/BenGui/BenGui.hpp
@@ -11,6 +11,7 @@ namespace BenGui {
     void Draw();
     void Destroy();
     UIWidgets::Colors GetMenuThemeColor();
+    void SetDisplayOverlayVisibility(bool visible);
 }
 
 #define THEME_COLOR BenGui::GetMenuThemeColor()

--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1,4 +1,5 @@
 #include "BenMenu.h"
+#include "BenGui.hpp"
 #include "UIWidgets.hpp"
 #include "BenPort.h"
 #include "BenInputEditorWindow.h"
@@ -9,6 +10,7 @@
 #include "2s2h/PresetManager/PresetManager.h"
 #include "HudEditor.h"
 #include "Notification.h"
+#include "2s2h/Enhancements/Trackers/DisplayOverlay.h"
 #include <variant>
 #include <ship/utils/StringHelper.h>
 #include <spdlog/fmt/fmt.h>
@@ -645,8 +647,12 @@ void BenMenu::AddSettings() {
     path.column = SECTION_COLUMN_2;
     AddWidget(path, "In-Game Timer", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Display", WIDGET_CVAR_COMBOBOX)
-        .CVar("gWindows.DisplayOverlay")
+        .CVar(CVAR_DISPLAY_OVERLAY_MODE)
         .WindowName("Display Overlay")
+        .Callback([](WidgetInfo& info) {
+            int mode = CVarGetInteger(CVAR_DISPLAY_OVERLAY_MODE, TIMER_DISPLAY_NONE);
+            SetDisplayOverlayVisibility(mode != TIMER_DISPLAY_NONE);
+        })
         .Options(
             ComboboxOptions()
                 .Tooltip(

--- a/mm/2s2h/Enhancements/Trackers/DisplayOverlay.cpp
+++ b/mm/2s2h/Enhancements/Trackers/DisplayOverlay.cpp
@@ -105,18 +105,3 @@ void DisplayOverlayWindow::Draw() {
 
 void DisplayOverlayWindow::InitElement() {
 }
-
-void DisplayOverlay_Init() {
-    if (CVarGetInteger(CVAR_DISPLAY_OVERLAY_MODE, -1) == -1) {
-        int oldVal = CVarGetInteger("gWindows.DisplayOverlay", 0);
-        // Map legacy overloaded CVar to new split CVars
-        if (oldVal == TIMER_DISPLAY_RTA || oldVal == TIMER_DISPLAY_IGT) {
-            CVarSetInteger(CVAR_DISPLAY_OVERLAY_MODE, oldVal);
-            CVarSetInteger("gWindows.DisplayOverlay", 1);
-        } else {
-            CVarSetInteger(CVAR_DISPLAY_OVERLAY_MODE, TIMER_DISPLAY_NONE);
-            CVarSetInteger("gWindows.DisplayOverlay", 0);
-        }
-        Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
-    }
-}

--- a/mm/2s2h/Enhancements/Trackers/DisplayOverlay.cpp
+++ b/mm/2s2h/Enhancements/Trackers/DisplayOverlay.cpp
@@ -43,10 +43,10 @@ void DrawInGameTimer(uint32_t timer, ImVec4 color = ImVec4(1, 1, 1, 1)) {
 }
 
 void DisplayOverlayWindow::Draw() {
-    if (!gPlayState) {
+    if (!IsVisible() || !gPlayState) {
         return;
     }
-    int displayOverlay = CVarGetInteger("gWindows.DisplayOverlay", 0);
+    int displayOverlay = CVarGetInteger(CVAR_DISPLAY_OVERLAY_MODE, 0);
     if (displayOverlay == TIMER_DISPLAY_NONE) {
         return;
     }
@@ -104,4 +104,19 @@ void DisplayOverlayWindow::Draw() {
 }
 
 void DisplayOverlayWindow::InitElement() {
+}
+
+void DisplayOverlay_Init() {
+    if (CVarGetInteger(CVAR_DISPLAY_OVERLAY_MODE, -1) == -1) {
+        int oldVal = CVarGetInteger("gWindows.DisplayOverlay", 0);
+        // Map legacy overloaded CVar to new split CVars
+        if (oldVal == TIMER_DISPLAY_RTA || oldVal == TIMER_DISPLAY_IGT) {
+            CVarSetInteger(CVAR_DISPLAY_OVERLAY_MODE, oldVal);
+            CVarSetInteger("gWindows.DisplayOverlay", 1);
+        } else {
+            CVarSetInteger(CVAR_DISPLAY_OVERLAY_MODE, TIMER_DISPLAY_NONE);
+            CVarSetInteger("gWindows.DisplayOverlay", 0);
+        }
+        Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
+    }
 }

--- a/mm/2s2h/Enhancements/Trackers/DisplayOverlay.h
+++ b/mm/2s2h/Enhancements/Trackers/DisplayOverlay.h
@@ -2,8 +2,6 @@
 
 #define CVAR_DISPLAY_OVERLAY_MODE "gDisplayOverlay.Mode"
 
-void DisplayOverlay_Init();
-
 void DisplayOverlayInitSettings();
 
 class DisplayOverlayWindow : public Ship::GuiWindow {

--- a/mm/2s2h/Enhancements/Trackers/DisplayOverlay.h
+++ b/mm/2s2h/Enhancements/Trackers/DisplayOverlay.h
@@ -1,5 +1,9 @@
 #include <ship/window/gui/GuiWindow.h>
 
+#define CVAR_DISPLAY_OVERLAY_MODE "gDisplayOverlay.Mode"
+
+void DisplayOverlay_Init();
+
 void DisplayOverlayInitSettings();
 
 class DisplayOverlayWindow : public Ship::GuiWindow {


### PR DESCRIPTION
Fixes the in-game timer option not sticking when set to In-Game Time.

The problem was that `gWindows.DisplayOverlay` was being used for two different things at the same time:

- whether the overlay window is visible
- which timer mode is selected

That worked fine for Off and Real-Time, but In-Game Time uses value `2`. Since the window visibility stuff treats that CVar like a bool, it would turn `2` into `1` on restart, which made the setting come back as Real-Time.

This splits the timer mode out into its own CVar:

- `gWindows.DisplayOverlay` = window visible/hidden
- `gDisplayOverlay.Mode` = Off / Real-Time / In-Game Time

~Also added a small migration for the old values so existing configs keep whatever timer option they had selected.~

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/6997070480.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/6996916898.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/6996735943.zip)
<!--- section:artifacts:end -->