### PR TITLE
[Fix] Don't Consume Bombs During Arrow Cycle

### DIFF
--- a/mm/2s2h/Enhancements/Equipment/ArrowCycle.cpp
+++ b/mm/2s2h/Enhancements/Equipment/ArrowCycle.cpp
@@ -286,6 +286,7 @@ static void CycleToNextArrow(PlayState* play, Player* player) {
             Actor_Kill(arrow->actor.child);
         }
 
+        // Killing the held arrow while parent is still set does not consume bomb-arrow ammo
         Actor_Kill(&arrow->actor);
     }
 

--- a/mm/2s2h/Enhancements/Equipment/BombArrows.cpp
+++ b/mm/2s2h/Enhancements/Equipment/BombArrows.cpp
@@ -32,6 +32,7 @@ struct BombArrowData {
     f32 flashBrightness = 0.0f;
     s16 timer = 70;
     s16 flashSpeedScale = 7;
+    bool bombConsumed = false;
 };
 
 static ObjectExtension::Register<BombArrowData> BombArrowDataRegister;
@@ -665,6 +666,76 @@ static void DrawBombArrowOverlayDpad(PlayState* play, DpadEquipSlot slot, s16 al
     CLOSE_DISPS(play->state.gfxCtx);
 }
 
+static void TryConsumeBombAmmo(BombArrowData* data) {
+    if (data == nullptr || data->bombConsumed || (AMMO(ITEM_BOMB) <= 0)) {
+        return;
+    }
+
+    Inventory_ChangeAmmo(ITEM_BOMB, -1);
+    data->bombConsumed = true;
+}
+
+// Mirrors func_80831194 ammo consumption; do not call func_80831194 here (detaches the actor).
+static void TryConsumeArrowOnHeldExpiry(PlayState* play, Player* player) {
+    if (player == nullptr || player->transformation == PLAYER_FORM_DEKU || (player->stateFlags3 & PLAYER_STATE3_400)) {
+        return;
+    }
+
+    if (gSaveContext.minigameStatus == MINIGAME_STATUS_ACTIVE) {
+        if ((play->sceneId != SCENE_SYATEKI_MIZU) && (play->sceneId != SCENE_F01) &&
+            (play->sceneId != SCENE_SYATEKI_MORI)) {
+            play->interfaceCtx.minigameAmmo--;
+        }
+    } else if (play->bButtonAmmoPlusOne != 0) {
+        play->bButtonAmmoPlusOne--;
+    } else {
+        Inventory_ChangeAmmo(ITEM_BOW, -1);
+    }
+
+    if (play->bButtonAmmoPlusOne == 1) {
+        play->bButtonAmmoPlusOne = -10;
+    }
+}
+
+static void BombArrowDetonate(EnArrow* arrow, BombArrowData* data) {
+    if (!data->bombConsumed) {
+        if (arrow->actor.child != NULL) {
+            Actor_Kill(arrow->actor.child);
+        }
+        Actor_Kill(&arrow->actor);
+        return;
+    }
+
+    EnBom* bomb = (EnBom*)Actor_Spawn(&gPlayState->actorCtx, gPlayState, ACTOR_EN_BOM, arrow->actor.world.pos.x,
+                                      arrow->actor.world.pos.y, arrow->actor.world.pos.z, 0, 0, 0, BOMB_TYPE_BODY);
+    if (bomb != NULL) {
+        bomb->timer = 0;
+    }
+
+    if (arrow->actor.child != NULL) {
+        Actor_Kill(arrow->actor.child);
+    }
+
+    Actor_Kill(&arrow->actor);
+}
+
+static void OnPlayerReleaseHeldActor(PlayState* play, Player* player, Actor* heldActor) {
+    if (heldActor == nullptr || heldActor->id != ACTOR_EN_ARROW) {
+        return;
+    }
+
+    EnArrow* arrow = (EnArrow*)heldActor;
+
+    if (!BOMB_ARROW_IS_SET(arrow) || !ARROW_IS_ARROW(arrow->actor.params)) {
+        return;
+    }
+
+    auto data = ObjectExtension::GetInstance().Get<BombArrowData>(heldActor);
+    if (data != nullptr) {
+        TryConsumeBombAmmo(data);
+    }
+}
+
 static void UpdateBombArrowFlash(PlayState* play, BombArrowData* data) {
     if (data == nullptr) {
         return;
@@ -721,7 +792,6 @@ static void OnBombArrowInit(Actor* actor) {
     }
 
     BOMB_ARROW_SET(arrow);
-    Inventory_ChangeAmmo(ITEM_BOMB, -1);
 
     BombArrowData data;
 
@@ -778,17 +848,11 @@ static void OnBombArrowUpdate(Actor* actor) {
     }
 
     if (data->timer <= 0) {
-        EnBom* bomb = (EnBom*)Actor_Spawn(&gPlayState->actorCtx, gPlayState, ACTOR_EN_BOM, arrow->actor.world.pos.x,
-                                          arrow->actor.world.pos.y, arrow->actor.world.pos.z, 0, 0, 0, BOMB_TYPE_BODY);
-        if (bomb != NULL) {
-            bomb->timer = 0;
+        if (actor->parent != NULL) {
+            TryConsumeArrowOnHeldExpiry(gPlayState, GET_PLAYER(gPlayState));
         }
-
-        if (arrow->actor.child != NULL) {
-            Actor_Kill(arrow->actor.child);
-        }
-
-        Actor_Kill(&arrow->actor);
+        TryConsumeBombAmmo(data);
+        BombArrowDetonate(arrow, data);
         return;
     }
 
@@ -827,17 +891,8 @@ static void OnBombArrowUpdate(Actor* actor) {
         return;
     }
 
-    EnBom* bomb = (EnBom*)Actor_Spawn(&gPlayState->actorCtx, gPlayState, ACTOR_EN_BOM, arrow->actor.world.pos.x,
-                                      arrow->actor.world.pos.y, arrow->actor.world.pos.z, 0, 0, 0, BOMB_TYPE_BODY);
-    if (bomb != NULL) {
-        bomb->timer = 0;
-    }
-
-    if (arrow->actor.child != NULL) {
-        Actor_Kill(arrow->actor.child);
-    }
-
-    Actor_Kill(&arrow->actor);
+    TryConsumeBombAmmo(data);
+    BombArrowDetonate(arrow, data);
 }
 
 static void OnBombArrowDraw(Actor* actor) {
@@ -1108,6 +1163,7 @@ static void OnKaleidoUpdate(PauseContext* pauseCtx) {
 
 static void RegisterBombArrows() {
     COND_HOOK(OnKaleidoUpdate, CVAR, OnKaleidoUpdate);
+    COND_HOOK(OnPlayerReleaseHeldActor, CVAR, OnPlayerReleaseHeldActor);
 
     COND_ID_HOOK(AfterKaleidoDrawPage, PAUSE_ITEM, CVAR, OnAfterKaleidoDrawPage);
     COND_ID_HOOK(BeforeKaleidoDrawPage, PAUSE_ITEM, CVAR, OnBeforeKaleidoDrawPage);

--- a/mm/2s2h/GameInteractor/GameInteractor.cpp
+++ b/mm/2s2h/GameInteractor/GameInteractor.cpp
@@ -184,6 +184,11 @@ void GameInteractor_ExecuteOnPlayerPostLimbDraw(Player* player, s32 limbIndex) {
     GameInteractor::Instance->ExecuteHooksForFilter<GameInteractor::OnPlayerPostLimbDraw>(player, limbIndex);
 }
 
+void GameInteractor_ExecuteOnPlayerReleaseHeldActor(PlayState* play, Player* player, Actor* heldActor) {
+    GameInteractor::Instance->ExecuteHooks<GameInteractor::OnPlayerReleaseHeldActor>(play, player, heldActor);
+    GameInteractor::Instance->ExecuteHooksForFilter<GameInteractor::OnPlayerReleaseHeldActor>(play, player, heldActor);
+}
+
 void GameInteractor_ExecuteOnBossDefeated(s16 actorId) {
     SPDLOG_DEBUG("GameInteractor_ExecuteOnBossDefeated: actorId: {}", actorId);
     GameInteractor::Instance->ExecuteHooks<GameInteractor::OnBossDefeated>(actorId);

--- a/mm/2s2h/GameInteractor/GameInteractor.h
+++ b/mm/2s2h/GameInteractor/GameInteractor.h
@@ -517,6 +517,7 @@ void GameInteractor_ExecuteOnActorDraw(Actor* actor);
 void GameInteractor_ExecuteOnActorKill(Actor* actor);
 void GameInteractor_ExecuteOnActorDestroy(Actor* actor);
 void GameInteractor_ExecuteOnPlayerPostLimbDraw(Player* player, s32 limbIndex);
+void GameInteractor_ExecuteOnPlayerReleaseHeldActor(PlayState* play, Player* player, Actor* heldActor);
 void GameInteractor_ExecuteOnBossDefeated(s16 actorId);
 
 void GameInteractor_ExecuteOnSceneFlagSet(s16 sceneId, FlagType flagType, u32 flag);

--- a/mm/2s2h/GameInteractor/GameInteractor_HookTable.h
+++ b/mm/2s2h/GameInteractor/GameInteractor_HookTable.h
@@ -32,6 +32,7 @@ DEFINE_HOOK(OnActorDraw, (Actor * actor))
 DEFINE_HOOK(OnActorKill, (Actor * actor))
 DEFINE_HOOK(OnActorDestroy, (Actor * actor))
 DEFINE_HOOK(OnPlayerPostLimbDraw, (Player * player, s32 limbIndex))
+DEFINE_HOOK(OnPlayerReleaseHeldActor, (PlayState * play, Player* player, Actor* heldActor))
 DEFINE_HOOK(OnBossDefeated, (s16 actorId))
 
 DEFINE_HOOK(OnSceneFlagSet, (s16 sceneId, FlagType flagType, u32 flag))

--- a/mm/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/mm/src/overlays/actors/ovl_player_actor/z_player.c
@@ -4419,6 +4419,7 @@ bool func_80831194(PlayState* play, Player* this) {
         }
 
         this->unk_D57 = (this->transformation == PLAYER_FORM_DEKU) ? 20 : 4;
+        GameInteractor_ExecuteOnPlayerReleaseHeldActor(play, this, this->heldActor);
 
         this->heldActor->parent = NULL;
         this->actor.child = NULL;


### PR DESCRIPTION
Resolves #1694 

Now bombs only get spent when you actually use the arrow on release (new `OnPlayerReleaseHeldActor` hook off `func_80831194`) or when the fuse runs out. Cycling away still just kills the held arrow, no ammo tick.

Held fuse timeout mirrors vanilla arrow ammo properly, and we won't spawn an explosion if there's no bomb to consume.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7045433551.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7045409607.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7045336186.zip)
<!--- section:artifacts:end -->