### PR TITLE
Port Config Updaters

### DIFF
--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -64,6 +64,7 @@ CrowdControl* CrowdControl::Instance;
 #include "2s2h/ShipUtils.h"
 #include "2s2h/ShipInit.hpp"
 #include "2s2h/PresetManager/PresetManager.h"
+#include "2s2h/config/ConfigUpdaters.h"
 
 // Resource Types/Factories
 #include <ship/resource/type/Blob.h>
@@ -716,6 +717,12 @@ extern "C" void InitOTR() {
 #endif
 
     OTRGlobals::Instance = new OTRGlobals();
+
+    std::shared_ptr<Ship::Config> conf = OTRGlobals::Instance->context->GetConfig();
+    conf->RegisterVersionUpdater(std::make_shared<Ben::ConfigVersion1Updater>());
+    conf->RunVersionUpdates();
+    Ship::Context::GetInstance()->GetConsoleVariables()->Save();
+
     GameInteractor::Instance = new GameInteractor();
     AudioCollection::Instance = new AudioCollection();
     LoadGuiTextures();
@@ -757,7 +764,6 @@ extern "C" void InitOTR() {
     }
 #endif
 
-    std::shared_ptr<Ship::Config> conf = OTRGlobals::Instance->context->GetConfig();
     Ship::Context::GetInstance()->GetFileDropMgr()->RegisterDropHandler(BinarySaveConverter_HandleFileDropped);
     Ship::Context::GetInstance()->GetFileDropMgr()->RegisterDropHandler(SaveManager_HandleFileDropped);
 }

--- a/mm/2s2h/config/ConfigUpdaters.cpp
+++ b/mm/2s2h/config/ConfigUpdaters.cpp
@@ -1,6 +1,5 @@
 #include "2s2h/config/ConfigUpdaters.h"
 
-#include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/Enhancements/Enhancements.h"
 #include "2s2h/Enhancements/Trackers/DisplayOverlay.h"
 

--- a/mm/2s2h/config/ConfigUpdaters.cpp
+++ b/mm/2s2h/config/ConfigUpdaters.cpp
@@ -1,0 +1,62 @@
+#include "2s2h/config/ConfigUpdaters.h"
+
+#include <libultraship/bridge/consolevariablebridge.h>
+#include "2s2h/Enhancements/Enhancements.h"
+#include "2s2h/Enhancements/Trackers/DisplayOverlay.h"
+
+namespace Ben {
+
+struct Migration {
+    const char* from;
+    const char* to;
+};
+
+static void ApplyMigrationActions(const Migration* migrations) {
+    while (migrations->from != nullptr) {
+        if (migrations->to != nullptr) {
+            CVarCopy(migrations->from, migrations->to);
+        }
+        CVarClear(migrations->from);
+        migrations++;
+    }
+}
+
+static const Migration version1Migrations[] = {
+    { "gFixes.FixAmmoCountEnvColor", "gFixes.FixButtonEnvColor" },
+    { nullptr, nullptr },
+};
+
+static bool HasDisplayOverlayModeInConfig(Ship::Config* conf) {
+    if (!conf->GetNestedJson().contains("CVars")) {
+        return false;
+    }
+
+    const auto& cvars = conf->GetNestedJson()["CVars"];
+    return cvars.contains("gDisplayOverlay") && cvars["gDisplayOverlay"].is_object() &&
+           cvars["gDisplayOverlay"].contains("Mode");
+}
+
+static void MigrateDisplayOverlayTimerMode(Ship::Config* conf) {
+    if (HasDisplayOverlayModeInConfig(conf)) {
+        return;
+    }
+
+    int oldVal = CVarGetInteger("gWindows.DisplayOverlay", 0);
+    if (oldVal == TIMER_DISPLAY_RTA || oldVal == TIMER_DISPLAY_IGT) {
+        CVarSetInteger(CVAR_DISPLAY_OVERLAY_MODE, oldVal);
+        CVarSetInteger("gWindows.DisplayOverlay", 1);
+    } else {
+        CVarSetInteger(CVAR_DISPLAY_OVERLAY_MODE, TIMER_DISPLAY_NONE);
+        CVarSetInteger("gWindows.DisplayOverlay", 0);
+    }
+}
+
+ConfigVersion1Updater::ConfigVersion1Updater() : ConfigVersionUpdater(1) {
+}
+
+void ConfigVersion1Updater::Update(Ship::Config* conf) {
+    ApplyMigrationActions(version1Migrations);
+    MigrateDisplayOverlayTimerMode(conf);
+}
+
+} // namespace Ben

--- a/mm/2s2h/config/ConfigUpdaters.h
+++ b/mm/2s2h/config/ConfigUpdaters.h
@@ -1,4 +1,4 @@
-#include "libultraship/libultraship.h"
+#include <libultraship/libultraship.h>
 
 namespace Ben {
 

--- a/mm/2s2h/config/ConfigUpdaters.h
+++ b/mm/2s2h/config/ConfigUpdaters.h
@@ -1,0 +1,11 @@
+#include "libultraship/libultraship.h"
+
+namespace Ben {
+
+class ConfigVersion1Updater final : public Ship::ConfigVersionUpdater {
+  public:
+    ConfigVersion1Updater();
+    void Update(Ship::Config* conf) override;
+};
+
+} // namespace Ben


### PR DESCRIPTION
Ports over 1Ship's config version updater setup. Adds v1 migrations for the recent CVar renames (button env color fix + timer overlay split).

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7140673408.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7140426246.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7140276347.zip)
<!--- section:artifacts:end -->