### PR TITLE
Lazy load sort DL Viewer unfiltered results

### DIFF
--- a/mm/2s2h/DeveloperTools/DLViewer.cpp
+++ b/mm/2s2h/DeveloperTools/DLViewer.cpp
@@ -38,6 +38,7 @@ std::string activeDisplayList = "";
 std::vector<std::string> displayListSearchResults;
 int16_t searchDebounceFrames = -1;
 bool doSearch = false;
+bool sortedFirstUnfiltered = false;
 
 // Extended command map with all GBI commands
 std::unordered_map<int, std::string> cmdMap = {
@@ -145,7 +146,7 @@ CommandCategory GetCommandCategory(int cmd) {
 
 void PerformDisplayListSearch() {
     // Get all DL files using broad pattern (glob_match is case-sensitive, so we filter manually)
-    auto result = Ship::Context::GetInstance()->GetResourceManager()->GetArchiveManager()->ListFiles("*DL*");
+    static auto result = Ship::Context::GetInstance()->GetResourceManager()->GetArchiveManager()->ListFiles("*DL*");
 
     displayListSearchResults.clear();
 
@@ -758,6 +759,11 @@ void DLViewerWindow::DrawElement() {
     if (cachedActionsHeaderWidth == 0.0f) {
         cachedActionsHeaderWidth = ImGui::CalcTextSize("Actions").x + ImGui::GetStyle().FramePadding.x * 2.0f;
     }
+    // Sorting ~16k unfiltered DLs is expensive on debug, so lazy load it on first draw
+    if (!sortedFirstUnfiltered) {
+        PerformDisplayListSearch();
+        sortedFirstUnfiltered = true;
+    }
 
     ImGui::BeginDisabled(CVarGetInteger("gDeveloperTools.DisableChanges", 0));
 
@@ -801,5 +807,4 @@ void DLViewerWindow::DrawElement() {
 }
 
 void DLViewerWindow::InitElement() {
-    PerformDisplayListSearch();
 }


### PR DESCRIPTION
Sorting all ~16k DLs is taxing and results in noticeable startup lag on debug, to my personal annoyance. Since the list does not need to be sorted until the user opens the menu, I changed it to lazy load on first draw, like other calculations in the DL Viewer.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7278139406.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7277943356.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7277788713.zip)
<!--- section:artifacts:end -->