### PR TITLE
[Rando] Adjust Heart Pieces in pool per starting health

### DIFF
--- a/mm/2s2h/Rando/Logic/GeneratePools.cpp
+++ b/mm/2s2h/Rando/Logic/GeneratePools.cpp
@@ -281,6 +281,28 @@ void GeneratePools(RandoSaveInfo& saveInfo, std::vector<RandoCheckId>& checkPool
         }
     }
 
+    // Adjust Heart Containers/Pieces based on starting health
+    if (saveInfo.randoSaveOptions[RO_STARTING_HEALTH] < 3) {
+        // Add up to 8 Heart Pieces
+        int piecesToAdd = 4 * (3 - saveInfo.randoSaveOptions[RO_STARTING_HEALTH]);
+        while (piecesToAdd) {
+            itemPool.emplace_back(RI_HEART_PIECE);
+            piecesToAdd--;
+        }
+    } else if (saveInfo.randoSaveOptions[RO_STARTING_HEALTH] > 3) {
+        // Remove up to 52 Heart Pieces
+        int piecesToRemove = 4 * (saveInfo.randoSaveOptions[RO_STARTING_HEALTH] - 3);
+        while (piecesToRemove) {
+            auto it = std::find(itemPool.begin(), itemPool.end(), RI_HEART_PIECE);
+            if (it != itemPool.end()) {
+                itemPool.erase(it);
+            } else {
+                break;
+            }
+            piecesToRemove--;
+        }
+    }
+
     // Plentiful
     if (saveInfo.randoSaveOptions[RO_PLENTIFUL_ITEMS] == RO_GENERIC_YES) {
         std::vector<RandoItemId> plentifulItems;

--- a/mm/2s2h/Rando/Logic/GeneratePools.cpp
+++ b/mm/2s2h/Rando/Logic/GeneratePools.cpp
@@ -281,7 +281,7 @@ void GeneratePools(RandoSaveInfo& saveInfo, std::vector<RandoCheckId>& checkPool
         }
     }
 
-    // Adjust Heart Containers/Pieces based on starting health
+    // Adjust Heart Pieces based on starting health
     if (saveInfo.randoSaveOptions[RO_STARTING_HEALTH] < 3) {
         // Add up to 8 Heart Pieces
         int piecesToAdd = 4 * (3 - saveInfo.randoSaveOptions[RO_STARTING_HEALTH]);


### PR DESCRIPTION
Now, changing starting health will affect how many Heart Pieces are put into the pool. Lower than the default of 3 will add 4-8 pieces to the pool, while higher than default will remove pieces from the pool.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7571303360.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7571077104.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7570859920.zip)
<!--- section:artifacts:end -->