### PR TITLE
[Enhancement] Port multiple warp points from SoH

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1504,7 +1504,8 @@ void BenMenu::AddEnhancements() {
     AddWidget(path, "Skip to File Select", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Cutscenes.SkipToFileSelect")
         .Options(CheckboxOptions().Tooltip(
-            "Skip the opening title sequence and go straight to the file select menu after boot."));
+            "Skip the opening title sequence and go straight to the file select menu after boot.\n\n"
+            "Note: Takes priority over debug warp points with [Boot] enabled."));
     AddWidget(path, "Skip Intro Sequence", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Cutscenes.SkipIntroSequence")
         .Options(CheckboxOptions().Tooltip(

--- a/mm/2s2h/BenJsonConversions.hpp
+++ b/mm/2s2h/BenJsonConversions.hpp
@@ -12,21 +12,21 @@ extern "C" {
 
 using json = nlohmann::json;
 
-void to_json(json& j, const DpadSaveInfo& dpadEquips) {
+inline void to_json(json& j, const DpadSaveInfo& dpadEquips) {
     j = json{
         { "dpadItems", dpadEquips.dpadItems },
         { "dpadSlots", dpadEquips.dpadSlots },
     };
 }
 
-void from_json(const json& j, DpadSaveInfo& dpadEquips) {
+inline void from_json(const json& j, DpadSaveInfo& dpadEquips) {
     for (int i = 0; i < ARRAY_COUNT(dpadEquips.dpadItems); i++) {
         j.at("dpadItems").at(i).get_to(dpadEquips.dpadItems[i]);
         j.at("dpadSlots").at(i).get_to(dpadEquips.dpadSlots[i]);
     }
 }
 
-void to_json(json& j, const RandoSaveCheck& randoSaveCheck) {
+inline void to_json(json& j, const RandoSaveCheck& randoSaveCheck) {
     j = json{
         { "randoItemId", randoSaveCheck.randoItemId },
         { "eligible", randoSaveCheck.eligible },
@@ -38,7 +38,7 @@ void to_json(json& j, const RandoSaveCheck& randoSaveCheck) {
     };
 }
 
-void from_json(const json& j, RandoSaveCheck& randoSaveCheck) {
+inline void from_json(const json& j, RandoSaveCheck& randoSaveCheck) {
     j.at("randoItemId").get_to(randoSaveCheck.randoItemId);
     j.at("eligible").get_to(randoSaveCheck.eligible);
     j.at("cycleObtained").get_to(randoSaveCheck.cycleObtained);
@@ -48,7 +48,7 @@ void from_json(const json& j, RandoSaveCheck& randoSaveCheck) {
     j.at("price").get_to(randoSaveCheck.price);
 }
 
-void to_json(json& j, const RandoSaveInfo& rando) {
+inline void to_json(json& j, const RandoSaveInfo& rando) {
     j = json{
         { "randoInf", rando.randoInf },
         { "randoEvents", rando.randoEvents },
@@ -61,7 +61,7 @@ void to_json(json& j, const RandoSaveInfo& rando) {
     };
 }
 
-void from_json(const json& j, RandoSaveInfo& rando) {
+inline void from_json(const json& j, RandoSaveInfo& rando) {
     j.at("randoInf").get_to(rando.randoInf);
     j.at("randoEvents").get_to(rando.randoEvents);
     j.at("randoSaveChecks").get_to(rando.randoSaveChecks);
@@ -72,7 +72,7 @@ void from_json(const json& j, RandoSaveInfo& rando) {
     j.at("foundTriforcePieces").get_to(rando.foundTriforcePieces);
 }
 
-void to_json(json& j, const Vec3f& vec) {
+inline void to_json(json& j, const Vec3f& vec) {
     j = json{
         { "x", vec.x },
         { "y", vec.y },
@@ -80,13 +80,13 @@ void to_json(json& j, const Vec3f& vec) {
     };
 }
 
-void from_json(const json& j, Vec3f& vec) {
+inline void from_json(const json& j, Vec3f& vec) {
     j.at("x").get_to(vec.x);
     j.at("y").get_to(vec.y);
     j.at("z").get_to(vec.z);
 }
 
-void to_json(json& j, const RespawnData& respawnData) {
+inline void to_json(json& j, const RespawnData& respawnData) {
     j = json{
         { "pos", respawnData.pos },
         { "yaw", respawnData.yaw },
@@ -100,7 +100,7 @@ void to_json(json& j, const RespawnData& respawnData) {
     };
 }
 
-void from_json(const json& j, RespawnData& respawnData) {
+inline void from_json(const json& j, RespawnData& respawnData) {
     j.at("pos").get_to(respawnData.pos);
     j.at("yaw").get_to(respawnData.yaw);
     j.at("playerParams").get_to(respawnData.playerParams);
@@ -112,7 +112,7 @@ void from_json(const json& j, RespawnData& respawnData) {
     j.at("tempCollectFlags").get_to(respawnData.tempCollectFlags);
 }
 
-void to_json(json& j, const ShipSaveInfo& shipSaveInfo) {
+inline void to_json(json& j, const ShipSaveInfo& shipSaveInfo) {
     uint8_t commitHash[8];
     memcpy(commitHash, shipSaveInfo.commitHash, sizeof(commitHash));
 
@@ -132,7 +132,7 @@ void to_json(json& j, const ShipSaveInfo& shipSaveInfo) {
     }
 }
 
-void from_json(const json& j, ShipSaveInfo& shipSaveInfo) {
+inline void from_json(const json& j, ShipSaveInfo& shipSaveInfo) {
     j.at("dpadEquips").get_to(shipSaveInfo.dpadEquips);
     j.at("pauseSaveEntrance").get_to(shipSaveInfo.pauseSaveEntrance);
     j.at("saveType").get_to(shipSaveInfo.saveType);
@@ -152,7 +152,7 @@ void from_json(const json& j, ShipSaveInfo& shipSaveInfo) {
     }
 }
 
-void to_json(json& j, const ItemEquips& itemEquips) {
+inline void to_json(json& j, const ItemEquips& itemEquips) {
     j = json{
         { "buttonItems", itemEquips.buttonItems },
         { "cButtonSlots", itemEquips.cButtonSlots },
@@ -160,7 +160,7 @@ void to_json(json& j, const ItemEquips& itemEquips) {
     };
 }
 
-void from_json(const json& j, ItemEquips& itemEquips) {
+inline void from_json(const json& j, ItemEquips& itemEquips) {
     j.at("equipment").get_to(itemEquips.equipment);
     // buttonItems and cButtonSlots are arrays of arrays, so we need to manually parse them
     for (int i = 0; i < ARRAY_COUNT(itemEquips.buttonItems); i++) {
@@ -169,8 +169,8 @@ void from_json(const json& j, ItemEquips& itemEquips) {
     }
 }
 
-void to_json(json& j, const Inventory& inventory) {
-    // Setup and copy u8 arrays to avoid json treating char[] as strings
+inline void to_json(json& j, const Inventory& inventory) {
+    // Setup and copy u8 arrays to ainline void json treating char[] as strings
     // These char[] are not null-terminated, so saving as strings causes overflow/corruption
     uint8_t dekuPlaygroundPlayerName[3][8];
     memcpy(dekuPlaygroundPlayerName, inventory.dekuPlaygroundPlayerName, sizeof(dekuPlaygroundPlayerName));
@@ -188,7 +188,7 @@ void to_json(json& j, const Inventory& inventory) {
     };
 }
 
-void from_json(const json& j, Inventory& inventory) {
+inline void from_json(const json& j, Inventory& inventory) {
     j.at("items").get_to(inventory.items);
     j.at("ammo").get_to(inventory.ammo);
     j.at("upgrades").get_to(inventory.upgrades);
@@ -203,7 +203,7 @@ void from_json(const json& j, Inventory& inventory) {
     }
 }
 
-void to_json(json& j, const PermanentSceneFlags& permanentSceneFlags) {
+inline void to_json(json& j, const PermanentSceneFlags& permanentSceneFlags) {
     j = json{
         { "chest", permanentSceneFlags.chest },
         { "switch0", permanentSceneFlags.switch0 },
@@ -215,7 +215,7 @@ void to_json(json& j, const PermanentSceneFlags& permanentSceneFlags) {
     };
 }
 
-void from_json(const json& j, PermanentSceneFlags& permanentSceneFlags) {
+inline void from_json(const json& j, PermanentSceneFlags& permanentSceneFlags) {
     j.at("chest").get_to(permanentSceneFlags.chest);
     j.at("switch0").get_to(permanentSceneFlags.switch0);
     j.at("switch1").get_to(permanentSceneFlags.switch1);
@@ -225,8 +225,8 @@ void from_json(const json& j, PermanentSceneFlags& permanentSceneFlags) {
     j.at("rooms").get_to(permanentSceneFlags.rooms);
 }
 
-void to_json(json& j, const SavePlayerData& savePlayerData) {
-    // Setup and copy u8 arrays to avoid json treating char[] as strings
+inline void to_json(json& j, const SavePlayerData& savePlayerData) {
+    // Setup and copy u8 arrays to ainline void json treating char[] as strings
     // These char[] are not null-terminated, so saving as strings causes overflow/corruption
     u8 newf[6];
     u8 playerName[8];
@@ -255,7 +255,7 @@ void to_json(json& j, const SavePlayerData& savePlayerData) {
     };
 }
 
-void from_json(const json& j, SavePlayerData& savePlayerData) {
+inline void from_json(const json& j, SavePlayerData& savePlayerData) {
     j.at("newf").get_to(savePlayerData.newf);
     j.at("threeDayResetCount").get_to(savePlayerData.threeDayResetCount);
     j.at("playerName").get_to(savePlayerData.playerName);
@@ -276,7 +276,7 @@ void from_json(const json& j, SavePlayerData& savePlayerData) {
     j.at("savedSceneId").get_to(savePlayerData.savedSceneId);
 }
 
-void to_json(json& j, const Vec3s& vec) {
+inline void to_json(json& j, const Vec3s& vec) {
     j = json{
         { "x", vec.x },
         { "y", vec.y },
@@ -284,13 +284,13 @@ void to_json(json& j, const Vec3s& vec) {
     };
 }
 
-void from_json(const json& j, Vec3s& vec) {
+inline void from_json(const json& j, Vec3s& vec) {
     j.at("x").get_to(vec.x);
     j.at("y").get_to(vec.y);
     j.at("z").get_to(vec.z);
 }
 
-void to_json(json& j, const HorseData& horseData) {
+inline void to_json(json& j, const HorseData& horseData) {
     j = json{
         { "sceneId", horseData.sceneId },
         { "pos", horseData.pos },
@@ -298,13 +298,13 @@ void to_json(json& j, const HorseData& horseData) {
     };
 }
 
-void from_json(const json& j, HorseData& horseData) {
+inline void from_json(const json& j, HorseData& horseData) {
     j.at("sceneId").get_to(horseData.sceneId);
     j.at("pos").get_to(horseData.pos);
     j.at("yaw").get_to(horseData.yaw);
 }
 
-void to_json(json& j, const SaveInfo& saveInfo) {
+inline void to_json(json& j, const SaveInfo& saveInfo) {
     j = json{
         { "playerData", saveInfo.playerData },
         { "equips", saveInfo.equips },
@@ -341,7 +341,7 @@ void to_json(json& j, const SaveInfo& saveInfo) {
     };
 }
 
-void from_json(const json& j, SaveInfo& saveInfo) {
+inline void from_json(const json& j, SaveInfo& saveInfo) {
     j.at("playerData").get_to(saveInfo.playerData);
     j.at("equips").get_to(saveInfo.equips);
     j.at("inventory").get_to(saveInfo.inventory);
@@ -379,7 +379,7 @@ void from_json(const json& j, SaveInfo& saveInfo) {
     j.at("checksum").get_to(saveInfo.checksum);
 }
 
-void to_json(json& j, const Save& save) {
+inline void to_json(json& j, const Save& save) {
     j = json{
         { "entrance", save.entrance },
         { "equippedMask", save.equippedMask },
@@ -402,7 +402,7 @@ void to_json(json& j, const Save& save) {
     };
 }
 
-void from_json(const json& j, Save& save) {
+inline void from_json(const json& j, Save& save) {
     j.at("entrance").get_to(save.entrance);
     j.at("equippedMask").get_to(save.equippedMask);
     j.at("isFirstCycle").get_to(save.isFirstCycle);
@@ -423,7 +423,7 @@ void from_json(const json& j, Save& save) {
     j.at("shipSaveInfo").get_to(save.shipSaveInfo);
 }
 
-void to_json(json& j, const SaveContext& saveContext) {
+inline void to_json(json& j, const SaveContext& saveContext) {
     j = json{
         { "save", saveContext.save },
         { "eventInf", saveContext.eventInf },
@@ -440,7 +440,7 @@ void to_json(json& j, const SaveContext& saveContext) {
     };
 }
 
-void from_json(const json& j, SaveContext& saveContext) {
+inline void from_json(const json& j, SaveContext& saveContext) {
     j.at("save").get_to(saveContext.save);
     j.at("eventInf").get_to(saveContext.eventInf);
     j.at("unk_1014").get_to(saveContext.unk_1014);
@@ -455,7 +455,7 @@ void from_json(const json& j, SaveContext& saveContext) {
     j.at("pictoPhotoI5").get_to(saveContext.pictoPhotoI5);
 }
 
-void to_json(json& j, const SaveOptions& saveOptions) {
+inline void to_json(json& j, const SaveOptions& saveOptions) {
     j = json{
         { "optionId", saveOptions.optionId },
         { "language", saveOptions.language },
@@ -465,7 +465,7 @@ void to_json(json& j, const SaveOptions& saveOptions) {
     };
 }
 
-void from_json(const json& j, SaveOptions& saveOptions) {
+inline void from_json(const json& j, SaveOptions& saveOptions) {
     j.at("optionId").get_to(saveOptions.optionId);
     j.at("language").get_to(saveOptions.language);
     j.at("audioSetting").get_to(saveOptions.audioSetting);

--- a/mm/2s2h/DeveloperTools/DeveloperTools.h
+++ b/mm/2s2h/DeveloperTools/DeveloperTools.h
@@ -1,8 +1,6 @@
 #ifndef DEVELOPER_TOOLS_H
 #define DEVELOPER_TOOLS_H
 
-#define WARP_POINT_CVAR "gDeveloperTools.WarpPoint."
-
 enum DebugSaveInfo {
     DEBUG_SAVE_INFO_NONE,
     DEBUG_SAVE_INFO_VANILLA_DEBUG,

--- a/mm/2s2h/DeveloperTools/WarpPoint.cpp
+++ b/mm/2s2h/DeveloperTools/WarpPoint.cpp
@@ -1,9 +1,11 @@
 #include "2s2h/BenGui/UIWidgets.hpp"
+#include <ship/config/Config.h>
 #include <ship/window/gui/IconsFontAwesome4.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/DeveloperTools/DeveloperTools.h"
 #include "2s2h/ShipInit.hpp"
 #include "2s2h/BenGui/BenGui.hpp"
+#include "BenJsonConversions.hpp"
 
 extern "C" {
 #include "z64.h"
@@ -15,30 +17,37 @@ extern SaveContext gSaveContext;
 extern GameState* gGameState;
 }
 
-// 2S2H Added columns to scene table: entranceSceneId, betterMapSelectIndex, humanName
-#define DEFINE_SCENE(_name, enumValue, _textId, _drawConfig, _restrictionFlags, _persistentCycleFlags, \
-                     _entranceSceneId, _betterMapSelectIndex, humanName)                               \
-    { enumValue, humanName },
-#define DEFINE_SCENE_UNSET(_enumValue)
+typedef struct WarpPoint {
+    s32 entranceId;
+    s8 roomNum;
+    Vec3f pos;
+    s16 rotY;
+    bool bootToPoint;
+} WarpPoint;
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(WarpPoint, entranceId, roomNum, pos, rotY, bootToPoint)
+std::map<std::string, WarpPoint> warpPoints;
 
-std::unordered_map<s16, const char*> warpPointSceneList = {
-#include "tables/scene_table.h"
-};
+#define CVAR_BOOT_TO_FILE_SELECT_NAME "gEnhancements.Cutscenes.SkipToFileSelect"
+#define CVAR_BOOT_TO_FILE_SELECT ((bool)CVarGetInteger(CVAR_BOOT_TO_FILE_SELECT_NAME, 0))
 
-#undef DEFINE_SCENE
-#undef DEFINE_SCENE_UNSET
+void LoadConfig() {
+    auto allConfig = Ship::Context::GetInstance()->GetConfig()->GetNestedJson();
+    if (allConfig.find("WarpPoints") == allConfig.end() || !allConfig["WarpPoints"].is_object()) {
+        allConfig["WarpPoints"] = nlohmann::json::object();
+    }
+    warpPoints = allConfig["WarpPoints"];
+}
 
-void Warp() {
-    Vec3f pos = { CVarGetFloat(WARP_POINT_CVAR "X", 0.0f), CVarGetFloat(WARP_POINT_CVAR "Y", 0.0f),
-                  CVarGetFloat(WARP_POINT_CVAR "Z", 0.0f) };
-    s32 entrance = CVarGetInteger(WARP_POINT_CVAR "Entrance", ENTRANCE(SOUTH_CLOCK_TOWN, 0));
+void SaveConfig() {
+    auto allConfig = Ship::Context::GetInstance()->GetConfig()->GetNestedJson();
+    allConfig["WarpPoints"] = warpPoints;
+    Ship::Context::GetInstance()->GetConfig()->SetBlock("WarpPoints", warpPoints);
+    Ship::Context::GetInstance()->GetConfig()->Save();
+}
 
+void Warp(WarpPoint& warpPoint) {
     if (gPlayState == NULL) {
-        // If gPlayState is NULL, it means the the user opted into BootToWarpPoint and the game is starting up. This is
-        // a hidden cvar for developers, while it is extremely useful for quick testing and debugging, I am not 100%
-        // confident in it's stability and ability to initialize the game properly in all cases. So for now, I'm going
-        // to leave it as a hidden cvar. This is incompatible with the SkipToFileSelect enhancement. To enable it open
-        // the Console and type: `set gDeveloperTools.WarpPoint.BootToWarpPoint 1`
+        // If gPlayState is NULL, it means the the user opted into BootToWarpPoint and the game is starting up.
         gSaveContext.gameMode = GAMEMODE_NORMAL;
         Sram_InitNewSave();
         gSaveContext.sceneLayer = 0;
@@ -64,105 +73,129 @@ void Warp() {
 
         // Using dummy file num to bypass debug save setup in map select and manually execute save init/load hooks after
         gSaveContext.fileNum = 0xFE;
-        MapSelect_LoadGame((MapSelectState*)gGameState, entrance, 0);
+        MapSelect_LoadGame((MapSelectState*)gGameState, warpPoint.entranceId, 0);
         // Then back to debug file num
         gSaveContext.fileNum = 0xFF;
         // These two lines allow randomizer to be used with BootToWarpPoint. Not sure how reliable this is, might remove
         GameInteractor_ExecuteOnSaveInit(gSaveContext.fileNum);
         GameInteractor_ExecuteOnSaveLoad(gSaveContext.fileNum);
-        gSaveContext.save.entrance = entrance;
+        gSaveContext.save.entrance = warpPoint.entranceId;
     } else {
         // The else case, and the rest of this function is primarily relevant code copied from Play_SetRespawnData and
         // func_80169EFC, minus the parts that copy scene flags to scene we are warping to (this is obviously
         // undesirable)
-        gPlayState->nextEntrance = Entrance_Create(entrance >> 9, 0, entrance & 0xF);
+        gPlayState->nextEntrance = Entrance_Create(warpPoint.entranceId >> 9, 0, warpPoint.entranceId & 0xF);
         gPlayState->transitionTrigger = TRANS_TRIGGER_START;
         gPlayState->transitionType = TRANS_TYPE_INSTANT;
     }
-    gSaveContext.respawn[RESPAWN_MODE_DOWN].entrance = Entrance_Create(entrance >> 9, 0, entrance & 0xF);
-    gSaveContext.respawn[RESPAWN_MODE_DOWN].roomIndex = CVarGetInteger(WARP_POINT_CVAR "Room", 0);
-    gSaveContext.respawn[RESPAWN_MODE_DOWN].pos = pos;
-    gSaveContext.respawn[RESPAWN_MODE_DOWN].yaw = CVarGetFloat(WARP_POINT_CVAR "Rotation", 0.0f);
+    gSaveContext.respawn[RESPAWN_MODE_DOWN].entrance =
+        Entrance_Create(warpPoint.entranceId >> 9, 0, warpPoint.entranceId & 0xF);
+    gSaveContext.respawn[RESPAWN_MODE_DOWN].roomIndex = warpPoint.roomNum;
+    gSaveContext.respawn[RESPAWN_MODE_DOWN].pos = warpPoint.pos;
+    gSaveContext.respawn[RESPAWN_MODE_DOWN].yaw = warpPoint.rotY;
     gSaveContext.respawn[RESPAWN_MODE_DOWN].playerParams = PLAYER_PARAMS(0xFF, PLAYER_START_MODE_D);
     gSaveContext.nextTransitionType = TRANS_TYPE_FADE_BLACK_FAST;
     gSaveContext.respawnFlag = -8;
 }
 
-void RegisterWarpPoint() {
-    static bool registered = false;
-    if (registered) {
-        return;
-    }
-    registered = true;
+static std::string warpNameInput = "";
 
-    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnConsoleLogoUpdate>([]() {
-        if (!CVarGetInteger("gEnhancements.Cutscenes.SkipToFileSelect", 0) &&
-            CVarGetInteger(WARP_POINT_CVAR "BootToWarpPoint", 0) && CVarGetInteger(WARP_POINT_CVAR "Saved", 0)) {
-            // Normally called on console logo screen
-            gSaveContext.seqId = NA_BGM_DISABLED;
-            gSaveContext.ambienceId = AMBIENCE_ID_DISABLED;
-            gSaveContext.gameMode = GAMEMODE_TITLE_SCREEN;
-            Warp();
+void RenderWarpPointSection() {
+    ImGui::SeparatorText("Warp Points");
+    if (gPlayState != NULL && GET_PLAYER(gPlayState) != NULL) {
+        UIWidgets::InputString("##WarpPointNameInput", &warpNameInput,
+                               {
+                                   .labelPosition = UIWidgets::LabelPosition::None,
+                                   .size = ImVec2(ImGui::GetContentRegionAvail().x - 50.0f, 0.0f),
+                                   .placeholder = "Enter warp point name...",
+                               });
+
+        ImGui::SameLine();
+        bool isEmpty = warpNameInput.empty();
+        if (isEmpty) {
+            ImGui::BeginDisabled();
+        }
+
+        if (UIWidgets::Button(ICON_FA_PLUS)) {
+            Player* player = GET_PLAYER(gPlayState);
+
+            std::string warpName = Ship_GetSceneName(gPlayState->sceneId);
+            if (gPlayState->roomCtx.curRoom.num != 0) {
+                warpName += " (" + std::to_string(gPlayState->roomCtx.curRoom.num) + ")";
+            }
+
+            warpPoints[warpNameInput] = WarpPoint{
+                .entranceId = gSaveContext.save.entrance,
+                .roomNum = gPlayState->roomCtx.curRoom.num,
+                .pos = player->actor.world.pos,
+                .rotY = player->actor.shape.rot.y,
+            };
+            SaveConfig();
+            warpNameInput = "";
+        }
+        if (isEmpty) {
+            ImGui::EndDisabled();
+        }
+    }
+    // List of warp points, showing just their name, a button to warp and a button to delete
+    for (auto it = warpPoints.begin(); it != warpPoints.end();) {
+        ImGui::PushID(it->first.c_str());
+
+        ImGui::AlignTextToFramePadding();
+        ImGui::Text("%s", it->first.c_str());
+        if (it->second.bootToPoint) {
+            ImGui::SameLine();
+            ImGui::TextColored(ImVec4(0.85f, 0.55f, 0.0f, 1.0f), "[Boot]");
+        }
+        ImGui::SameLine(ImGui::GetContentRegionAvail().x - 115.0f);
+        if (gPlayState == NULL)
+            ImGui::BeginDisabled();
+        if (UIWidgets::Button(ICON_FA_PLANE, { .size = UIWidgets::Sizes::Inline })) {
+            // Warp to this point
+            Warp(it->second);
+        }
+        if (gPlayState == NULL)
+            ImGui::EndDisabled();
+        ImGui::SameLine();
+        if (UIWidgets::Button(ICON_FA_REFRESH,
+                              { .size = UIWidgets::Sizes::Inline, .color = UIWidgets::Colors::Orange })) {
+            bool wasEnabled = it->second.bootToPoint;
+            for (auto& wp : warpPoints) {
+                wp.second.bootToPoint = false;
+            }
+            it->second.bootToPoint = !wasEnabled;
+            SaveConfig();
+        }
+        ImGui::SameLine();
+        if (UIWidgets::Button(ICON_FA_TRASH, { .size = UIWidgets::Sizes::Inline, .color = UIWidgets::Colors::Red })) {
+            it = warpPoints.erase(it);
+            SaveConfig();
+            ImGui::PopID();
+            continue;
+        }
+        ImGui::PopID();
+
+        ++it;
+    }
+}
+
+void RegisterWarpPoints() {
+    static bool loadedConfig = false;
+    if (!loadedConfig) {
+        LoadConfig();
+        loadedConfig = true;
+    }
+
+    // Warp to point that has bootToWarp enabled. Do not run if Skip to File Select is enabled.
+    COND_HOOK(OnConsoleLogoUpdate, !CVAR_BOOT_TO_FILE_SELECT, []() {
+        // Normally called on console logo screen
+        for (auto& wp : warpPoints) {
+            if (wp.second.bootToPoint) {
+                Warp(wp.second);
+                break;
+            }
         }
     });
 }
 
-void RenderWarpPointSection() {
-    bool skipToFileSelect = (bool)CVarGetInteger("gEnhancements.Cutscenes.SkipToFileSelect", 0);
-    UIWidgets::CVarCheckbox(
-        "Boot to Warp Point on Launch", WARP_POINT_CVAR "BootToWarpPoint",
-        UIWidgets::CheckboxOptions({ { .disabled = skipToFileSelect,
-                                       .disabledTooltip = "Incompatible with Skip to File Select enhancement" } })
-            .Color(THEME_COLOR)
-            .Tooltip(
-                "If enabled, the game will boot directly to the saved warp point with the debug save when launching "
-                "the game. Make temporary changes to the debug save (in code) to speed up your debugging experience\n\n"
-                "Incompatible with Skip to File Select enhancement."));
-    if (UIWidgets::Button("Set Warp Point", { { .disabled = gPlayState == NULL,
-                                                .disabledTooltip = "Cannot set warp points when not in-game" } })) {
-        Player* player = GET_PLAYER(gPlayState);
-
-        CVarSetInteger(WARP_POINT_CVAR "Entrance", gSaveContext.save.entrance);
-        CVarSetInteger(WARP_POINT_CVAR "Room", gPlayState->roomCtx.curRoom.num);
-        CVarSetFloat(WARP_POINT_CVAR "X", player->actor.world.pos.x);
-        CVarSetFloat(WARP_POINT_CVAR "Y", player->actor.world.pos.y);
-        CVarSetFloat(WARP_POINT_CVAR "Z", player->actor.world.pos.z);
-        CVarSetFloat(WARP_POINT_CVAR "Rotation", player->actor.shape.rot.y);
-        CVarSetInteger(WARP_POINT_CVAR "Saved", 1);
-        Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
-    }
-    if (CVarGetInteger(WARP_POINT_CVAR "Saved", 0)) {
-        u32 sceneId =
-            Entrance_GetSceneIdAbsolute(CVarGetInteger(WARP_POINT_CVAR "Entrance", ENTRANCE(SOUTH_CLOCK_TOWN, 0)));
-        if (ImGui::BeginTable("Warp point table", 3, ImGuiTableFlags_SizingFixedFit)) {
-            ImGui::TableSetupColumn("##Entrance", ImGuiTableColumnFlags_WidthStretch);
-            ImGui::TableSetupColumn("##Clear", ImGuiTableColumnFlags_WidthFixed);
-            ImGui::TableSetupColumn("##Warp", ImGuiTableColumnFlags_WidthFixed);
-            ImGui::TableNextRow();
-
-            ImGui::TableNextColumn();
-            ImGui::TextWrapped("%s Room %d", warpPointSceneList[sceneId], CVarGetInteger(WARP_POINT_CVAR "Room", 0));
-
-            ImGui::TableNextColumn();
-            if (UIWidgets::Button(ICON_FA_TIMES, { .size = UIWidgets::Sizes::Inline })) {
-                CVarClear(WARP_POINT_CVAR "Entrance");
-                CVarClear(WARP_POINT_CVAR "Room");
-                CVarClear(WARP_POINT_CVAR "X");
-                CVarClear(WARP_POINT_CVAR "Y");
-                CVarClear(WARP_POINT_CVAR "Z");
-                CVarClear(WARP_POINT_CVAR "Rotation");
-                CVarClear(WARP_POINT_CVAR "Saved");
-                Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
-            }
-
-            ImGui::TableNextColumn();
-            if (UIWidgets::Button("Warp", { .size = UIWidgets::Sizes::Inline })) {
-                Warp();
-            }
-
-            ImGui::EndTable();
-        }
-    }
-}
-
-RegisterShipInitFunc initFuncWarpPoint(RegisterWarpPoint, {});
+static RegisterShipInitFunc initFunc(RegisterWarpPoints, { CVAR_BOOT_TO_FILE_SELECT_NAME });

--- a/mm/2s2h/DeveloperTools/WarpPoint.cpp
+++ b/mm/2s2h/DeveloperTools/WarpPoint.cpp
@@ -111,17 +111,15 @@ void RenderWarpPointSection() {
                                });
 
         ImGui::SameLine();
-        bool isEmpty = warpNameInput.empty();
-        if (isEmpty) {
-            ImGui::BeginDisabled();
-        }
-
         if (UIWidgets::Button(ICON_FA_PLUS)) {
             Player* player = GET_PLAYER(gPlayState);
 
-            std::string warpName = Ship_GetSceneName(gPlayState->sceneId);
-            if (gPlayState->roomCtx.curRoom.num != 0) {
-                warpName += " (" + std::to_string(gPlayState->roomCtx.curRoom.num) + ")";
+            bool isEmpty = warpNameInput.empty();
+            if (warpNameInput.empty()) {
+                warpNameInput = Ship_GetSceneName(gPlayState->sceneId);
+                if (gPlayState->roomCtx.curRoom.num != 0) {
+                    warpNameInput += " (" + std::to_string(gPlayState->roomCtx.curRoom.num) + ")";
+                }
             }
 
             warpPoints[warpNameInput] = WarpPoint{
@@ -132,9 +130,6 @@ void RenderWarpPointSection() {
             };
             SaveConfig();
             warpNameInput = "";
-        }
-        if (isEmpty) {
-            ImGui::EndDisabled();
         }
     }
     // List of warp points, showing just their name, a button to warp and a button to delete

--- a/mm/2s2h/config/ConfigUpdaters.cpp
+++ b/mm/2s2h/config/ConfigUpdaters.cpp
@@ -50,12 +50,36 @@ static void MigrateDisplayOverlayTimerMode(Ship::Config* conf) {
     }
 }
 
+static void MigrateWarpPoints(Ship::Config* conf) {
+    auto warpPoints = nlohmann::json::object();
+
+    if (conf->GetNestedJson().contains("CVars")) {
+        if (CVarGetInteger("gDeveloperTools.WarpPoint.Saved", 0) != 0) {
+            s32 entranceId = CVarGetInteger("gDeveloperTools.WarpPoint.Entrance", 0);
+            s8 roomNum = CVarGetInteger("gDeveloperTools.WarpPoint.Room", 0);
+            Vec3f pos = { CVarGetFloat("gDeveloperTools.WarpPoint.X", 0.0f),
+                          CVarGetFloat("gDeveloperTools.WarpPoint.Y", 0.0f),
+                          CVarGetFloat("gDeveloperTools.WarpPoint.Z", 0.0f) };
+            s16 rotY = CVarGetFloat("gDeveloperTools.WarpPoint.Rotation", 0.0f);
+            bool bootToPoint = CVarGetInteger("gDeveloperTools.WarpPoint.BootToWarpPoint", 0) > 0;
+            warpPoints["Debug Warp Point"] = { { "entranceId", entranceId },
+                                               { "roomNum", roomNum },
+                                               { "pos", { { "x", pos.x }, { "y", pos.y }, { "z", pos.z } } },
+                                               { "rotY", rotY },
+                                               { "bootToPoint", bootToPoint } };
+        }
+    }
+
+    Ship::Context::GetInstance()->GetConfig()->SetBlock("WarpPoints", warpPoints);
+}
+
 ConfigVersion1Updater::ConfigVersion1Updater() : ConfigVersionUpdater(1) {
 }
 
 void ConfigVersion1Updater::Update(Ship::Config* conf) {
     ApplyMigrationActions(version1Migrations);
     MigrateDisplayOverlayTimerMode(conf);
+    MigrateWarpPoints(conf);
 }
 
 } // namespace Ben


### PR DESCRIPTION
<img width="708" height="133" alt="image" src="https://github.com/user-attachments/assets/22536b2c-806a-46bb-88f9-23977ee29ae2" />

- Multiple warp points with buttons to warp, set as boot point, and delete (Boot to Warp is no longer hidden)
- Added tooltip to Skip to File Select to clarify that it takes priority over boot to warp
- Added migration from singular warp point to new structure, with a default name of "Debug Warp Point"
- Set all nlohmann json conversions to `inline` because I couldn't get the `WarpPoint` struct conversion to compile otherwise

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7340448230.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7340227181.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7340032017.zip)
<!--- section:artifacts:end -->