### PR TITLE
[Bug fix] Execute moon crash hooks during Oath to Order edge case

### DIFF
--- a/mm/src/code/z_parameter.c
+++ b/mm/src/code/z_parameter.c
@@ -8337,6 +8337,12 @@ void Interface_DrawTimers(PlayState* play) {
                     if (sTimerId == TIMER_ID_MOON_CRASH) {
                         gSaveContext.save.day = 4;
                         if ((play->sceneId == SCENE_OKUJOU) && (gSaveContext.sceneLayer == 3)) {
+                            // This is a moon crash edge case that only occurs if the player played Oath to Order
+                            // without saving the Four Giants. An extra cutscene plays in Termina Field before the
+                            // standard moon crash cutscene, and Interface_StartMoonCrash never gets called. Therefore,
+                            // we add an extra call here to execute the moon crash hooks.
+                            GameInteractor_ExecuteBeforeMoonCrash();
+
                             play->nextEntrance = ENTRANCE(TERMINA_FIELD, 1);
                             gSaveContext.nextCutsceneIndex = 0xFFF0;
                             play->transitionTrigger = TRANS_TRIGGER_START;


### PR DESCRIPTION
Closes #1626

There's an edge case of the timer running out on the Clock Tower rooftop, after playing the Oath to Order. The game bypasses the standard moon crash function call, which meant the hooks never get triggered. I fixed this by adding an execution call for the hooks at the beginning of that edge case.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7047411503.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7046894176.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7046870660.zip)
<!--- section:artifacts:end -->