### PR TITLE
Disable interpolation on falling rocks

### DIFF
--- a/mm/src/overlays/actors/ovl_En_Water_Effect/z_en_water_effect.c
+++ b/mm/src/overlays/actors/ovl_En_Water_Effect/z_en_water_effect.c
@@ -544,8 +544,8 @@ void func_80A5A184(Actor* thisx, PlayState* play2) {
 
             gDPSetPrimColor(POLY_XLU_DISP++, 0x80, 0x80, (u8)ptr->unk_38, 0, 0, (u8)ptr->unk_3C);
             gSPSegment(POLY_XLU_DISP++, 0x08,
-                       Gfx_TwoTexScrollEx(play->state.gfxCtx, 0, 0, 0, 0x20, 0x40, 1, 0, (ptr->unk_01 * -20) & 0x1FF,
-                                          0x20, 0x80, 0, 0, 0, -20));
+                       Gfx_TwoTexScroll(play->state.gfxCtx, 0, 0, 0, 0x20, 0x40, 1, 0, (ptr->unk_01 * -20) & 0x1FF,
+                                          0x20, 0x80));
 
             Matrix_Translate(ptr->unk_04.x, ptr->unk_04.y, ptr->unk_04.z, MTXMODE_NEW);
 

--- a/mm/src/overlays/actors/ovl_En_Water_Effect/z_en_water_effect.c
+++ b/mm/src/overlays/actors/ovl_En_Water_Effect/z_en_water_effect.c
@@ -545,7 +545,7 @@ void func_80A5A184(Actor* thisx, PlayState* play2) {
             gDPSetPrimColor(POLY_XLU_DISP++, 0x80, 0x80, (u8)ptr->unk_38, 0, 0, (u8)ptr->unk_3C);
             gSPSegment(POLY_XLU_DISP++, 0x08,
                        Gfx_TwoTexScroll(play->state.gfxCtx, 0, 0, 0, 0x20, 0x40, 1, 0, (ptr->unk_01 * -20) & 0x1FF,
-                                          0x20, 0x80));
+                                        0x20, 0x80));
 
             Matrix_Translate(ptr->unk_04.x, ptr->unk_04.y, ptr->unk_04.z, MTXMODE_NEW);
 


### PR DESCRIPTION
The ISTT falling rocks have scrolling texture interpolation that tries to step by -20. The problem is that the -20 is multiplied against a variable that is not linear with each frame. It is not correct to step by -20, and this might be responsible for crashes that some users are experiencing.

This disables the interpolation on that actor.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7208706709.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7207813082.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7207743096.zip)
<!--- section:artifacts:end -->