### PR TITLE
[Enhancement] Port Extraction Flow, ImGui scaling, file perm check from SoH

### DIFF
--- a/mm/2s2h/BenGui/BenGui.cpp
+++ b/mm/2s2h/BenGui/BenGui.cpp
@@ -72,16 +72,23 @@ UIWidgets::Colors GetMenuThemeColor() {
     return mBenMenu->GetMenuThemeColor();
 }
 
-void SetupGuiElements() {
+void SetupMenu() {
     auto gui = Ship::Context::GetInstance()->GetWindow()->GetGui();
+    mBenMenu = std::make_shared<BenMenu>("gWindows.Menu", "Settings Menu");
+    gui->SetMenu(mBenMenu);
 
     auto& style = ImGui::GetStyle();
     style.FramePadding = ImVec2(4.0f, 6.0f);
     style.ItemSpacing = ImVec2(8.0f, 6.0f);
     style.Colors[ImGuiCol_MenuBarBg] = UIWidgets::ColorValues.at(UIWidgets::Colors::DarkGray);
 
-    mBenMenuBar = std::make_shared<BenMenuBar>(CVAR_MENU_BAR_OPEN, CVarGetInteger(CVAR_MENU_BAR_OPEN, 0));
-    gui->SetMenuBar(std::reinterpret_pointer_cast<Ship::GuiMenuBar>(mBenMenuBar));
+    mModalWindow = std::make_shared<BenModalWindow>("gWindows.ModalWindow", "Modal Window");
+    gui->AddGuiWindow(mModalWindow);
+    mModalWindow->Show();
+}
+
+void SetupGuiElements() {
+    auto gui = Ship::Context::GetInstance()->GetWindow()->GetGui();
 
     if (!gui->GetMenuBar() && !CVarGetInteger("gSettings.DisableMenuShortcutNotify", 0)) {
 #if defined(__SWITCH__) || defined(__WIIU__)
@@ -90,9 +97,6 @@ void SetupGuiElements() {
         gui->GetGameOverlay()->TextDrawNotification(30.0f, true, "Press F1 to access enhancements menu");
 #endif
     }
-
-    mBenMenu = std::make_shared<BenMenu>("gWindows.Menu", "Settings Menu");
-    gui->SetMenu(mBenMenu);
 
     mStatsWindow = gui->GetGuiWindow("Stats");
     if (mStatsWindow == nullptr) {
@@ -181,9 +185,6 @@ void SetupGuiElements() {
     mInputViewerSettings = std::make_shared<InputViewerSettingsWindow>("gWindows.InputViewerSettings",
                                                                        "Input Viewer Settings", ImVec2(500, 525));
     gui->AddGuiWindow(mInputViewerSettings);
-    mModalWindow = std::make_shared<BenModalWindow>("gWindows.ModalWindow", "Modal Window");
-    gui->AddGuiWindow(mModalWindow);
-    mModalWindow->Show();
 }
 
 void Destroy() {
@@ -220,6 +221,18 @@ void Destroy() {
 void RegisterPopup(std::string title, std::string message, std::string button1, std::string button2,
                    std::function<void()> button1callback, std::function<void()> button2callback) {
     mModalWindow->RegisterPopup(title, message, button1, button2, button1callback, button2callback);
+}
+
+size_t PopupsQueued() {
+    return mModalWindow->PopupsQueued();
+}
+
+bool DismissPopup(std::string title) {
+    if (mModalWindow->IsPopupOpen(title)) {
+        mModalWindow->DismissPopup();
+        return true;
+    }
+    return false;
 }
 
 void SetDisplayOverlayVisibility(bool visible) {

--- a/mm/2s2h/BenGui/BenGui.cpp
+++ b/mm/2s2h/BenGui/BenGui.cpp
@@ -90,14 +90,6 @@ void SetupMenu() {
 void SetupGuiElements() {
     auto gui = Ship::Context::GetInstance()->GetWindow()->GetGui();
 
-    if (!gui->GetMenuBar() && !CVarGetInteger("gSettings.DisableMenuShortcutNotify", 0)) {
-#if defined(__SWITCH__) || defined(__WIIU__)
-        gui->GetGameOverlay()->TextDrawNotification(30.0f, true, "Press - to access enhancements menu");
-#else
-        gui->GetGameOverlay()->TextDrawNotification(30.0f, true, "Press F1 to access enhancements menu");
-#endif
-    }
-
     mStatsWindow = gui->GetGuiWindow("Stats");
     if (mStatsWindow == nullptr) {
         SPDLOG_ERROR("Could not find stats window");

--- a/mm/2s2h/BenGui/BenGui.hpp
+++ b/mm/2s2h/BenGui/BenGui.hpp
@@ -7,9 +7,15 @@
 
 namespace BenGui {
     void SetupHooks();
+    void SetupMenu();
+    void SetupMenuElements();
     void SetupGuiElements();
     void Draw();
     void Destroy();
+    size_t PopupsQueued();
+    void RegisterPopup(std::string title, std::string message, std::string button1 = "OK", std::string button2 = "",
+                   std::function<void()> button1callback = nullptr, std::function<void()> button2callback = nullptr);
+    bool DismissPopup(std::string title);
     UIWidgets::Colors GetMenuThemeColor();
     void SetDisplayOverlayVisibility(bool visible);
 }

--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -31,6 +31,13 @@ extern SaveContext gSaveContext;
 extern std::unordered_map<s16, const char*> warpPointSceneList;
 extern void Warp();
 
+static std::unordered_map<int32_t, const char*> imguiScaleOptions = {
+    { 0, "Small" },
+    { 1, "Normal" },
+    { 2, "Large" },
+    { 3, "X-Large" },
+};
+
 static const std::unordered_map<int32_t, const char*> menuThemeOptions = {
     { UIWidgets::Colors::Red, "Red" },
     { UIWidgets::Colors::DarkRed, "Dark Red" },
@@ -378,6 +385,16 @@ void BenMenu::AddSettings() {
             SDL_OpenURL(std::string("file:///" + std::filesystem::absolute(filesPath).string()).c_str());
         })
         .Options(ButtonOptions().Tooltip("Opens the folder that contains the save and mods folders, etc."));
+
+    AddWidget(path, "ImGui Menu Scaling", WIDGET_CVAR_COMBOBOX)
+        .CVar("gSettings.ImGuiScale")
+        .Options(ComboboxOptions()
+                     .ComboMap(&imguiScaleOptions)
+                     .Tooltip("Changes the scaling of the ImGui menu elements.")
+                     .DefaultIndex(1)
+                     .ComponentAlignment(UIWidgets::Right)
+                     .LabelPosition(UIWidgets::Far))
+        .Callback([](WidgetInfo& info) { OTRGlobals::Instance->ScaleImGui(); });
 
     path.column = SECTION_COLUMN_2;
     AddWidget(path, "about", WIDGET_CUSTOM).CustomFunction([](WidgetInfo& info) {

--- a/mm/2s2h/BenGui/BenMenu.h
+++ b/mm/2s2h/BenGui/BenMenu.h
@@ -20,9 +20,13 @@ class BenMenu : public Ship::Menu {
 
     void AddSidebarEntry(std::string sectionName, std::string sidbarName, uint32_t columnCount);
     WidgetInfo& AddWidget(WidgetPath& pathInfo, std::string widgetName, WidgetType widgetType);
+    void AddMenuElements();
     void AddSettings();
     void AddEnhancements();
     void AddDevTools();
+
+  private:
+    bool mMenuElementsInitialized = false;
 };
 } // namespace BenGui
 

--- a/mm/2s2h/BenGui/BenModals.cpp
+++ b/mm/2s2h/BenGui/BenModals.cpp
@@ -37,6 +37,7 @@ void BenModalWindow::DrawElement() {
             modals.erase(modals.begin());
             closePopup = false;
         }
+        ImGui::SetNextWindowPos(ImGui::GetMainViewport()->GetCenter(), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
         if (ImGui::BeginPopupModal(curModal.title_.c_str(), NULL,
                                    ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoResize |
                                        ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoScrollbar |
@@ -63,14 +64,18 @@ void BenModalWindow::DrawElement() {
                 }
                 UIWidgets::PopStyleButton();
             }
+            ImGui::EndPopup();
         }
-        ImGui::EndPopup();
     }
 }
 
 void BenModalWindow::RegisterPopup(std::string title, std::string message, std::string button1, std::string button2,
                                    std::function<void()> button1callback, std::function<void()> button2callback) {
     modals.push_back({ title, message, button1, button2, button1callback, button2callback });
+}
+
+size_t BenModalWindow::PopupsQueued() {
+    return modals.size();
 }
 
 bool BenModalWindow::IsPopupOpen(std::string title) {

--- a/mm/2s2h/BenGui/BenModals.h
+++ b/mm/2s2h/BenGui/BenModals.h
@@ -15,5 +15,6 @@ class BenModalWindow final : public Ship::GuiWindow {
                        std::function<void()> button1callback = nullptr,
                        std::function<void()> button2callback = nullptr);
     bool IsPopupOpen(std::string title);
+    size_t PopupsQueued();
     void DismissPopup();
 };

--- a/mm/2s2h/BenGui/Menu.cpp
+++ b/mm/2s2h/BenGui/Menu.cpp
@@ -534,6 +534,9 @@ void Menu::Draw() {
 
 static bool freshOpen = true;
 void Menu::DrawElement() {
+    if (OTRGlobals::Instance->fontStandardLargest == nullptr) {
+        return;
+    }
     for (auto& [reason, info] : disabledMap) {
         info.active = info.evaluation(info);
     }

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -37,7 +37,7 @@
 #endif
 #include "Extractor/Extract.h"
 // OTRTODO
-//#include <functions.h>
+// #include <functions.h>
 #include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
 
 #ifdef ENABLE_CROWD_CONTROL
@@ -49,6 +49,7 @@ CrowdControl* CrowdControl::Instance;
 #include <libultraship/controller/controldeck/ControlDeck.h>
 #include <fast/resource/ResourceType.h>
 #include <BenGui/BenGui.hpp>
+#include <BenGui/BenMenu.h>
 
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/Enhancements/Enhancements.h"
@@ -124,73 +125,32 @@ Color_RGB8 kokiriColor = { 0x1E, 0x69, 0x1B };
 Color_RGB8 goronColor = { 0x64, 0x14, 0x00 };
 Color_RGB8 zoraColor = { 0x00, 0xEC, 0x64 };
 
+int32_t previousImGuiScaleIndex;
+float previousImGuiScale;
+
+typedef struct {
+    uint16_t major;
+    uint16_t minor;
+    uint16_t patch;
+} ArchiveVersion;
+
+std::shared_ptr<Fast::Fast3dWindow> benFast3dWindow;
+static ArchiveVersion DetectArchiveVersion(std::string path, bool isO2rType);
+static bool VerifyArchiveVersion(ArchiveVersion version);
+std::string portArchivePath = "";
+static bool shipArchiveVersionMatch = false;
+
 OTRGlobals::OTRGlobals() {
-    std::vector<std::string> archiveFiles;
-    std::vector<std::string> patchFiles;
-    std::string mmPathO2R = Ship::Context::LocateFileAcrossAppDirs("mm.o2r", appShortName);
-    std::string mmPathZIP = Ship::Context::LocateFileAcrossAppDirs("mm.zip", appShortName);
-    if (std::filesystem::exists(mmPathO2R)) {
-        archiveFiles.push_back(mmPathO2R);
-    } else if (std::filesystem::exists(mmPathZIP)) {
-        archiveFiles.push_back(mmPathZIP);
-    } else {
-        std::string mmPath = Ship::Context::LocateFileAcrossAppDirs("mm.otr", appShortName);
-        if (std::filesystem::exists(mmPath)) {
-            archiveFiles.push_back(mmPath);
-        }
-    }
-
-    std::string shipOtrPath = Ship::Context::GetPathRelativeToAppBundle("2ship.o2r");
-    if (std::filesystem::exists(shipOtrPath)) {
-        archiveFiles.push_back(shipOtrPath);
-    }
-
-    std::string patchesPath = Ship::Context::LocateFileAcrossAppDirs("mods", appShortName);
-    if (patchesPath.length() > 0 && std::filesystem::exists(patchesPath)) {
-        if (std::filesystem::is_directory(patchesPath)) {
-            for (const auto& p : std::filesystem::recursive_directory_iterator(patchesPath)) {
-                if (StringHelper::IEquals(p.path().extension().string(), ".o2r")) {
-                    patchFiles.push_back(p.path().generic_string());
-                } else if (StringHelper::IEquals(p.path().extension().string(), ".zip")) {
-                    patchFiles.push_back(p.path().generic_string());
-                } else if (StringHelper::IEquals(p.path().extension().string(), ".otr")) {
-                    patchFiles.push_back(p.path().generic_string());
-                }
-            }
-        }
-    }
-
-    // Sort all patch files from the mods directory lexigraphically to guarantee sort order across all platforms
-    std::sort(patchFiles.begin(), patchFiles.end(), [](const std::string& a, const std::string& b) {
-        // Sort based on file name alone, excluding file extension, so that order is not impacted by archive format
-        const std::string aFileName = a.substr(0, a.find_last_of("."));
-        const std::string bFileName = b.substr(0, b.find_last_of("."));
-        return std::lexicographical_compare(aFileName.begin(), aFileName.end(), bFileName.begin(), bFileName.end(),
-                                            [](char c1, char c2) { return std::tolower(c1) < std::tolower(c2); });
-    });
-
-    archiveFiles.insert(archiveFiles.end(), patchFiles.begin(), patchFiles.end());
-
-    std::unordered_set<uint32_t> validHashes = { MM_NTSC_US_10, MM_NTSC_US_GC };
-
     context = Ship::Context::CreateUninitializedInstance("2 Ship 2 Harkinian", appShortName, "2ship2harkinian.json");
-    context->InitFileDropMgr();
-    context->InitGfxDebugger();
+
+    portArchivePath = Ship::Context::LocateFileAcrossAppDirs("2ship.o2r");
+    ArchiveVersion portArchiveVersion = DetectArchiveVersion("2ship.o2r", true);
+    shipArchiveVersionMatch = portArchiveVersion.major == gBuildVersionMajor &&
+                              portArchiveVersion.minor == gBuildVersionMinor &&
+                              portArchiveVersion.patch == gBuildVersionPatch;
+
     context->InitConfiguration();
     context->InitConsoleVariables();
-#if (_DEBUG)
-    auto defaultLogLevel = spdlog::level::trace;
-#else
-    auto defaultLogLevel = spdlog::level::info;
-#endif
-    auto logLevel = (spdlog::level::level_enum)CVarGetInteger("gDeveloperTools.LogLevel", defaultLogLevel);
-    context->InitLogging(logLevel, logLevel);
-    Ship::Context::GetInstance()->GetLogger()->set_pattern("[%H:%M:%S.%e] [%s:%#] [%^%l%$] %v");
-
-    // tell LUS to reserve 3 SoH specific threads (Game, Audio, Save)
-    context->InitResourceManager(archiveFiles, {}, 3);
-    prevAltAssets = CVarGetInteger("gEnhancements.Mods.AlternateAssets", 0);
-    context->GetResourceManager()->SetAltAssetsEnabled(prevAltAssets);
 
     auto controlDeck = std::make_shared<LUS::ControlDeck>(std::vector<CONTROLLERBUTTONS_T>({
         BTN_CUSTOM_MODIFIER1,
@@ -205,20 +165,487 @@ OTRGlobals::OTRGlobals() {
         BTN_CUSTOM_OCARINA_PITCH_DOWN,
     }));
     context->InitControlDeck(controlDeck);
-
-    context->InitCrashHandler();
+    context->InitResourceManager({ portArchivePath }, {}, 3, true);
     context->InitConsole();
 
     auto benInputEditorWindow = std::make_shared<BenInputEditorWindow>("gWindows.BenInputEditor", "2S2H Input Editor");
-    auto benFast3dWindow =
+    benFast3dWindow =
         std::make_shared<Fast::Fast3dWindow>(std::vector<std::shared_ptr<Ship::GuiWindow>>({ benInputEditorWindow }));
     context->InitWindow(benFast3dWindow);
 
-    // Override LUS defaults
-    auto overlay = context->GetInstance()->GetWindow()->GetGui()->GetGameOverlay();
-    overlay->LoadFont("Press Start 2P", 12.0f, "fonts/PressStart2P-Regular.ttf");
-    overlay->LoadFont("Fipps", 32.0f, "fonts/Fipps-Regular.otf");
-    overlay->SetCurrentFont(CVarGetString(CVAR_GAME_OVERLAY_FONT, "Press Start 2P"));
+    BenGui::SetupMenu();
+
+    if (shipArchiveVersionMatch) {
+
+        auto overlay = context->GetInstance()->GetWindow()->GetGui()->GetGameOverlay();
+        overlay->LoadFont("Press Start 2P", 12.0f, "fonts/PressStart2P-Regular.ttf");
+        overlay->LoadFont("Fipps", 32.0f, "fonts/Fipps-Regular.otf");
+        overlay->SetCurrentFont(CVarGetString(CVAR_GAME_OVERLAY_FONT, "Press Start 2P"));
+
+        fontMono = CreateFontWithSize(16.0f, "fonts/Inconsolata-Regular.ttf");
+        fontMonoLarger = CreateFontWithSize(20.0f, "fonts/Inconsolata-Regular.ttf");
+        fontMonoLargest = CreateFontWithSize(24.0f, "fonts/Inconsolata-Regular.ttf");
+        fontStandard = CreateFontWithSize(16.0f, "fonts/Montserrat-Regular.ttf");
+        fontStandardLarger = CreateFontWithSize(20.0f, "fonts/Montserrat-Regular.ttf");
+        fontStandardLargest = CreateFontWithSize(24.0f, "fonts/Montserrat-Regular.ttf");
+        ImGui::GetIO().FontDefault = fontStandardLarger;
+    }
+
+    previousImGuiScaleIndex = -1;
+    previousImGuiScale = defaultImGuiScale;
+    ScaleImGui();
+}
+
+typedef enum ExtractSteps {
+    ES_PORT_ARCHIVE,
+    ES_WINDOWS,
+    ES_EXTRACT_ARGS,
+    ES_EXTRACT,
+    ES_VERIFY,
+} ExtractSteps;
+
+typedef enum PromptSteps {
+    PS_FILE_CHECK,
+    PS_LOCAL,
+    PS_FIRST,
+    PS_SECOND,
+    PS_DUPE,
+    PS_WAIT,
+    PS_NONE,
+} PromptSteps;
+
+typedef enum WindowsSteps {
+    WS_TEMP,
+    WS_PERMS,
+    WS_ONEDRIVE,
+    WS_DONE,
+} WindowsSteps;
+
+bool IsSubpath(const std::filesystem::path& path, const std::filesystem::path& base) {
+    auto rel = std::filesystem::relative(path, base);
+    return !rel.empty() && rel.native()[0] != '.';
+}
+
+bool PathTestCleanup(FILE* tfile) {
+    try {
+        if (std::filesystem::exists("./text.txt"))
+            std::filesystem::remove("./text.txt");
+        if (std::filesystem::exists("./test/"))
+            std::filesystem::remove("./test/");
+    } catch (std::filesystem::filesystem_error const& ex) { return false; }
+    return true;
+}
+
+void CheckAndCreateModFolder() {
+    try {
+        std::string modsPath = Ship::Context::LocateFileAcrossAppDirs("mods", appShortName);
+        if (!std::filesystem::exists(modsPath)) {
+            // Create mods folder relative to app dir
+            modsPath = Ship::Context::GetPathRelativeToAppDirectory("mods", appShortName);
+            std::string filePath = modsPath + "/custom_mod_files_go_here.txt";
+            if (std::filesystem::create_directories(modsPath)) {
+                std::ofstream(filePath).close();
+            }
+        }
+    } catch (std::filesystem::filesystem_error const& ex) {
+        // Couldn't make the folder, continue silently
+        return;
+    }
+}
+
+namespace BenGui {
+extern std::shared_ptr<BenGui::BenMenu> mBenMenu;
+}
+
+void OTRGlobals::RunExtract(int argc, char* argv[]) {
+    bool extractDone = false;
+    ExtractSteps extractStep = ES_PORT_ARCHIVE;
+    WindowsSteps windowsStep = WS_TEMP;
+    auto wnd = std::dynamic_pointer_cast<Fast::Fast3dWindow>(OTRGlobals::Instance->context->GetWindow());
+    auto gui = wnd->GetGui();
+
+    bool shouldRegen = VerifyArchiveVersion(DetectArchiveVersion("mm.o2r", true));
+
+    std::filesystem::path ownPath;
+    std::vector<std::string> args;
+    if (argc > 1) {
+        for (int i = 1; i < argc; i++) {
+            args.push_back(argv[i]);
+        }
+    }
+    Extractor extract;
+    PromptSteps promptStep = PS_FILE_CHECK;
+    std::atomic<size_t> extractCount = 0, totalExtract = 0;
+
+    std::string installPath = Ship::Context::GetAppBundlePath();
+    std::string dataPath = Ship::Context::GetAppDirectoryPath(appShortName);
+    std::string file;
+
+#if defined(__SWITCH__)
+    BenGui::RegisterPopup("Outdated ROM Archives",
+                          "\x1b[2;2HYou've launched 2Ship with an old ROM O2R file."
+                          "\x1b[4;2HPlease regenerate a new ROM O2R and relaunch."
+                          "\x1b[6;2HPress the Home button to exit...",
+                          "OK", "", [&]() { exit(1); });
+#elif defined(__WIIU__)
+    BenGui::RegisterPopup("Outdated ROM Archives",
+                          "You've launched 2Ship with an old a ROM O2R file.\n\n"
+                          "Please generate a ROM O2R and relaunch.\n\n"
+                          "Press and hold the Power button to shutdown...",
+                          "OK", "", [&]() { exit(1); });
+    OSFatal();
+#endif
+
+    if (!std::filesystem::exists(installPath + "/assets")) {
+        BenGui::RegisterPopup("Extractor assets not found",
+                              "No O2R files found. Missing 'assets/' folder needed to generate OTR file.\nPlease "
+                              "re-extract them from the download or.\n\nExiting...",
+                              "OK", "", [&]() { exit(1); });
+    } else if (shouldRegen) {
+        BenGui::RegisterPopup("Outdated ROM Archives",
+                              "Your mm.o2r was created with incompatible versions of 2Ship.\nYou will "
+                              "now be redirected to re-extract them.");
+        std::filesystem::remove("mm.o2r");
+    }
+
+    std::shared_ptr<BS::thread_pool> threadPool = std::make_shared<BS::thread_pool>(1);
+    std::optional<std::future<void>> extractionTask;
+
+#if not defined(__SWITCH__) && not defined(__WIIU__)
+    CheckAndCreateModFolder();
+#endif
+
+    while (!extractDone) {
+        if (BenGui::PopupsQueued() > 0 || extractionTask.has_value()) {
+            goto render;
+        }
+        switch (extractStep) {
+            case ES_PORT_ARCHIVE: {
+                if (shipArchiveVersionMatch) {
+#ifdef _WIN32
+                    extractStep = ES_WINDOWS;
+#elif (defined(__WIIU__) || defined(__SWITCH__))
+                    extractStep = ES_VERIFY;
+#else
+                    extractStep = args.empty() ? ES_EXTRACT : ES_EXTRACT_ARGS;
+#endif
+                } else {
+                    std::string msg;
+
+#if defined(__SWITCH__)
+                    msg = "\x1b[4;2HPlease re-extract it from the download.\n"
+                          "\x1b[6;2HPress the Home button to exit...";
+#elif defined(__WIIU__)
+                    msg = "Please extract the 2ship.o2r from the 2 Ship 2 Harkinian download\nto your folder.\n\nPress "
+                          "and hold the power\n"
+                          "button to shutdown...";
+#else
+                    msg = "Please extract the 2ship.o2r from the 2 Ship 2 Harkinian download to your "
+                          "folder.\n\nExiting...";
+#endif
+                    std::string title =
+                        !std::filesystem::exists(portArchivePath) ? "Missing 2ship.o2r" : "2ship.o2r is outdated";
+                    BenGui::RegisterPopup(title, msg, "OK", "", [&]() { exit(1); });
+                }
+                continue;
+            }
+            case ES_WINDOWS: {
+                switch (windowsStep) {
+                    case WS_TEMP: {
+#ifdef _WIN32
+                        char* tempVar = getenv("TEMP");
+                        std::filesystem::path tempPath;
+                        try {
+                            tempPath = std::filesystem::canonical(tempVar);
+                        } catch (std::filesystem::filesystem_error const& ex) {
+                            std::string userPath = getenv("USERPROFILE");
+                            userPath.append("\\AppData\\Local\\Temp");
+                            tempPath = std::filesystem::canonical(userPath);
+                        }
+                        wchar_t buffer[MAX_PATH];
+                        GetModuleFileName(NULL, buffer, _countof(buffer));
+                        ownPath = std::filesystem::canonical(buffer).parent_path();
+                        if (IsSubpath(ownPath, tempPath)) {
+                            BenGui::RegisterPopup("2S2H Path Error",
+                                                  "2S2H is running in a temp folder.\nExtract the .zip and run again.",
+                                                  "OK", "", [&]() { exit(0); });
+                        } else {
+                            windowsStep = WS_PERMS;
+                        }
+#endif
+                        continue;
+                    }
+                    case WS_PERMS: {
+                        FILE* tfile = fopen("./text.txt", "w");
+                        std::filesystem::path tfolder = std::filesystem::path("./test/");
+                        bool error = false;
+                        try {
+                            create_directories(tfolder);
+                        } catch (std::filesystem::filesystem_error const& ex) { error = true; }
+                        if (tfile == NULL || error) {
+                            BenGui::RegisterPopup("2S2H Permissions Error",
+                                                  "2S2H does not have proper file permissions.\nPlease move it to a "
+                                                  "folder that does and run again.",
+                                                  "OK", "", [&]() {
+                                                      fclose(tfile);
+                                                      PathTestCleanup(tfile);
+                                                      exit(0);
+                                                  });
+                        } else {
+                            fclose(tfile);
+                            if (!PathTestCleanup(tfile)) {
+                                BenGui::RegisterPopup(
+                                    "2S2H Permissions Error",
+                                    "2S2H does not have proper file permissions.\nPlease move it to a "
+                                    "folder that does and run again.",
+                                    "OK", "", [&]() { exit(0); });
+                            }
+                            windowsStep = WS_ONEDRIVE;
+                        }
+                        continue;
+                    }
+                    case WS_ONEDRIVE: {
+                        if (ownPath.string().find("OneDrive") != std::string::npos) {
+                            BenGui::RegisterPopup("2S2H Path Error",
+                                                  "2S2H appears to be in a OneDrive folder, which will cause issues.\n"
+                                                  "Please move it to a folder outside of OneDrive, like the root of a\n"
+                                                  "drive (e.g. \"C:\\Games\\2S2H\").",
+                                                  "OK", "", [&]() { exit(0); });
+                        } else {
+                            windowsStep = WS_DONE;
+                            extractStep = args.empty() ? ES_EXTRACT : ES_EXTRACT_ARGS;
+                        }
+                        continue;
+                    }
+                    default:
+                        continue;
+                }
+                break;
+            }
+            case ES_EXTRACT_ARGS: {
+#if !defined(__SWITCH__) && !defined(__WIIU__)
+                if (args.empty()) {
+                    BenGui::RegisterPopup(
+                        "Run 2 Ship 2 Harkinian", "All files have been processed. Run 2S2H?", "Yes", "No",
+                        [&]() {
+                            if (!std::filesystem::exists(Ship::Context::GetAppDirectoryPath(appShortName) +
+                                                         "/mm.o2r")) {
+                                extractStep = ES_EXTRACT;
+                                promptStep = PS_FILE_CHECK;
+                            } else {
+                                extractStep = ES_VERIFY;
+                            }
+                        },
+                        [&]() { exit(0); });
+                    break;
+                }
+                file = args.at(0);
+                args.erase(args.begin());
+                extract = Extractor();
+                if (extract.RunFileStandalone(file)) {
+                    bool doExtract = true;
+                    if (std::filesystem::exists(Ship::Context::GetAppDirectoryPath(appShortName) + "/mm.o2r")) {
+                        std::string msg = "Archive for current ROM, mm.o2r, already exists.\nExtract again?";
+                        BenGui::RegisterPopup("Confirm Re-extract", msg.c_str(), "Yes", "No", [&]() {
+                            extractionTask = threadPool->submit_task([&]() -> void {
+                                extract.CallZapd(installPath, Ship::Context::GetAppDirectoryPath(appShortName),
+                                                 &extractCount, &totalExtract);
+                                extractCount = totalExtract = 0;
+                            });
+                        });
+                    } else {
+                        extractionTask = threadPool->submit_task([&]() -> void {
+                            extract.CallZapd(installPath, Ship::Context::GetAppDirectoryPath(appShortName),
+                                             &extractCount, &totalExtract);
+                            extractCount = totalExtract = 0;
+                        });
+                    }
+                } else {
+                    bool open = true;
+                    std::string msg = "File\n" + std::string(file) + "\nis not a ROM or does not match supported ROMs.";
+                    BenGui::RegisterPopup("2S2H ROM Error", msg.c_str());
+                }
+#else
+                extractStep = ES_VERIFY;
+#endif
+                break;
+            }
+            case ES_EXTRACT: {
+                switch (promptStep) {
+                    case PS_FILE_CHECK: {
+                        if (!std::filesystem::exists(Ship::Context::LocateFileAcrossAppDirs("mm.o2r", appShortName))) {
+                            BenGui::RegisterPopup(
+                                "No O2R Files", "No O2R files found. Generate one now?", "Yes", "No",
+                                [&]() { promptStep = PS_LOCAL; }, [&]() { exit(0); });
+                        } else {
+                            extractStep = ES_VERIFY;
+                        }
+                        continue;
+                    }
+                    case PS_LOCAL: {
+                        extract = Extractor();
+                        extract.SetSearchPath(installPath);
+                        extract.GetRoms(args);
+                        extract.SetSearchPath(dataPath);
+                        extract.GetRoms(args);
+                        if (!args.empty()) {
+                            promptStep = PS_WAIT;
+                            BenGui::RegisterPopup(
+                                "ROMs found", "ROMs found in application directory. Would you like to process them?",
+                                "Yes", "No", [&]() { extractStep = ES_EXTRACT_ARGS; },
+                                [&]() { promptStep = PS_FIRST; });
+                        } else {
+                            promptStep = PS_FIRST;
+                        }
+                        continue;
+                    }
+                    case PS_FIRST: {
+                        if (!extract.ManuallySearchForRomMatchingType(RomSearchMode::Both)) {
+                            promptStep = PS_FILE_CHECK;
+                            continue;
+                        }
+                        extractionTask = threadPool->submit_task([&]() -> void {
+                            extract.CallZapd(installPath, Ship::Context::GetAppDirectoryPath(appShortName),
+                                             &extractCount, &totalExtract);
+                            promptStep = PS_SECOND;
+                            extractCount = 0;
+                            totalExtract = 0;
+                        });
+                        continue;
+                    }
+                    case PS_SECOND: {
+                        BenGui::RegisterPopup(
+                            "Extraction Complete", "ROM Extracted. Extract another?", "Yes", "No",
+                            [&]() {
+                                if (!extract.ManuallySearchForRomMatchingType(RomSearchMode::Vanilla)) {
+                                    extractStep = ES_VERIFY;
+                                } else {
+                                    extractionTask = threadPool->submit_task([&]() -> void {
+                                        extract.CallZapd(installPath, Ship::Context::GetAppDirectoryPath(appShortName),
+                                                         &extractCount, &totalExtract);
+                                        extractStep = ES_VERIFY;
+                                        extractCount = 0;
+                                        totalExtract = 0;
+                                    });
+                                }
+                            },
+                            [&]() { extractStep = ES_VERIFY; });
+                        continue;
+                    }
+                    default:
+                        break;
+                }
+                break;
+            }
+            case ES_VERIFY: {
+                if (!std::filesystem::exists(Ship::Context::LocateFileAcrossAppDirs("mm.o2r", appShortName))) {
+                    BenGui::RegisterPopup("No ROM Archives",
+                                          "No ROM O2R files detected. Please generate a ROM O2R and relaunch.", "OK",
+                                          "", [&]() { exit(0); });
+                }
+                extractDone = true;
+                continue;
+            }
+            default:
+                break;
+        }
+
+    render:
+        if (!WindowIsRunning()) {
+            exit(0);
+        }
+        // Process window events for resize, mouse, keyboard events
+        wnd->HandleEvents();
+        UIWidgets::Colors themeColor =
+            static_cast<UIWidgets::Colors>(CVarGetInteger("gSettings.Menu.Theme", UIWidgets::Colors::LightBlue));
+        ImGui::PushStyleColor(ImGuiCol_TitleBgActive, UIWidgets::ColorValues.at(themeColor));
+        ImGui::PushStyleColor(ImGuiCol_ModalWindowDimBg, UIWidgets::ColorValues.at(UIWidgets::Colors::DarkGray));
+
+        // Skip dropped frames
+        if (!wnd->IsFrameReady()) {
+            continue;
+        }
+        gui->StartDraw();
+        benFast3dWindow->StartFrame();
+        benFast3dWindow->RunGuiOnly();
+        if (extractionTask.has_value()) {
+            auto status = extractionTask->wait_for(std::chrono::milliseconds(0));
+            if (status == std::future_status::ready) {
+                try {
+                    extractionTask->get();
+                } catch (const std::exception& e) {
+                    BenGui::RegisterPopup("Extraction Crashed", e.what(), "Close", "", []() { exit(1); });
+                }
+                extractionTask.reset();
+            } else {
+                if (!ImGui::IsPopupOpen("ROM Extraction")) {
+                    ImGui::OpenPopup("ROM Extraction");
+                }
+                ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 3.0f);
+                ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(10.0f, 8.0f));
+                auto color = UIWidgets::ColorValues.at(THEME_COLOR);
+                ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(color.x, color.y, color.z, 0.6f));
+                ImGui::PushStyleColor(ImGuiCol_PlotHistogram, ImVec4(color.x, color.y, color.z, 1.0f));
+                ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(0.0f, 0.0f, 0.0f, 0.3f));
+                if (ImGui::BeginPopupModal("ROM Extraction", NULL,
+                                           ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoResize |
+                                               ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoScrollbar |
+                                               ImGuiWindowFlags_NoSavedSettings)) {
+                    float progress = (totalExtract > 0.0f ? (float)extractCount / (float)totalExtract : 0) * 100.0f;
+                    auto filename = std::filesystem::path(file).filename().string();
+                    ImGui::Text("Extracting %s...%s", filename.c_str(),
+                                roundf(progress) == 100.0f ? " Done. Finishing up." : "");
+                    std::string overlay = extractCount > 0 ? fmt::format("{:.0f}%", progress) : "Starting Up";
+                    ImGui::ProgressBar(progress / 100.0f, ImVec2(600.0f, 50.0f), overlay.c_str());
+                    ImGui::EndPopup();
+                }
+                ImGui::PopStyleColor(3);
+                ImGui::PopStyleVar(2);
+            }
+        }
+        gui->EndDraw();
+        benFast3dWindow->EndFrame();
+        ImGui::PopStyleColor(2);
+    }
+
+#ifdef __SWITCH__
+    Ship::Switch::Init(Ship::PreInitPhase);
+#elif defined(__WIIU__)
+    Ship::WiiU::Init(appShortName);
+#endif
+}
+
+void OTRGlobals::Initialize() {
+    std::string mmPath = Ship::Context::LocateFileAcrossAppDirs("mm.o2r", appShortName);
+    if (std::filesystem::exists(mmPath)) {
+        context->GetResourceManager()->GetArchiveManager()->AddArchive(mmPath);
+    }
+
+    std::unordered_set<uint32_t> validHashes = { MM_NTSC_US_10, MM_NTSC_US_GC };
+
+#if (_DEBUG)
+    auto defaultLogLevel = spdlog::level::trace;
+#else
+    auto defaultLogLevel = spdlog::level::info;
+#endif
+    context->InitConfiguration();
+    context->InitConsoleVariables();
+    auto logLevel = static_cast<spdlog::level::level_enum>(CVarGetInteger("gDeveloperTools.LogLevel", defaultLogLevel));
+    context->InitLogging(logLevel, logLevel);
+    Ship::Context::GetInstance()->GetLogger()->set_pattern("[%H:%M:%S.%e] [%s:%#] [%l] %v");
+
+    context->InitGfxDebugger();
+    context->InitFileDropMgr();
+
+    // tell LUS to reserve 3 2S2H specific threads (Game, Audio, Save)
+    prevAltAssets = CVarGetInteger("gEnhancements.Mods.AlternateAssets", 1);
+    context->GetResourceManager()->SetAltAssetsEnabled(prevAltAssets);
+
+    context->InitCrashHandler();
+
+    context->GetWindow()->SetAutoCaptureMouse(CVarGetInteger("gSettings.EnableMouse", 0) &&
+                                              CVarGetInteger("gSettings.AutoCaptureMouse", 1));
+    context->GetWindow()->SetForceCursorVisibility(CVarGetInteger("gSettings.CursorVisibility", 0));
 
     context->InitAudio({ .SampleRate = 32000, .SampleLength = 1024, .DesiredBuffered = 1680 });
 
@@ -312,28 +739,9 @@ OTRGlobals::OTRGlobals() {
             exit(1);
         }
     }
-
-    fontMono = CreateFontWithSize(16.0f, "fonts/Inconsolata-Regular.ttf");
-    fontMonoLarger = CreateFontWithSize(20.0f, "fonts/Inconsolata-Regular.ttf");
-    fontMonoLargest = CreateFontWithSize(24.0f, "fonts/Inconsolata-Regular.ttf");
-    fontStandard = CreateFontWithSize(16.0f, "fonts/Montserrat-Regular.ttf");
-    fontStandardLarger = CreateFontWithSize(20.0f, "fonts/Montserrat-Regular.ttf");
-    fontStandardLargest = CreateFontWithSize(24.0f, "fonts/Montserrat-Regular.ttf");
-    ImGui::GetIO().FontDefault = fontMono;
 }
 
 OTRGlobals::~OTRGlobals() {
-}
-
-uint32_t OTRGlobals::GetInterpolationFPS() {
-    if (CVarGetInteger("gMatchRefreshRate", 0)) {
-        return Ship::Context::GetInstance()->GetWindow()->GetCurrentRefreshRate();
-    } else if (CVarGetInteger(CVAR_VSYNC_ENABLED, 1) ||
-               !Ship::Context::GetInstance()->GetWindow()->CanDisableVerticalSync()) {
-        return std::min<uint32_t>(Ship::Context::GetInstance()->GetWindow()->GetCurrentRefreshRate(),
-                                  CVarGetInteger("gInterpolationFPS", 20));
-    }
-    return CVarGetInteger("gInterpolationFPS", 20);
 }
 
 extern "C" uint32_t Ship_GetInterpolationFPS() {
@@ -350,28 +758,27 @@ struct ExtensionEntry {
     std::string ext;
 };
 
-ImFont* OTRGlobals::CreateFontWithSize(float size, std::string fontPath) {
-    auto mImGuiIo = &ImGui::GetIO();
-    ImFont* font;
-    if (fontPath == "") {
-        ImFontConfig fontCfg = ImFontConfig();
-        fontCfg.OversampleH = fontCfg.OversampleV = 1;
-        fontCfg.PixelSnapH = true;
-        fontCfg.SizePixels = size;
-        font = mImGuiIo->Fonts->AddFontDefault(&fontCfg);
-    } else {
-        auto initData = std::make_shared<Ship::ResourceInitData>();
-        ImFontConfig config;
-        config.FontDataOwnedByAtlas = false;
-
-        initData->Format = RESOURCE_FORMAT_BINARY;
-        initData->Type = static_cast<uint32_t>(RESOURCE_TYPE_FONT);
-        initData->ResourceVersion = 0;
-        initData->Path = fontPath;
-        std::shared_ptr<Ship::Font> fontData = std::static_pointer_cast<Ship::Font>(
-            Ship::Context::GetInstance()->GetResourceManager()->LoadResource(fontPath, false, initData));
-        font = mImGuiIo->Fonts->AddFontFromMemoryTTF(fontData->Data, fontData->DataSize, size, &config);
+void OTRGlobals::ScaleImGui() {
+    int32_t imGuiScaleIndex = CVarGetInteger("gSettings.ImGuiScale", defaultImGuiScale);
+    if (imGuiScaleIndex == previousImGuiScaleIndex) {
+        return;
     }
+
+    float scale = imguiScaleOptionToValue[imGuiScaleIndex];
+    float newScale = scale / previousImGuiScale;
+    ImGui::GetStyle().ScaleAllSizes(newScale);
+    ImGui::GetIO().FontGlobalScale = scale;
+    previousImGuiScale = scale;
+    previousImGuiScaleIndex = imGuiScaleIndex;
+}
+
+ImFont* OTRGlobals::CreateDefaultFontWithSize(float size) {
+    auto mImGuiIo = &ImGui::GetIO();
+    ImFontConfig fontCfg = ImFontConfig();
+    fontCfg.OversampleH = fontCfg.OversampleV = 1;
+    fontCfg.PixelSnapH = true;
+    fontCfg.SizePixels = size;
+    ImFont* font = mImGuiIo->Fonts->AddFontDefault(&fontCfg);
     // FontAwesome fonts need to have their sizes reduced by 2.0f/3.0f in order to align correctly
     float iconFontSize = size * 2.0f / 3.0f;
     static const ImWchar sIconsRanges[] = { ICON_MIN_FA, ICON_MAX_16_FA, 0 };
@@ -382,6 +789,17 @@ ImFont* OTRGlobals::CreateFontWithSize(float size, std::string fontPath) {
     mImGuiIo->Fonts->AddFontFromMemoryCompressedBase85TTF(fontawesome_compressed_data_base85, iconFontSize,
                                                           &iconsConfig, sIconsRanges);
     return font;
+}
+
+uint32_t OTRGlobals::GetInterpolationFPS() {
+    if (CVarGetInteger("gMatchRefreshRate", 0)) {
+        return Ship::Context::GetInstance()->GetWindow()->GetCurrentRefreshRate();
+    } else if (CVarGetInteger(CVAR_VSYNC_ENABLED, 1) ||
+               !Ship::Context::GetInstance()->GetWindow()->CanDisableVerticalSync()) {
+        return std::min<uint32_t>(Ship::Context::GetInstance()->GetWindow()->GetCurrentRefreshRate(),
+                                  CVarGetInteger("gInterpolationFPS", 20));
+    }
+    return CVarGetInteger("gInterpolationFPS", 20);
 }
 
 extern "C" void OTRMessage_Init();
@@ -493,12 +911,6 @@ extern "C" void OTRExtScanner() {
     }
 }
 
-typedef struct {
-    uint16_t major;
-    uint16_t minor;
-    uint16_t patch;
-} ArchiveVersion;
-
 // Read the port version from an archive file
 ArchiveVersion ReadPortVersionFromArchive(std::string archivePath, bool isO2rType) {
     ArchiveVersion version = {};
@@ -533,190 +945,32 @@ ArchiveVersion ReadPortVersionFromArchive(std::string archivePath, bool isO2rTyp
 
 // Check that a 2ship.o2r exists and matches the version of 2ship running
 // Otherwise show a message and exit
-void Check2ShipArchiveVersion(std::string archivePath) {
-    std::string msg;
-
-#if defined(__SWITCH__)
-    msg = "\x1b[4;2HPlease re-extract it from the download."
-          "\x1b[6;2HPress the Home button to exit...";
-#elif defined(__WIIU__)
-    msg = "Please extract the 2ship.o2r from the 2 Ship 2 Harkinian download\nto your folder.\n\n"
-          "Press and hold the power button to shutdown...";
-#else
-    msg = "Please extract the 2ship.o2r from the 2 Ship 2 Harkinian download to your folder.\n\nExiting...";
-#endif
-
-    if (!std::filesystem::exists(archivePath)) {
-#if not defined(__SWITCH__) && not defined(__WIIU__)
-        Extractor::ShowErrorBox("2ship.o2r file is missing", msg.c_str());
-        exit(1);
-#elif defined(__SWITCH__)
-        Ship::Switch::PrintErrorMessageToScreen(("\x1b[2;2HYou are missing the 2ship.o2r file." + msg).c_str());
-#elif defined(__WIIU__)
-        OSFatal(("You are missing the 2ship.o2r file\n\n" + msg).c_str());
-#endif
-    }
-
-    ArchiveVersion archiveVer = ReadPortVersionFromArchive(archivePath, true);
-
-    if (archiveVer.major != gBuildVersionMajor || archiveVer.minor != gBuildVersionMinor ||
-        archiveVer.patch != gBuildVersionPatch) {
-#if not defined(__SWITCH__) && not defined(__WIIU__)
-        Extractor::ShowErrorBox("2ship.o2r file version does not match", msg.c_str());
-        exit(1);
-#elif defined(__SWITCH__)
-        Ship::Switch::PrintErrorMessageToScreen(("\x1b[2;2HYou have an old 2ship.o2r file." + msg).c_str());
-#elif defined(__WIIU__)
-        OSFatal(("You have an old 2ship.o2r file\n\n" + msg).c_str());
-#endif
-    }
-}
-
-// Checks the program version stored in the o2r and compares the major/minor value to 2ship
 // For Windows/Mac/Linux if the version doesn't match, offer to regenerate it
-void DetectArchiveVersion(std::string fileName, bool isO2rType) {
+ArchiveVersion DetectArchiveVersion(std::string fileName, bool isO2rType) {
     bool isArchiveOld = false;
     std::string archivePath = Ship::Context::LocateFileAcrossAppDirs(fileName, appShortName);
 
     // Doesn't exist so nothing to do here
     if (!std::filesystem::exists(archivePath)) {
-        return;
+        return { INT16_MAX, INT16_MAX, INT16_MAX };
     }
 
-    ArchiveVersion archiveVer = ReadPortVersionFromArchive(archivePath, isO2rType);
-
-    // Check both major and minor for game archives
-    if (archiveVer.major != gBuildVersionMajor || archiveVer.minor != gBuildVersionMinor) {
-        isArchiveOld = true;
-    }
-
-    if (isArchiveOld) {
-#if not defined(__SWITCH__) && not defined(__WIIU__)
-        char msgBuf[250];
-        char version[18]; // 5 digits for int16_max (x3) + separators + terminator
-
-        if (archiveVer.major != 0 || archiveVer.minor != 0 || archiveVer.patch != 0) {
-            snprintf(version, 18, "%d.%d.%d", archiveVer.major, archiveVer.minor, archiveVer.patch);
-        } else {
-            snprintf(version, 18, "no version found");
-        }
-
-        snprintf(msgBuf, 250,
-                 "The %s file was generated with a different version of 2 Ship 2 Harkinian.\n"
-                 "O2R version: %s\n\n"
-                 "You must regenerate to be able to play, otherwise the program will exit.\n"
-                 "Would you like to regenerate it now?",
-                 fileName.c_str(), version);
-
-        if (Extractor::ShowYesNoBox("Old O2R File Found", msgBuf) == IDYES) {
-            std::string installPath = Ship::Context::GetAppBundlePath();
-            if (!std::filesystem::exists(installPath + "/assets")) {
-                Extractor::ShowErrorBox(
-                    "Extractor assets not found",
-                    "Unable to regenerate. Missing assets folder needed to generate O2R file.\n\nExiting...");
-                exit(1);
-            }
-
-            Extractor extract;
-            if (!extract.Run(Ship::Context::GetAppDirectoryPath(appShortName))) {
-                Extractor::ShowErrorBox("Error", "An error occurred, no O2R file was generated.\n\nExiting...");
-                exit(1);
-            }
-
-            // We can only regenerate O2R archives, so we should just delete the old OTR file
-            if (!isO2rType) {
-                std::filesystem::remove(archivePath);
-            }
-
-            extract.CallZapd(installPath, Ship::Context::GetAppDirectoryPath(appShortName));
-
-            // Rename the new O2R with the previously used extension
-            if (isO2rType) {
-                std::filesystem::rename(Ship::Context::LocateFileAcrossAppDirs("mm.o2r", appShortName), archivePath);
-            }
-        } else {
-            exit(1);
-        }
-
-#elif defined(__SWITCH__)
-        Ship::Switch::PrintErrorMessageToScreen("\x1b[2;2HYou've launched the 2Ship with an old game O2R file."
-                                                "\x1b[4;2HPlease regenerate a new game O2R and relaunch."
-                                                "\x1b[6;2HPress the Home button to exit...");
-#elif defined(__WIIU__)
-        OSFatal("You've launched the 2Ship with an old a game O2R file.\n\n"
-                "Please generate a game O2R and relaunch.\n\n"
-                "Press and hold the Power button to shutdown...");
-#endif
-    }
+    return ReadPortVersionFromArchive(archivePath, isO2rType);
 }
 
-void CheckAndCreateModFolder() {
-    try {
-        std::string modsPath = Ship::Context::LocateFileAcrossAppDirs("mods", appShortName);
-        if (!std::filesystem::exists(modsPath)) {
-            // Create mods folder relative to app dir
-            modsPath = Ship::Context::GetPathRelativeToAppDirectory("mods", appShortName);
-            std::string filePath = modsPath + "/custom_mod_files_go_here.txt";
-            if (std::filesystem::create_directories(modsPath)) {
-                std::ofstream(filePath).close();
-            }
-        }
-    } catch (std::filesystem::filesystem_error const& ex) {
-        // Couldn't make the folder, continue silently
-        return;
-    }
+extern "C" void Messagebox_ShowErrorBox(char* title, char* body) {
+    Extractor::ShowErrorBox(title, body);
 }
 
-extern "C" void InitOTR() {
+bool VerifyArchiveVersion(ArchiveVersion version) {
+    return version.major != INT16_MAX && version.major != gBuildVersionMajor;
+}
 
-#ifdef __SWITCH__
-    Ship::Switch::Init(Ship::PreInitPhase);
-#elif defined(__WIIU__)
-    Ship::WiiU::Init(appShortName);
-#endif
-
-    // BENTODO: OTRExporter is filling the version file with garbage. Uncomment once fixed.
-    // Check2ShipArchiveVersion(Ship::Context::GetPathRelativeToAppBundle("2ship.o2r"));
-
-    std::string mmPathO2R = Ship::Context::LocateFileAcrossAppDirs("mm.o2r", appShortName);
-    std::string mmPathZIP = Ship::Context::LocateFileAcrossAppDirs("mm.zip", appShortName);
-    std::string mmPathOtr = Ship::Context::LocateFileAcrossAppDirs("mm.otr", appShortName);
-
-    // Check game archives in preferred order
-    if (std::filesystem::exists(mmPathO2R)) {
-        DetectArchiveVersion("mm.o2r", true);
-    } else if (std::filesystem::exists(mmPathZIP)) {
-        DetectArchiveVersion("mm.zip", true);
-    } else if (std::filesystem::exists(mmPathOtr)) {
-        DetectArchiveVersion("mm.otr", false);
-    }
-
-#if not defined(__SWITCH__) && not defined(__WIIU__)
-    CheckAndCreateModFolder();
-    if (!std::filesystem::exists(mmPathO2R) && !std::filesystem::exists(mmPathZIP) &&
-        !std::filesystem::exists(mmPathOtr)) {
-        std::string installPath = Ship::Context::GetAppBundlePath();
-        if (!std::filesystem::exists(installPath + "/assets")) {
-            Extractor::ShowErrorBox(
-                "Extractor assets not found",
-                "No game O2R file found. Missing assets folder needed to generate O2R file. Exiting...");
-            exit(1);
-        }
-
-        if (Extractor::ShowYesNoBox("No O2R File", "No O2R files found. Generate one now?") == IDYES) {
-            Extractor extract;
-            if (!extract.Run(Ship::Context::GetAppDirectoryPath(appShortName))) {
-                Extractor::ShowErrorBox("Error", "An error occurred, no O2R file was generated. Exiting...");
-                exit(1);
-            }
-            extract.CallZapd(installPath, Ship::Context::GetAppDirectoryPath(appShortName));
-        } else {
-            exit(1);
-        }
-    }
-#endif
-
+extern "C" void InitOTR(int argc, char* argv[]) {
     OTRGlobals::Instance = new OTRGlobals();
+    OTRGlobals::Instance->RunExtract(argc, argv);
+
+    OTRGlobals::Instance->Initialize();
 
     std::shared_ptr<Ship::Config> conf = OTRGlobals::Instance->context->GetConfig();
     conf->RegisterVersionUpdater(std::make_shared<Ben::ConfigVersion1Updater>());
@@ -783,6 +1037,7 @@ extern "C" void DeinitOTR() {
     // Destroying gui here because we have shared ptrs to LUS objects which output to SPDLOG which is destroyed before
     // these shared ptrs.
     BenGui::Destroy();
+    benFast3dWindow = nullptr;
 
     OTRGlobals::Instance->context = nullptr;
     delete AudioCollection::Instance;
@@ -932,10 +1187,14 @@ void RunCommands(Gfx* Commands, const std::vector<std::unordered_map<Mtx*, MtxF>
     auto intp = wnd->GetInterpreterWeak().lock().get();
     intp->mInterpolationIndex = 0;
 
+    UIWidgets::Colors themeColor =
+        static_cast<UIWidgets::Colors>(CVarGetInteger("gSettings.Menu.Theme", UIWidgets::Colors::LightBlue));
+    ImGui::PushStyleColor(ImGuiCol_TitleBgActive, UIWidgets::ColorValues.at(themeColor));
     for (const auto& m : mtx_replacements) {
         wnd->DrawAndRunGraphicsCommands(Commands, m);
         intp->mInterpolationIndex++;
     }
+    ImGui::PopStyleColor();
 }
 
 // C->C++ Bridge
@@ -1616,6 +1875,39 @@ extern "C" s32* ResourceMgr_LoadCSByName(const char* path) {
     return (s32*)ResourceGetDataByName(path);
 }
 
+ImFont* OTRGlobals::CreateFontWithSize(float size, std::string fontPath) {
+    auto mImGuiIo = &ImGui::GetIO();
+    ImFont* font;
+    if (fontPath == "") {
+        ImFontConfig fontCfg = ImFontConfig();
+        fontCfg.OversampleH = fontCfg.OversampleV = 1;
+        fontCfg.PixelSnapH = true;
+        fontCfg.SizePixels = size;
+        font = mImGuiIo->Fonts->AddFontDefault(&fontCfg);
+    } else {
+        auto initData = std::make_shared<Ship::ResourceInitData>();
+        initData->Format = RESOURCE_FORMAT_BINARY;
+        initData->Type = static_cast<uint32_t>(RESOURCE_TYPE_FONT);
+        initData->ResourceVersion = 0;
+        initData->Path = fontPath;
+        std::shared_ptr<Ship::Font> fontData = std::static_pointer_cast<Ship::Font>(
+            Ship::Context::GetInstance()->GetResourceManager()->LoadResource(fontPath, false, initData));
+        ImFontConfig fontConf;
+        fontConf.FontDataOwnedByAtlas = false;
+        font = mImGuiIo->Fonts->AddFontFromMemoryTTF(fontData->Data, fontData->DataSize, size, &fontConf, nullptr);
+    }
+    // FontAwesome fonts need to have their sizes reduced by 2.0f/3.0f in order to align correctly
+    float iconFontSize = size * 2.0f / 3.0f;
+    static const ImWchar sIconsRanges[] = { ICON_MIN_FA, ICON_MAX_16_FA, 0 };
+    ImFontConfig iconsConfig;
+    iconsConfig.MergeMode = true;
+    iconsConfig.PixelSnapH = true;
+    iconsConfig.GlyphMinAdvanceX = iconFontSize;
+    mImGuiIo->Fonts->AddFontFromMemoryCompressedBase85TTF(fontawesome_compressed_data_base85, iconFontSize,
+                                                          &iconsConfig, sIconsRanges);
+    return font;
+}
+
 std::filesystem::path GetSaveFile(std::shared_ptr<Ship::Config> Conf) {
     const std::string fileName =
         Conf->GetString("Game.SaveName", Ship::Context::GetPathRelativeToAppDirectory("oot_save.sav"));
@@ -2024,10 +2316,6 @@ extern "C" int Controller_ShouldRumble(size_t slot) {
 
     // rumble
     return 1;
-}
-
-extern "C" void Messagebox_ShowErrorBox(char* title, char* body) {
-    Extractor::ShowErrorBox(title, body);
 }
 
 // Helper to redirect the user to the boot screen in place of known console crash scenarios, and emits a notification

--- a/mm/2s2h/BenPort.h
+++ b/mm/2s2h/BenPort.h
@@ -35,16 +35,24 @@ struct ImFont;
 const std::string customMessageTableID = "BaseGameOverrides";
 const std::string appShortName = "2ship";
 
+#ifdef __WIIU__
+const uint32_t defaultImGuiScale = 3;
+#else
+const uint32_t defaultImGuiScale = 1;
+#endif
+
+const float imguiScaleOptionToValue[4] = { 0.75f, 1.0f, 1.5f, 2.0f };
+
 class OTRGlobals {
   public:
     static OTRGlobals* Instance;
 
-    ImFont* fontStandard;
-    ImFont* fontStandardLarger;
-    ImFont* fontStandardLargest;
-    ImFont* fontMono;
-    ImFont* fontMonoLarger;
-    ImFont* fontMonoLargest;
+    ImFont* fontStandard = nullptr;
+    ImFont* fontStandardLarger = nullptr;
+    ImFont* fontStandardLargest = nullptr;
+    ImFont* fontMono = nullptr;
+    ImFont* fontMonoLarger = nullptr;
+    ImFont* fontMonoLargest = nullptr;
 
     std::shared_ptr<Ship::Context> context;
 
@@ -53,10 +61,14 @@ class OTRGlobals {
 
     uint32_t GetInterpolationFPS();
     std::shared_ptr<std::vector<std::string>> ListFiles(std::string path);
+    void RunExtract(int argc, char* argv[]);
+    void Initialize();
+    void ScaleImGui();
 
   private:
     ImFont* CreateFontWithSize(float size, std::string fontPath = "");
     void CheckSaveFile(size_t sramSize) const;
+    ImFont* CreateDefaultFontWithSize(float size);
 };
 
 uint32_t IsGameMasterQuest();
@@ -70,7 +82,7 @@ uint32_t IsGameMasterQuest();
 #include <z64keyframe.h>
 #include <z64scene.h>
 #include <z64skin.h>
-void InitOTR(void);
+void InitOTR(int argc, char* argv[]);
 void DeinitOTR(void);
 void VanillaItemTable_Init();
 void OTRAudio_Init();

--- a/mm/2s2h/Extractor/Extract.cpp
+++ b/mm/2s2h/Extractor/Extract.cpp
@@ -362,7 +362,6 @@ bool Extractor::ManuallySearchForRom() {
     std::ifstream inFile;
 
     if (!GetRomPathFromBox()) {
-        ShowErrorBox("No rom selected", "No Rom selected. Exiting");
         return false;
     }
 
@@ -414,11 +413,43 @@ bool Extractor::ManuallySearchForRomMatchingType(RomSearchMode searchMode) {
     return true;
 }
 
+bool Extractor::RunFileStandalone(std::string rom) {
+    if (std::filesystem::is_directory(rom)) {
+        return false;
+    }
+    auto file = std::filesystem::path(rom);
+    if ((file.extension() != ".n64") && (file.extension() != ".z64") && (file.extension() != ".v64")) {
+        return false;
+    }
+    SetRomInfo(rom);
+
+    if (!ValidateRomSize()) {
+        return false;
+    }
+    std::ifstream inFile;
+
+    inFile.open(rom, std::ios::in | std::ios::binary);
+    inFile.read((char*)mRomData.get(), mCurRomSize);
+    inFile.clear();
+    inFile.close();
+    BitConverter::RomToBigEndian(mRomData.get(), mCurRomSize);
+
+    if (!ValidateRom(true)) {
+        return false;
+    }
+
+    return true;
+}
+
+void Extractor::SetSearchPath(const std::string& path) {
+    mSearchPath = path;
+}
+
 bool Extractor::Run(std::string searchPath, RomSearchMode searchMode) {
     std::vector<std::string> roms;
     std::ifstream inFile;
 
-    mSearchPath = searchPath;
+    SetSearchPath(searchPath);
 
     GetRoms(roms);
     FilterRoms(roms, searchMode);
@@ -535,10 +566,11 @@ std::string Extractor::Mkdtemp() {
     return tmppath;
 }
 
-extern "C" int zapd_main(int argc, char** argv);
+extern "C" int zapd_report(int argc, char** argv, std::atomic<size_t>* extractCount, std::atomic<size_t>* totalExtract);
 static void MessageboxWorker();
 
-bool Extractor::CallZapd(std::string installPath, std::string exportdir) {
+bool Extractor::CallZapd(std::string installPath, std::string exportdir, std::atomic<size_t>* extractCount,
+                         std::atomic<size_t>* totalExtract) {
     constexpr int argc = 22;
     char xmlPath[1024];
     char confPath[1024];
@@ -589,25 +621,7 @@ bool Extractor::CallZapd(std::string installPath, std::string exportdir) {
     argv[20] = "-osf";
     argv[21] = "placeholder";
 
-#ifdef _WIN32
-    // Grab a handle to the command window.
-    HWND cmdWindow = GetConsoleWindow();
-
-    // Normally the command window is hidden. We want the window to be shown here so the user can see the progess of the
-    // extraction.
-    ShowWindow(cmdWindow, SW_SHOW);
-    SetWindowPos(cmdWindow, HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE);
-#else
-    std::thread mbThread(MessageboxWorker);
-    mbThread.detach();
-#endif
-
-    zapd_main(argc, (char**)argv.data());
-
-#ifdef _WIN32
-    // Hide the command window again.
-    ShowWindow(cmdWindow, SW_HIDE);
-#endif
+    zapd_report(argc, (char**)argv.data(), extractCount, totalExtract);
 
     std::filesystem::copy(otrFile, exportdir + "/" + otrFile, std::filesystem::copy_options::overwrite_existing);
 

--- a/mm/2s2h/Extractor/Extract.h
+++ b/mm/2s2h/Extractor/Extract.h
@@ -1,6 +1,7 @@
 #ifndef EXTRACT_H
 #define EXTRACT_H
 
+#include <atomic>
 #include <stdint.h>
 #include <string>
 #include <memory>
@@ -45,22 +46,25 @@ class Extractor {
     void SetRomInfo(const std::string& path);
 
     void FilterRoms(std::vector<std::string>& roms, RomSearchMode searchMode);
-    void GetRoms(std::vector<std::string>& roms);
     void ShowSizeErrorBox() const;
     void ShowCrcErrorBox() const;
     void ShowCompressedErrorBox() const;
     int ShowRomPickBox(uint32_t verCrc) const;
     bool ManuallySearchForRom();
-    bool ManuallySearchForRomMatchingType(RomSearchMode searchMode);
 
   public:
     // TODO create some kind of abstraction for message boxes.
     static int ShowYesNoBox(const char* title, const char* text);
     static void ShowErrorBox(const char* title, const char* text);
     bool IsMasterQuest() const;
+    bool ManuallySearchForRomMatchingType(RomSearchMode searchMode);
 
+    void SetSearchPath(const std::string& path);
+    void GetRoms(std::vector<std::string>& roms);
+    bool RunFileStandalone(std::string file);
     bool Run(std::string searchPath, RomSearchMode searchMode = RomSearchMode::Both);
-    bool CallZapd(std::string installPath, std::string exportdir);
+    bool CallZapd(std::string installPath, std::string exportdir, std::atomic<size_t>* extractCount,
+                  std::atomic<size_t>* totalExtract);
     const char* GetZapdStr();
     std::string Mkdtemp();
 };

--- a/mm/src/code/main.c
+++ b/mm/src/code/main.c
@@ -47,13 +47,13 @@ s32 gScreenWidth = SCREEN_WIDTH;
 s32 gScreenHeight = SCREEN_HEIGHT;
 size_t gSystemHeapSize = 0;
 
-void InitOTR();
+void InitOTR(int argc, char* argv[]);
 void Heaps_Free(void);
 #ifdef __GNUC__
 #define SDL_main main
 #endif
 
-void SDL_main(int argc, char** argv /* void* arg*/) {
+int SDL_main(int argc, char* argv[] /* void* arg*/) {
     intptr_t fb;
     intptr_t sysHeap;
     s32 exit;
@@ -72,7 +72,7 @@ void SDL_main(int argc, char** argv /* void* arg*/) {
     setlocale(LC_ALL, ".UTF8");
 #endif // _WIN32
 
-    InitOTR();
+    InitOTR(argc, argv);
     CrashHandlerRegisterCallback(CrashHandler_PrintExt);
     Heaps_Alloc();
 


### PR DESCRIPTION
Ports the following from SoH (adopted from their current iteration as of https://github.com/HarbourMasters/Shipwright/commit/772fe2bb92b3c75173435c98e17b7edc9ec2f7c0). I initially wanted to port these separately, but given how much things touch each other, it was easier to just lump these altogether:

- ImGui extraction flow
- ImGui menu scaling
- OneDrive, temp folder, filesystem permissions checks
- Alternate assets default to on
- Take ROM as command line argument

Note: #1203 is now moot, as it was a bandaid fix to an issue that couldn't be replicated as-is.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7174184266.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7174156285.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7174098473.zip)
<!--- section:artifacts:end -->