### PR TITLE
[Enhancement] Remove explosives limit

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1085,19 +1085,6 @@ void BenMenu::AddEnhancements() {
         .CVar("gEnhancements.PlayerActions.ArrowCycle")
         .Options(CheckboxOptions().Tooltip(
             "While aiming the bow, use R to cycle between Normal, Fire, Ice and Light arrows."));
-    AddWidget(path, "Bomb Arrows", WIDGET_CVAR_CHECKBOX)
-        .CVar("gEnhancements.Equipment.BombArrows")
-        .Options(CheckboxOptions().Tooltip(
-            "Allows equipping Bomb Arrows by equipping Bombs onto a bow button in the pause menu."));
-    AddWidget(path, "Remote Bombchu Control", WIDGET_CVAR_CHECKBOX)
-        .CVar("gEnhancements.PlayerActions.RemoteBombchu")
-        .Options(CheckboxOptions().Tooltip(
-            "Allows you to control the direction of the Bombchu while it is moving. Press B to detonate. Press A to "
-            "stop controlling the Bombchu."));
-    AddWidget(path, "Bombchu Drops", WIDGET_CVAR_CHECKBOX)
-        .CVar("gEnhancements.Equipment.ChuDrops")
-        .Options(
-            CheckboxOptions().Tooltip("When a bomb drop is spawned, it has a 50% chance to be a Bombchu instead."));
     AddWidget(path, "Invert Shield Y Axis", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Equipment.InvertShieldY")
         .Options(CheckboxOptions().Tooltip(
@@ -1161,10 +1148,6 @@ void BenMenu::AddEnhancements() {
                               "-Half Price: Sell at half value (rounded up)"
                               "Arrows will always be sold back at Full Price.")
                      .ComboVec(&ammoBuybackOptions));
-    AddWidget(path, "Extra Powder Kegs", WIDGET_CVAR_CHECKBOX)
-        .CVar("gEnhancements.Items.ExtraPowderKegs")
-        .Options(CheckboxOptions().Tooltip(
-            "Allows carrying up to 3 Powder Kegs at once instead of the vanilla limit of 1."));
     AddWidget(path, "Extended Projectile Interaction Distance", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Gameplay.ExtendedProjectileInteractionDistance")
         .Options(CheckboxOptions().Tooltip(
@@ -1192,6 +1175,29 @@ void BenMenu::AddEnhancements() {
         .CVar("gEnhancements.Minigames.MarkShootingGalleryOctoroks")
         .Options(CheckboxOptions().Tooltip("Places markers on the Town Shooting Gallery Octoroks, indicating whether "
                                            "they should be hit."));
+
+    AddWidget(path, "Explosives", WIDGET_SEPARATOR_TEXT);
+    AddWidget(path, "Extra Powder Kegs", WIDGET_CVAR_CHECKBOX)
+        .CVar("gEnhancements.Items.ExtraPowderKegs")
+        .Options(CheckboxOptions().Tooltip(
+            "Allows carrying up to 3 Powder Kegs at once instead of the vanilla limit of 1."));
+    AddWidget(path, "Bomb Arrows", WIDGET_CVAR_CHECKBOX)
+        .CVar("gEnhancements.Equipment.BombArrows")
+        .Options(CheckboxOptions().Tooltip(
+            "Allows equipping Bomb Arrows by equipping Bombs onto a bow button in the pause menu."));
+    AddWidget(path, "Remote Bombchu Control", WIDGET_CVAR_CHECKBOX)
+        .CVar("gEnhancements.PlayerActions.RemoteBombchu")
+        .Options(CheckboxOptions().Tooltip(
+            "Allows you to control the direction of the Bombchu while it is moving. Press B to detonate. Press A to "
+            "stop controlling the Bombchu."));
+    AddWidget(path, "Bombchu Drops", WIDGET_CVAR_CHECKBOX)
+        .CVar("gEnhancements.Equipment.ChuDrops")
+        .Options(
+            CheckboxOptions().Tooltip("When a bomb drop is spawned, it has a 50% chance to be a Bombchu instead."));
+    AddWidget(path, "Remove Explosive Limit", WIDGET_CVAR_CHECKBOX)
+        .CVar("gEnhancements.Items.RemoveExplosiveLimit")
+        .Options(CheckboxOptions().Tooltip("Removes the cap of 3 active explosives being deployed at once."));
+
     path.column = SECTION_COLUMN_3;
     AddWidget(path, "Saving", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "3rd Save File Slot", WIDGET_CVAR_CHECKBOX)

--- a/mm/2s2h/Enhancements/Items/RemoveExplosiveLimit.cpp
+++ b/mm/2s2h/Enhancements/Items/RemoveExplosiveLimit.cpp
@@ -1,0 +1,13 @@
+#include <libultraship/bridge/consolevariablebridge.h>
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/ShipInit.hpp"
+
+#define CVAR_NAME "gEnhancements.Items.RemoveExplosiveLimit"
+#define CVAR CVarGetInteger(CVAR_NAME, 0)
+
+void RegisterRemoveExplosiveLimit() {
+    // Ignore vanilla limit of 3 (or 5 for Honey & Darling)
+    COND_VB_SHOULD(VB_LIMIT_EXPLOSIVES, CVAR, { *should = false; });
+}
+
+static RegisterShipInitFunc initFunc(RegisterRemoveExplosiveLimit, { CVAR_NAME });

--- a/mm/2s2h/GameInteractor/GameInteractor_VanillaBehavior.h
+++ b/mm/2s2h/GameInteractor/GameInteractor_VanillaBehavior.h
@@ -1316,6 +1316,14 @@ typedef enum {
 
     // #### `result`
     // ```c
+    // play->actorCtx.actorLists[ACTORCAT_EXPLOSIVES].length >= 3
+    // ```
+    // #### `args`
+    // - None
+    VB_LIMIT_EXPLOSIVES,
+
+    // #### `result`
+    // ```c
     // WaterBox_GetSurface1(play, &play->colCtx, sp4C.x, sp4C.z, &sp44, &waterBox) && ((sp44 - sp48) > 50.0f)
     // ```
     // #### `args`

--- a/mm/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/mm/src/overlays/actors/ovl_player_actor/z_player.c
@@ -4672,11 +4672,13 @@ void Player_UseItem(PlayState* play, Player* this, ItemId item) {
             }
         } else if (((itemAction == PLAYER_IA_DEKU_STICK) && (AMMO(ITEM_DEKU_STICK) == 0)) ||
                    (((play->unk_1887D != 0) || (play->unk_1887E != 0)) &&
-                    (play->actorCtx.actorLists[ACTORCAT_EXPLOSIVES].length >= 5)) ||
+                    GameInteractor_Should(VB_LIMIT_EXPLOSIVES,
+                                          play->actorCtx.actorLists[ACTORCAT_EXPLOSIVES].length >= 5)) ||
                    ((play->unk_1887D == 0) && (play->unk_1887E == 0) &&
                     ((explosiveType = Player_ExplosiveFromIA(this, itemAction)) > PLAYER_EXPLOSIVE_NONE) &&
                     ((AMMO(sPlayerExplosiveInfo[explosiveType].itemId) == 0) ||
-                     (play->actorCtx.actorLists[ACTORCAT_EXPLOSIVES].length >= 3)))) {
+                     GameInteractor_Should(VB_LIMIT_EXPLOSIVES,
+                                           play->actorCtx.actorLists[ACTORCAT_EXPLOSIVES].length >= 3)))) {
             // Prevent some items from being used if player is out of ammo.
             // Also prevent explosives from being used if too many are active
             Audio_PlaySfx(NA_SE_SY_ERROR);


### PR DESCRIPTION
No longer capped at 3 (or 5 in Honey & Darling's minigames). Also reorganized the enhancement menu somewhat by grouping explosive-related enhancements together like in SoH.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7575324737.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7575035686.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7574846960.zip)
<!--- section:artifacts:end -->