### PR TITLE
Fix GC US assets conflicting with N64 US HD assets

### DIFF
--- a/mm/assets/misc/title_static/title_static.h
+++ b/mm/assets/misc/title_static/title_static.h
@@ -6,17 +6,32 @@
 #define dgFileSelNoFileToCopyENGTex "__OTR__misc/title_static/gFileSelNoFileToCopyENGTex"
 static const ALIGN_ASSET(2) char gFileSelNoFileToCopyENGTex[] = dgFileSelNoFileToCopyENGTex;
 
+#define dgFileSelNoFileToCopyIA4ENGTex "__OTR__misc/title_static/gFileSelNoFileToCopyIA4ENGTex"
+static const ALIGN_ASSET(2) char gFileSelNoFileToCopyIA4ENGTex[] = dgFileSelNoFileToCopyIA4ENGTex;
+
 #define dgFileSelNoFileToEraseENGTex "__OTR__misc/title_static/gFileSelNoFileToEraseENGTex"
 static const ALIGN_ASSET(2) char gFileSelNoFileToEraseENGTex[] = dgFileSelNoFileToEraseENGTex;
+
+#define dgFileSelNoFileToEraseIA4ENGTex "__OTR__misc/title_static/gFileSelNoFileToEraseIA4ENGTex"
+static const ALIGN_ASSET(2) char gFileSelNoFileToEraseIA4ENGTex[] = dgFileSelNoFileToEraseIA4ENGTex;
 
 #define dgFileSelNoEmptyFileENGTex "__OTR__misc/title_static/gFileSelNoEmptyFileENGTex"
 static const ALIGN_ASSET(2) char gFileSelNoEmptyFileENGTex[] = dgFileSelNoEmptyFileENGTex;
 
+#define dgFileSelNoEmptyFileIA4ENGTex "__OTR__misc/title_static/gFileSelNoEmptyFileIA4ENGTex"
+static const ALIGN_ASSET(2) char gFileSelNoEmptyFileIA4ENGTex[] = dgFileSelNoEmptyFileIA4ENGTex;
+
 #define dgFileSelFileEmptyENGTex "__OTR__misc/title_static/gFileSelFileEmptyENGTex"
 static const ALIGN_ASSET(2) char gFileSelFileEmptyENGTex[] = dgFileSelFileEmptyENGTex;
 
+#define dgFileSelFileEmptyIA4ENGTex "__OTR__misc/title_static/gFileSelFileEmptyIA4ENGTex"
+static const ALIGN_ASSET(2) char gFileSelFileEmptyIA4ENGTex[] = dgFileSelFileEmptyIA4ENGTex;
+
 #define dgFileSelFileInUseENGTex "__OTR__misc/title_static/gFileSelFileInUseENGTex"
 static const ALIGN_ASSET(2) char gFileSelFileInUseENGTex[] = dgFileSelFileInUseENGTex;
+
+#define dgFileSelFileInUseIA4ENGTex "__OTR__misc/title_static/gFileSelFileInUseIA4ENGTex"
+static const ALIGN_ASSET(2) char gFileSelFileInUseIA4ENGTex[] = dgFileSelFileInUseIA4ENGTex;
 
 #define dgFileSelConnectorTex "__OTR__misc/title_static/gFileSelConnectorTex"
 static const ALIGN_ASSET(2) char gFileSelConnectorTex[] = dgFileSelConnectorTex;
@@ -51,35 +66,65 @@ static const ALIGN_ASSET(2) char gFileSelFileErasedENGTex[] = dgFileSelFileErase
 #define dgFileSelOptionsENGTex "__OTR__misc/title_static/gFileSelOptionsENGTex"
 static const ALIGN_ASSET(2) char gFileSelOptionsENGTex[] = dgFileSelOptionsENGTex;
 
+#define dgFileSelOptionsIA4ENGTex "__OTR__misc/title_static/gFileSelOptionsIA4ENGTex"
+static const ALIGN_ASSET(2) char gFileSelOptionsIA4ENGTex[] = dgFileSelOptionsIA4ENGTex;
+
 #define dgFileSelNameENGTex "__OTR__misc/title_static/gFileSelNameENGTex"
 static const ALIGN_ASSET(2) char gFileSelNameENGTex[] = dgFileSelNameENGTex;
 
 #define dgFileSelSurroundENGTex "__OTR__misc/title_static/gFileSelSurroundENGTex"
 static const ALIGN_ASSET(2) char gFileSelSurroundENGTex[] = dgFileSelSurroundENGTex;
 
+#define dgFileSelSurroundIA4ENGTex "__OTR__misc/title_static/gFileSelSurroundIA4ENGTex"
+static const ALIGN_ASSET(2) char gFileSelSurroundIA4ENGTex[] = dgFileSelSurroundIA4ENGTex;
+
 #define dgFileSelHeadsetENGTex "__OTR__misc/title_static/gFileSelHeadsetENGTex"
 static const ALIGN_ASSET(2) char gFileSelHeadsetENGTex[] = dgFileSelHeadsetENGTex;
+
+#define dgFileSelHeadsetIA4ENGTex "__OTR__misc/title_static/gFileSelHeadsetIA4ENGTex"
+static const ALIGN_ASSET(2) char gFileSelHeadsetIA4ENGTex[] = dgFileSelHeadsetIA4ENGTex;
 
 #define dgFileSelMonoENGTex "__OTR__misc/title_static/gFileSelMonoENGTex"
 static const ALIGN_ASSET(2) char gFileSelMonoENGTex[] = dgFileSelMonoENGTex;
 
+#define dgFileSelMonoIA4ENGTex "__OTR__misc/title_static/gFileSelMonoIA4ENGTex"
+static const ALIGN_ASSET(2) char gFileSelMonoIA4ENGTex[] = dgFileSelMonoIA4ENGTex;
+
 #define dgFileSelSoundENGTex "__OTR__misc/title_static/gFileSelSoundENGTex"
 static const ALIGN_ASSET(2) char gFileSelSoundENGTex[] = dgFileSelSoundENGTex;
+
+#define dgFileSelSoundIA4ENGTex "__OTR__misc/title_static/gFileSelSoundIA4ENGTex"
+static const ALIGN_ASSET(2) char gFileSelSoundIA4ENGTex[] = dgFileSelSoundIA4ENGTex;
 
 #define dgFileSelStereoENGTex "__OTR__misc/title_static/gFileSelStereoENGTex"
 static const ALIGN_ASSET(2) char gFileSelStereoENGTex[] = dgFileSelStereoENGTex;
 
+#define dgFileSelStereoIA4ENGTex "__OTR__misc/title_static/gFileSelStereoIA4ENGTex"
+static const ALIGN_ASSET(2) char gFileSelStereoIA4ENGTex[] = dgFileSelStereoIA4ENGTex;
+
 #define dgFileSelTargetingENGTex "__OTR__misc/title_static/gFileSelTargetingENGTex"
 static const ALIGN_ASSET(2) char gFileSelTargetingENGTex[] = dgFileSelTargetingENGTex;
+
+#define dgFileSelTargetingIA4ENGTex "__OTR__misc/title_static/gFileSelTargetingIA4ENGTex"
+static const ALIGN_ASSET(2) char gFileSelTargetingIA4ENGTex[] = dgFileSelTargetingIA4ENGTex;
 
 #define dgFileSelSwitchENGTex "__OTR__misc/title_static/gFileSelSwitchENGTex"
 static const ALIGN_ASSET(2) char gFileSelSwitchENGTex[] = dgFileSelSwitchENGTex;
 
+#define dgFileSelSwitchIA4ENGTex "__OTR__misc/title_static/gFileSelSwitchIA4ENGTex"
+static const ALIGN_ASSET(2) char gFileSelSwitchIA4ENGTex[] = dgFileSelSwitchIA4ENGTex;
+
 #define dgFileSelHoldENGTex "__OTR__misc/title_static/gFileSelHoldENGTex"
 static const ALIGN_ASSET(2) char gFileSelHoldENGTex[] = dgFileSelHoldENGTex;
 
+#define dgFileSelHoldIA4ENGTex "__OTR__misc/title_static/gFileSelHoldIA4ENGTex"
+static const ALIGN_ASSET(2) char gFileSelHoldIA4ENGTex[] = dgFileSelHoldIA4ENGTex;
+
 #define dgFileSelCheckBrightnessENGTex "__OTR__misc/title_static/gFileSelCheckBrightnessENGTex"
 static const ALIGN_ASSET(2) char gFileSelCheckBrightnessENGTex[] = dgFileSelCheckBrightnessENGTex;
+
+#define dgFileSelCheckBrightnessIA4ENGTex "__OTR__misc/title_static/gFileSelCheckBrightnessIA4ENGTex"
+static const ALIGN_ASSET(2) char gFileSelCheckBrightnessIA4ENGTex[] = dgFileSelCheckBrightnessIA4ENGTex;
 
 #define dgFileSelDolbySurroundLogoENGTex "__OTR__misc/title_static/gFileSelDolbySurroundLogoENGTex"
 static const ALIGN_ASSET(2) char gFileSelDolbySurroundLogoENGTex[] = dgFileSelDolbySurroundLogoENGTex;

--- a/mm/assets/objects/object_mag/object_mag.h
+++ b/mm/assets/objects/object_mag/object_mag.h
@@ -66,6 +66,9 @@ static const ALIGN_ASSET(2) char gTitleScreenFlame3Tex[] = dgTitleScreenFlame3Te
 #define dgTitleScreenCopyright2000NintendoTex "__OTR__objects/object_mag/gTitleScreenCopyright2000NintendoTex"
 static const ALIGN_ASSET(2) char gTitleScreenCopyright2000NintendoTex[] = dgTitleScreenCopyright2000NintendoTex;
 
+#define dgTitleScreenCopyright20002003NintendoTex "__OTR__objects/object_mag/gTitleScreenCopyright20002003NintendoTex"
+static const ALIGN_ASSET(2) char gTitleScreenCopyright20002003NintendoTex[] = dgTitleScreenCopyright20002003NintendoTex;
+
 #define dgTitleScreenControllerNotConnectedTextTex "__OTR__objects/object_mag/gTitleScreenControllerNotConnectedTextTex"
 static const ALIGN_ASSET(2) char gTitleScreenControllerNotConnectedTextTex[] = dgTitleScreenControllerNotConnectedTextTex;
 

--- a/mm/assets/xml/GC_US/misc/title_static.xml
+++ b/mm/assets/xml/GC_US/misc/title_static.xml
@@ -1,10 +1,10 @@
 <Root>
     <File Name="title_static" Segment="1">
-        <Texture Name="gFileSelNoFileToCopyENGTex" OutName="no_file_to_copy_eng" Format="ia4" Width="128" Height="16" Offset="0x0"/>
-        <Texture Name="gFileSelNoFileToEraseENGTex" OutName="no_file_to_erase_eng" Format="ia4" Width="128" Height="16" Offset="0x400"/>
-        <Texture Name="gFileSelNoEmptyFileENGTex" OutName="no_empty_file_eng" Format="ia4" Width="128" Height="16" Offset="0x800"/>
-        <Texture Name="gFileSelFileEmptyENGTex" OutName="file_empty_eng" Format="ia4" Width="128" Height="16" Offset="0xC00"/>
-        <Texture Name="gFileSelFileInUseENGTex" OutName="file_in_use_eng" Format="ia4" Width="128" Height="16" Offset="0x1000"/>
+        <Texture Name="gFileSelNoFileToCopyIA4ENGTex" OutName="no_file_to_copy_ia4_eng" Format="ia4" Width="128" Height="16" Offset="0x0"/>
+        <Texture Name="gFileSelNoFileToEraseIA4ENGTex" OutName="no_file_to_erase_ia4_eng" Format="ia4" Width="128" Height="16" Offset="0x400"/>
+        <Texture Name="gFileSelNoEmptyFileIA4ENGTex" OutName="no_empty_file_ia4_eng" Format="ia4" Width="128" Height="16" Offset="0x800"/>
+        <Texture Name="gFileSelFileEmptyIA4ENGTex" OutName="file_empty_ia4_eng" Format="ia4" Width="128" Height="16" Offset="0xC00"/>
+        <Texture Name="gFileSelFileInUseIA4ENGTex" OutName="file_in_use_ia4_eng" Format="ia4" Width="128" Height="16" Offset="0x1000"/>
 
         <Texture Name="gFileSelConnectorTex" OutName="connector" Format="ia8" Width="24" Height="16" Offset="0x1400"/>
 
@@ -28,17 +28,17 @@
         <Texture Name="gFileSelDecideCancelENGTex" OutName="decide_cancel_eng" Format="ia8" Width="144" Height="16" Offset="0x6DB0"/>
         <Texture Name="gFileSelPleaseWaitENGTex" OutName="please_wait_eng" Format="ia8" Width="144" Height="16" Offset="0x76B0"/>
 
-        <Texture Name="gFileSelOptionsENGTex" OutName="options_eng" Format="ia4" Width="128" Height="16" Offset="0x7FB0"/>
+        <Texture Name="gFileSelOptionsIA4ENGTex" OutName="options_ia4_eng" Format="ia4" Width="128" Height="16" Offset="0x7FB0"/>
 
-        <Texture Name="gFileSelSurroundENGTex" OutName="surround_eng" Format="ia4" Width="48" Height="16" Offset="0x83B0"/>
-        <Texture Name="gFileSelHeadsetENGTex" OutName="headset_eng" Format="ia4" Width="48" Height="16" Offset="0x8530"/>
-        <Texture Name="gFileSelMonoENGTex" OutName="mono_eng" Format="ia4" Width="48" Height="16" Offset="0x86B0"/>
-        <Texture Name="gFileSelSoundENGTex" OutName="sound_eng" Format="ia4" Width="64" Height="16" Offset="0x8830"/>
-        <Texture Name="gFileSelStereoENGTex" OutName="stereo_eng" Format="ia4" Width="48" Height="16" Offset="0x8A30"/>
-        <Texture Name="gFileSelTargetingENGTex" OutName="targeting_eng" Format="ia4" Width="64" Height="16" Offset="0x8BB0"/>
-        <Texture Name="gFileSelSwitchENGTex" OutName="switch_eng" Format="ia4" Width="48" Height="16" Offset="0x8DB0"/>
-        <Texture Name="gFileSelHoldENGTex" OutName="hold_eng" Format="ia4" Width="48" Height="16" Offset="0x8F30"/>
-        <Texture Name="gFileSelCheckBrightnessENGTex" OutName="check_brightness_eng" Format="ia4" Width="96" Height="16" Offset="0x90B0"/>
+        <Texture Name="gFileSelSurroundIA4ENGTex" OutName="surround_ia4_eng" Format="ia4" Width="48" Height="16" Offset="0x83B0"/>
+        <Texture Name="gFileSelHeadsetIA4ENGTex" OutName="headset_ia4_eng" Format="ia4" Width="48" Height="16" Offset="0x8530"/>
+        <Texture Name="gFileSelMonoIA4ENGTex" OutName="mono_ia4_eng" Format="ia4" Width="48" Height="16" Offset="0x86B0"/>
+        <Texture Name="gFileSelSoundIA4ENGTex" OutName="sound_ia4_eng" Format="ia4" Width="64" Height="16" Offset="0x8830"/>
+        <Texture Name="gFileSelStereoIA4ENGTex" OutName="stereo_ia4_eng" Format="ia4" Width="48" Height="16" Offset="0x8A30"/>
+        <Texture Name="gFileSelTargetingIA4ENGTex" OutName="targeting_ia4_eng" Format="ia4" Width="64" Height="16" Offset="0x8BB0"/>
+        <Texture Name="gFileSelSwitchIA4ENGTex" OutName="switch_ia4_eng" Format="ia4" Width="48" Height="16" Offset="0x8DB0"/>
+        <Texture Name="gFileSelHoldIA4ENGTex" OutName="hold_ia4_eng" Format="ia4" Width="48" Height="16" Offset="0x8F30"/>
+        <Texture Name="gFileSelCheckBrightnessIA4ENGTex" OutName="check_brightness_ia4_eng" Format="ia4" Width="96" Height="16" Offset="0x90B0"/>
 
         <Texture Name="gFileSelWindow00Tex" OutName="window_00" Format="ia16" Width="64" Height="32" Offset="0x93B0"/>
         <Texture Name="gFileSelWindow01Tex" OutName="window_01" Format="ia16" Width="64" Height="32" Offset="0xA3B0"/>

--- a/mm/assets/xml/GC_US/objects/object_mag.xml
+++ b/mm/assets/xml/GC_US/objects/object_mag.xml
@@ -25,7 +25,7 @@
         <Texture Name="gTitleScreenFlame2Tex" OutName="title_screen_flame_2" Format="i8" Width="32" Height="32" Offset="0x10740"/>
         <Texture Name="gTitleScreenFlame3Tex" OutName="title_screen_flame_3" Format="i8" Width="32" Height="32" Offset="0x10B40"/>
 
-        <Texture Name="gTitleScreenCopyright2000NintendoTex" OutName="title_screen_copyright_2000_nintendo_text" Format="i8" Width="200" Height="16" Offset="0x10F40"/>
+        <Texture Name="gTitleScreenCopyright20002003NintendoTex" OutName="title_screen_copyright_20002003_nintendo_text" Format="i8" Width="200" Height="16" Offset="0x10F40"/>
         <Texture Name="gTitleScreenControllerNotConnectedTextTex" OutName="title_screen_controller_not_connected_text" Format="i4" Width="256" Height="9" Offset="0x11BC0"/>
         <Texture Name="gTitleScreenInsertControllerTextTex" OutName="title_screen_insert_controller_text" Format="i4" Width="144" Height="9" Offset="0x12040"/>
         <Texture Name="gTitleScreenMajorasMaskTex" OutName="title_screen_majoras_mask" Format="rgba32" Width="128" Height="112" Offset="0x122C8"/>

--- a/mm/src/overlays/actors/ovl_En_Mag/z_en_mag.c
+++ b/mm/src/overlays/actors/ovl_En_Mag/z_en_mag.c
@@ -876,7 +876,7 @@ void EnMag_DrawInner(Actor* thisx, PlayState* play, Gfx** gfxP) {
         uint32_t gameVersion = ResourceMgr_GetGameVersion(0);
 
         if (gameVersion == MM_NTSC_US_GC) {
-            EnMag_DrawTextureIA8(&gfx, gTitleScreenCopyright2000NintendoTex, COPYRIGHT_TEX_WIDTH_GC,
+            EnMag_DrawTextureIA8(&gfx, gTitleScreenCopyright20002003NintendoTex, COPYRIGHT_TEX_WIDTH_GC,
                                  COPYRIGHT_TEX_HEIGHT, COPYRIGHT_TEX_LEFT_GC, COPYRIGHT_TEX_TOP);
         } else { // Default: MM_NTSC_US_10
             EnMag_DrawTextureIA8(&gfx, gTitleScreenCopyright2000NintendoTex, COPYRIGHT_TEX_WIDTH, COPYRIGHT_TEX_HEIGHT,

--- a/mm/src/overlays/gamestates/ovl_file_choose/z_file_choose_NES.c
+++ b/mm/src/overlays/gamestates/ovl_file_choose/z_file_choose_NES.c
@@ -1663,6 +1663,11 @@ TexturePtr sWarningLabels[] = {
     gFileSelFileEmptyENGTex,    gFileSelFileInUseENGTex,
 };
 
+TexturePtr sWarningLabelsIA4[] = {
+    gFileSelNoFileToCopyIA4ENGTex, gFileSelNoFileToEraseIA4ENGTex, gFileSelNoEmptyFileIA4ENGTex,
+    gFileSelFileEmptyIA4ENGTex,    gFileSelFileInUseIA4ENGTex,
+};
+
 TexturePtr sFileButtonTextures[] = {
     gFileSelFile1ButtonENGTex,
     gFileSelFile2ButtonENGTex,
@@ -1846,7 +1851,7 @@ void FileSelect_DrawWindowContents(GameState* thisx) {
         gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 255, 255, 255, this->emptyFileTextAlpha);
         gDPSetEnvColor(POLY_OPA_DISP++, 0, 0, 0, 0);
         if (ResourceMgr_GetGameVersion(0) == MM_NTSC_US_GC) {
-            gDPLoadTextureBlock_4b(POLY_OPA_DISP++, sWarningLabels[this->warningLabel], G_IM_FMT_IA, 128, 16, 0,
+            gDPLoadTextureBlock_4b(POLY_OPA_DISP++, sWarningLabelsIA4[this->warningLabel], G_IM_FMT_IA, 128, 16, 0,
                                    G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK,
                                    G_TX_NOLOD, G_TX_NOLOD);
         } else { // MM_NTSC_US_10

--- a/mm/src/overlays/gamestates/ovl_file_choose/z_file_nameset_NES.c
+++ b/mm/src/overlays/gamestates/ovl_file_choose/z_file_nameset_NES.c
@@ -844,9 +844,20 @@ OptionsMenuTextureInfo gOptionsMenuHeaders[] = {
     { gFileSelDolbySurroundLogoENGTex, 48, 17 },
 };
 
+OptionsMenuTextureInfo gOptionsMenuHeadersIA4[] = {
+    { gFileSelOptionsIA4ENGTex, 128, 16 },       { gFileSelSoundIA4ENGTex, 64, 16 },
+    { gFileSelTargetingIA4ENGTex, 64, 16 },      { gFileSelCheckBrightnessIA4ENGTex, 96, 16 },
+    { gFileSelDolbySurroundLogoENGTex, 48, 17 },
+};
+
 OptionsMenuTextureInfo gOptionsMenuSettings[] = {
     { gFileSelStereoENGTex, 48, 16 },   { gFileSelMonoENGTex, 48, 16 },   { gFileSelHeadsetENGTex, 48, 16 },
     { gFileSelSurroundENGTex, 48, 16 }, { gFileSelSwitchENGTex, 48, 16 }, { gFileSelHoldENGTex, 48, 16 },
+};
+
+OptionsMenuTextureInfo gOptionsMenuSettingsIA4[] = {
+    { gFileSelStereoIA4ENGTex, 48, 16 },   { gFileSelMonoIA4ENGTex, 48, 16 },   { gFileSelHeadsetIA4ENGTex, 48, 16 },
+    { gFileSelSurroundIA4ENGTex, 48, 16 }, { gFileSelSwitchIA4ENGTex, 48, 16 }, { gFileSelHoldIA4ENGTex, 48, 16 },
 };
 
 void FileSelect_DrawOptionsImpl_NES_GC(GameState* thisx) {
@@ -981,13 +992,13 @@ void FileSelect_DrawOptionsImpl_NES_GC(GameState* thisx) {
                 gDPSetEnvColor(POLY_OPA_DISP++, 0, 0, 0, 255);
             }
 
-            gDPLoadTextureBlock(POLY_OPA_DISP++, gOptionsMenuHeaders[i].texture, G_IM_FMT_IA, G_IM_SIZ_8b,
-                                gOptionsMenuHeaders[i].width, gOptionsMenuHeaders[i].height, 0,
+            gDPLoadTextureBlock(POLY_OPA_DISP++, gOptionsMenuHeadersIA4[i].texture, G_IM_FMT_IA, G_IM_SIZ_8b,
+                                gOptionsMenuHeadersIA4[i].width, gOptionsMenuHeadersIA4[i].height, 0,
                                 G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK,
                                 G_TX_NOLOD, G_TX_NOLOD);
         } else {
-            gDPLoadTextureBlock_4b(POLY_OPA_DISP++, gOptionsMenuHeaders[i].texture, G_IM_FMT_IA,
-                                   gOptionsMenuHeaders[i].width, gOptionsMenuHeaders[i].height, 0,
+            gDPLoadTextureBlock_4b(POLY_OPA_DISP++, gOptionsMenuHeadersIA4[i].texture, G_IM_FMT_IA,
+                                   gOptionsMenuHeadersIA4[i].width, gOptionsMenuHeadersIA4[i].height, 0,
                                    G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK,
                                    G_TX_NOLOD, G_TX_NOLOD);
         }
@@ -1018,8 +1029,8 @@ void FileSelect_DrawOptionsImpl_NES_GC(GameState* thisx) {
             gDPSetEnvColor(POLY_OPA_DISP++, 0, 0, 0, 255);
         }
 
-        gDPLoadTextureBlock_4b(POLY_OPA_DISP++, gOptionsMenuSettings[i].texture, G_IM_FMT_IA,
-                               gOptionsMenuSettings[i].width, gOptionsMenuSettings[i].height, 0,
+        gDPLoadTextureBlock_4b(POLY_OPA_DISP++, gOptionsMenuSettingsIA4[i].texture, G_IM_FMT_IA,
+                               gOptionsMenuSettingsIA4[i].width, gOptionsMenuSettingsIA4[i].height, 0,
                                G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK,
                                G_TX_NOLOD, G_TX_NOLOD);
         gSP1Quadrangle(POLY_OPA_DISP++, vtx, vtx + 2, vtx + 3, vtx + 1, 0);
@@ -1042,8 +1053,8 @@ void FileSelect_DrawOptionsImpl_NES_GC(GameState* thisx) {
             gDPSetEnvColor(POLY_OPA_DISP++, 0, 0, 0, 255);
         }
 
-        gDPLoadTextureBlock_4b(POLY_OPA_DISP++, gOptionsMenuSettings[i].texture, G_IM_FMT_IA,
-                               gOptionsMenuSettings[i].width, gOptionsMenuSettings[i].height, 0,
+        gDPLoadTextureBlock_4b(POLY_OPA_DISP++, gOptionsMenuSettingsIA4[i].texture, G_IM_FMT_IA,
+                               gOptionsMenuSettingsIA4[i].width, gOptionsMenuSettingsIA4[i].height, 0,
                                G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK,
                                G_TX_NOLOD, G_TX_NOLOD);
         gSP1Quadrangle(POLY_OPA_DISP++, vtx, vtx + 2, vtx + 3, vtx + 1, 0);


### PR DESCRIPTION
Turn the copyright text (different width) and some of the File Select text (different texture format: ia4 vs. ia8) into uniquely named texture files. This is required to make the same HD texture pack work for both ROMs without exhibiting issues. Fixes #610.

_before (GC US)_
<img width="3840" height="2066" alt="image" src="https://github.com/user-attachments/assets/8484e4d5-1cbb-40a4-a439-f5b4ed957496" />
<img width="3840" height="2066" alt="image" src="https://github.com/user-attachments/assets/194fa050-75aa-45f5-8ef8-6248f4a8cfc3" />

_after (GC US with updated HD pack)_
<img width="3840" height="2066" alt="image" src="https://github.com/user-attachments/assets/c0ebf0cf-c4e6-42ad-aea5-ba43ae58609e" />
<img width="3840" height="2066" alt="image" src="https://github.com/user-attachments/assets/bd333789-75af-4c14-8121-e1a7a9c62440" />


<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7414355101.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7414084727.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7413869432.zip)
<!--- section:artifacts:end -->