### PR TITLE
[Enhancement] SoT does not reset Scarecrow's Song

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1212,6 +1212,9 @@ void BenMenu::AddEnhancements() {
         .CVar("gEnhancements.Cycle.DoNotResetChateau")
         .Options(CheckboxOptions().Tooltip(
             "Playing the Song of Time will not reset the infinite magic status granted by Chateau Romani."));
+    AddWidget(path, "Do not reset Scarecrow's Song", WIDGET_CVAR_CHECKBOX)
+        .CVar("gEnhancements.Cycle.DoNotResetScarecrowSong")
+        .Options(CheckboxOptions().Tooltip("Playing the Song of Time will not reset the Scarecrow's Song."));
     AddWidget(path, "Keep Express Mail", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Cycle.KeepExpressMail")
         .Options(CheckboxOptions().Tooltip(

--- a/mm/2s2h/Enhancements/Cycle/EndOfCycle.cpp
+++ b/mm/2s2h/Enhancements/Cycle/EndOfCycle.cpp
@@ -89,7 +89,7 @@ static RegisterShipInitFunc initFunc_Consumables(RegisterEndOfCycleSaveHook_Cons
 static void RegisterEndOfCycleSaveHook_Bottles() {
     COND_HOOK(AfterEndOfCycleSave, CVAR_BOTTLE, []() {
         int stolenBottles = (((saveInfoCopy.stolenItems & 0xFF000000) >> 0x18) == ITEM_BOTTLE) +
-            (((saveInfoCopy.stolenItems & 0x00FF0000) >> 0x10) == ITEM_BOTTLE);
+                            (((saveInfoCopy.stolenItems & 0x00FF0000) >> 0x10) == ITEM_BOTTLE);
 
         // Replace bottles back, accounting for any stolen bottles
         for (int i = SLOT_BOTTLE_1; i <= SLOT_BOTTLE_6; i++) {
@@ -124,9 +124,9 @@ static void RegisterEndOfCycleSaveHook_Sword() {
         // Check for razor sword equipped, stolen, or turned into the smithy
         if (curSword == EQUIP_VALUE_SWORD_RAZOR ||
             (curSword == EQUIP_VALUE_SWORD_NONE &&
-                ((saveInfoCopy.permanentSceneFlags[SCENE_KAJIYA].unk_14 & 4) ||
-                    (((saveInfoCopy.stolenItems & 0xFF000000) >> 0x18) == ITEM_SWORD_RAZOR) ||
-                    (((saveInfoCopy.stolenItems & 0x00FF0000) >> 0x10) == ITEM_SWORD_RAZOR)))) {
+             ((saveInfoCopy.permanentSceneFlags[SCENE_KAJIYA].unk_14 & 4) ||
+              (((saveInfoCopy.stolenItems & 0xFF000000) >> 0x18) == ITEM_SWORD_RAZOR) ||
+              (((saveInfoCopy.stolenItems & 0x00FF0000) >> 0x10) == ITEM_SWORD_RAZOR)))) {
 
             SET_EQUIP_VALUE(EQUIP_TYPE_SWORD, EQUIP_VALUE_SWORD_RAZOR);
             BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_B) = ITEM_SWORD_RAZOR;
@@ -145,7 +145,7 @@ static RegisterShipInitFunc initFunc_Time(RegisterEndOfCycleSaveHook_Time, { CVA
 static void RegisterEndOfCycleSaveHook_Chateau() {
     COND_HOOK(AfterEndOfCycleSave, CVAR_CHATEAU, []() {
         if (saveInfoCopy.weekEventReg[((WEEKEVENTREG_DRANK_CHATEAU_ROMANI) >> 8)] &
-            ((WEEKEVENTREG_DRANK_CHATEAU_ROMANI) & 0xFF)) {
+            ((WEEKEVENTREG_DRANK_CHATEAU_ROMANI)&0xFF)) {
             SET_WEEKEVENTREG(WEEKEVENTREG_DRANK_CHATEAU_ROMANI);
         }
     });
@@ -154,9 +154,8 @@ static void RegisterEndOfCycleSaveHook_Chateau() {
 static RegisterShipInitFunc initFunc_Chateau(RegisterEndOfCycleSaveHook_Chateau, { CVAR_NAME_CHATEAU });
 
 static void RegisterEndOfCycleSaveHook_ScarecrowSong() {
-    COND_HOOK(AfterEndOfCycleSave, CVAR_SCARECROW, []() {
-        gSaveContext.save.saveInfo.scarecrowSpawnSongSet = saveInfoCopy.scarecrowSpawnSongSet;
-    });
+    COND_HOOK(AfterEndOfCycleSave, CVAR_SCARECROW,
+              []() { gSaveContext.save.saveInfo.scarecrowSpawnSongSet = saveInfoCopy.scarecrowSpawnSongSet; });
 }
 
 static RegisterShipInitFunc initFunc_ScarecrowSong(RegisterEndOfCycleSaveHook_ScarecrowSong, { CVAR_NAME_SCARECROW });

--- a/mm/2s2h/Enhancements/Cycle/EndOfCycle.cpp
+++ b/mm/2s2h/Enhancements/Cycle/EndOfCycle.cpp
@@ -156,6 +156,13 @@ static RegisterShipInitFunc initFunc_Time(RegisterEndOfCycleSaveHook_Time, { CVA
 static void RegisterEndOfCycleSaveHook_ScarecrowSong() {
     COND_HOOK(AfterEndOfCycleSave, CVAR_SCARECROW,
               []() { gSaveContext.save.saveInfo.scarecrowSpawnSongSet = saveInfoCopy.scarecrowSpawnSongSet; });
+
+    COND_HOOK(OnSaveLoad, CVAR_SCARECROW, [](s16 fileNum) {
+        if (!gSaveContext.save.isOwlSave && gSaveContext.save.saveInfo.scarecrowSpawnSongSet) {
+            memcpy(gScarecrowSpawnSongPtr, gSaveContext.save.saveInfo.scarecrowSpawnSong,
+                   sizeof(gSaveContext.save.saveInfo.scarecrowSpawnSong));
+        }
+    });
 }
 
 static RegisterShipInitFunc initFunc_ScarecrowSong(RegisterEndOfCycleSaveHook_ScarecrowSong, { CVAR_NAME_SCARECROW });

--- a/mm/2s2h/Enhancements/Cycle/EndOfCycle.cpp
+++ b/mm/2s2h/Enhancements/Cycle/EndOfCycle.cpp
@@ -20,23 +20,33 @@ extern "C" {
 #define CVAR_TIME CVarGetInteger(CVAR_NAME_TIME, 0)
 #define CVAR_NAME_CHATEAU "gEnhancements.Cycle.DoNotResetChateau"
 #define CVAR_CHATEAU CVarGetInteger(CVAR_NAME_CHATEAU, 0)
+#define CVAR_NAME_SCARECROW "gEnhancements.Cycle.DoNotResetScarecrowSong"
+#define CVAR_SCARECROW CVarGetInteger(CVAR_NAME_SCARECROW, 0)
 
 SaveInfo saveInfoCopy;
 ShipSaveInfo shipSaveInfoCopy;
 s32 timeSpeedOffsetCopy = 0;
 
-void RegisterEndOfCycleSaveHooks() {
+static void RegisterBeforeEndOfCycleSaveHook() {
     COND_HOOK(BeforeEndOfCycleSave, true, []() {
         memcpy(&saveInfoCopy, &gSaveContext.save.saveInfo, sizeof(SaveInfo));
         memcpy(&shipSaveInfoCopy, &gSaveContext.save.shipSaveInfo, sizeof(ShipSaveInfo));
         timeSpeedOffsetCopy = gSaveContext.save.timeSpeedOffset;
     });
+}
 
+static RegisterShipInitFunc initFunc_Before(RegisterBeforeEndOfCycleSaveHook);
+
+static void RegisterEndOfCycleSaveHook_Rupees() {
     COND_HOOK(AfterEndOfCycleSave, CVAR_RUPEES, []() {
         gSaveContext.save.saveInfo.playerData.rupees = saveInfoCopy.playerData.rupees;
         CLEAR_EVENTINF(EVENTINF_THREEDAYRESET_LOST_RUPEES);
     });
+}
 
+static RegisterShipInitFunc initFunc_Rupees(RegisterEndOfCycleSaveHook_Rupees, { CVAR_NAME_RUPEES });
+
+static void RegisterEndOfCycleSaveHook_Consumables() {
     COND_HOOK(AfterEndOfCycleSave, CVAR_CONSUME, []() {
         if (INV_CONTENT(ITEM_BOMB) == ITEM_BOMB) {
             INV_CONTENT(ITEM_BOMB) = saveInfoCopy.inventory.items[ITEM_BOMB];
@@ -72,10 +82,14 @@ void RegisterEndOfCycleSaveHooks() {
         CLEAR_EVENTINF(EVENTINF_THREEDAYRESET_LOST_STICK_AMMO);
         CLEAR_EVENTINF(EVENTINF_THREEDAYRESET_LOST_ARROW_AMMO);
     });
+}
 
+static RegisterShipInitFunc initFunc_Consumables(RegisterEndOfCycleSaveHook_Consumables, { CVAR_NAME_CONSUME });
+
+static void RegisterEndOfCycleSaveHook_Bottles() {
     COND_HOOK(AfterEndOfCycleSave, CVAR_BOTTLE, []() {
         int stolenBottles = (((saveInfoCopy.stolenItems & 0xFF000000) >> 0x18) == ITEM_BOTTLE) +
-                            (((saveInfoCopy.stolenItems & 0x00FF0000) >> 0x10) == ITEM_BOTTLE);
+            (((saveInfoCopy.stolenItems & 0x00FF0000) >> 0x10) == ITEM_BOTTLE);
 
         // Replace bottles back, accounting for any stolen bottles
         for (int i = SLOT_BOTTLE_1; i <= SLOT_BOTTLE_6; i++) {
@@ -99,32 +113,50 @@ void RegisterEndOfCycleSaveHooks() {
             }
         }
     });
+}
 
-    COND_HOOK(AfterEndOfCycleSave, CVAR_CHATEAU, []() {
-        if (saveInfoCopy.weekEventReg[((WEEKEVENTREG_DRANK_CHATEAU_ROMANI) >> 8)] &
-            ((WEEKEVENTREG_DRANK_CHATEAU_ROMANI)&0xFF)) {
-            SET_WEEKEVENTREG(WEEKEVENTREG_DRANK_CHATEAU_ROMANI);
-        }
-    });
+static RegisterShipInitFunc initFunc_Bottles(RegisterEndOfCycleSaveHook_Bottles, { CVAR_NAME_BOTTLE });
 
+static void RegisterEndOfCycleSaveHook_Sword() {
     COND_HOOK(AfterEndOfCycleSave, CVAR_SWORD || IS_RANDO, []() {
         u8 curSword = (saveInfoCopy.equips.equipment & gEquipMasks[EQUIP_TYPE_SWORD]) >> gEquipShifts[EQUIP_TYPE_SWORD];
 
         // Check for razor sword equipped, stolen, or turned into the smithy
         if (curSword == EQUIP_VALUE_SWORD_RAZOR ||
             (curSword == EQUIP_VALUE_SWORD_NONE &&
-             ((saveInfoCopy.permanentSceneFlags[SCENE_KAJIYA].unk_14 & 4) ||
-              (((saveInfoCopy.stolenItems & 0xFF000000) >> 0x18) == ITEM_SWORD_RAZOR) ||
-              (((saveInfoCopy.stolenItems & 0x00FF0000) >> 0x10) == ITEM_SWORD_RAZOR)))) {
+                ((saveInfoCopy.permanentSceneFlags[SCENE_KAJIYA].unk_14 & 4) ||
+                    (((saveInfoCopy.stolenItems & 0xFF000000) >> 0x18) == ITEM_SWORD_RAZOR) ||
+                    (((saveInfoCopy.stolenItems & 0x00FF0000) >> 0x10) == ITEM_SWORD_RAZOR)))) {
 
             SET_EQUIP_VALUE(EQUIP_TYPE_SWORD, EQUIP_VALUE_SWORD_RAZOR);
             BUTTON_ITEM_EQUIP(0, EQUIP_SLOT_B) = ITEM_SWORD_RAZOR;
         }
     });
+}
 
+static RegisterShipInitFunc initFunc_Sword(RegisterEndOfCycleSaveHook_Sword, { CVAR_NAME_SWORD, "IS_RANDO" });
+
+static void RegisterEndOfCycleSaveHook_Time() {
     COND_HOOK(AfterEndOfCycleSave, CVAR_TIME, []() { gSaveContext.save.timeSpeedOffset = timeSpeedOffsetCopy; });
 }
 
-static RegisterShipInitFunc initFunc(RegisterEndOfCycleSaveHooks,
-                                     { CVAR_NAME_RUPEES, CVAR_NAME_CONSUME, CVAR_NAME_BOTTLE, CVAR_NAME_SWORD,
-                                       CVAR_NAME_TIME, CVAR_NAME_CHATEAU, "IS_RANDO" });
+static RegisterShipInitFunc initFunc_Time(RegisterEndOfCycleSaveHook_Time, { CVAR_NAME_TIME });
+
+static void RegisterEndOfCycleSaveHook_Chateau() {
+    COND_HOOK(AfterEndOfCycleSave, CVAR_CHATEAU, []() {
+        if (saveInfoCopy.weekEventReg[((WEEKEVENTREG_DRANK_CHATEAU_ROMANI) >> 8)] &
+            ((WEEKEVENTREG_DRANK_CHATEAU_ROMANI) & 0xFF)) {
+            SET_WEEKEVENTREG(WEEKEVENTREG_DRANK_CHATEAU_ROMANI);
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc_Chateau(RegisterEndOfCycleSaveHook_Chateau, { CVAR_NAME_CHATEAU });
+
+static void RegisterEndOfCycleSaveHook_ScarecrowSong() {
+    COND_HOOK(AfterEndOfCycleSave, CVAR_SCARECROW, []() {
+        gSaveContext.save.saveInfo.scarecrowSpawnSongSet = saveInfoCopy.scarecrowSpawnSongSet;
+    });
+}
+
+static RegisterShipInitFunc initFunc_ScarecrowSong(RegisterEndOfCycleSaveHook_ScarecrowSong, { CVAR_NAME_SCARECROW });

--- a/mm/2s2h/Enhancements/Cycle/EndOfCycle.cpp
+++ b/mm/2s2h/Enhancements/Cycle/EndOfCycle.cpp
@@ -117,6 +117,17 @@ static void RegisterEndOfCycleSaveHook_Bottles() {
 
 static RegisterShipInitFunc initFunc_Bottles(RegisterEndOfCycleSaveHook_Bottles, { CVAR_NAME_BOTTLE });
 
+static void RegisterEndOfCycleSaveHook_Chateau() {
+    COND_HOOK(AfterEndOfCycleSave, CVAR_CHATEAU, []() {
+        if (saveInfoCopy.weekEventReg[((WEEKEVENTREG_DRANK_CHATEAU_ROMANI) >> 8)] &
+            ((WEEKEVENTREG_DRANK_CHATEAU_ROMANI)&0xFF)) {
+            SET_WEEKEVENTREG(WEEKEVENTREG_DRANK_CHATEAU_ROMANI);
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc_Chateau(RegisterEndOfCycleSaveHook_Chateau, { CVAR_NAME_CHATEAU });
+
 static void RegisterEndOfCycleSaveHook_Sword() {
     COND_HOOK(AfterEndOfCycleSave, CVAR_SWORD || IS_RANDO, []() {
         u8 curSword = (saveInfoCopy.equips.equipment & gEquipMasks[EQUIP_TYPE_SWORD]) >> gEquipShifts[EQUIP_TYPE_SWORD];
@@ -141,17 +152,6 @@ static void RegisterEndOfCycleSaveHook_Time() {
 }
 
 static RegisterShipInitFunc initFunc_Time(RegisterEndOfCycleSaveHook_Time, { CVAR_NAME_TIME });
-
-static void RegisterEndOfCycleSaveHook_Chateau() {
-    COND_HOOK(AfterEndOfCycleSave, CVAR_CHATEAU, []() {
-        if (saveInfoCopy.weekEventReg[((WEEKEVENTREG_DRANK_CHATEAU_ROMANI) >> 8)] &
-            ((WEEKEVENTREG_DRANK_CHATEAU_ROMANI)&0xFF)) {
-            SET_WEEKEVENTREG(WEEKEVENTREG_DRANK_CHATEAU_ROMANI);
-        }
-    });
-}
-
-static RegisterShipInitFunc initFunc_Chateau(RegisterEndOfCycleSaveHook_Chateau, { CVAR_NAME_CHATEAU });
 
 static void RegisterEndOfCycleSaveHook_ScarecrowSong() {
     COND_HOOK(AfterEndOfCycleSave, CVAR_SCARECROW,


### PR DESCRIPTION
Closes out the first half of discussion #684 (the second half is already done).

I also split up all the EoC Save hooks by the appropriate setting so that one change doesn't reevaluate all of them.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7038277374.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7038250149.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7038186257.zip)
<!--- section:artifacts:end -->