### PR TITLE
Fierce Deity can use transformation masks

### DIFF
--- a/mm/2s2h/Enhancements/Masks/FierceDeityAnywhere.cpp
+++ b/mm/2s2h/Enhancements/Masks/FierceDeityAnywhere.cpp
@@ -234,6 +234,15 @@ static void RegisterFierceDeityAnywhere() {
         ItemId* itemId = va_arg(args, ItemId*);
         AllowTransformationMask(itemId, should);
     });
+
+    /*
+     * Needed to allow FD Link to use transformation masks while in water.
+     */
+    COND_VB_SHOULD(VB_FD_ALWAYS_WIELD_SWORD, CVAR, {
+        if (Player_GetEnvironmentalHazard(gPlayState) >= PLAYER_ENV_HAZARD_UNDERWATER_FLOOR) {
+            *should = false;
+        }
+    });
 }
 
 static RegisterShipInitFunc initFunc(RegisterFierceDeityAnywhere, { CVAR_NAME });

--- a/mm/2s2h/Enhancements/Masks/FierceDeityAnywhere.cpp
+++ b/mm/2s2h/Enhancements/Masks/FierceDeityAnywhere.cpp
@@ -22,16 +22,27 @@ struct SwordBeamCollision {
 };
 static ObjectExtension::Register<SwordBeamCollision> SwordBeamCollisionRegister;
 
-bool GetActorHitBySwordBeam(Actor* actor) {
+static bool GetActorHitBySwordBeam(Actor* actor) {
     const SwordBeamCollision* collision = ObjectExtension::GetInstance().Get<SwordBeamCollision>(actor);
     return collision != nullptr ? collision->hitBySwordBeam : SwordBeamCollision{}.hitBySwordBeam;
 }
 
-void SetActorHitBySwordBeam(const Actor* actor, bool hitBySwordBeam) {
+static void SetActorHitBySwordBeam(const Actor* actor, bool hitBySwordBeam) {
     ObjectExtension::GetInstance().Set<SwordBeamCollision>(actor, SwordBeamCollision{ hitBySwordBeam });
 }
 
-void RegisterFierceDeityAnywhere() {
+static void AllowTransformationMask(ItemId* itemId, bool* should) {
+    Player* player = GET_PLAYER(gPlayState);
+    if ((player == NULL) || (player->transformation != PLAYER_FORM_FIERCE_DEITY)) {
+        return;
+    }
+
+    if (*itemId >= ITEM_MASK_DEKU && *itemId <= ITEM_MASK_ZORA) {
+        *should = false;
+    }
+}
+
+static void RegisterFierceDeityAnywhere() {
     COND_VB_SHOULD(VB_DISABLE_FD_MASK, CVAR, { *should = false; });
 
     COND_VB_SHOULD(VB_DAMAGE_MULTIPLIER, CVAR, {
@@ -217,6 +228,11 @@ void RegisterFierceDeityAnywhere() {
             Player_GetEnvironmentalHazard(gPlayState) > PLAYER_ENV_HAZARD_UNDERWATER_FLOOR) {
             *should = false;
         }
+    });
+
+    COND_VB_SHOULD(VB_ITEM_BE_RESTRICTED, CVAR, {
+        ItemId * itemId = va_arg(args, ItemId*);
+        AllowTransformationMask(itemId, should);
     });
 }
 

--- a/mm/2s2h/Enhancements/Masks/FierceDeityAnywhere.cpp
+++ b/mm/2s2h/Enhancements/Masks/FierceDeityAnywhere.cpp
@@ -231,7 +231,7 @@ static void RegisterFierceDeityAnywhere() {
     });
 
     COND_VB_SHOULD(VB_ITEM_BE_RESTRICTED, CVAR, {
-        ItemId * itemId = va_arg(args, ItemId*);
+        ItemId* itemId = va_arg(args, ItemId*);
         AllowTransformationMask(itemId, should);
     });
 }


### PR DESCRIPTION
While in Fierce Deity form, allows other transformation masks to be used. However, they appear _huge_ on FD Link's head.

<img width="1920" height="1080" alt="FD to Deku" src="https://github.com/user-attachments/assets/0123f3c3-ff17-4122-8e44-f1d5dd1ac65e" />
<img width="1920" height="1080" alt="FD to Goron" src="https://github.com/user-attachments/assets/be02468d-2bb5-4d13-a986-1bfd4978fb61" />
<img width="1920" height="1080" alt="FD to Zora" src="https://github.com/user-attachments/assets/f5b537be-7a46-4c9a-a132-8d064f840025" />


<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7599198152.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7599026897.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7598797010.zip)
<!--- section:artifacts:end -->