### PR TITLE
fix stale SkelAnime cache on alt toggle

### DIFF
--- a/mm/2s2h/resource/type/Skeleton.cpp
+++ b/mm/2s2h/resource/type/Skeleton.cpp
@@ -23,24 +23,32 @@ size_t Skeleton::GetPointerSize() {
 std::vector<SkeletonPatchInfo> SkeletonPatcher::skeletons;
 
 void SkeletonPatcher::RegisterSkeleton(std::string& path, SkelAnime* skelAnime) {
-    SkeletonPatchInfo info;
-
-    info.skelAnime = skelAnime;
-
     static const std::string sOtr = "__OTR__";
 
     if (path.starts_with(sOtr)) {
         path = path.substr(sOtr.length());
     }
 
+    std::string vanillaSkeletonPath;
+
     // Determine if we're using an alternate skeleton
     if (path.starts_with(Ship::IResource::gAltAssetPrefix)) {
-        info.vanillaSkeletonPath = path.substr(Ship::IResource::gAltAssetPrefix.length(),
-                                               path.size() - Ship::IResource::gAltAssetPrefix.length());
+        vanillaSkeletonPath = path.substr(Ship::IResource::gAltAssetPrefix.length(),
+                                          path.size() - Ship::IResource::gAltAssetPrefix.length());
     } else {
-        info.vanillaSkeletonPath = path;
+        vanillaSkeletonPath = path;
     }
 
+    for (auto& skel : skeletons) {
+        if (skel.skelAnime == skelAnime) {
+            skel.vanillaSkeletonPath = vanillaSkeletonPath;
+            return;
+        }
+    }
+
+    SkeletonPatchInfo info;
+    info.skelAnime = skelAnime;
+    info.vanillaSkeletonPath = vanillaSkeletonPath;
     skeletons.push_back(info);
 }
 
@@ -52,7 +60,7 @@ void SkeletonPatcher::UnregisterSkeleton(SkelAnime* skelAnime) {
 
         if (skel.skelAnime == skelAnime) {
             skeletons.erase(skeletons.begin() + i);
-            break;
+            i--;
         }
     }
 }


### PR DESCRIPTION
skeleton oversight with #1623

when toggling mods on and off and switching forms, the game would load the model of the previous form over the current form which results in insanely cursed graphics, only way to fix was a hard reset of 2ship. this fixes that bug

footage of said bug:
<img width="400" height="225" alt="2026-05-14 01-14-22" src="https://github.com/user-attachments/assets/bd719084-b4c3-4350-bec1-413cf160d6da" />


<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/6988091488.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/6987985486.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/6987883291.zip)
<!--- section:artifacts:end -->