### PR TITLE
[Fix] Song Items Softlock

### DIFF
--- a/mm/2s2h/Enhancements/Songs/SongItems.cpp
+++ b/mm/2s2h/Enhancements/Songs/SongItems.cpp
@@ -6,10 +6,15 @@
 extern "C" {
 #include "archives/icon_item_static/icon_item_static_yar.h"
 #include "interface/parameter_static/parameter_static.h"
+#include "overlays/actors/ovl_En_Gs/z_en_gs.h"
 extern s16 sEquipState;
 extern s16 sEquipAnimTimer;
+extern PlayerAnimationHeader* D_8085D17C[];
 char* ResourceMgr_LoadTexOrDListByName(const char* filePath);
 void Message_ResetOcarinaButtonAlphas(void);
+void func_80836A5C(Player* player, PlayState* play);
+void Player_Anim_PlayOnceAdjustedReverse(PlayState* play, Player* player, PlayerAnimationHeader* anim);
+void Player_Action_63(Player* player, PlayState* play);
 }
 
 #define CVAR_NAME "gEnhancements.Songs.SongItems"
@@ -305,6 +310,48 @@ static void HandleSongEquip(PauseContext* pauseCtx) {
     Audio_PlaySfx(NA_SE_SY_DECIDE);
 }
 
+// Mirrors Player_Action_63 OCARINA_MODE_END teardown
+static void FinishOcarinaPlay(PlayState* play) {
+    Player* player = GET_PLAYER(play);
+
+    sPendingAutoPlaySong = 0xFF;
+    sHideOcarinaStaff = false;
+    Message_ResetOcarinaButtonAlphas();
+
+    AudioOcarina_SetInstrument(OCARINA_INSTRUMENT_OFF);
+    play->interfaceCtx.bButtonInterfaceDoActionActive = false;
+    CutsceneManager_Stop(play->playerCsIds[PLAYER_CS_ID_ITEM_OCARINA]);
+    player->actor.flags &= ~ACTOR_FLAG_OCARINA_INTERACTION;
+    if (player->ocarinaInteractionActor != NULL) {
+        player->ocarinaInteractionActor->flags &= ~ACTOR_FLAG_OCARINA_INTERACTION;
+    }
+    player->stateFlags2 &= ~PLAYER_STATE2_USING_OCARINA;
+    player->cv.haltActorsDuringCsAction = false;
+    player->csAction = PLAYER_CSACTION_NONE;
+    Message_CloseTextbox(play);
+    play->msgCtx.ocarinaMode = OCARINA_MODE_NONE;
+
+    if (player->actionFunc == Player_Action_63) {
+        player->av2.actionVar2 = 1;
+        func_80836A5C(player, play);
+        Player_Anim_PlayOnceAdjustedReverse(play, player, D_8085D17C[player->transformation]);
+    }
+}
+
+static bool NeedsOcarinaCleanup(EnGs* enGs, PlayState* play) {
+    Player* player = GET_PLAYER(play);
+
+    bool stoneInvolved = (enGs->unk_19A & 0x200) || (player->ocarinaInteractionActor == &enGs->actor);
+
+    if (!stoneInvolved) {
+        return false;
+    }
+
+    return (player->actor.flags & ACTOR_FLAG_OCARINA_INTERACTION) ||
+           (player->stateFlags2 & PLAYER_STATE2_USING_OCARINA) || (play->msgCtx.ocarinaMode != OCARINA_MODE_NONE) ||
+           (player->actionFunc == Player_Action_63);
+}
+
 static void RegisterSongItems() {
     InitSongIcons();
 
@@ -469,6 +516,24 @@ static void RegisterSongItems() {
     COND_VB_SHOULD(VB_DRAW_OCARINA_STAFF, CVAR, {
         if (sHideOcarinaStaff) {
             *should = false;
+        }
+    });
+
+    COND_VB_SHOULD(VB_EN_GS_BEFORE_GOSSIP_GROTTO_SEQUENCE, CVAR, {
+        EnGs* enGs = va_arg(args, EnGs*);
+        PlayState* play = va_arg(args, PlayState*);
+
+        if (NeedsOcarinaCleanup(enGs, play)) {
+            FinishOcarinaPlay(play);
+        }
+    });
+
+    COND_VB_SHOULD(VB_EN_GS_FINISH_OCARINA_ON_RESET, CVAR, {
+        EnGs* enGs = va_arg(args, EnGs*);
+        PlayState* play = va_arg(args, PlayState*);
+
+        if (NeedsOcarinaCleanup(enGs, play)) {
+            FinishOcarinaPlay(play);
         }
     });
 

--- a/mm/2s2h/GameInteractor/GameInteractor_VanillaBehavior.h
+++ b/mm/2s2h/GameInteractor/GameInteractor_VanillaBehavior.h
@@ -734,6 +734,24 @@ typedef enum {
 
     // #### `result`
     // ```c
+    // true
+    // ```
+    // #### `args`
+    // - `*EnGs`
+    // - `*PlayState`
+    VB_EN_GS_BEFORE_GOSSIP_GROTTO_SEQUENCE,
+
+    // #### `result`
+    // ```c
+    // true
+    // ```
+    // #### `args`
+    // - `*EnGs`
+    // - `*PlayState`
+    VB_EN_GS_FINISH_OCARINA_ON_RESET,
+
+    // #### `result`
+    // ```c
     // itemAction == GET_IA_FROM_MASK(this->currentMask)
     // ```
     // #### `args`

--- a/mm/src/overlays/actors/ovl_En_Gs/z_en_gs.c
+++ b/mm/src/overlays/actors/ovl_En_Gs/z_en_gs.c
@@ -178,6 +178,7 @@ void EnGs_Destroy(Actor* thisx, PlayState* play) {
 }
 
 void func_80997D14(EnGs* this, PlayState* play) {
+    GameInteractor_Should(VB_EN_GS_FINISH_OCARINA_ON_RESET, true, this, play);
     this->unk_19A &= ~0x200;
     this->actionFunc = func_80997D38;
 }
@@ -378,6 +379,7 @@ f32 func_80998334(EnGs* this, PlayState* play, f32* arg2, f32* arg3, s16* arg4, 
 }
 
 void func_809984F4(EnGs* this, PlayState* play) {
+    GameInteractor_Should(VB_EN_GS_BEFORE_GOSSIP_GROTTO_SEQUENCE, true, this, play);
     EnGs* gossipStone = NULL;
 
     do {


### PR DESCRIPTION
Resolved #1639

tl;dr
Song Items lifecycle clashes with `En_Gs`’s grotto flow (`func_809984F4` / `func_809985B8`). This hooks gossip stone reset and sequence entry and does the proper `Player_Action_63` cleanup that for whatever reason it only does for Elegy.


<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7038771337.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7038728329.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7038694181.zip)
<!--- section:artifacts:end -->