### PR TITLE
[Enhancement] Port Anchor co-op multiplayer from SoH

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,7 +102,7 @@ jobs:
       env:
         CCACHE_SLOPPINESS: pch_defines,time_macros
       run: |
-        cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" -DCMAKE_C_FLAGS="-Xclang -fno-pch-timestamp" -DCMAKE_CXX_FLAGS="-Xclang -fno-pch-timestamp"
+        cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" -DCMAKE_C_FLAGS="-Xclang -fno-pch-timestamp" -DCMAKE_CXX_FLAGS="-Xclang -fno-pch-timestamp" -DBUILD_NETWORKING=1
         cmake --build build-cmake -j
         (cd build-cmake && cpack)
 
@@ -173,6 +173,18 @@ jobs:
         cmake ..
         make
         sudo make install
+    - name: Install latest SDL_net
+      run: |
+        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+        if [ ! -d "SDL2_net-2.2.0" ]; then
+          wget https://www.libsdl.org/projects/SDL_net/release/SDL2_net-2.2.0.tar.gz
+          tar -xzf SDL2_net-2.2.0.tar.gz
+        fi
+        cd SDL2_net-2.2.0
+        ./configure
+        make -j 10
+        sudo make install
+        sudo cp -av /usr/local/lib/libSDL* /lib/x86_64-linux-gnu/
     - name: Install libzip without crypto
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
@@ -195,7 +207,7 @@ jobs:
     - name: Build 2Ship
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-        cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release -DBUILD_REMOTE_CONTROL=1
+        cmake --no-warn-unused-cli -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release -DBUILD_NETWORKING=1
         cmake --build build-cmake --config Release -j3
         (cd build-cmake && cpack -G External)
 
@@ -262,7 +274,7 @@ jobs:
         VCPKG_ROOT: ${{github.workspace}}/vcpkg
       run: |
         set $env:PATH="$env:USERPROFILE/.cargo/bin;$env:PATH"
-        cmake -S . -B build-windows -G Ninja -DCMAKE_MAKE_PROGRAM=ninja -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+        cmake -S . -B build-windows -G Ninja -DCMAKE_MAKE_PROGRAM=ninja -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DBUILD_NETWORKING=1
         cmake --build build-windows --config Release --parallel 10
 
         (cd build-windows && cpack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,12 +59,6 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     endif()
 endif()
 
-if (CMAKE_SYSTEM_NAME MATCHES "Windows|Linux")
-    if(NOT DEFINED BUILD_CROWD_CONTROL)
-        set(BUILD_CROWD_CONTROL OFF)
-    endif()
-endif()
-
 # Enable the Gfx debugger in LUS to use libgfxd from ZAPDTR
 set(GFX_DEBUG_DISASSEMBLER ON)
 

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -41,6 +41,7 @@
 #include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
 
 #include "2s2h/Network/Sail/Sail.h"
+#include "2s2h/Network/Anchor/Anchor.h"
 
 #include <libultraship/libultraship.h>
 #include <libultraship/controller/controldeck/ControlDeck.h>
@@ -114,6 +115,7 @@ OTRGlobals* OTRGlobals::Instance;
 GameInteractor* GameInteractor::Instance;
 AudioCollection* AudioCollection::Instance;
 Sail* Sail::Instance;
+Anchor* Anchor::Instance;
 
 extern "C" char** cameraStrings;
 bool prevAltAssets = false;
@@ -978,6 +980,7 @@ extern "C" void InitOTR(int argc, char* argv[]) {
     GameInteractor::Instance = new GameInteractor();
     AudioCollection::Instance = new AudioCollection();
     Sail::Instance = new Sail();
+    Anchor::Instance = new Anchor();
     LoadGuiTextures();
     BenGui::SetupGuiElements();
     ShipInit::InitAll();
@@ -1013,6 +1016,9 @@ extern "C" void InitOTR(int argc, char* argv[]) {
     if (CVarGetInteger("gNetwork.Sail.Enabled", 0)) {
         Sail::Instance->Enable();
     }
+    if (CVarGetInteger("gNetwork.Anchor.Enabled", 0)) {
+        Anchor::Instance->Enable();
+    }
 
     Ship::Context::GetInstance()->GetFileDropMgr()->RegisterDropHandler(BinarySaveConverter_HandleFileDropped);
     Ship::Context::GetInstance()->GetFileDropMgr()->RegisterDropHandler(SaveManager_HandleFileDropped);
@@ -1027,6 +1033,9 @@ extern "C" void DeinitOTR() {
     OTRAudio_Exit();
     if (CVarGetInteger("gNetwork.Sail.Enabled", 0)) {
         Sail::Instance->Disable();
+    }
+    if (CVarGetInteger("gNetwork.Anchor.Enabled", 0)) {
+        Anchor::Instance->Disable();
     }
 #ifdef ENABLE_NETWORKING
     SDLNet_Quit();

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -40,10 +40,7 @@
 // #include <functions.h>
 #include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
 
-#ifdef ENABLE_CROWD_CONTROL
-#include "Enhancements/crowd-control/CrowdControl.h"
-CrowdControl* CrowdControl::Instance;
-#endif
+#include "2s2h/Network/Sail/Sail.h"
 
 #include <libultraship/libultraship.h>
 #include <libultraship/controller/controldeck/ControlDeck.h>
@@ -116,6 +113,7 @@ CrowdControl* CrowdControl::Instance;
 OTRGlobals* OTRGlobals::Instance;
 GameInteractor* GameInteractor::Instance;
 AudioCollection* AudioCollection::Instance;
+Sail* Sail::Instance;
 
 extern "C" char** cameraStrings;
 bool prevAltAssets = false;
@@ -979,6 +977,7 @@ extern "C" void InitOTR(int argc, char* argv[]) {
 
     GameInteractor::Instance = new GameInteractor();
     AudioCollection::Instance = new AudioCollection();
+    Sail::Instance = new Sail();
     LoadGuiTextures();
     BenGui::SetupGuiElements();
     ShipInit::InitAll();
@@ -1008,15 +1007,12 @@ extern "C" void InitOTR(int argc, char* argv[]) {
     }
 
     srand(now);
-#ifdef ENABLE_CROWD_CONTROL
-    CrowdControl::Instance = new CrowdControl();
-    CrowdControl::Instance->Init();
-    if (CVarGetInteger("gCrowdControl", 0)) {
-        CrowdControl::Instance->Enable();
-    } else {
-        CrowdControl::Instance->Disable();
-    }
+#ifdef ENABLE_NETWORKING
+    SDLNet_Init();
 #endif
+    if (CVarGetInteger("gNetwork.Sail.Enabled", 0)) {
+        Sail::Instance->Enable();
+    }
 
     Ship::Context::GetInstance()->GetFileDropMgr()->RegisterDropHandler(BinarySaveConverter_HandleFileDropped);
     Ship::Context::GetInstance()->GetFileDropMgr()->RegisterDropHandler(SaveManager_HandleFileDropped);
@@ -1029,9 +1025,11 @@ extern "C" void SaveManager_ThreadPoolWait() {
 extern "C" void DeinitOTR() {
     SaveManager_ThreadPoolWait();
     OTRAudio_Exit();
-#ifdef ENABLE_CROWD_CONTROL
-    CrowdControl::Instance->Disable();
-    CrowdControl::Instance->Shutdown();
+    if (CVarGetInteger("gNetwork.Sail.Enabled", 0)) {
+        Sail::Instance->Disable();
+    }
+#ifdef ENABLE_NETWORKING
+    SDLNet_Quit();
 #endif
 
     // Destroying gui here because we have shared ptrs to LUS objects which output to SPDLOG which is destroyed before

--- a/mm/2s2h/Network/Anchor/Anchor.cpp
+++ b/mm/2s2h/Network/Anchor/Anchor.cpp
@@ -25,6 +25,9 @@ void Anchor::Enable() {
     roomState.ownerClientId = 0;
     // Default progression sync on. (Future: drive this from server room state.)
     roomState.syncItemsAndFlags = 1;
+    // Request the team's current save state once we're connected and in game.
+    justLoadedSave = true;
+    upgradeSnapshotValid = false;
 
     // Register the game-thread hooks once for the lifetime of the connection. The handlers
     // bail out early when not connected, so it is safe to leave them registered.
@@ -92,6 +95,11 @@ void Anchor::RegisterHooks() {
                     Anchor::Instance->shouldRefreshActors = false;
                     Anchor::Instance->RefreshClientActors();
                 }
+                if (Anchor::Instance->justLoadedSave) {
+                    Anchor::Instance->justLoadedSave = false;
+                    Anchor::Instance->SendPacket_RequestTeamState();
+                }
+                Anchor::Instance->CheckAndPushSaveUpgrades();
                 Anchor::Instance->SendPacket_PlayerUpdate();
             });
     }
@@ -127,6 +135,26 @@ void Anchor::RegisterHooks() {
                 }
             });
     }
+    if (giveItemHookId == 0) {
+        giveItemHookId = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnItemGive>([](u8 item) {
+            if (Anchor::Instance->isConnected && !Anchor::Instance->isApplyingRemotePacket) {
+                Anchor::Instance->SendPacket_GiveItem(item);
+            }
+        });
+    }
+    if (saveLoadHookId == 0) {
+        saveLoadHookId = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSaveLoad>([](s16 fileNum) {
+            Anchor::Instance->justLoadedSave = true;
+            Anchor::Instance->upgradeSnapshotValid = false;
+        });
+    }
+    if (saveHookId == 0) {
+        saveHookId = GameInteractor::Instance->RegisterGameHook<GameInteractor::AfterEndOfCycleSave>([]() {
+            if (Anchor::Instance->isConnected) {
+                Anchor::Instance->SendPacket_UpdateTeamState();
+            }
+        });
+    }
 }
 
 void Anchor::UnregisterHooks() {
@@ -161,6 +189,18 @@ void Anchor::UnregisterHooks() {
     if (sceneFlagUnsetHookId != 0) {
         GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnSceneFlagUnset>(sceneFlagUnsetHookId);
         sceneFlagUnsetHookId = 0;
+    }
+    if (giveItemHookId != 0) {
+        GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnItemGive>(giveItemHookId);
+        giveItemHookId = 0;
+    }
+    if (saveLoadHookId != 0) {
+        GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnSaveLoad>(saveLoadHookId);
+        saveLoadHookId = 0;
+    }
+    if (saveHookId != 0) {
+        GameInteractor::Instance->UnregisterGameHook<GameInteractor::AfterEndOfCycleSave>(saveHookId);
+        saveHookId = 0;
     }
 }
 
@@ -211,6 +251,14 @@ void Anchor::OnIncomingJson(nlohmann::json payload) {
         HandlePacket_SetFlag(payload);
     } else if (packetType == UNSET_FLAG) {
         HandlePacket_UnsetFlag(payload);
+    } else if (packetType == GIVE_ITEM) {
+        HandlePacket_GiveItem(payload);
+    } else if (packetType == REQUEST_TEAM_STATE) {
+        HandlePacket_RequestTeamState(payload);
+    } else if (packetType == UPDATE_TEAM_STATE) {
+        HandlePacket_UpdateTeamState(payload);
+    } else if (packetType == GIVE_UPGRADE) {
+        HandlePacket_GiveUpgrade(payload);
     } else if (packetType == SERVER_MESSAGE) {
         HandlePacket_ServerMessage(payload);
     } else if (packetType == DISABLE_ANCHOR) {

--- a/mm/2s2h/Network/Anchor/Anchor.cpp
+++ b/mm/2s2h/Network/Anchor/Anchor.cpp
@@ -60,14 +60,14 @@ void Anchor::RegisterHooks() {
         });
     }
     if (sceneInitHookId == 0) {
-        sceneInitHookId = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSceneInit>([](s8 sceneId,
-                                                                                                     s8 spawnNum) {
-            if (Anchor::Instance->isConnected) {
-                Anchor::Instance->SendPacket_UpdateClientState();
-                // Respawn dummy players for this scene on the next player update tick.
-                Anchor::Instance->shouldRefreshActors = true;
-            }
-        });
+        sceneInitHookId =
+            GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSceneInit>([](s8 sceneId, s8 spawnNum) {
+                if (Anchor::Instance->isConnected) {
+                    Anchor::Instance->SendPacket_UpdateClientState();
+                    // Respawn dummy players for this scene on the next player update tick.
+                    Anchor::Instance->shouldRefreshActors = true;
+                }
+            });
     }
     if (actorInitHookId == 0) {
         // Intercept the player actors we spawn for remote clients and repurpose them as dummies.
@@ -104,20 +104,20 @@ void Anchor::RegisterHooks() {
             });
     }
     if (flagSetHookId == 0) {
-        flagSetHookId = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnFlagSet>([](FlagType flagType,
-                                                                                                 u32 flag) {
-            if (Anchor::Instance->isConnected && !Anchor::Instance->isApplyingRemotePacket) {
-                Anchor::Instance->SendPacket_SetFlag(SCENE_MAX, (s16)flagType, (s32)flag);
-            }
-        });
+        flagSetHookId =
+            GameInteractor::Instance->RegisterGameHook<GameInteractor::OnFlagSet>([](FlagType flagType, u32 flag) {
+                if (Anchor::Instance->isConnected && !Anchor::Instance->isApplyingRemotePacket) {
+                    Anchor::Instance->SendPacket_SetFlag(SCENE_MAX, (s16)flagType, (s32)flag);
+                }
+            });
     }
     if (flagUnsetHookId == 0) {
-        flagUnsetHookId = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnFlagUnset>([](FlagType flagType,
-                                                                                                     u32 flag) {
-            if (Anchor::Instance->isConnected && !Anchor::Instance->isApplyingRemotePacket) {
-                Anchor::Instance->SendPacket_UnsetFlag(SCENE_MAX, (s16)flagType, (s32)flag);
-            }
-        });
+        flagUnsetHookId =
+            GameInteractor::Instance->RegisterGameHook<GameInteractor::OnFlagUnset>([](FlagType flagType, u32 flag) {
+                if (Anchor::Instance->isConnected && !Anchor::Instance->isApplyingRemotePacket) {
+                    Anchor::Instance->SendPacket_UnsetFlag(SCENE_MAX, (s16)flagType, (s32)flag);
+                }
+            });
     }
     if (sceneFlagSetHookId == 0) {
         sceneFlagSetHookId = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSceneFlagSet>(

--- a/mm/2s2h/Network/Anchor/Anchor.cpp
+++ b/mm/2s2h/Network/Anchor/Anchor.cpp
@@ -23,6 +23,8 @@ const std::string Anchor::clientVersion = (const char*)gGitCommitHash;
 void Anchor::Enable() {
     ownClientId = CVarGetInteger("gNetwork.Anchor.LastClientId", 0);
     roomState.ownerClientId = 0;
+    // Default progression sync on. (Future: drive this from server room state.)
+    roomState.syncItemsAndFlags = 1;
 
     // Register the game-thread hooks once for the lifetime of the connection. The handlers
     // bail out early when not connected, so it is safe to leave them registered.
@@ -93,6 +95,38 @@ void Anchor::RegisterHooks() {
                 Anchor::Instance->SendPacket_PlayerUpdate();
             });
     }
+    if (flagSetHookId == 0) {
+        flagSetHookId = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnFlagSet>([](FlagType flagType,
+                                                                                                 u32 flag) {
+            if (Anchor::Instance->isConnected && !Anchor::Instance->isApplyingRemotePacket) {
+                Anchor::Instance->SendPacket_SetFlag(SCENE_MAX, (s16)flagType, (s32)flag);
+            }
+        });
+    }
+    if (flagUnsetHookId == 0) {
+        flagUnsetHookId = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnFlagUnset>([](FlagType flagType,
+                                                                                                     u32 flag) {
+            if (Anchor::Instance->isConnected && !Anchor::Instance->isApplyingRemotePacket) {
+                Anchor::Instance->SendPacket_UnsetFlag(SCENE_MAX, (s16)flagType, (s32)flag);
+            }
+        });
+    }
+    if (sceneFlagSetHookId == 0) {
+        sceneFlagSetHookId = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSceneFlagSet>(
+            [](s16 sceneId, FlagType flagType, u32 flag) {
+                if (Anchor::Instance->isConnected && !Anchor::Instance->isApplyingRemotePacket) {
+                    Anchor::Instance->SendPacket_SetFlag(sceneId, (s16)flagType, (s32)flag);
+                }
+            });
+    }
+    if (sceneFlagUnsetHookId == 0) {
+        sceneFlagUnsetHookId = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSceneFlagUnset>(
+            [](s16 sceneId, FlagType flagType, u32 flag) {
+                if (Anchor::Instance->isConnected && !Anchor::Instance->isApplyingRemotePacket) {
+                    Anchor::Instance->SendPacket_UnsetFlag(sceneId, (s16)flagType, (s32)flag);
+                }
+            });
+    }
 }
 
 void Anchor::UnregisterHooks() {
@@ -111,6 +145,22 @@ void Anchor::UnregisterHooks() {
     if (actorUpdateHookId != 0) {
         GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::OnActorUpdate>(actorUpdateHookId);
         actorUpdateHookId = 0;
+    }
+    if (flagSetHookId != 0) {
+        GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnFlagSet>(flagSetHookId);
+        flagSetHookId = 0;
+    }
+    if (flagUnsetHookId != 0) {
+        GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnFlagUnset>(flagUnsetHookId);
+        flagUnsetHookId = 0;
+    }
+    if (sceneFlagSetHookId != 0) {
+        GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnSceneFlagSet>(sceneFlagSetHookId);
+        sceneFlagSetHookId = 0;
+    }
+    if (sceneFlagUnsetHookId != 0) {
+        GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnSceneFlagUnset>(sceneFlagUnsetHookId);
+        sceneFlagUnsetHookId = 0;
     }
 }
 
@@ -157,6 +207,10 @@ void Anchor::OnIncomingJson(nlohmann::json payload) {
         HandlePacket_UpdateClientState(payload);
     } else if (packetType == PLAYER_UPDATE) {
         HandlePacket_PlayerUpdate(payload);
+    } else if (packetType == SET_FLAG) {
+        HandlePacket_SetFlag(payload);
+    } else if (packetType == UNSET_FLAG) {
+        HandlePacket_UnsetFlag(payload);
     } else if (packetType == SERVER_MESSAGE) {
         HandlePacket_ServerMessage(payload);
     } else if (packetType == DISABLE_ANCHOR) {

--- a/mm/2s2h/Network/Anchor/Anchor.cpp
+++ b/mm/2s2h/Network/Anchor/Anchor.cpp
@@ -1,0 +1,277 @@
+#include "Anchor.h"
+#include "JsonConversions.hpp"
+#include <nlohmann/json.hpp>
+#include <libultraship/libultraship.h>
+#include <spdlog/spdlog.h>
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/BenGui/Notification.h"
+
+extern "C" {
+#include "variables.h"
+#include "functions.h"
+extern PlayState* gPlayState;
+extern char gGitCommitHash[];
+}
+
+const std::string Anchor::clientVersion = (const char*)gGitCommitHash;
+
+// MARK: - Lifecycle
+
+void Anchor::Enable() {
+    ownClientId = CVarGetInteger("gNetwork.Anchor.LastClientId", 0);
+    roomState.ownerClientId = 0;
+
+    // Register the game-thread hooks once for the lifetime of the connection. The handlers
+    // bail out early when not connected, so it is safe to leave them registered.
+    RegisterHooks();
+
+    Network::Enable(CVarGetString("gNetwork.Anchor.Host", "anchor.hm64.org"),
+                    CVarGetInteger("gNetwork.Anchor.Port", 43383));
+}
+
+void Anchor::Disable() {
+    Network::Disable();
+    UnregisterHooks();
+    clients.clear();
+}
+
+void Anchor::OnConnected() {
+    // Runs on the network thread; isConnected is already true here.
+    SendPacket_Handshake();
+}
+
+void Anchor::OnDisconnected() {
+}
+
+void Anchor::RegisterHooks() {
+    if (processPacketsHookId == 0) {
+        processPacketsHookId = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnGameStateMainStart>([]() {
+            if (Anchor::Instance->isConnected) {
+                Anchor::Instance->ProcessIncomingPacketQueue();
+            }
+        });
+    }
+    if (sceneInitHookId == 0) {
+        sceneInitHookId = GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSceneInit>([](s8 sceneId,
+                                                                                                     s8 spawnNum) {
+            if (Anchor::Instance->isConnected) {
+                Anchor::Instance->SendPacket_UpdateClientState();
+            }
+        });
+    }
+}
+
+void Anchor::UnregisterHooks() {
+    if (processPacketsHookId != 0) {
+        GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnGameStateMainStart>(processPacketsHookId);
+        processPacketsHookId = 0;
+    }
+    if (sceneInitHookId != 0) {
+        GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnSceneInit>(sceneInitHookId);
+        sceneInitHookId = 0;
+    }
+}
+
+// MARK: - Send
+
+void Anchor::SendPacket(nlohmann::json payload) {
+    if (!isConnected) {
+        return;
+    }
+
+    payload["clientId"] = ownClientId;
+    QueueOutgoingPacket(payload);
+}
+
+// MARK: - Receive
+
+void Anchor::ProcessIncomingPacketQueue() {
+    std::queue<nlohmann::json> packetsToProcess;
+    SwapIncomingPacketQueue(packetsToProcess);
+
+    while (!packetsToProcess.empty()) {
+        nlohmann::json payload = packetsToProcess.front();
+        packetsToProcess.pop();
+
+        try {
+            OnIncomingJson(payload);
+        } catch (const std::exception& e) {
+            SPDLOG_ERROR("[Anchor] Exception while processing incoming packet: {}", e.what());
+            SPDLOG_ERROR("[Anchor] Packet: {}", payload.dump());
+        } catch (...) { SPDLOG_ERROR("[Anchor] Unknown exception while processing incoming packet"); }
+    }
+}
+
+void Anchor::OnIncomingJson(nlohmann::json payload) {
+    if (!payload.contains("type")) {
+        return;
+    }
+
+    std::string packetType = payload["type"].get<std::string>();
+
+    if (packetType == ALL_CLIENT_STATE) {
+        HandlePacket_AllClientState(payload);
+    } else if (packetType == UPDATE_CLIENT_STATE) {
+        HandlePacket_UpdateClientState(payload);
+    } else if (packetType == SERVER_MESSAGE) {
+        HandlePacket_ServerMessage(payload);
+    } else if (packetType == DISABLE_ANCHOR) {
+        HandlePacket_DisableAnchor(payload);
+    }
+}
+
+// MARK: - Helpers
+
+bool Anchor::IsSaveLoaded() {
+    if (gPlayState == nullptr) {
+        return false;
+    }
+    if (GET_PLAYER(gPlayState) == nullptr) {
+        return false;
+    }
+    if (gSaveContext.gameMode != GAMEMODE_NORMAL) {
+        return false;
+    }
+    return true;
+}
+
+// MARK: - Packets
+
+nlohmann::json Anchor::PrepRoomState() {
+    nlohmann::json payload;
+    payload["pvpMode"] = roomState.pvpMode;
+    payload["showLocationsMode"] = roomState.showLocationsMode;
+    payload["teleportMode"] = roomState.teleportMode;
+    payload["syncItemsAndFlags"] = roomState.syncItemsAndFlags;
+    return payload;
+}
+
+nlohmann::json Anchor::PrepClientState() {
+    nlohmann::json payload;
+    payload["name"] = CVarGetString("gNetwork.Anchor.Name", "");
+    payload["color"] = CVarGetColor24("gNetwork.Anchor.Color.Value", { 100, 255, 100 });
+    payload["clientVersion"] = clientVersion;
+    payload["teamId"] = CVarGetString("gNetwork.Anchor.TeamId", "default");
+    payload["online"] = true;
+
+    if (IsSaveLoaded()) {
+        payload["seed"] = 0;
+        payload["isSaveLoaded"] = true;
+        payload["isGameComplete"] = false;
+        payload["sceneId"] = gPlayState->sceneId;
+        payload["curRoomNum"] = gPlayState->roomCtx.curRoom.num;
+        payload["entranceIndex"] = gSaveContext.save.entrance;
+    } else {
+        payload["seed"] = 0;
+        payload["isSaveLoaded"] = false;
+        payload["isGameComplete"] = false;
+        payload["sceneId"] = SCENE_MAX;
+        payload["curRoomNum"] = -1;
+        payload["entranceIndex"] = 0;
+    }
+
+    return payload;
+}
+
+// HANDSHAKE: sent on first connection, includes our room settings (in case the room needs
+// creating) and our current client state.
+void Anchor::SendPacket_Handshake() {
+    nlohmann::json payload;
+    payload["type"] = HANDSHAKE;
+    payload["roomId"] = CVarGetString("gNetwork.Anchor.RoomId", "");
+    payload["roomState"] = PrepRoomState();
+    payload["clientState"] = PrepClientState();
+    SendPacket(payload);
+}
+
+// UPDATE_CLIENT_STATE: small subset of cached state, sent on scene change etc.
+void Anchor::SendPacket_UpdateClientState() {
+    nlohmann::json payload;
+    payload["type"] = UPDATE_CLIENT_STATE;
+    payload["state"] = PrepClientState();
+    SendPacket(payload);
+}
+
+// ALL_CLIENT_STATE: full roster, broadcast by the server when a client connects/disconnects.
+void Anchor::HandlePacket_AllClientState(nlohmann::json payload) {
+    std::vector<AnchorClient> newClients = payload["state"].get<std::vector<AnchorClient>>();
+
+    for (auto& client : newClients) {
+        if (client.self) {
+            ownClientId = client.clientId;
+            CVarSetInteger("gNetwork.Anchor.LastClientId", ownClientId);
+            Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
+            clients[client.clientId].self = true;
+        } else {
+            bool wasKnown = clients.contains(client.clientId);
+            bool wasOnline = wasKnown && clients[client.clientId].online;
+            clients[client.clientId].self = false;
+            if ((!wasKnown && client.online) || (wasKnown && wasOnline != client.online)) {
+                Notification::Emit({
+                    .prefix = client.name,
+                    .message = client.online ? "Connected" : "Disconnected",
+                });
+            }
+        }
+
+        clients[client.clientId].clientId = client.clientId;
+        clients[client.clientId].name = client.name;
+        clients[client.clientId].color = client.color;
+        clients[client.clientId].clientVersion = client.clientVersion;
+        clients[client.clientId].teamId = client.teamId;
+        clients[client.clientId].online = client.online;
+        clients[client.clientId].seed = client.seed;
+        clients[client.clientId].isSaveLoaded = client.isSaveLoaded;
+        clients[client.clientId].isGameComplete = client.isGameComplete;
+        clients[client.clientId].sceneId = client.sceneId;
+        clients[client.clientId].curRoomNum = client.curRoomNum;
+        clients[client.clientId].entranceIndex = client.entranceIndex;
+    }
+
+    // Remove clients no longer present in the roster.
+    std::vector<uint32_t> clientsToRemove;
+    for (auto& [clientId, client] : clients) {
+        if (std::find_if(newClients.begin(), newClients.end(),
+                         [clientId](AnchorClient& c) { return c.clientId == clientId; }) == newClients.end()) {
+            clientsToRemove.push_back(clientId);
+        }
+    }
+    for (auto& clientId : clientsToRemove) {
+        clients.erase(clientId);
+    }
+}
+
+void Anchor::HandlePacket_UpdateClientState(nlohmann::json payload) {
+    uint32_t clientId = payload.at("clientId").get<uint32_t>();
+    if (!clients.contains(clientId)) {
+        return;
+    }
+
+    AnchorClient client = payload["state"].get<AnchorClient>();
+    clients[clientId].name = client.name;
+    clients[clientId].color = client.color;
+    clients[clientId].clientVersion = client.clientVersion;
+    clients[clientId].teamId = client.teamId;
+    clients[clientId].online = client.online;
+    clients[clientId].seed = client.seed;
+    clients[clientId].isSaveLoaded = client.isSaveLoaded;
+    clients[clientId].isGameComplete = client.isGameComplete;
+    clients[clientId].sceneId = client.sceneId;
+    clients[clientId].curRoomNum = client.curRoomNum;
+    clients[clientId].entranceIndex = client.entranceIndex;
+}
+
+void Anchor::HandlePacket_ServerMessage(nlohmann::json payload) {
+    if (payload.contains("message")) {
+        Notification::Emit({
+            .prefix = "Server: ",
+            .message = payload["message"].get<std::string>(),
+        });
+    }
+}
+
+void Anchor::HandlePacket_DisableAnchor(nlohmann::json payload) {
+    CVarClear("gNetwork.Anchor.Enabled");
+    Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
+    Disable();
+}

--- a/mm/2s2h/Network/Anchor/Anchor.cpp
+++ b/mm/2s2h/Network/Anchor/Anchor.cpp
@@ -5,8 +5,11 @@
 #include <spdlog/spdlog.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/BenGui/Notification.h"
+#include "2s2h/ObjectExtension/ObjectExtension.h"
+#include "2s2h/NameTag/NameTag.h"
 
 extern "C" {
+#include "macros.h"
 #include "variables.h"
 #include "functions.h"
 extern PlayState* gPlayState;
@@ -56,8 +59,39 @@ void Anchor::RegisterHooks() {
                                                                                                      s8 spawnNum) {
             if (Anchor::Instance->isConnected) {
                 Anchor::Instance->SendPacket_UpdateClientState();
+                // Respawn dummy players for this scene on the next player update tick.
+                Anchor::Instance->shouldRefreshActors = true;
             }
         });
+    }
+    if (actorInitHookId == 0) {
+        // Intercept the player actors we spawn for remote clients and repurpose them as dummies.
+        actorInitHookId = GameInteractor::Instance->RegisterGameHookForID<GameInteractor::ShouldActorInit>(
+            ACTOR_PLAYER, [](Actor* actor, bool* should) {
+                if (Anchor::Instance->spawningDummyPlayerForClientId != 0) {
+                    Anchor::Instance->SetDummyPlayerClientId(actor, Anchor::Instance->spawningDummyPlayerForClientId);
+                    Actor_ChangeCategory(gPlayState, &gPlayState->actorCtx, actor, ACTORCAT_NPC);
+                    actor->id = ACTOR_EN_TEST;
+                    actor->init = DummyPlayer_Init;
+                    actor->update = DummyPlayer_Update;
+                    actor->draw = DummyPlayer_Draw;
+                    actor->destroy = DummyPlayer_Destroy;
+                }
+            });
+    }
+    if (actorUpdateHookId == 0) {
+        // Fires every frame for the local player only (dummies are relabeled ACTOR_EN_TEST).
+        actorUpdateHookId = GameInteractor::Instance->RegisterGameHookForID<GameInteractor::OnActorUpdate>(
+            ACTOR_PLAYER, [](Actor* actor) {
+                if (!Anchor::Instance->isConnected) {
+                    return;
+                }
+                if (Anchor::Instance->shouldRefreshActors) {
+                    Anchor::Instance->shouldRefreshActors = false;
+                    Anchor::Instance->RefreshClientActors();
+                }
+                Anchor::Instance->SendPacket_PlayerUpdate();
+            });
     }
 }
 
@@ -69,6 +103,14 @@ void Anchor::UnregisterHooks() {
     if (sceneInitHookId != 0) {
         GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnSceneInit>(sceneInitHookId);
         sceneInitHookId = 0;
+    }
+    if (actorInitHookId != 0) {
+        GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::ShouldActorInit>(actorInitHookId);
+        actorInitHookId = 0;
+    }
+    if (actorUpdateHookId != 0) {
+        GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::OnActorUpdate>(actorUpdateHookId);
+        actorUpdateHookId = 0;
     }
 }
 
@@ -113,6 +155,8 @@ void Anchor::OnIncomingJson(nlohmann::json payload) {
         HandlePacket_AllClientState(payload);
     } else if (packetType == UPDATE_CLIENT_STATE) {
         HandlePacket_UpdateClientState(payload);
+    } else if (packetType == PLAYER_UPDATE) {
+        HandlePacket_PlayerUpdate(payload);
     } else if (packetType == SERVER_MESSAGE) {
         HandlePacket_ServerMessage(payload);
     } else if (packetType == DISABLE_ANCHOR) {
@@ -239,6 +283,9 @@ void Anchor::HandlePacket_AllClientState(nlohmann::json payload) {
     for (auto& clientId : clientsToRemove) {
         clients.erase(clientId);
     }
+
+    // Roster changed; respawn dummy players on the next player update tick.
+    shouldRefreshActors = true;
 }
 
 void Anchor::HandlePacket_UpdateClientState(nlohmann::json payload) {
@@ -247,6 +294,7 @@ void Anchor::HandlePacket_UpdateClientState(nlohmann::json payload) {
         return;
     }
 
+    s16 oldSceneId = clients[clientId].sceneId;
     AnchorClient client = payload["state"].get<AnchorClient>();
     clients[clientId].name = client.name;
     clients[clientId].color = client.color;
@@ -259,6 +307,11 @@ void Anchor::HandlePacket_UpdateClientState(nlohmann::json payload) {
     clients[clientId].sceneId = client.sceneId;
     clients[clientId].curRoomNum = client.curRoomNum;
     clients[clientId].entranceIndex = client.entranceIndex;
+
+    // A remote player entering or leaving our scene must (de)spawn their dummy.
+    if (oldSceneId != client.sceneId) {
+        shouldRefreshActors = true;
+    }
 }
 
 void Anchor::HandlePacket_ServerMessage(nlohmann::json payload) {
@@ -274,4 +327,55 @@ void Anchor::HandlePacket_DisableAnchor(nlohmann::json payload) {
     CVarClear("gNetwork.Anchor.Enabled");
     Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
     Disable();
+}
+
+// MARK: - Dummy players
+
+// Attaches the owning clientId to a dummy player actor via the ObjectExtension system.
+struct DummyPlayerClientId {
+    uint32_t clientId = 0;
+};
+static ObjectExtension::Register<DummyPlayerClientId> DummyPlayerClientIdRegister;
+
+uint32_t Anchor::GetDummyPlayerClientId(const Actor* actor) {
+    const DummyPlayerClientId* data = ObjectExtension::GetInstance().Get<DummyPlayerClientId>(actor);
+    return data != nullptr ? data->clientId : 0;
+}
+
+void Anchor::SetDummyPlayerClientId(const Actor* actor, uint32_t clientId) {
+    ObjectExtension::GetInstance().Set<DummyPlayerClientId>(actor, DummyPlayerClientId{ clientId });
+}
+
+// Kills all existing dummy players and respawns one for each online client in our scene.
+void Anchor::RefreshClientActors() {
+    if (!IsSaveLoaded()) {
+        return;
+    }
+
+    Actor* actor = gPlayState->actorCtx.actorLists[ACTORCAT_NPC].first;
+    while (actor != NULL) {
+        Actor* next = actor->next;
+        if (actor->id == ACTOR_EN_TEST && actor->update == DummyPlayer_Update) {
+            NameTag_RemoveAllForActor(actor);
+            Actor_Kill(actor);
+        }
+        actor = next;
+    }
+
+    for (auto& [clientId, client] : clients) {
+        if (!client.online || client.self || !client.isSaveLoaded) {
+            continue;
+        }
+        if (client.sceneId != gPlayState->sceneId) {
+            continue;
+        }
+
+        spawningDummyPlayerForClientId = clientId;
+        // ShouldActorInit (registered above) intercepts this spawn and converts it to a dummy.
+        Actor* dummy =
+            Actor_Spawn(&gPlayState->actorCtx, gPlayState, ACTOR_PLAYER, client.posRot.pos.x, client.posRot.pos.y,
+                        client.posRot.pos.z, client.posRot.rot.x, client.posRot.rot.y, client.posRot.rot.z, 0);
+        client.player = (Player*)dummy;
+    }
+    spawningDummyPlayerForClientId = 0;
 }

--- a/mm/2s2h/Network/Anchor/Anchor.h
+++ b/mm/2s2h/Network/Anchor/Anchor.h
@@ -11,6 +11,11 @@ extern "C" {
 #include "z64.h"
 }
 
+void DummyPlayer_Init(Actor* actor, PlayState* play);
+void DummyPlayer_Update(Actor* actor, PlayState* play);
+void DummyPlayer_Draw(Actor* actor, PlayState* play);
+void DummyPlayer_Destroy(Actor* actor, PlayState* play);
+
 // Per-client state shared across the room. This is the Majora's Mask flavored equivalent of
 // Shipwright's AnchorClient; field names track MM structures (e.g. sceneId rather than sceneNum).
 typedef struct {
@@ -27,6 +32,25 @@ typedef struct {
     s16 sceneId;
     s8 curRoomNum;
     s32 entranceIndex;
+
+    // Only populated by PLAYER_UPDATE packets (real-time, sent every frame).
+    s32 form; // PlayerTransformation
+    PosRot posRot;
+    Vec3s jointTable[PLAYER_LIMB_MAX];
+    Vec3s prevTransl;
+    Vec3s upperLimbRot;
+    u8 movementFlags;
+    s8 currentBoots;
+    u8 currentMask;
+    u32 stateFlags1;
+    u32 stateFlags2;
+    s8 itemAction;
+    s8 heldItemAction;
+    s8 invincibilityTimer;
+    u8 face;
+
+    // Pointer to the spawned dummy player actor (if any).
+    Player* player;
 } AnchorClient;
 
 typedef struct {
@@ -41,6 +65,11 @@ class Anchor : public Network {
   private:
     HOOK_ID processPacketsHookId = 0;
     HOOK_ID sceneInitHookId = 0;
+    HOOK_ID actorInitHookId = 0;
+    HOOK_ID actorUpdateHookId = 0;
+
+    uint32_t spawningDummyPlayerForClientId = 0;
+    bool shouldRefreshActors = false;
 
     void RegisterHooks();
     void UnregisterHooks();
@@ -56,6 +85,7 @@ class Anchor : public Network {
 
     void HandlePacket_AllClientState(nlohmann::json payload);
     void HandlePacket_UpdateClientState(nlohmann::json payload);
+    void HandlePacket_PlayerUpdate(nlohmann::json payload);
     void HandlePacket_ServerMessage(nlohmann::json payload);
     void HandlePacket_DisableAnchor(nlohmann::json payload);
 
@@ -71,6 +101,7 @@ class Anchor : public Network {
     inline static const std::string HANDSHAKE = "HANDSHAKE";
     inline static const std::string ALL_CLIENT_STATE = "ALL_CLIENT_STATE";
     inline static const std::string UPDATE_CLIENT_STATE = "UPDATE_CLIENT_STATE";
+    inline static const std::string PLAYER_UPDATE = "PLAYER_UPDATE";
     inline static const std::string SERVER_MESSAGE = "SERVER_MESSAGE";
     inline static const std::string DISABLE_ANCHOR = "DISABLE_ANCHOR";
 
@@ -84,8 +115,14 @@ class Anchor : public Network {
 
     bool IsSaveLoaded();
 
+    // Remote player (dummy actor) management.
+    void RefreshClientActors();
+    uint32_t GetDummyPlayerClientId(const Actor* actor);
+    void SetDummyPlayerClientId(const Actor* actor, uint32_t clientId);
+
     void SendPacket_Handshake();
     void SendPacket_UpdateClientState();
+    void SendPacket_PlayerUpdate();
 };
 
 #endif // __cplusplus

--- a/mm/2s2h/Network/Anchor/Anchor.h
+++ b/mm/2s2h/Network/Anchor/Anchor.h
@@ -67,9 +67,15 @@ class Anchor : public Network {
     HOOK_ID sceneInitHookId = 0;
     HOOK_ID actorInitHookId = 0;
     HOOK_ID actorUpdateHookId = 0;
+    HOOK_ID flagSetHookId = 0;
+    HOOK_ID flagUnsetHookId = 0;
+    HOOK_ID sceneFlagSetHookId = 0;
+    HOOK_ID sceneFlagUnsetHookId = 0;
 
     uint32_t spawningDummyPlayerForClientId = 0;
     bool shouldRefreshActors = false;
+    // Set while applying an incoming packet so our own send-hooks don't echo it back out.
+    bool isApplyingRemotePacket = false;
 
     void RegisterHooks();
     void UnregisterHooks();
@@ -86,6 +92,8 @@ class Anchor : public Network {
     void HandlePacket_AllClientState(nlohmann::json payload);
     void HandlePacket_UpdateClientState(nlohmann::json payload);
     void HandlePacket_PlayerUpdate(nlohmann::json payload);
+    void HandlePacket_SetFlag(nlohmann::json payload);
+    void HandlePacket_UnsetFlag(nlohmann::json payload);
     void HandlePacket_ServerMessage(nlohmann::json payload);
     void HandlePacket_DisableAnchor(nlohmann::json payload);
 
@@ -102,6 +110,8 @@ class Anchor : public Network {
     inline static const std::string ALL_CLIENT_STATE = "ALL_CLIENT_STATE";
     inline static const std::string UPDATE_CLIENT_STATE = "UPDATE_CLIENT_STATE";
     inline static const std::string PLAYER_UPDATE = "PLAYER_UPDATE";
+    inline static const std::string SET_FLAG = "SET_FLAG";
+    inline static const std::string UNSET_FLAG = "UNSET_FLAG";
     inline static const std::string SERVER_MESSAGE = "SERVER_MESSAGE";
     inline static const std::string DISABLE_ANCHOR = "DISABLE_ANCHOR";
 
@@ -123,6 +133,8 @@ class Anchor : public Network {
     void SendPacket_Handshake();
     void SendPacket_UpdateClientState();
     void SendPacket_PlayerUpdate();
+    void SendPacket_SetFlag(s16 sceneId, s16 flagType, s32 flag);
+    void SendPacket_UnsetFlag(s16 sceneId, s16 flagType, s32 flag);
 };
 
 #endif // __cplusplus

--- a/mm/2s2h/Network/Anchor/Anchor.h
+++ b/mm/2s2h/Network/Anchor/Anchor.h
@@ -1,0 +1,92 @@
+#ifndef NETWORK_ANCHOR_H
+#define NETWORK_ANCHOR_H
+#ifdef __cplusplus
+
+#include "2s2h/Network/Network.h"
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include <map>
+#include <string>
+
+extern "C" {
+#include "z64.h"
+}
+
+// Per-client state shared across the room. This is the Majora's Mask flavored equivalent of
+// Shipwright's AnchorClient; field names track MM structures (e.g. sceneId rather than sceneNum).
+typedef struct {
+    uint32_t clientId;
+    std::string name;
+    Color_RGB8 color;
+    std::string clientVersion;
+    std::string teamId;
+    bool online;
+    bool self;
+    uint32_t seed;
+    bool isSaveLoaded;
+    bool isGameComplete;
+    s16 sceneId;
+    s8 curRoomNum;
+    s32 entranceIndex;
+} AnchorClient;
+
+typedef struct {
+    uint32_t ownerClientId;
+    u8 pvpMode;           // 0 = off, 1 = on, 2 = on with friendly fire
+    u8 showLocationsMode; // 0 = none, 1 = team, 2 = all
+    u8 teleportMode;      // 0 = off, 1 = team, 2 = all
+    u8 syncItemsAndFlags; // 0 = off, 1 = on
+} RoomState;
+
+class Anchor : public Network {
+  private:
+    HOOK_ID processPacketsHookId = 0;
+    HOOK_ID sceneInitHookId = 0;
+
+    void RegisterHooks();
+    void UnregisterHooks();
+
+    nlohmann::json PrepClientState();
+    nlohmann::json PrepRoomState();
+
+    // Injects our clientId and queues the packet on the network thread.
+    void SendPacket(nlohmann::json payload);
+
+    // Dispatches a single incoming packet (called on the game thread).
+    void OnIncomingJson(nlohmann::json payload);
+
+    void HandlePacket_AllClientState(nlohmann::json payload);
+    void HandlePacket_UpdateClientState(nlohmann::json payload);
+    void HandlePacket_ServerMessage(nlohmann::json payload);
+    void HandlePacket_DisableAnchor(nlohmann::json payload);
+
+  public:
+    static Anchor* Instance;
+
+    uint32_t ownClientId = 0;
+    static const std::string clientVersion;
+    std::map<uint32_t, AnchorClient> clients;
+    RoomState roomState = {};
+
+    // Packet types
+    inline static const std::string HANDSHAKE = "HANDSHAKE";
+    inline static const std::string ALL_CLIENT_STATE = "ALL_CLIENT_STATE";
+    inline static const std::string UPDATE_CLIENT_STATE = "UPDATE_CLIENT_STATE";
+    inline static const std::string SERVER_MESSAGE = "SERVER_MESSAGE";
+    inline static const std::string DISABLE_ANCHOR = "DISABLE_ANCHOR";
+
+    void Enable();
+    void Disable();
+    void OnConnected() override;
+    void OnDisconnected() override;
+
+    // Drains the base class' incoming queue and dispatches each packet. Game thread only.
+    void ProcessIncomingPacketQueue();
+
+    bool IsSaveLoaded();
+
+    void SendPacket_Handshake();
+    void SendPacket_UpdateClientState();
+};
+
+#endif // __cplusplus
+#endif // NETWORK_ANCHOR_H

--- a/mm/2s2h/Network/Anchor/Anchor.h
+++ b/mm/2s2h/Network/Anchor/Anchor.h
@@ -71,11 +71,31 @@ class Anchor : public Network {
     HOOK_ID flagUnsetHookId = 0;
     HOOK_ID sceneFlagSetHookId = 0;
     HOOK_ID sceneFlagUnsetHookId = 0;
+    HOOK_ID giveItemHookId = 0;
+    HOOK_ID saveLoadHookId = 0;
+    HOOK_ID saveHookId = 0;
 
     uint32_t spawningDummyPlayerForClientId = 0;
     bool shouldRefreshActors = false;
     // Set while applying an incoming packet so our own send-hooks don't echo it back out.
     bool isApplyingRemotePacket = false;
+    // Set when a save is (re)loaded; the next game-thread tick requests team state.
+    bool justLoadedSave = false;
+
+    // Snapshot of key save upgrades, used to detect mid-game acquisitions (e.g. magic, heart
+    // containers) that aren't covered by a flag or item-give and push them to the team live.
+    bool upgradeSnapshotValid = false;
+    s8 prevMagicLevel = 0;
+    u8 prevIsMagicAcquired = 0;
+    u8 prevIsDoubleMagicAcquired = 0;
+    u8 prevDoubleDefense = 0;
+    s16 prevHealthCapacity = 0;
+    void CheckAndPushSaveUpgrades();
+    void SnapshotSaveUpgrades();
+    // Applies the magic-meter kick + emits contextual notifications after upgrades change.
+    // Returns true if it emitted a notification.
+    bool ReconcileUpgrades(const std::string& senderName, u8 oldMagicAcquired, u8 oldDoubleMagic, u8 oldDoubleDefense,
+                           s16 oldHealthCapacity, s8 oldMagicLevel);
 
     void RegisterHooks();
     void UnregisterHooks();
@@ -94,6 +114,10 @@ class Anchor : public Network {
     void HandlePacket_PlayerUpdate(nlohmann::json payload);
     void HandlePacket_SetFlag(nlohmann::json payload);
     void HandlePacket_UnsetFlag(nlohmann::json payload);
+    void HandlePacket_GiveItem(nlohmann::json payload);
+    void HandlePacket_RequestTeamState(nlohmann::json payload);
+    void HandlePacket_UpdateTeamState(nlohmann::json payload);
+    void HandlePacket_GiveUpgrade(nlohmann::json payload);
     void HandlePacket_ServerMessage(nlohmann::json payload);
     void HandlePacket_DisableAnchor(nlohmann::json payload);
 
@@ -112,6 +136,10 @@ class Anchor : public Network {
     inline static const std::string PLAYER_UPDATE = "PLAYER_UPDATE";
     inline static const std::string SET_FLAG = "SET_FLAG";
     inline static const std::string UNSET_FLAG = "UNSET_FLAG";
+    inline static const std::string GIVE_ITEM = "GIVE_ITEM";
+    inline static const std::string REQUEST_TEAM_STATE = "REQUEST_TEAM_STATE";
+    inline static const std::string UPDATE_TEAM_STATE = "UPDATE_TEAM_STATE";
+    inline static const std::string GIVE_UPGRADE = "GIVE_UPGRADE";
     inline static const std::string SERVER_MESSAGE = "SERVER_MESSAGE";
     inline static const std::string DISABLE_ANCHOR = "DISABLE_ANCHOR";
 
@@ -135,6 +163,10 @@ class Anchor : public Network {
     void SendPacket_PlayerUpdate();
     void SendPacket_SetFlag(s16 sceneId, s16 flagType, s32 flag);
     void SendPacket_UnsetFlag(s16 sceneId, s16 flagType, s32 flag);
+    void SendPacket_GiveItem(u8 item);
+    void SendPacket_RequestTeamState();
+    void SendPacket_UpdateTeamState();
+    void SendPacket_GiveUpgrade();
 };
 
 #endif // __cplusplus

--- a/mm/2s2h/Network/Anchor/DummyPlayer.cpp
+++ b/mm/2s2h/Network/Anchor/DummyPlayer.cpp
@@ -1,0 +1,129 @@
+#include "Anchor.h"
+#include "2s2h/NameTag/NameTag.h"
+#include <cstring>
+
+extern "C" {
+#include "macros.h"
+#include "variables.h"
+#include "functions.h"
+extern PlayState* gPlayState;
+
+// Per-form physical properties (shadow scale, etc). Not declared in a header, but has external
+// linkage in z_player.c. The dummy needs ageProperties set before Player_InitCommon runs.
+extern PlayerAgeProperties sPlayerAgeProperties[];
+
+void Player_Draw(Actor* thisx, PlayState* play);
+}
+
+static void DummyPlayer_CopyVec3s(Vec3s* dest, Vec3s* src) {
+    dest->x = src->x;
+    dest->y = src->y;
+    dest->z = src->z;
+}
+
+// Dummy players are spawned as ACTOR_PLAYER (so the full player skeleton/overlay is loaded), then
+// repurposed in Anchor's ShouldActorInit hook: moved to ACTORCAT_NPC, relabeled ACTOR_EN_TEST, and
+// given these init/update/draw/destroy functions.
+void DummyPlayer_Init(Actor* actor, PlayState* play) {
+    Player* player = (Player*)actor;
+
+    uint32_t clientId = Anchor::Instance->GetDummyPlayerClientId(actor);
+    if (!Anchor::Instance->clients.contains(clientId)) {
+        Actor_Kill(actor);
+        return;
+    }
+
+    AnchorClient& client = Anchor::Instance->clients[clientId];
+
+    // Player_InitCommon picks behavior from these; set them before it runs to avoid using the
+    // local player's state (and to avoid dereferencing a null ageProperties).
+    player->transformation = client.form;
+    player->ageProperties = &sPlayerAgeProperties[client.form];
+    actor->room = -1;
+
+    play->playerInit(player, play, gPlayerSkeletons[client.form]);
+
+    // Populate the per-model display list pointers (waist/sheath/hands/etc). Without this the
+    // gameplay limb-draw callback dereferences null DList arrays and crashes.
+    player->itemAction = client.itemAction;
+    player->heldItemAction = client.heldItemAction;
+    Player_SetModelGroup(player, Player_ActionToModelGroup(player, (PlayerItemAction)player->heldItemAction));
+
+    NameTag_RegisterForActor(actor, client.name.c_str());
+}
+
+void DummyPlayer_Update(Actor* actor, PlayState* play) {
+    Player* player = (Player*)actor;
+
+    uint32_t clientId = Anchor::Instance->GetDummyPlayerClientId(actor);
+    if (!Anchor::Instance->clients.contains(clientId)) {
+        Actor_Kill(actor);
+        return;
+    }
+
+    AnchorClient& client = Anchor::Instance->clients[clientId];
+
+    // Hide the dummy when the client is in another scene / not in game.
+    if (client.sceneId != gPlayState->sceneId || !client.online || !client.isSaveLoaded) {
+        actor->world.pos.x = -9999.0f;
+        actor->world.pos.y = -9999.0f;
+        actor->world.pos.z = -9999.0f;
+        actor->shape.shadowAlpha = 0;
+        return;
+    }
+
+    actor->shape.shadowAlpha = 255;
+
+    DummyPlayer_CopyVec3s(&player->upperLimbRot, &client.upperLimbRot);
+    DummyPlayer_CopyVec3s(&actor->shape.rot, &client.posRot.rot);
+    Math_Vec3f_Copy(&actor->world.pos, &client.posRot.pos);
+
+    memcpy(player->skelAnime.jointTable, client.jointTable, sizeof(Vec3s) * PLAYER_LIMB_MAX);
+    player->skelAnime.movementFlags = client.movementFlags;
+    DummyPlayer_CopyVec3s(&player->skelAnime.prevTransl, &client.prevTransl);
+    player->currentBoots = client.currentBoots;
+    player->currentMask = client.currentMask;
+    player->stateFlags1 = client.stateFlags1;
+    player->stateFlags2 = client.stateFlags2;
+    player->itemAction = client.itemAction;
+    // Re-select the model group when the held item changes so the correct DLists are bound.
+    if (player->heldItemAction != client.heldItemAction) {
+        player->heldItemAction = client.heldItemAction;
+        Player_SetModelGroup(player, Player_ActionToModelGroup(player, (PlayerItemAction)player->heldItemAction));
+    }
+    player->invincibilityTimer = client.invincibilityTimer;
+
+    // Apply in-place animation root motion (mirrors Player's own translation handling).
+    Vec3f diff;
+    SkelAnime_UpdateTranslation(&player->skelAnime, &diff, actor->shape.rot.y);
+    if (player->skelAnime.movementFlags & 1) {
+        actor->world.pos.x += diff.x * actor->scale.x;
+        actor->world.pos.z += diff.z * actor->scale.z;
+    }
+    if (player->skelAnime.movementFlags & 2) {
+        actor->world.pos.y += diff.y * actor->scale.y;
+    }
+}
+
+void DummyPlayer_Draw(Actor* actor, PlayState* play) {
+    Player* player = (Player*)actor;
+
+    uint32_t clientId = Anchor::Instance->GetDummyPlayerClientId(actor);
+    if (!Anchor::Instance->clients.contains(clientId)) {
+        Actor_Kill(actor);
+        return;
+    }
+
+    AnchorClient& client = Anchor::Instance->clients[clientId];
+    if (client.sceneId != gPlayState->sceneId || !client.online || !client.isSaveLoaded) {
+        return;
+    }
+
+    Player_Draw((Actor*)player, play);
+}
+
+void DummyPlayer_Destroy(Actor* actor, PlayState* play) {
+    // The actor was spawned as ACTOR_PLAYER but relabeled ACTOR_EN_TEST. Restore the id so the
+    // ActorDB's numLoaded for ACTOR_PLAYER is decremented correctly on destroy.
+    actor->id = ACTOR_PLAYER;
+}

--- a/mm/2s2h/Network/Anchor/JsonConversions.hpp
+++ b/mm/2s2h/Network/Anchor/JsonConversions.hpp
@@ -1,0 +1,42 @@
+#ifndef NETWORK_ANCHOR_JSON_CONVERSIONS_H
+#define NETWORK_ANCHOR_JSON_CONVERSIONS_H
+#ifdef __cplusplus
+
+#include <nlohmann/json.hpp>
+#include <libultraship/libultraship.h>
+#include "Anchor.h"
+
+extern "C" {
+#include "z64.h"
+}
+
+using json = nlohmann::json;
+
+inline void to_json(json& j, const Color_RGB8& color) {
+    j = json{ { "r", color.r }, { "g", color.g }, { "b", color.b } };
+}
+
+inline void from_json(const json& j, Color_RGB8& color) {
+    j.at("r").get_to(color.r);
+    j.at("g").get_to(color.g);
+    j.at("b").get_to(color.b);
+}
+
+inline void from_json(const json& j, AnchorClient& client) {
+    client.clientId = j.value("clientId", (u32)0);
+    client.name = j.value("name", "???");
+    client.color = j.value("color", Color_RGB8{ 255, 255, 255 });
+    client.clientVersion = j.value("clientVersion", "???");
+    client.teamId = j.value("teamId", "default");
+    client.online = j.value("online", false);
+    client.self = j.value("self", false);
+    client.seed = j.value("seed", (u32)0);
+    client.isSaveLoaded = j.value("isSaveLoaded", false);
+    client.isGameComplete = j.value("isGameComplete", false);
+    client.sceneId = j.value("sceneId", (s16)SCENE_MAX);
+    client.curRoomNum = j.value("curRoomNum", (s8)-1);
+    client.entranceIndex = j.value("entranceIndex", (s32)0);
+}
+
+#endif // __cplusplus
+#endif // NETWORK_ANCHOR_JSON_CONVERSIONS_H

--- a/mm/2s2h/Network/Anchor/JsonConversions.hpp
+++ b/mm/2s2h/Network/Anchor/JsonConversions.hpp
@@ -22,6 +22,35 @@ inline void from_json(const json& j, Color_RGB8& color) {
     j.at("b").get_to(color.b);
 }
 
+inline void to_json(json& j, const Vec3f& vec) {
+    j = json{ { "x", vec.x }, { "y", vec.y }, { "z", vec.z } };
+}
+
+inline void from_json(const json& j, Vec3f& vec) {
+    j.at("x").get_to(vec.x);
+    j.at("y").get_to(vec.y);
+    j.at("z").get_to(vec.z);
+}
+
+inline void to_json(json& j, const Vec3s& vec) {
+    j = json{ { "x", vec.x }, { "y", vec.y }, { "z", vec.z } };
+}
+
+inline void from_json(const json& j, Vec3s& vec) {
+    j.at("x").get_to(vec.x);
+    j.at("y").get_to(vec.y);
+    j.at("z").get_to(vec.z);
+}
+
+inline void to_json(json& j, const PosRot& posRot) {
+    j = json{ { "pos", posRot.pos }, { "rot", posRot.rot } };
+}
+
+inline void from_json(const json& j, PosRot& posRot) {
+    j.at("pos").get_to(posRot.pos);
+    j.at("rot").get_to(posRot.rot);
+}
+
 inline void from_json(const json& j, AnchorClient& client) {
     client.clientId = j.value("clientId", (u32)0);
     client.name = j.value("name", "???");

--- a/mm/2s2h/Network/Anchor/Packets/Flags.cpp
+++ b/mm/2s2h/Network/Anchor/Packets/Flags.cpp
@@ -1,0 +1,138 @@
+#include "2s2h/Network/Anchor/Anchor.h"
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include <nlohmann/json.hpp>
+#include <libultraship/libultraship.h>
+
+extern "C" {
+#include "variables.h"
+#include "functions.h"
+extern PlayState* gPlayState;
+}
+
+/**
+ * SET_FLAG / UNSET_FLAG
+ *
+ * Sent when the local player sets/unsets a save flag (event, scene switch/chest/etc). Applied on
+ * other clients to keep progression in sync. sceneId == SCENE_MAX denotes a non-scene (global)
+ * flag such as week event reg or event inf.
+ *
+ * Scene flags are only applied when the sender is in our current scene; cross-scene scene flags
+ * are reconciled via team save-state sync.
+ */
+
+void Anchor::SendPacket_SetFlag(s16 sceneId, s16 flagType, s32 flag) {
+    if (!IsSaveLoaded() || !roomState.syncItemsAndFlags) {
+        return;
+    }
+
+    nlohmann::json payload;
+    payload["type"] = SET_FLAG;
+    payload["targetTeamId"] = CVarGetString("gNetwork.Anchor.TeamId", "default");
+    payload["addToQueue"] = true;
+    payload["sceneId"] = sceneId;
+    payload["flagType"] = flagType;
+    payload["flag"] = flag;
+
+    SendPacket(payload);
+}
+
+void Anchor::SendPacket_UnsetFlag(s16 sceneId, s16 flagType, s32 flag) {
+    if (!IsSaveLoaded() || !roomState.syncItemsAndFlags) {
+        return;
+    }
+
+    nlohmann::json payload;
+    payload["type"] = UNSET_FLAG;
+    payload["targetTeamId"] = CVarGetString("gNetwork.Anchor.TeamId", "default");
+    payload["addToQueue"] = true;
+    payload["sceneId"] = sceneId;
+    payload["flagType"] = flagType;
+    payload["flag"] = flag;
+
+    SendPacket(payload);
+}
+
+void Anchor::HandlePacket_SetFlag(nlohmann::json payload) {
+    if (!IsSaveLoaded() || !roomState.syncItemsAndFlags) {
+        return;
+    }
+
+    s16 sceneId = payload.at("sceneId").get<s16>();
+    s16 flagType = payload.at("flagType").get<s16>();
+    s32 flag = payload.at("flag").get<s32>();
+
+    isApplyingRemotePacket = true;
+    switch (flagType) {
+        case FLAG_WEEK_EVENT_REG:
+            Flags_SetWeekEventReg(flag);
+            break;
+        case FLAG_WEEK_EVENT_REG_HORSE_RACE:
+            Flags_SetWeekEventRegHorseRace((u8)flag);
+            break;
+        case FLAG_EVENT_INF:
+            Flags_SetEventInf(flag);
+            break;
+        case FLAG_RANDO_INF:
+            Flags_SetRandoInf(flag);
+            break;
+        case FLAG_CYCL_SCENE_SWITCH:
+            if (sceneId == gPlayState->sceneId) {
+                Flags_SetSwitch(gPlayState, flag);
+            }
+            break;
+        case FLAG_CYCL_SCENE_CHEST:
+            if (sceneId == gPlayState->sceneId) {
+                Flags_SetTreasure(gPlayState, flag);
+            }
+            break;
+        case FLAG_CYCL_SCENE_CLEARED_ROOM:
+            if (sceneId == gPlayState->sceneId) {
+                Flags_SetClear(gPlayState, flag);
+            }
+            break;
+        case FLAG_CYCL_SCENE_COLLECTIBLE:
+            if (sceneId == gPlayState->sceneId) {
+                Flags_SetCollectible(gPlayState, flag);
+            }
+            break;
+        default:
+            break;
+    }
+    isApplyingRemotePacket = false;
+}
+
+void Anchor::HandlePacket_UnsetFlag(nlohmann::json payload) {
+    if (!IsSaveLoaded() || !roomState.syncItemsAndFlags) {
+        return;
+    }
+
+    s16 sceneId = payload.at("sceneId").get<s16>();
+    s16 flagType = payload.at("flagType").get<s16>();
+    s32 flag = payload.at("flag").get<s32>();
+
+    isApplyingRemotePacket = true;
+    switch (flagType) {
+        case FLAG_WEEK_EVENT_REG:
+            Flags_ClearWeekEventReg(flag);
+            break;
+        case FLAG_EVENT_INF:
+            Flags_ClearEventInf(flag);
+            break;
+        case FLAG_RANDO_INF:
+            Flags_ClearRandoInf(flag);
+            break;
+        case FLAG_CYCL_SCENE_SWITCH:
+            if (sceneId == gPlayState->sceneId) {
+                Flags_UnsetSwitch(gPlayState, flag);
+            }
+            break;
+        case FLAG_CYCL_SCENE_CLEARED_ROOM:
+            if (sceneId == gPlayState->sceneId) {
+                Flags_UnsetClear(gPlayState, flag);
+            }
+            break;
+        default:
+            break;
+    }
+    isApplyingRemotePacket = false;
+}

--- a/mm/2s2h/Network/Anchor/Packets/GiveItem.cpp
+++ b/mm/2s2h/Network/Anchor/Packets/GiveItem.cpp
@@ -1,0 +1,63 @@
+#include "2s2h/Network/Anchor/Anchor.h"
+#include "2s2h/BenGui/Notification.h"
+#include <nlohmann/json.hpp>
+#include <libultraship/libultraship.h>
+
+extern "C" {
+#include "variables.h"
+#include "functions.h"
+extern PlayState* gPlayState;
+}
+
+/**
+ * GIVE_ITEM
+ *
+ * Sent when the local player is granted an item (via Item_Give). Applied on teammates so found
+ * items are shared. The isApplyingRemotePacket guard prevents the applied Item_Give from echoing
+ * back out through the OnItemGive hook.
+ *
+ * Like SoH/Anchor, ALL items are shared, but only "notable" items raise a notification. Junk drops
+ * and refills (rupees, recovery hearts, magic jars, ammo) are still given silently.
+ */
+
+// Mirrors SoH's ITEM_CATEGORY_JUNK: the contiguous block of drops/refills. MM has no item-category
+// enum, so we test the id ranges directly.
+static bool Anchor_IsJunkItem(u8 item) {
+    return item == ITEM_MAGIC_JAR_SMALL || item == ITEM_MAGIC_JAR_BIG ||
+           (item >= ITEM_RECOVERY_HEART && item <= ITEM_BOMBCHUS_5);
+}
+
+void Anchor::SendPacket_GiveItem(u8 item) {
+    if (!IsSaveLoaded() || isApplyingRemotePacket || !roomState.syncItemsAndFlags) {
+        return;
+    }
+
+    nlohmann::json payload;
+    payload["type"] = GIVE_ITEM;
+    payload["targetTeamId"] = CVarGetString("gNetwork.Anchor.TeamId", "default");
+    payload["addToQueue"] = true;
+    payload["item"] = item;
+
+    SendPacket(payload);
+}
+
+void Anchor::HandlePacket_GiveItem(nlohmann::json payload) {
+    if (!IsSaveLoaded() || !roomState.syncItemsAndFlags) {
+        return;
+    }
+
+    uint32_t clientId = payload.at("clientId").get<uint32_t>();
+    u8 item = payload.at("item").get<u8>();
+
+    isApplyingRemotePacket = true;
+    Item_Give(gPlayState, item);
+    isApplyingRemotePacket = false;
+
+    // Share everything, but don't spam notifications for junk drops/refills (rupees, hearts, ammo).
+    if (!Anchor_IsJunkItem(item) && clients.contains(clientId)) {
+        Notification::Emit({
+            .prefix = clients[clientId].name,
+            .message = "shared an item",
+        });
+    }
+}

--- a/mm/2s2h/Network/Anchor/Packets/PlayerUpdate.cpp
+++ b/mm/2s2h/Network/Anchor/Packets/PlayerUpdate.cpp
@@ -1,0 +1,118 @@
+#include "2s2h/Network/Anchor/Anchor.h"
+#include "2s2h/Network/Anchor/JsonConversions.hpp"
+#include <nlohmann/json.hpp>
+#include <libultraship/libultraship.h>
+
+extern "C" {
+#include "macros.h"
+#include "variables.h"
+#include "functions.h"
+extern PlayState* gPlayState;
+}
+
+/**
+ * PLAYER_UPDATE
+ *
+ * Real-time data needed to render another player in the same scene. Sent every frame to each
+ * other client currently in the same scene. Marked "quiet" so it does not spam the logs.
+ *
+ * This is sent _a lot_, so keep the payload as small as is practical.
+ */
+
+void Anchor::SendPacket_PlayerUpdate() {
+    if (!IsSaveLoaded()) {
+        return;
+    }
+
+    // Only send if at least one other client is in our scene.
+    uint32_t recipients = 0;
+    for (auto& [clientId, client] : clients) {
+        if (!client.self && client.online && client.isSaveLoaded && client.sceneId == gPlayState->sceneId) {
+            recipients++;
+        }
+    }
+    if (recipients == 0) {
+        return;
+    }
+
+    Player* player = GET_PLAYER(gPlayState);
+
+    nlohmann::json payload;
+    payload["type"] = PLAYER_UPDATE;
+    payload["sceneId"] = gPlayState->sceneId;
+    payload["entranceIndex"] = gSaveContext.save.entrance;
+    payload["form"] = player->transformation;
+    payload["posRot"]["pos"] = player->actor.world.pos;
+    payload["posRot"]["rot"] = player->actor.shape.rot;
+
+    std::vector<int> jointArray;
+    jointArray.reserve(PLAYER_LIMB_MAX * 3);
+    for (size_t i = 0; i < PLAYER_LIMB_MAX; i++) {
+        Vec3s joint = player->skelAnime.jointTable[i];
+        jointArray.push_back(joint.x);
+        jointArray.push_back(joint.y);
+        jointArray.push_back(joint.z);
+    }
+    payload["jointTable"] = jointArray;
+    payload["prevTransl"] = player->skelAnime.prevTransl;
+    payload["movementFlags"] = player->skelAnime.movementFlags;
+    payload["upperLimbRot"] = player->upperLimbRot;
+    payload["currentBoots"] = player->currentBoots;
+    payload["currentMask"] = player->currentMask;
+    payload["stateFlags1"] = player->stateFlags1;
+    payload["stateFlags2"] = player->stateFlags2;
+    payload["itemAction"] = player->itemAction;
+    payload["heldItemAction"] = player->heldItemAction;
+    payload["invincibilityTimer"] = player->invincibilityTimer;
+    payload["face"] = player->actor.shape.face;
+    payload["quiet"] = true;
+
+    for (auto& [clientId, client] : clients) {
+        if (!client.self && client.online && client.isSaveLoaded && client.sceneId == gPlayState->sceneId) {
+            payload["targetClientId"] = clientId;
+            SendPacket(payload);
+        }
+    }
+}
+
+void Anchor::HandlePacket_PlayerUpdate(nlohmann::json payload) {
+    uint32_t clientId = payload["clientId"].get<uint32_t>();
+    if (!clients.contains(clientId)) {
+        return;
+    }
+
+    auto& client = clients[clientId];
+
+    s32 newForm = payload.value("form", (s32)PLAYER_FORM_HUMAN);
+    s16 newSceneId = payload.value("sceneId", (s16)SCENE_MAX);
+    if (client.form != newForm || client.sceneId != newSceneId) {
+        // A form change means a different skeleton; a scene change means the dummy must be
+        // (de)spawned. Either way, respawn dummy actors on the next tick.
+        shouldRefreshActors = true;
+    }
+
+    client.sceneId = newSceneId;
+    client.entranceIndex = payload.value("entranceIndex", (s32)0);
+    client.form = newForm;
+    client.posRot = payload.value("posRot", PosRot{ 0 });
+
+    std::vector<int> jointArray = payload.value("jointTable", std::vector<int>{});
+    jointArray.resize(PLAYER_LIMB_MAX * 3); // pad in case of missing data
+    for (size_t i = 0; i < PLAYER_LIMB_MAX; i++) {
+        client.jointTable[i].x = jointArray[i * 3];
+        client.jointTable[i].y = jointArray[i * 3 + 1];
+        client.jointTable[i].z = jointArray[i * 3 + 2];
+    }
+
+    client.prevTransl = payload.value("prevTransl", Vec3s{ 0 });
+    client.movementFlags = payload.value("movementFlags", (u8)0);
+    client.upperLimbRot = payload.value("upperLimbRot", Vec3s{ 0 });
+    client.currentBoots = payload.value("currentBoots", (s8)0);
+    client.currentMask = payload.value("currentMask", (u8)0);
+    client.stateFlags1 = payload.value("stateFlags1", (u32)0);
+    client.stateFlags2 = payload.value("stateFlags2", (u32)0);
+    client.itemAction = payload.value("itemAction", (s8)0);
+    client.heldItemAction = payload.value("heldItemAction", (s8)0);
+    client.invincibilityTimer = payload.value("invincibilityTimer", (s8)0);
+    client.face = payload.value("face", (u8)0);
+}

--- a/mm/2s2h/Network/Anchor/Packets/TeamState.cpp
+++ b/mm/2s2h/Network/Anchor/Packets/TeamState.cpp
@@ -1,0 +1,298 @@
+#include "2s2h/Network/Anchor/Anchor.h"
+#include "2s2h/BenGui/Notification.h"
+#include <nlohmann/json.hpp>
+#include <libultraship/libultraship.h>
+#include <vector>
+
+extern "C" {
+#include "macros.h"
+#include "variables.h"
+extern PlayState* gPlayState;
+}
+
+using json = nlohmann::json;
+
+/**
+ * REQUEST_TEAM_STATE / UPDATE_TEAM_STATE
+ *
+ * On loading a save (or connecting while already in game) a client requests the team's current
+ * save state. A teammate responds with UPDATE_TEAM_STATE, a curated subset of gSaveContext
+ * (progression-relevant fields), which the requester adopts. Also pushed on saving the game so the
+ * server's last-known team state stays fresh for late joiners.
+ *
+ * This is what reconciles save *values* (magic, hearts, upgrades, inventory) that aren't covered
+ * by per-event flag or item-give packets.
+ */
+
+void Anchor::SendPacket_RequestTeamState() {
+    if (!IsSaveLoaded() || !roomState.syncItemsAndFlags) {
+        return;
+    }
+
+    json payload;
+    payload["type"] = REQUEST_TEAM_STATE;
+    payload["targetTeamId"] = CVarGetString("gNetwork.Anchor.TeamId", "default");
+    SendPacket(payload);
+}
+
+void Anchor::HandlePacket_RequestTeamState(json payload) {
+    if (!IsSaveLoaded() || !roomState.syncItemsAndFlags) {
+        return;
+    }
+    SendPacket_UpdateTeamState();
+}
+
+void Anchor::SendPacket_UpdateTeamState() {
+    if (!IsSaveLoaded() || !roomState.syncItemsAndFlags) {
+        return;
+    }
+
+    SavePlayerData& pd = gSaveContext.save.saveInfo.playerData;
+    Inventory& inv = gSaveContext.save.saveInfo.inventory;
+    SaveInfo& si = gSaveContext.save.saveInfo;
+
+    json state;
+    state["healthCapacity"] = pd.healthCapacity;
+    state["magicLevel"] = pd.magicLevel;
+    state["isMagicAcquired"] = pd.isMagicAcquired;
+    state["isDoubleMagicAcquired"] = pd.isDoubleMagicAcquired;
+    state["doubleDefense"] = pd.doubleDefense;
+    state["owlActivationFlags"] = pd.owlActivationFlags;
+
+    state["items"] = std::vector<u8>(inv.items, inv.items + ARRAY_COUNT(inv.items));
+    state["ammo"] = std::vector<s8>(inv.ammo, inv.ammo + ARRAY_COUNT(inv.ammo));
+    state["upgrades"] = inv.upgrades;
+    state["questItems"] = inv.questItems;
+    state["dungeonItems"] = std::vector<u8>(inv.dungeonItems, inv.dungeonItems + ARRAY_COUNT(inv.dungeonItems));
+    state["dungeonKeys"] = std::vector<s8>(inv.dungeonKeys, inv.dungeonKeys + ARRAY_COUNT(inv.dungeonKeys));
+    state["defenseHearts"] = inv.defenseHearts;
+    state["strayFairies"] = std::vector<s8>(inv.strayFairies, inv.strayFairies + ARRAY_COUNT(inv.strayFairies));
+
+    state["weekEventReg"] = std::vector<u8>(si.weekEventReg, si.weekEventReg + ARRAY_COUNT(si.weekEventReg));
+    state["eventInf"] = std::vector<u8>(gSaveContext.eventInf, gSaveContext.eventInf + ARRAY_COUNT(gSaveContext.eventInf));
+    state["scenesVisible"] = std::vector<u32>(si.scenesVisible, si.scenesVisible + ARRAY_COUNT(si.scenesVisible));
+    state["skullTokenCount"] = si.skullTokenCount;
+    state["regionsVisited"] = si.regionsVisited;
+
+    json payload;
+    payload["type"] = UPDATE_TEAM_STATE;
+    payload["targetTeamId"] = CVarGetString("gNetwork.Anchor.TeamId", "default");
+    payload["state"] = state;
+    SendPacket(payload);
+}
+
+template <typename T, size_t N> static void CopyJsonArray(const json& src, const char* key, T (&dest)[N]) {
+    if (!src.contains(key)) {
+        return;
+    }
+    std::vector<T> v = src[key].get<std::vector<T>>();
+    for (size_t i = 0; i < v.size() && i < N; i++) {
+        dest[i] = v[i];
+    }
+}
+
+void Anchor::HandlePacket_UpdateTeamState(json payload) {
+    if (!roomState.syncItemsAndFlags || !payload.contains("state") || !IsSaveLoaded()) {
+        return;
+    }
+
+    const json& s = payload["state"];
+    SavePlayerData& pd = gSaveContext.save.saveInfo.playerData;
+    Inventory& inv = gSaveContext.save.saveInfo.inventory;
+    SaveInfo& si = gSaveContext.save.saveInfo;
+
+    // Capture pre-apply values so we can report what changed.
+    u8 oldMagicAcquired = pd.isMagicAcquired;
+    u8 oldDoubleMagic = pd.isDoubleMagicAcquired;
+    u8 oldDoubleDefense = pd.doubleDefense;
+    s16 oldHealthCapacity = pd.healthCapacity;
+    s8 oldMagicLevel = pd.magicLevel;
+
+    std::string senderName = "A teammate";
+    if (payload.contains("clientId")) {
+        uint32_t senderId = payload["clientId"].get<uint32_t>();
+        if (clients.contains(senderId)) {
+            senderName = clients[senderId].name;
+        }
+    }
+
+    isApplyingRemotePacket = true;
+
+    pd.healthCapacity = s.value("healthCapacity", pd.healthCapacity);
+    pd.magicLevel = s.value("magicLevel", pd.magicLevel);
+    pd.isMagicAcquired = s.value("isMagicAcquired", pd.isMagicAcquired);
+    pd.isDoubleMagicAcquired = s.value("isDoubleMagicAcquired", pd.isDoubleMagicAcquired);
+    pd.doubleDefense = s.value("doubleDefense", pd.doubleDefense);
+    pd.owlActivationFlags = s.value("owlActivationFlags", pd.owlActivationFlags);
+
+    CopyJsonArray(s, "items", inv.items);
+    CopyJsonArray(s, "ammo", inv.ammo);
+    inv.upgrades = s.value("upgrades", inv.upgrades);
+    inv.questItems = s.value("questItems", inv.questItems);
+    CopyJsonArray(s, "dungeonItems", inv.dungeonItems);
+    CopyJsonArray(s, "dungeonKeys", inv.dungeonKeys);
+    inv.defenseHearts = s.value("defenseHearts", inv.defenseHearts);
+    CopyJsonArray(s, "strayFairies", inv.strayFairies);
+
+    CopyJsonArray(s, "weekEventReg", si.weekEventReg);
+    CopyJsonArray(s, "eventInf", gSaveContext.eventInf);
+    CopyJsonArray(s, "scenesVisible", si.scenesVisible);
+    si.skullTokenCount = s.value("skullTokenCount", si.skullTokenCount);
+    si.regionsVisited = s.value("regionsVisited", si.regionsVisited);
+
+    isApplyingRemotePacket = false;
+
+    bool notified =
+        ReconcileUpgrades(senderName, oldMagicAcquired, oldDoubleMagic, oldDoubleDefense, oldHealthCapacity,
+                          oldMagicLevel);
+    if (!notified) {
+        Notification::Emit({ .message = "Save synced from team" });
+    }
+}
+
+// Kicks the magic meter and emits contextual notifications after upgrade values change. Shared by
+// the team-state (join) path and the live GIVE_UPGRADE path.
+bool Anchor::ReconcileUpgrades(const std::string& senderName, u8 oldMagicAcquired, u8 oldDoubleMagic,
+                               u8 oldDoubleDefense, s16 oldHealthCapacity, s8 oldMagicLevel) {
+    (void)oldMagicLevel;
+    SavePlayerData& pd = gSaveContext.save.saveInfo.playerData;
+
+    // When magic is newly acquired (or upgraded to double), replicate the game's native grant
+    // (z_parameter.c Interface magic update): set the level, ramp/fill the meter, and enable the
+    // Deku form's magic attack on B. Setting only magicLevel shows the meter but leaves magic
+    // unusable (e.g. the Deku bubble), because the B-button equip is never set.
+    bool newMagic = !oldMagicAcquired && pd.isMagicAcquired;
+    bool newDoubleMagic = !oldDoubleMagic && pd.isDoubleMagicAcquired;
+    if (newMagic || newDoubleMagic) {
+        pd.magicLevel = pd.isDoubleMagicAcquired ? 2 : 1;
+        gSaveContext.magicFillTarget = pd.magicLevel * MAGIC_NORMAL_METER;
+        pd.magic = 0;
+        gSaveContext.magicState = MAGIC_STATE_STEP_CAPACITY;
+        BUTTON_ITEM_EQUIP(PLAYER_FORM_DEKU, EQUIP_SLOT_B) = ITEM_DEKU_NUT;
+    }
+
+    // Adopted values are now our baseline; don't let the dirty-check re-broadcast them.
+    SnapshotSaveUpgrades();
+
+    bool notified = false;
+    auto emit = [&](const char* what) {
+        Notification::Emit({ .prefix = senderName, .message = "found", .suffix = what });
+        notified = true;
+    };
+    if (!oldMagicAcquired && pd.isMagicAcquired) {
+        emit("Magic Power");
+    }
+    if (!oldDoubleMagic && pd.isDoubleMagicAcquired) {
+        emit("Double Magic");
+    }
+    if (!oldDoubleDefense && pd.doubleDefense) {
+        emit("Double Defense");
+    }
+    if (pd.healthCapacity > oldHealthCapacity) {
+        emit("a Heart Container");
+    }
+    return notified;
+}
+
+/**
+ * GIVE_UPGRADE
+ *
+ * Lightweight, live-broadcast packet for save-value upgrades that aren't items or flags (magic,
+ * double magic, double defense, heart capacity). Unlike UPDATE_TEAM_STATE (which the server only
+ * delivers to clients awaiting state), this uses the generic team broadcast so it reaches online
+ * teammates immediately. Values are applied monotonically so a stale packet never downgrades.
+ */
+
+void Anchor::SendPacket_GiveUpgrade() {
+    if (!IsSaveLoaded() || !roomState.syncItemsAndFlags) {
+        return;
+    }
+
+    SavePlayerData& pd = gSaveContext.save.saveInfo.playerData;
+
+    json payload;
+    payload["type"] = GIVE_UPGRADE;
+    payload["targetTeamId"] = CVarGetString("gNetwork.Anchor.TeamId", "default");
+    payload["addToQueue"] = true;
+    payload["magicLevel"] = pd.magicLevel;
+    payload["isMagicAcquired"] = pd.isMagicAcquired;
+    payload["isDoubleMagicAcquired"] = pd.isDoubleMagicAcquired;
+    payload["doubleDefense"] = pd.doubleDefense;
+    payload["healthCapacity"] = pd.healthCapacity;
+    SendPacket(payload);
+}
+
+void Anchor::HandlePacket_GiveUpgrade(json payload) {
+    if (!roomState.syncItemsAndFlags || !IsSaveLoaded()) {
+        return;
+    }
+
+    SavePlayerData& pd = gSaveContext.save.saveInfo.playerData;
+    u8 oldMagicAcquired = pd.isMagicAcquired;
+    u8 oldDoubleMagic = pd.isDoubleMagicAcquired;
+    u8 oldDoubleDefense = pd.doubleDefense;
+    s16 oldHealthCapacity = pd.healthCapacity;
+    s8 oldMagicLevel = pd.magicLevel;
+
+    std::string senderName = "A teammate";
+    if (payload.contains("clientId")) {
+        uint32_t senderId = payload["clientId"].get<uint32_t>();
+        if (clients.contains(senderId)) {
+            senderName = clients[senderId].name;
+        }
+    }
+
+    isApplyingRemotePacket = true;
+    s8 newMagicLevel = payload.value("magicLevel", pd.magicLevel);
+    if (newMagicLevel > pd.magicLevel) {
+        pd.magicLevel = newMagicLevel;
+    }
+    if (payload.value("isMagicAcquired", (u8)0)) {
+        pd.isMagicAcquired = true;
+    }
+    if (payload.value("isDoubleMagicAcquired", (u8)0)) {
+        pd.isDoubleMagicAcquired = true;
+    }
+    if (payload.value("doubleDefense", (u8)0)) {
+        pd.doubleDefense = true;
+    }
+    s16 newHealthCapacity = payload.value("healthCapacity", pd.healthCapacity);
+    if (newHealthCapacity > pd.healthCapacity) {
+        pd.healthCapacity = newHealthCapacity;
+    }
+    isApplyingRemotePacket = false;
+
+    ReconcileUpgrades(senderName, oldMagicAcquired, oldDoubleMagic, oldDoubleDefense, oldHealthCapacity, oldMagicLevel);
+}
+
+void Anchor::SnapshotSaveUpgrades() {
+    SavePlayerData& pd = gSaveContext.save.saveInfo.playerData;
+    prevMagicLevel = pd.magicLevel;
+    prevIsMagicAcquired = pd.isMagicAcquired;
+    prevIsDoubleMagicAcquired = pd.isDoubleMagicAcquired;
+    prevDoubleDefense = pd.doubleDefense;
+    prevHealthCapacity = pd.healthCapacity;
+    upgradeSnapshotValid = true;
+}
+
+// Detects mid-game upgrade acquisitions (magic, double magic, double defense, heart capacity)
+// that aren't covered by flag/item packets, and pushes team state so they propagate live.
+void Anchor::CheckAndPushSaveUpgrades() {
+    if (!isConnected || !roomState.syncItemsAndFlags || !IsSaveLoaded() || isApplyingRemotePacket) {
+        return;
+    }
+
+    if (!upgradeSnapshotValid) {
+        SnapshotSaveUpgrades();
+        return;
+    }
+
+    SavePlayerData& pd = gSaveContext.save.saveInfo.playerData;
+    if (pd.magicLevel != prevMagicLevel || pd.isMagicAcquired != prevIsMagicAcquired ||
+        pd.isDoubleMagicAcquired != prevIsDoubleMagicAcquired || pd.doubleDefense != prevDoubleDefense ||
+        pd.healthCapacity != prevHealthCapacity) {
+        SnapshotSaveUpgrades();
+        // Live-broadcast the upgrade (UPDATE_TEAM_STATE is not forwarded to online teammates).
+        SendPacket_GiveUpgrade();
+    }
+}

--- a/mm/2s2h/Network/Anchor/Packets/TeamState.cpp
+++ b/mm/2s2h/Network/Anchor/Packets/TeamState.cpp
@@ -69,7 +69,8 @@ void Anchor::SendPacket_UpdateTeamState() {
     state["strayFairies"] = std::vector<s8>(inv.strayFairies, inv.strayFairies + ARRAY_COUNT(inv.strayFairies));
 
     state["weekEventReg"] = std::vector<u8>(si.weekEventReg, si.weekEventReg + ARRAY_COUNT(si.weekEventReg));
-    state["eventInf"] = std::vector<u8>(gSaveContext.eventInf, gSaveContext.eventInf + ARRAY_COUNT(gSaveContext.eventInf));
+    state["eventInf"] =
+        std::vector<u8>(gSaveContext.eventInf, gSaveContext.eventInf + ARRAY_COUNT(gSaveContext.eventInf));
     state["scenesVisible"] = std::vector<u32>(si.scenesVisible, si.scenesVisible + ARRAY_COUNT(si.scenesVisible));
     state["skullTokenCount"] = si.skullTokenCount;
     state["regionsVisited"] = si.regionsVisited;
@@ -142,9 +143,8 @@ void Anchor::HandlePacket_UpdateTeamState(json payload) {
 
     isApplyingRemotePacket = false;
 
-    bool notified =
-        ReconcileUpgrades(senderName, oldMagicAcquired, oldDoubleMagic, oldDoubleDefense, oldHealthCapacity,
-                          oldMagicLevel);
+    bool notified = ReconcileUpgrades(senderName, oldMagicAcquired, oldDoubleMagic, oldDoubleDefense, oldHealthCapacity,
+                                      oldMagicLevel);
     if (!notified) {
         Notification::Emit({ .message = "Save synced from team" });
     }

--- a/mm/2s2h/Network/Network.cpp
+++ b/mm/2s2h/Network/Network.cpp
@@ -1,0 +1,179 @@
+#include "Network.h"
+#include <spdlog/spdlog.h>
+#include <libultraship/libultraship.h>
+
+// MARK: - Public
+
+void Network::Enable(const char* host, uint16_t port) {
+#ifdef ENABLE_NETWORKING
+    if (isEnabled) {
+        return;
+    }
+
+    if (SDLNet_ResolveHost(&networkAddress, host, port) == -1) {
+        SPDLOG_ERROR("[Network] SDLNet_ResolveHost: {}", SDLNet_GetError());
+    }
+
+    isEnabled = true;
+
+    // First check if there is a thread running, if so, join it
+    if (receiveThread.joinable()) {
+        receiveThread.join();
+    }
+
+    receiveThread = std::thread(&Network::ReceiveFromServer, this);
+#endif
+}
+
+void Network::Disable() {
+    if (!isEnabled) {
+        return;
+    }
+
+    isEnabled = false;
+    isConnected = false;
+#ifdef ENABLE_NETWORKING
+    if (networkSocket) {
+        SDLNet_TCP_Close(networkSocket);
+        networkSocket = nullptr;
+    }
+    receiveThread.join();
+#endif
+}
+
+void Network::OnConnected() {
+}
+
+void Network::OnDisconnected() {
+}
+
+void Network::SwapIncomingPacketQueue(std::queue<nlohmann::json>& emptyQueue) {
+    if (incomingPacketQueueMutex.try_lock()) {
+        std::swap(incomingPacketQueue, emptyQueue);
+        incomingPacketQueueMutex.unlock();
+    }
+}
+
+void Network::QueueOutgoingPacket(nlohmann::json packet) {
+    if (outgoingPacketQueueMutex.try_lock()) {
+        outgoingPacketQueue.push(packet);
+        outgoingPacketQueueMutex.unlock();
+    }
+}
+
+// MARK: - Private
+
+void Network::ReceiveFromServer() {
+#ifdef ENABLE_NETWORKING
+    while (isEnabled) {
+        while (!isConnected && isEnabled) {
+            SPDLOG_TRACE("[Network] Attempting to make connection to server...");
+            networkSocket = SDLNet_TCP_Open(&networkAddress);
+
+            if (networkSocket) {
+                isConnected = true;
+                receivedData.clear();
+                SPDLOG_INFO("[Network] Connection to server established!");
+
+                OnConnected();
+                break;
+            }
+        }
+
+        SDLNet_SocketSet socketSet = SDLNet_AllocSocketSet(1);
+        if (networkSocket) {
+            SDLNet_TCP_AddSocket(socketSet, networkSocket);
+        }
+
+        // Listen to socket messages
+        while (isConnected && networkSocket && isEnabled) {
+            // we check first if socket has data, to not block in the TCP_Recv
+            int socketsReady = SDLNet_CheckSockets(socketSet, 10); // 10ms timeout
+
+            if (socketsReady == -1) {
+                SPDLOG_ERROR("[Network] SDLNet_CheckSockets: {}", SDLNet_GetError());
+                break;
+            }
+
+            if (socketsReady > 0) {
+                char remoteDataReceived[512];
+                memset(remoteDataReceived, 0, sizeof(remoteDataReceived));
+                int len = SDLNet_TCP_Recv(networkSocket, &remoteDataReceived, sizeof(remoteDataReceived));
+                if (!len || !networkSocket || len == -1) {
+                    SPDLOG_ERROR("[Network] SDLNet_TCP_Recv: {}", SDLNet_GetError());
+                    break;
+                }
+
+                receivedData.append(remoteDataReceived, len);
+
+                // Process all complete packets
+                size_t delimiterPos = receivedData.find('\0');
+                while (delimiterPos != std::string::npos) {
+                    // Extract the complete packet until the delimiter
+                    std::string packet = receivedData.substr(0, delimiterPos);
+                    // Remove the packet (including the delimiter) from the received data
+                    receivedData.erase(0, delimiterPos + 1);
+                    HandleCompletePacket(packet);
+                    // Find the next delimiter
+                    delimiterPos = receivedData.find('\0');
+                }
+            }
+
+            // Always send outgoing packets, not just when receiving data
+            ProcessOutgoingPackets();
+        }
+
+        if (socketSet) {
+            SDLNet_FreeSocketSet(socketSet);
+        }
+
+        if (isConnected && networkSocket) {
+            SDLNet_TCP_Close(networkSocket);
+            networkSocket = nullptr;
+            isConnected = false;
+            receivedData.clear();
+            OnDisconnected();
+            SPDLOG_INFO("[Network] Ending receiving thread...");
+        }
+    }
+#endif
+}
+
+void Network::HandleCompletePacket(std::string payload) {
+    SPDLOG_TRACE("[Network] Received json:\n{}", payload);
+    try {
+        nlohmann::json jsonPayload = nlohmann::json::parse(payload);
+        std::lock_guard<std::mutex> lock(incomingPacketQueueMutex);
+        incomingPacketQueue.push(jsonPayload);
+    } catch (const std::exception& e) {
+        SPDLOG_ERROR("[Network] Failed to parse json: \n{}\n{}\n", payload, e.what());
+        return;
+    }
+}
+
+void Network::ProcessOutgoingPackets() {
+    if (!isConnected || !networkSocket) {
+        return;
+    }
+
+    // Copy all queued packets while holding the lock, then send them after releasing
+    std::queue<nlohmann::json> packetsToSend;
+    {
+        std::lock_guard<std::mutex> lock(outgoingPacketQueueMutex);
+        packetsToSend.swap(outgoingPacketQueue);
+    }
+
+    while (!packetsToSend.empty()) {
+        nlohmann::json payload = packetsToSend.front();
+        packetsToSend.pop();
+
+        std::string rawPayload = payload.dump();
+        if (!payload.contains("quiet")) {
+            SPDLOG_TRACE("[Network] Sending json:\n{}", rawPayload);
+        }
+
+#ifdef ENABLE_NETWORKING
+        SDLNet_TCP_Send(networkSocket, rawPayload.c_str(), rawPayload.length() + 1);
+#endif
+    }
+}

--- a/mm/2s2h/Network/Network.h
+++ b/mm/2s2h/Network/Network.h
@@ -1,0 +1,45 @@
+#ifndef NETWORK_H
+#define NETWORK_H
+#ifdef __cplusplus
+
+#include <thread>
+#ifdef ENABLE_NETWORKING
+#include <SDL2/SDL_net.h>
+#endif
+#include <nlohmann/json.hpp>
+
+class Network {
+  private:
+#ifdef ENABLE_NETWORKING
+    IPaddress networkAddress;
+    TCPsocket networkSocket;
+#endif
+    std::thread receiveThread;
+    std::string receivedData;
+
+    void ReceiveFromServer();
+    void HandleCompletePacket(std::string payload);
+    void ProcessOutgoingPackets();
+
+    std::mutex incomingPacketQueueMutex;
+    std::queue<nlohmann::json> incomingPacketQueue;
+    std::mutex outgoingPacketQueueMutex;
+    std::queue<nlohmann::json> outgoingPacketQueue;
+
+  public:
+    bool isEnabled;
+    bool isConnected;
+
+    void Enable(const char* host, uint16_t port);
+    void Disable();
+
+    virtual void OnConnected();
+    virtual void OnDisconnected();
+
+    // To be called from the Game thread
+    void SwapIncomingPacketQueue(std::queue<nlohmann::json>& emptyQueue);
+    void QueueOutgoingPacket(nlohmann::json packet);
+};
+
+#endif // __cplusplus
+#endif // NETWORK_H

--- a/mm/2s2h/Network/NetworkMenu.cpp
+++ b/mm/2s2h/Network/NetworkMenu.cpp
@@ -1,0 +1,106 @@
+#include "2s2h/BenGui/UIWidgets.hpp"
+#include "ShipUtils.h"
+#include "2s2h/BenGui/BenMenu.h"
+#include "2s2h/BenGui/Notification.h"
+#include "2s2h/Network/Sail/Sail.h"
+
+namespace BenGui {
+extern std::shared_ptr<BenMenu> mBenMenu;
+} // namespace BenGui
+using namespace UIWidgets;
+
+void RegisterNetworkMenu() {
+    // Add Network Menu
+    BenGui::mBenMenu->AddMenuEntry("Network", "gSettings.Menu.NetworkSidebarSection");
+    WidgetPath path;
+
+#ifndef ENABLE_NETWORKING
+    path = { "Network", "Info", SECTION_COLUMN_1 };
+    BenGui::mBenMenu->AddSidebarEntry("Network", path.sidebarName, 2);
+
+    BenGui::mBenMenu
+        ->AddWidget(path,
+                    ICON_FA_EXCLAMATION_TRIANGLE
+                    " The Network features are unavailable because SoH was compiled without "
+                    "network support (\"ENABLE_NETWORKING\" build flag).",
+                    WIDGET_TEXT)
+        .Options(TextOptions().Color(Colors::Orange));
+    return;
+#endif
+
+    // Sail
+    path = { "Network", "Sail", SECTION_COLUMN_1 };
+    BenGui::mBenMenu->AddSidebarEntry("Network", path.sidebarName, 3);
+    BenGui::mBenMenu->AddWidget(path, "Host & Port", WIDGET_CUSTOM).CustomFunction([](WidgetInfo& info) {
+        ImGui::BeginDisabled(Sail::Instance->isEnabled);
+        ImGui::Text("%s", info.name.c_str());
+        CVarInputString("##HostSail", "gNetwork.Sail.Host",
+                        InputOptions()
+                            .PlaceholderText("127.0.0.1")
+                            .DefaultValue("127.0.0.1")
+                            .Size(ImVec2(ImGui::GetContentRegionAvail().x - ImGui::GetFontSize() * 7, 0))
+                            .LabelPosition(LabelPosition::None));
+        ImGui::SameLine();
+        ImGui::Text(":");
+        ImGui::SameLine();
+        CVarInputInt("##PortSail", "gNetwork.Sail.Port",
+                     InputOptions()
+                         .PlaceholderText("43384")
+                         .DefaultValue("43384")
+                         .Size(ImVec2(ImGui::GetFontSize() * 5, 0))
+                         .LabelPosition(LabelPosition::None));
+        ImGui::EndDisabled();
+    });
+    BenGui::mBenMenu->AddWidget(path, "Enable##Sail", WIDGET_BUTTON)
+        .PreFunc([](WidgetInfo& info) {
+            std::string host = CVarGetString("gNetwork.Sail.Host", "127.0.0.1");
+            uint16_t port = CVarGetInteger("gNetwork.Sail.Port", 43384);
+            info.options->disabled = !(!isStringEmpty(host) && port > 1024 && port < 65535);
+            if (Sail::Instance->isEnabled) {
+                info.name = "Disable##Sail";
+            } else {
+                info.name = "Enable##Sail";
+            }
+        })
+        .Callback([](WidgetInfo& info) {
+            if (Sail::Instance->isEnabled) {
+                CVarClear("gNetwork.Sail.Enabled");
+                Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
+                Sail::Instance->Disable();
+            } else {
+                CVarSetInteger("gNetwork.Sail.Enabled", 1);
+                Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
+                Sail::Instance->Enable();
+            }
+        });
+    BenGui::mBenMenu->AddWidget(path, "Connecting...", WIDGET_TEXT).PreFunc([](WidgetInfo& info) {
+        info.isHidden = !Sail::Instance->isEnabled;
+        if (Sail::Instance->isConnected) {
+            info.name = "Connected##Sail";
+        } else {
+            info.name = "Connecting...##Sail";
+        }
+    });
+    path.column = SECTION_COLUMN_2;
+    BenGui::mBenMenu->AddWidget(path,
+                                "Sail is a networking protocol designed to facilitate remote "
+                                "control of the 2Ship2Harkinian client. It is intended to "
+                                "be utilized alongside a Sail server, for which we provide a "
+                                "few straightforward implementations on our GitHub. The current "
+                                "implementations available allow integration with Twitch chat "
+                                "and SAMMI Bot, feel free to contribute your own!\n"
+                                "\n"
+                                "Click this button to copy the link to the Sail Github "
+                                "page to your clipboard.",
+                                WIDGET_TEXT);
+    BenGui::mBenMenu->AddWidget(path, ICON_FA_CLIPBOARD "##Sail", WIDGET_BUTTON)
+        .Callback([](WidgetInfo& info) {
+            ImGui::SetClipboardText("https://github.com/HarbourMasters/sail");
+            Notification::Emit({
+                .message = "Copied to clipboard",
+            });
+        })
+        .Options(ButtonOptions().Tooltip("https://github.com/HarbourMasters/sail"));
+}
+
+static RegisterMenuInitFunc initFunc(RegisterNetworkMenu);

--- a/mm/2s2h/Network/NetworkMenu.cpp
+++ b/mm/2s2h/Network/NetworkMenu.cpp
@@ -3,6 +3,7 @@
 #include "2s2h/BenGui/BenMenu.h"
 #include "2s2h/BenGui/Notification.h"
 #include "2s2h/Network/Sail/Sail.h"
+#include "2s2h/Network/Anchor/Anchor.h"
 
 namespace BenGui {
 extern std::shared_ptr<BenMenu> mBenMenu;
@@ -101,6 +102,91 @@ void RegisterNetworkMenu() {
             });
         })
         .Options(ButtonOptions().Tooltip("https://github.com/HarbourMasters/sail"));
+
+    // Anchor
+    path = { "Network", "Anchor", SECTION_COLUMN_1 };
+    BenGui::mBenMenu->AddSidebarEntry("Network", path.sidebarName, 4);
+    BenGui::mBenMenu->AddWidget(path, "Host & Port", WIDGET_CUSTOM).CustomFunction([](WidgetInfo& info) {
+        ImGui::BeginDisabled(Anchor::Instance->isEnabled);
+        ImGui::Text("%s", info.name.c_str());
+        CVarInputString("##HostAnchor", "gNetwork.Anchor.Host",
+                        InputOptions()
+                            .PlaceholderText("anchor.hm64.org")
+                            .DefaultValue("anchor.hm64.org")
+                            .Size(ImVec2(ImGui::GetContentRegionAvail().x - ImGui::GetFontSize() * 7, 0))
+                            .LabelPosition(LabelPosition::None));
+        ImGui::SameLine();
+        ImGui::Text(":");
+        ImGui::SameLine();
+        CVarInputInt("##PortAnchor", "gNetwork.Anchor.Port",
+                     InputOptions()
+                         .PlaceholderText("43383")
+                         .DefaultValue("43383")
+                         .Size(ImVec2(ImGui::GetFontSize() * 5, 0))
+                         .LabelPosition(LabelPosition::None));
+        ImGui::EndDisabled();
+    });
+    BenGui::mBenMenu->AddWidget(path, "Name", WIDGET_CUSTOM).CustomFunction([](WidgetInfo& info) {
+        ImGui::BeginDisabled(Anchor::Instance->isEnabled);
+        CVarInputString("Name##Anchor", "gNetwork.Anchor.Name", InputOptions().PlaceholderText("Player"));
+        CVarInputString("Room ID##Anchor", "gNetwork.Anchor.RoomId", InputOptions().PlaceholderText("(optional)"));
+        CVarInputString("Team ID##Anchor", "gNetwork.Anchor.TeamId",
+                        InputOptions().PlaceholderText("default").DefaultValue("default"));
+        ImGui::EndDisabled();
+    });
+    BenGui::mBenMenu->AddWidget(path, "Enable##Anchor", WIDGET_BUTTON)
+        .PreFunc([](WidgetInfo& info) {
+            std::string host = CVarGetString("gNetwork.Anchor.Host", "anchor.hm64.org");
+            uint16_t port = CVarGetInteger("gNetwork.Anchor.Port", 43383);
+            info.options->disabled = !(!isStringEmpty(host) && port > 1024 && port < 65535);
+            info.name = Anchor::Instance->isEnabled ? "Disable##Anchor" : "Enable##Anchor";
+        })
+        .Callback([](WidgetInfo& info) {
+            if (Anchor::Instance->isEnabled) {
+                CVarClear("gNetwork.Anchor.Enabled");
+                Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
+                Anchor::Instance->Disable();
+            } else {
+                CVarSetInteger("gNetwork.Anchor.Enabled", 1);
+                Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
+                Anchor::Instance->Enable();
+            }
+        });
+    BenGui::mBenMenu->AddWidget(path, "Connecting...", WIDGET_TEXT).PreFunc([](WidgetInfo& info) {
+        info.isHidden = !Anchor::Instance->isEnabled;
+        info.name = Anchor::Instance->isConnected ? "Connected##Anchor" : "Connecting...##Anchor";
+    });
+    BenGui::mBenMenu->AddWidget(path, "Players##Anchor", WIDGET_CUSTOM).CustomFunction([](WidgetInfo& info) {
+        if (!Anchor::Instance->isConnected) {
+            return;
+        }
+        ImGui::Text("Players in room:");
+        for (auto& [clientId, client] : Anchor::Instance->clients) {
+            if (!client.online) {
+                continue;
+            }
+            ImGui::TextColored(ImVec4(client.color.r / 255.0f, client.color.g / 255.0f, client.color.b / 255.0f, 1.0f),
+                               "%s%s", client.name.c_str(), client.self ? " (you)" : "");
+        }
+    });
+    path.column = SECTION_COLUMN_2;
+    BenGui::mBenMenu->AddWidget(path,
+                                "Anchor enables co-op multiplayer by syncing progress (and, in later "
+                                "versions, player positions) between everyone connected to the same "
+                                "room. Pick a Room ID to play privately with friends, and share a Team "
+                                "ID to share items and flags.\n"
+                                "\n"
+                                "The default host is the public Anchor server. You can also self-host "
+                                "the Anchor server from its GitHub repository.",
+                                WIDGET_TEXT);
+    BenGui::mBenMenu->AddWidget(path, ICON_FA_CLIPBOARD "##Anchor", WIDGET_BUTTON)
+        .Callback([](WidgetInfo& info) {
+            ImGui::SetClipboardText("https://github.com/garrettjoecox/anchor");
+            Notification::Emit({
+                .message = "Copied to clipboard",
+            });
+        })
+        .Options(ButtonOptions().Tooltip("https://github.com/garrettjoecox/anchor"));
 }
 
 static RegisterMenuInitFunc initFunc(RegisterNetworkMenu);

--- a/mm/2s2h/Network/Sail/Sail.cpp
+++ b/mm/2s2h/Network/Sail/Sail.cpp
@@ -1,0 +1,353 @@
+#include "Sail.h"
+#include <libultraship/libultraship.h>
+#include <nlohmann/json.hpp>
+#include "2s2h/GameInteractor/GameInteractor.h"
+
+extern "C" {
+#include "variables.h"
+}
+
+std::unordered_map<std::string, std::unordered_map<int32_t, HOOK_ID>> filteredHookIds;
+std::unordered_map<std::string, HOOK_ID> hookIds;
+
+void OnSceneInitHandler(s8 sceneId, s8 spawnNum) {
+    if (!Sail::Instance->isConnected)
+        return;
+
+    nlohmann::json payload;
+    payload["id"] = std::rand();
+    payload["type"] = "hook";
+    payload["hook"]["type"] = "OnSceneInit";
+    payload["hook"]["sceneNum"] = sceneId;
+
+    Sail::Instance->QueueOutgoingPacket(payload);
+}
+
+void OnItemGiveHandler(u8 item) {
+    if (!Sail::Instance->isConnected)
+        return;
+
+    nlohmann::json payload;
+    payload["id"] = std::rand();
+    payload["type"] = "hook";
+    payload["hook"]["type"] = "OnItemGive";
+    payload["hook"]["itemId"] = item;
+
+    Sail::Instance->QueueOutgoingPacket(payload);
+}
+
+void OnActorInitHandler(void* refActor) {
+    if (!Sail::Instance->isConnected)
+        return;
+
+    Actor* actor = (Actor*)refActor;
+    nlohmann::json payload;
+    payload["id"] = std::rand();
+    payload["type"] = "hook";
+    payload["hook"]["type"] = "OnActorInit";
+    payload["hook"]["actorId"] = actor->id;
+    payload["hook"]["params"] = actor->params;
+
+    Sail::Instance->QueueOutgoingPacket(payload);
+}
+
+void OnFlagSetHandler(int16_t flagType, int16_t flag) {
+    if (!Sail::Instance->isConnected)
+        return;
+
+    nlohmann::json payload;
+    payload["id"] = std::rand();
+    payload["type"] = "hook";
+    payload["hook"]["type"] = "OnFlagSet";
+    payload["hook"]["flagType"] = flagType;
+    payload["hook"]["flag"] = flag;
+
+    Sail::Instance->QueueOutgoingPacket(payload);
+}
+
+void OnFlagUnsetHandler(int16_t flagType, int16_t flag) {
+    if (!Sail::Instance->isConnected)
+        return;
+
+    nlohmann::json payload;
+    payload["id"] = std::rand();
+    payload["type"] = "hook";
+    payload["hook"]["type"] = "OnFlagUnset";
+    payload["hook"]["flagType"] = flagType;
+    payload["hook"]["flag"] = flag;
+
+    Sail::Instance->QueueOutgoingPacket(payload);
+}
+
+void OnSceneFlagSetHandler(int16_t sceneNum, int16_t flagType, int16_t flag) {
+    if (!Sail::Instance->isConnected)
+        return;
+
+    nlohmann::json payload;
+    payload["id"] = std::rand();
+    payload["type"] = "hook";
+    payload["hook"]["type"] = "OnSceneFlagSet";
+    payload["hook"]["flagType"] = flagType;
+    payload["hook"]["flag"] = flag;
+    payload["hook"]["sceneNum"] = sceneNum;
+
+    Sail::Instance->QueueOutgoingPacket(payload);
+}
+
+void OnSceneFlagUnsetHandler(int16_t sceneNum, int16_t flagType, int16_t flag) {
+    if (!Sail::Instance->isConnected)
+        return;
+
+    nlohmann::json payload;
+    payload["id"] = std::rand();
+    payload["type"] = "hook";
+    payload["hook"]["type"] = "OnSceneFlagUnset";
+    payload["hook"]["flagType"] = flagType;
+    payload["hook"]["flag"] = flag;
+    payload["hook"]["sceneNum"] = sceneNum;
+
+    Sail::Instance->QueueOutgoingPacket(payload);
+}
+
+void Sail::Enable() {
+    Network::Enable(CVarGetString("gNetwork.Sail.Host", "127.0.0.1"), CVarGetInteger("gNetwork.Sail.Port", 43384));
+}
+
+#define HANDLE_ID_SUBSCRIBE(hookType)                                                                                 \
+    {                                                                                                                 \
+        if (eventName == #hookType) {                                                                                 \
+            if (payload.contains("eventIdFilter")) {                                                                  \
+                int32_t eventIdFilter = payload["eventIdFilter"].get<int32_t>();                                      \
+                if (!filteredHookIds[eventName].contains(eventIdFilter)) {                                            \
+                    filteredHookIds[eventName][eventIdFilter] =                                                       \
+                        GameInteractor::Instance->RegisterGameHookForID<GameInteractor::hookType>(eventIdFilter,      \
+                                                                                                  hookType##Handler); \
+                }                                                                                                     \
+            } else {                                                                                                  \
+                if (!hookIds.contains(eventName)) {                                                                   \
+                    hookIds[eventName] =                                                                              \
+                        GameInteractor::Instance->RegisterGameHook<GameInteractor::hookType>(hookType##Handler);      \
+                }                                                                                                     \
+            }                                                                                                         \
+            responsePayload["status"] = "success";                                                                    \
+        }                                                                                                             \
+    }
+
+#define HANDLE_SUBSCRIBE(hookType)                                                                           \
+    {                                                                                                        \
+        if (eventName == #hookType) {                                                                        \
+            if (!hookIds.contains(eventName)) {                                                              \
+                hookIds[eventName] =                                                                         \
+                    GameInteractor::Instance->RegisterGameHook<GameInteractor::hookType>(hookType##Handler); \
+            }                                                                                                \
+            responsePayload["status"] = "success";                                                           \
+        }                                                                                                    \
+    }
+
+#define HANDLE_ID_UNSUBSCRIBE(hookType)                                                                         \
+    {                                                                                                           \
+        if (eventName == #hookType) {                                                                           \
+            if (payload.contains("eventIdFilter")) {                                                            \
+                int32_t eventIdFilter = payload["eventIdFilter"].get<int32_t>();                                \
+                if (filteredHookIds[eventName].contains(eventIdFilter)) {                                       \
+                    GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::hookType>(                \
+                        filteredHookIds[eventName][eventIdFilter]);                                             \
+                    filteredHookIds[eventName].erase(eventIdFilter);                                            \
+                }                                                                                               \
+            } else {                                                                                            \
+                if (hookIds.contains(eventName)) {                                                              \
+                    GameInteractor::Instance->UnregisterGameHook<GameInteractor::hookType>(hookIds[eventName]); \
+                    hookIds.erase(eventName);                                                                   \
+                }                                                                                               \
+            }                                                                                                   \
+            responsePayload["status"] = "success";                                                              \
+        }                                                                                                       \
+    }
+
+#define HANDLE_UNSUBSCRIBE(hookType)                                                                        \
+    {                                                                                                       \
+        if (eventName == #hookType) {                                                                       \
+            if (hookIds.contains(eventName)) {                                                              \
+                GameInteractor::Instance->UnregisterGameHook<GameInteractor::hookType>(hookIds[eventName]); \
+                hookIds.erase(eventName);                                                                   \
+            }                                                                                               \
+            responsePayload["status"] = "success";                                                          \
+        }                                                                                                   \
+    }
+
+void Sail::OnIncomingJson(nlohmann::json payload) {
+    nlohmann::json responsePayload;
+    responsePayload["type"] = "result";
+    responsePayload["status"] = "failure";
+
+    try {
+        if (!payload.contains("id")) {
+            SPDLOG_ERROR("[Sail] Received payload without ID");
+            QueueOutgoingPacket(responsePayload);
+            return;
+        }
+
+        responsePayload["id"] = payload["id"];
+
+        if (!payload.contains("type")) {
+            SPDLOG_ERROR("[Sail] Received payload without type");
+            QueueOutgoingPacket(responsePayload);
+            return;
+        }
+
+        std::string payloadType = payload["type"].get<std::string>();
+
+        if (payloadType == "command") {
+            if (!payload.contains("command")) {
+                SPDLOG_ERROR("[Sail] Received command payload without command");
+                QueueOutgoingPacket(responsePayload);
+                return;
+            }
+
+            std::string command = payload["command"].get<std::string>();
+            std::reinterpret_pointer_cast<Ship::ConsoleWindow>(
+                Ship::Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Console"))
+                ->Dispatch(command);
+            responsePayload["status"] = "success";
+            QueueOutgoingPacket(responsePayload);
+            return;
+        } else if (payloadType == "effect") {
+            if (!payload.contains("effect") || !payload["effect"].contains("type")) {
+                SPDLOG_ERROR("[Sail] Received effect payload without effect type");
+                QueueOutgoingPacket(responsePayload);
+                return;
+            }
+
+            std::string effectType = payload["effect"]["type"].get<std::string>();
+
+            // Special case for "command" effect, so we can also run commands from the `simple_twitch_sail` script
+            if (effectType == "command") {
+                if (!payload["effect"].contains("command")) {
+                    SPDLOG_ERROR("[Sail] Received command effect payload without command");
+                    QueueOutgoingPacket(responsePayload);
+                    return;
+                }
+
+                std::string command = payload["effect"]["command"].get<std::string>();
+                std::reinterpret_pointer_cast<Ship::ConsoleWindow>(
+                    Ship::Context::GetInstance()->GetWindow()->GetGui()->GetGuiWindow("Console"))
+                    ->Dispatch(command);
+                responsePayload["status"] = "success";
+                QueueOutgoingPacket(responsePayload);
+                return;
+            }
+
+            if (effectType == "teleport") {
+                if (gPlayState == NULL) {
+                    SPDLOG_ERROR("[Sail] Teleport failed, no gPlayState");
+                    QueueOutgoingPacket(responsePayload);
+                    return;
+                }
+
+                if (!payload["effect"].contains("entranceId")) {
+                    SPDLOG_ERROR("[Sail] Received teleport effect payload without entranceId");
+                    QueueOutgoingPacket(responsePayload);
+                    return;
+                }
+
+                gPlayState->nextEntrance = payload["effect"]["entranceId"].get<u16>();
+                gSaveContext.nextCutsceneIndex = 0;
+                gPlayState->transitionTrigger = TRANS_TRIGGER_START;
+                gPlayState->transitionType = TRANS_TYPE_INSTANT;
+            }
+
+            if (effectType != "apply" && effectType != "remove") {
+                SPDLOG_ERROR("[Sail] Received effect payload with unknown effect type: {}", effectType);
+                QueueOutgoingPacket(responsePayload);
+                return;
+            }
+
+            responsePayload["status"] = "success";
+            QueueOutgoingPacket(responsePayload);
+        } else if (payloadType == "subscribe") {
+            if (!payload.contains("eventName")) {
+                SPDLOG_ERROR("[Sail] Received subscribe payload without eventName");
+                QueueOutgoingPacket(responsePayload);
+                return;
+            }
+
+            std::string eventName = payload["eventName"].get<std::string>();
+
+            HANDLE_ID_SUBSCRIBE(OnSceneInit);
+            HANDLE_ID_SUBSCRIBE(OnItemGive);
+            HANDLE_ID_SUBSCRIBE(OnActorInit);
+            HANDLE_SUBSCRIBE(OnFlagSet);
+            HANDLE_SUBSCRIBE(OnFlagUnset);
+            HANDLE_SUBSCRIBE(OnSceneFlagSet);
+            HANDLE_SUBSCRIBE(OnSceneFlagUnset);
+
+            responsePayload["status"] = "success";
+            QueueOutgoingPacket(responsePayload);
+            return;
+        } else if (payloadType == "unsubscribe") {
+            if (!payload.contains("eventName")) {
+                SPDLOG_ERROR("[Sail] Received unsubscribe payload without eventName");
+                QueueOutgoingPacket(responsePayload);
+                return;
+            }
+
+            std::string eventName = payload["eventName"].get<std::string>();
+
+            HANDLE_ID_UNSUBSCRIBE(OnSceneInit);
+            HANDLE_ID_UNSUBSCRIBE(OnItemGive);
+            HANDLE_ID_UNSUBSCRIBE(OnActorInit);
+            HANDLE_UNSUBSCRIBE(OnFlagSet);
+            HANDLE_UNSUBSCRIBE(OnFlagUnset);
+            HANDLE_UNSUBSCRIBE(OnSceneFlagSet);
+            HANDLE_UNSUBSCRIBE(OnSceneFlagUnset);
+
+            QueueOutgoingPacket(responsePayload);
+            return;
+        } else {
+            SPDLOG_ERROR("[Sail] Unknown payload type: {}", payloadType);
+            QueueOutgoingPacket(responsePayload);
+            return;
+        }
+
+        // If we get here, something went wrong, send the failure response
+        SPDLOG_ERROR("[Sail] Failed to handle remote JSON, sending failure response");
+        QueueOutgoingPacket(responsePayload);
+    } catch (const std::exception& e) {
+        SPDLOG_ERROR("[Sail] Exception handling remote JSON: {}", e.what());
+    } catch (...) { SPDLOG_ERROR("[Sail] Unknown exception handling remote JSON"); }
+}
+
+void Sail::OnConnected() {
+    RegisterHooks();
+}
+
+void Sail::OnDisconnected() {
+    RegisterHooks();
+}
+
+void Sail::RegisterHooks() {
+    COND_HOOK(OnGameStateMainStart, isConnected, []() {
+        std::queue<nlohmann::json> packetQueue;
+        Sail::Instance->SwapIncomingPacketQueue(packetQueue);
+
+        while (!packetQueue.empty()) {
+            nlohmann::json payload = packetQueue.front();
+            packetQueue.pop();
+            Sail::Instance->OnIncomingJson(payload);
+        }
+    });
+
+    if (!isConnected) {
+        for (auto& [eventName, hookId] : hookIds) {
+            GameInteractor::Instance->UnregisterGameHook<GameInteractor::OnSceneInit>(hookId);
+        }
+        hookIds.clear();
+
+        for (auto& [eventName, filteredHookId] : filteredHookIds) {
+            for (auto& [eventIdFilter, hookId] : filteredHookId) {
+                GameInteractor::Instance->UnregisterGameHookForID<GameInteractor::OnSceneInit>(hookId);
+            }
+        }
+        filteredHookIds.clear();
+    }
+}

--- a/mm/2s2h/Network/Sail/Sail.h
+++ b/mm/2s2h/Network/Sail/Sail.h
@@ -1,0 +1,22 @@
+#ifndef NETWORK_SAIL_H
+#define NETWORK_SAIL_H
+#ifdef __cplusplus
+
+#include "2s2h/Network/Network.h"
+
+class Sail : public Network {
+  private:
+    void RegisterHooks();
+    void UnregisterAllHooks();
+    void OnIncomingJson(nlohmann::json payload);
+
+  public:
+    static Sail* Instance;
+
+    void Enable();
+    void OnConnected();
+    void OnDisconnected();
+};
+
+#endif // __cplusplus
+#endif // NETWORK_SAIL_H

--- a/mm/2s2h/ShipUtils.cpp
+++ b/mm/2s2h/ShipUtils.cpp
@@ -456,3 +456,17 @@ void Ship_DrawKaleidoCycleAButtonPrompt(PlayState* play, u8 alpha) {
     CLOSE_DISPS(play->state.gfxCtx);
 }
 }
+
+bool isStringEmpty(std::string str) {
+    // Remove spaces at the beginning of the string
+    std::string::size_type start = str.find_first_not_of(' ');
+    // Remove spaces at the end of the string
+    std::string::size_type end = str.find_last_not_of(' ');
+
+    // Check if the string is empty after stripping spaces
+    if (start == std::string::npos || end == std::string::npos) {
+        return true; // The string is empty
+    } else {
+        return false; // The string is not empty
+    }
+}

--- a/mm/2s2h/ShipUtils.h
+++ b/mm/2s2h/ShipUtils.h
@@ -31,6 +31,7 @@ extern uint32_t Ship_Hash(std::string str);
 extern std::string GetActorDescription(u16 actorNum);
 extern std::string GetActorDebugName(u16 actorNum);
 extern std::string GetActorCategoryName(u8 category);
+bool isStringEmpty(std::string str);
 
 extern "C" {
 #endif

--- a/mm/CMakeLists.txt
+++ b/mm/CMakeLists.txt
@@ -223,8 +223,8 @@ endif()
 find_package(SDL2)
 set(SDL2-INCLUDE ${SDL2_INCLUDE_DIRS})
 
-if (BUILD_CROWD_CONTROL)
-    find_package(SDL2_net)
+if (BUILD_NETWORKING)
+    find_package(SDL2_net 2.2.0 REQUIRED)
     set(SDL2-NET-INCLUDE ${SDL_NET_INCLUDE_DIRS})
 endif()
 
@@ -253,9 +253,8 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
 		"$<$<CONFIG:Release>:"
 			"NDEBUG;"
 		">"
-           #"$<$<BOOL:${BUILD_CROWD_CONTROL}>:ENABLE_CROWD_CONTROL>"
+        "$<$<BOOL:${BUILD_NETWORKING}>:ENABLE_NETWORKING>"
 		"INCLUDE_GAME_PRINTF;"
-           #"ENABLE_CROWD_CONTROL;"
 		"F3DEX_GBI_2"
 		"UNICODE;"
 		"_UNICODE"
@@ -288,8 +287,8 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU|Clang|AppleClang")
 		"$<$<CONFIG:Release>:"
 			"NDEBUG;"
 		">"
-        "F3DEX_GBI_2;"
-		# "$<$<BOOL:${BUILD_CROWD_CONTROL}>:ENABLE_CROWD_CONTROL>"
+		"F3DEX_GBI_2"
+		"$<$<BOOL:${BUILD_NETWORKING}>:ENABLE_NETWORKING>"
 		"_CONSOLE;"
 		"_CRT_SECURE_NO_WARNINGS;"
 		"ENABLE_OPENGL;"
@@ -539,7 +538,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
 		"glu32;"
 		"SDL2::SDL2;"
 		"SDL2::SDL2main;"
-        #"$<$<BOOL:${BUILD_CROWD_CONTROL}>:SDL2_net::SDL2_net-static>"
+        "$<$<BOOL:${BUILD_NETWORKING}>:SDL2_net::SDL2_net-static>"
 		"glfw;"
 		"winmm;"
 		"imm32;"
@@ -592,7 +591,7 @@ else()
         "Opus::opus"
         "Opusfile::Opusfile"
 		SDL2::SDL2
- #       "$<$<BOOL:${BUILD_CROWD_CONTROL}>:SDL2_net::SDL2_net>"
+        "$<$<BOOL:${BUILD_NETWORKING}>:SDL2_net::SDL2_net>"
 		${CMAKE_DL_LIBS}
 		Threads::Threads
 	)


### PR DESCRIPTION
Ports Shipwright's **Anchor** co-op multiplayer to 2S2H. The Anchor server
(garrettjoecox/anchor) is game-agnostic, so this is a client-only port; it
connects to anchor.hm64.org by default. Build with `-DBUILD_NETWORKING=ON`.

Built on top of the Network base from #790.

**Stages (each its own commit):**
- **Stage 1** – Connect, handshake, room roster + Network → Anchor menu (host/port/name/room/team, live player list).
- **Stage 2** – Remote player rendering: PLAYER_UPDATE + DummyPlayer (spawned as ACTOR_PLAYER, repurposed), adapted to MM transformation forms.
- **Stage 3** – Flag/progression sync (week-event/event-inf/rando-inf always; scene flags when in the same scene).
- **Stage 4** – Item sharing (all items shared, SoH-style junk filter on notifications), team save-state join-sync, and live GIVE_UPGRADE for magic/hearts/defense (magic replicates the native grant incl. the Deku B equip).

Co-op gameplay (movement, animation, transformations, flags, items, magic) verified in-game with two clients.

Known follow-ups: item-name strings in notifications (MM lacks a clean item→name table), shield-on-back on remote players, and merge/restore rules for divergent consumables on save-state adopt.
