### PR TITLE
Disable SFX replacement

### DIFF
--- a/mm/src/audio/sfx.c
+++ b/mm/src/audio/sfx.c
@@ -223,7 +223,9 @@ void AudioSfx_ProcessRequest(void) {
     if (req->sfxId == 0) {
         return;
     }
-    u16 newSfxId = AudioEditor_GetReplacementSeq(req->sfxId);
+    // All custom sequences use the same collection, which can result in collisions when different types (e.g. SFX and
+    // BGM) share the same IDs. As we do not yet shuffle SFX, simply do not get the replacement sequence for now.
+    u16 newSfxId = req->sfxId; // AudioEditor_GetReplacementSeq(req->sfxId);
     if (req->sfxId != newSfxId) {
         gAudioCtx.seqReplaced[SEQ_PLAYER_SFX] = 1;
         req->sfxId = newSfxId;

--- a/mm/src/audio/sfx.c
+++ b/mm/src/audio/sfx.c
@@ -225,11 +225,11 @@ void AudioSfx_ProcessRequest(void) {
     }
     // All custom sequences use the same collection, which can result in collisions when different types (e.g. SFX and
     // BGM) share the same IDs. As we do not yet shuffle SFX, simply do not get the replacement sequence for now.
-    u16 newSfxId = req->sfxId; // AudioEditor_GetReplacementSeq(req->sfxId);
-    if (req->sfxId != newSfxId) {
-        gAudioCtx.seqReplaced[SEQ_PLAYER_SFX] = 1;
-        req->sfxId = newSfxId;
-    }
+    // u16 newSfxId = AudioEditor_GetReplacementSeq(req->sfxId);
+    // if (req->sfxId != newSfxId) {
+    //     gAudioCtx.seqReplaced[SEQ_PLAYER_SFX] = 1;
+    //     req->sfxId = newSfxId;
+    // }
     // #end region
     bankId = SFX_BANK(req->sfxId);
     channelCount = 0;


### PR DESCRIPTION
tl;dr the audio editor's sequence replacement does not differentiate between the types of audio. For example, the Tatl & Tael track and `NA_SE_PL_ARROW_CHARGE_FIRE` both have values of 0x7D, which results in fire arrows attempting to load another sequence when Tatl & Tael is modified. As we do not currently shuffle SFX, I simply commented out the replacement and added a note.

The long term fix, once we do shuffle SFX, may be to separate `mSequenceMap` the different types of sequence.

Fixes #1599

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7046975046.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7046394759.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7046343315.zip)
<!--- section:artifacts:end -->