### PR TITLE
Add Boss Health Multiplier option and fix Z-Targeting health bar overflow

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1711,7 +1711,7 @@ void BenMenu::AddEnhancements() {
         .CVar("gEnhancements.DifficultyOptions.HyperEnemies")
         .Options(CheckboxOptions().Tooltip("Double the rate at which enemies are updated, making them more difficult"));
     static const std::unordered_map<int32_t, const char*> bossHealthOptions = {
-        { 1, "1.0x (Default)" }, { 2, "1.25x" }, { 3, "1.50x" }, { 4, "1.75x" }, { 5, "2.0x" }
+        { 1, "1x (Default)" }, { 2, "1.25x" }, { 3, "1.50x" }, { 4, "1.75x" }, { 5, "2x" }
     };
     AddWidget(path, "Boss Health Multiplier", WIDGET_CVAR_COMBOBOX)
         .CVar("gEnhancements.DifficultyOptions.BossHealthMultiplier")

--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1703,13 +1703,21 @@ void BenMenu::AddEnhancements() {
                      .Max(40)
                      .DefaultValue(0));
 
-    // Difficulty Options
+   // Difficulty Options
     path = { "Enhancements", "Difficulty Options", SECTION_COLUMN_1 };
     AddSidebarEntry("Enhancements", "Difficulty Options", 3);
     AddWidget(path, "Combat", WIDGET_SEPARATOR_TEXT);
     AddWidget(path, "Hyper Enemies", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.DifficultyOptions.HyperEnemies")
         .Options(CheckboxOptions().Tooltip("Double the rate at which enemies are updated, making them more difficult"));
+    static const std::unordered_map<int32_t, const char*> bossHealthOptions = { { 1, "1.0x (Default)" },
+                                                                                { 2, "1.5x" },
+                                                                                { 3, "2.0x" } };
+    AddWidget(path, "Boss Health Multiplier", WIDGET_CVAR_COMBOBOX)
+        .CVar("gEnhancements.DifficultyOptions.BossHealthMultiplier")
+        .Options(ComboboxOptions()
+                     .Tooltip("Multiply the health of all bosses (Restart Required).")
+                     .ComboMap(&bossHealthOptions));
     AddWidget(path, "Damage Multiplier", WIDGET_CVAR_COMBOBOX)
         .CVar("gEnhancements.DifficultyOptions.DamageMultiplier")
         .Options(ComboboxOptions()

--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1716,7 +1716,7 @@ void BenMenu::AddEnhancements() {
     AddWidget(path, "Boss Health Multiplier", WIDGET_CVAR_COMBOBOX)
         .CVar("gEnhancements.DifficultyOptions.BossHealthMultiplier")
         .Options(ComboboxOptions()
-                     .Tooltip("Multiply the health of all bosses (Restart Required).")
+                     .Tooltip("Multiply the health of all bosses. Requires a Scene Reload to take effect.")
                      .ComboMap(&bossHealthOptions));
     AddWidget(path, "Damage Multiplier", WIDGET_CVAR_COMBOBOX)
         .CVar("gEnhancements.DifficultyOptions.DamageMultiplier")

--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1703,7 +1703,7 @@ void BenMenu::AddEnhancements() {
                      .Max(40)
                      .DefaultValue(0));
 
-   // Difficulty Options
+    // Difficulty Options
     path = { "Enhancements", "Difficulty Options", SECTION_COLUMN_1 };
     AddSidebarEntry("Enhancements", "Difficulty Options", 3);
     AddWidget(path, "Combat", WIDGET_SEPARATOR_TEXT);

--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -61,6 +61,10 @@ static const std::vector<const char*> alwaysWinDoggyraceOptions = {
     "Always",                    // ALWAYS_WIN_DOGGY_RACE_ALWAYS
 };
 
+static const std::unordered_map<int32_t, const char*> bossHealthOptions = {
+    { 0, "1x (Default)" }, { 1, "1.25x" }, { 2, "1.50x" }, { 3, "1.75x" }, { 4, "2x" }
+};
+
 static const std::vector<const char*> cremiaRewardOptions = {
     "Vanilla", // CREMIA_REWARD_RANDOM
     "Hug",     // CREMIA_REWARD_ALWAYS_HUG
@@ -1710,9 +1714,6 @@ void BenMenu::AddEnhancements() {
     AddWidget(path, "Hyper Enemies", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.DifficultyOptions.HyperEnemies")
         .Options(CheckboxOptions().Tooltip("Double the rate at which enemies are updated, making them more difficult"));
-    static const std::unordered_map<int32_t, const char*> bossHealthOptions = {
-        { 1, "1x (Default)" }, { 2, "1.25x" }, { 3, "1.50x" }, { 4, "1.75x" }, { 5, "2x" }
-    };
     AddWidget(path, "Boss Health Multiplier", WIDGET_CVAR_COMBOBOX)
         .CVar("gEnhancements.DifficultyOptions.BossHealthMultiplier")
         .Options(ComboboxOptions()

--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1710,9 +1710,9 @@ void BenMenu::AddEnhancements() {
     AddWidget(path, "Hyper Enemies", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.DifficultyOptions.HyperEnemies")
         .Options(CheckboxOptions().Tooltip("Double the rate at which enemies are updated, making them more difficult"));
-    static const std::unordered_map<int32_t, const char*> bossHealthOptions = { { 1, "1.0x (Default)" },
-                                                                                { 2, "1.5x" },
-                                                                                { 3, "2.0x" } };
+    static const std::unordered_map<int32_t, const char*> bossHealthOptions = {
+        { 1, "1.0x (Default)" }, { 2, "1.25x" }, { 3, "1.50x" }, { 4, "1.75x" }, { 5, "2.0x" }
+    };
     AddWidget(path, "Boss Health Multiplier", WIDGET_CVAR_COMBOBOX)
         .CVar("gEnhancements.DifficultyOptions.BossHealthMultiplier")
         .Options(ComboboxOptions()

--- a/mm/2s2h/Enhancements/DifficultyOptions/BossHealthMultiplier.cpp
+++ b/mm/2s2h/Enhancements/DifficultyOptions/BossHealthMultiplier.cpp
@@ -36,7 +36,7 @@ void RegisterBossHealthMultiplier() {
                 // Every time a boss phases or unfreezes (e.g. Goth, Majora's transformations), the engine overwrites
                 // its health with hardcoded values, so we just watch for health surges and override it again.
                 if (sLastBossHealth.count(actor) == 0 || currentHealth > sLastBossHealth[actor]) {
-                    int option = CVarGetInteger(CVAR_NAME, 1);
+                    int option = CVAR;
                     float multiplier = 1.0f;
 
                     if (option == 2)

--- a/mm/2s2h/Enhancements/DifficultyOptions/BossHealthMultiplier.cpp
+++ b/mm/2s2h/Enhancements/DifficultyOptions/BossHealthMultiplier.cpp
@@ -9,51 +9,29 @@ extern "C" {
 }
 
 #define CVAR_NAME "gEnhancements.DifficultyOptions.BossHealthMultiplier"
-#define CVAR CVarGetInteger(CVAR_NAME, 1)
+#define CVAR CVarGetInteger(CVAR_NAME, 0)
 
 static std::unordered_map<Actor*, int> sLastBossHealth;
-static uint32_t sLastFrames = 0;
+
+// Array mapping the UI combo box selection (0-4) directly to its corresponding float multiplier.
+static const float sMultipliers[] = { 1.0f, 1.25f, 1.50f, 1.75f, 2.0f };
 
 void HandleBossHealthMultiplier(Actor* actor) {
     if (gPlayState != NULL && Player_InBlockingCsMode(gPlayState, GET_PLAYER(gPlayState))) {
         return;
     }
 
-    // If the gameplay frames reset or go backwards, it means the player reloaded the scene,
-    // died, or started a new fight. We wipe the map clean to avoid stale health data carrying over.
-    if (gPlayState != NULL) {
-        if (gPlayState->gameplayFrames < sLastFrames || gPlayState->gameplayFrames == 0) {
-            sLastBossHealth.clear();
-        }
-        sLastFrames = gPlayState->gameplayFrames;
-    }
-
     int currentHealth = actor->colChkInfo.health;
 
     if (currentHealth > 0) {
-        // Every time a boss phases or unfreezes (e.g. Goth, Majora's transformations), the engine overwrites
-        // its health with hardcoded values, so we just watch for health surges and override it again.
-        if (sLastBossHealth.count(actor) == 0 || currentHealth > sLastBossHealth[actor]) {
-            int option = CVAR;
-            float multiplier = 1.0f;
 
-            switch (option) {
-                case 2:
-                    multiplier = 1.25f;
-                    break;
-                case 3:
-                    multiplier = 1.50f;
-                    break;
-                case 4:
-                    multiplier = 1.75f;
-                    break;
-                case 5:
-                    multiplier = 2.0f;
-                    break;
-                default:
-                    multiplier = 1.0f;
-                    break;
-            }
+        if (sLastBossHealth.count(actor) == 0 || currentHealth > sLastBossHealth[actor]) {
+
+            int option = CVAR;
+            // Safety boundary check to prevent out-of-bounds array access if the CVAR contains an invalid value.
+            if (option < 0 || option > 4)
+                option = 0;
+            float multiplier = sMultipliers[option];
 
             currentHealth = (s8)(currentHealth * multiplier);
             actor->colChkInfo.health = currentHealth;
@@ -63,15 +41,26 @@ void HandleBossHealthMultiplier(Actor* actor) {
     }
 }
 
+// Hooked to OnActorDestroy to automatically erase the boss from memory when the scene unloads.
+void ClearBossHealthMultiplier(Actor* actor) {
+    sLastBossHealth.erase(actor);
+}
+
+// Registers conditional, ID-specific hooks for both updating and destroying bosses.
+// This optimizes performance by executing logic only for these 5 specific boss actors
+// when the multiplier is active (CVAR > 0), and ensures clean memory management on unload.
 void RegisterBossHealthMultiplier() {
-    // Specific COND_ID_HOOK hooks are used instead of a global OnActorUpdate to optimize performance.
-    // This prevents the engine from performing checks on thousands of regular actors in every frame,
-    // ensuring that this code connects ONLY to these 5 specific boss IDs.
-    COND_ID_HOOK(OnActorUpdate, ACTOR_BOSS_01, CVAR > 1, HandleBossHealthMultiplier);
-    COND_ID_HOOK(OnActorUpdate, ACTOR_BOSS_HAKUGIN, CVAR > 1, HandleBossHealthMultiplier);
-    COND_ID_HOOK(OnActorUpdate, ACTOR_BOSS_03, CVAR > 1, HandleBossHealthMultiplier);
-    COND_ID_HOOK(OnActorUpdate, ACTOR_BOSS_02, CVAR > 1, HandleBossHealthMultiplier);
-    COND_ID_HOOK(OnActorUpdate, ACTOR_BOSS_07, CVAR > 1, HandleBossHealthMultiplier);
+    COND_ID_HOOK(OnActorUpdate, ACTOR_BOSS_01, CVAR > 0, HandleBossHealthMultiplier);
+    COND_ID_HOOK(OnActorUpdate, ACTOR_BOSS_HAKUGIN, CVAR > 0, HandleBossHealthMultiplier);
+    COND_ID_HOOK(OnActorUpdate, ACTOR_BOSS_03, CVAR > 0, HandleBossHealthMultiplier);
+    COND_ID_HOOK(OnActorUpdate, ACTOR_BOSS_02, CVAR > 0, HandleBossHealthMultiplier);
+    COND_ID_HOOK(OnActorUpdate, ACTOR_BOSS_07, CVAR > 0, HandleBossHealthMultiplier);
+
+    COND_ID_HOOK(OnActorDestroy, ACTOR_BOSS_01, true, ClearBossHealthMultiplier);
+    COND_ID_HOOK(OnActorDestroy, ACTOR_BOSS_HAKUGIN, true, ClearBossHealthMultiplier);
+    COND_ID_HOOK(OnActorDestroy, ACTOR_BOSS_03, true, ClearBossHealthMultiplier);
+    COND_ID_HOOK(OnActorDestroy, ACTOR_BOSS_02, true, ClearBossHealthMultiplier);
+    COND_ID_HOOK(OnActorDestroy, ACTOR_BOSS_07, true, ClearBossHealthMultiplier);
 }
 
 static RegisterShipInitFunc initFunc(RegisterBossHealthMultiplier, { CVAR_NAME });

--- a/mm/2s2h/Enhancements/DifficultyOptions/BossHealthMultiplier.cpp
+++ b/mm/2s2h/Enhancements/DifficultyOptions/BossHealthMultiplier.cpp
@@ -44,10 +44,8 @@ void RegisterBossHealthMultiplier() {
                     if (option == 3)
                         multiplier = 2.0f;
 
-                    if (multiplier > 1.0f) {
-                        currentHealth = (s8)(currentHealth * multiplier);
-                        actor->colChkInfo.health = currentHealth;
-                    }
+                    currentHealth = (s8)(currentHealth * multiplier);
+                    actor->colChkInfo.health = currentHealth;
                 }
 
                 sLastBossHealth[actor] = currentHealth;

--- a/mm/2s2h/Enhancements/DifficultyOptions/BossHealthMultiplier.cpp
+++ b/mm/2s2h/Enhancements/DifficultyOptions/BossHealthMultiplier.cpp
@@ -1,0 +1,61 @@
+#include <libultraship/bridge/consolevariablebridge.h>
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/ShipInit.hpp"
+#include <unordered_map>
+
+extern "C" {
+#include "variables.h"
+#include "functions.h"
+}
+
+#define CVAR_NAME "gEnhancements.DifficultyOptions.BossHealthMultiplier"
+
+static std::unordered_map<Actor*, int> sLastBossHealth;
+static uint32_t sLastFrames = 0;
+
+void RegisterBossHealthMultiplier() {
+    COND_HOOK(OnActorUpdate, 1, [](Actor* actor) {
+        if (actor->id == ACTOR_BOSS_01 ||
+            actor->id == ACTOR_BOSS_HAKUGIN ||
+            actor->id == ACTOR_BOSS_03 ||
+            actor->id == ACTOR_BOSS_02 ||
+            actor->id == ACTOR_BOSS_07) {
+
+            if (gPlayState != NULL && Player_InBlockingCsMode(gPlayState, GET_PLAYER(gPlayState))) {
+                return;
+            }
+
+            if (gPlayState != NULL) {
+                if (gPlayState->gameplayFrames < sLastFrames || gPlayState->gameplayFrames == 0) {
+                    sLastBossHealth.clear();
+                }
+                sLastFrames = gPlayState->gameplayFrames;
+            }
+
+            int currentHealth = actor->colChkInfo.health;
+
+            if (currentHealth > 0) {
+                // Every time a boss phases or unfreezes (e.g. Goth, Majora's transformations), the engine overwrites
+                // its health with hardcoded values, so we just watch for health surges and override it again.
+                if (sLastBossHealth.count(actor) == 0 || currentHealth > sLastBossHealth[actor]) {
+                    int option = CVarGetInteger(CVAR_NAME, 1);
+                    float multiplier = 1.0f;
+
+                    if (option == 2)
+                        multiplier = 1.5f;
+                    if (option == 3)
+                        multiplier = 2.0f;
+
+                    if (multiplier > 1.0f) {
+                        currentHealth = (s8)(currentHealth * multiplier);
+                        actor->colChkInfo.health = currentHealth;
+                    }
+                }
+
+                sLastBossHealth[actor] = currentHealth;
+            }
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterBossHealthMultiplier, { CVAR_NAME });

--- a/mm/2s2h/Enhancements/DifficultyOptions/BossHealthMultiplier.cpp
+++ b/mm/2s2h/Enhancements/DifficultyOptions/BossHealthMultiplier.cpp
@@ -15,11 +15,8 @@ static uint32_t sLastFrames = 0;
 
 void RegisterBossHealthMultiplier() {
     COND_HOOK(OnActorUpdate, 1, [](Actor* actor) {
-        if (actor->id == ACTOR_BOSS_01 ||
-            actor->id == ACTOR_BOSS_HAKUGIN ||
-            actor->id == ACTOR_BOSS_03 ||
-            actor->id == ACTOR_BOSS_02 ||
-            actor->id == ACTOR_BOSS_07) {
+        if (actor->id == ACTOR_BOSS_01 || actor->id == ACTOR_BOSS_HAKUGIN || actor->id == ACTOR_BOSS_03 ||
+            actor->id == ACTOR_BOSS_02 || actor->id == ACTOR_BOSS_07) {
 
             if (gPlayState != NULL && Player_InBlockingCsMode(gPlayState, GET_PLAYER(gPlayState))) {
                 return;

--- a/mm/2s2h/Enhancements/DifficultyOptions/BossHealthMultiplier.cpp
+++ b/mm/2s2h/Enhancements/DifficultyOptions/BossHealthMultiplier.cpp
@@ -14,44 +14,64 @@ extern "C" {
 static std::unordered_map<Actor*, int> sLastBossHealth;
 static uint32_t sLastFrames = 0;
 
-void RegisterBossHealthMultiplier() {
-    COND_HOOK(OnActorUpdate, CVAR > 1, [](Actor* actor) {
-        if (actor->id == ACTOR_BOSS_01 || actor->id == ACTOR_BOSS_HAKUGIN || actor->id == ACTOR_BOSS_03 ||
-            actor->id == ACTOR_BOSS_02 || actor->id == ACTOR_BOSS_07) {
+void HandleBossHealthMultiplier(Actor* actor) {
+    if (gPlayState != NULL && Player_InBlockingCsMode(gPlayState, GET_PLAYER(gPlayState))) {
+        return;
+    }
 
-            if (gPlayState != NULL && Player_InBlockingCsMode(gPlayState, GET_PLAYER(gPlayState))) {
-                return;
-            }
-
-            if (gPlayState != NULL) {
-                if (gPlayState->gameplayFrames < sLastFrames || gPlayState->gameplayFrames == 0) {
-                    sLastBossHealth.clear();
-                }
-                sLastFrames = gPlayState->gameplayFrames;
-            }
-
-            int currentHealth = actor->colChkInfo.health;
-
-            if (currentHealth > 0) {
-                // Every time a boss phases or unfreezes (e.g. Goth, Majora's transformations), the engine overwrites
-                // its health with hardcoded values, so we just watch for health surges and override it again.
-                if (sLastBossHealth.count(actor) == 0 || currentHealth > sLastBossHealth[actor]) {
-                    int option = CVAR;
-                    float multiplier = 1.0f;
-
-                    if (option == 2)
-                        multiplier = 1.5f;
-                    if (option == 3)
-                        multiplier = 2.0f;
-
-                    currentHealth = (s8)(currentHealth * multiplier);
-                    actor->colChkInfo.health = currentHealth;
-                }
-
-                sLastBossHealth[actor] = currentHealth;
-            }
+    // If the gameplay frames reset or go backwards, it means the player reloaded the scene,
+    // died, or started a new fight. We wipe the map clean to avoid stale health data carrying over.
+    if (gPlayState != NULL) {
+        if (gPlayState->gameplayFrames < sLastFrames || gPlayState->gameplayFrames == 0) {
+            sLastBossHealth.clear();
         }
-    });
+        sLastFrames = gPlayState->gameplayFrames;
+    }
+
+    int currentHealth = actor->colChkInfo.health;
+
+    if (currentHealth > 0) {
+        // Every time a boss phases or unfreezes (e.g. Goth, Majora's transformations), the engine overwrites
+        // its health with hardcoded values, so we just watch for health surges and override it again.
+        if (sLastBossHealth.count(actor) == 0 || currentHealth > sLastBossHealth[actor]) {
+            int option = CVAR;
+            float multiplier = 1.0f;
+
+            switch (option) {
+                case 2:
+                    multiplier = 1.25f;
+                    break;
+                case 3:
+                    multiplier = 1.50f;
+                    break;
+                case 4:
+                    multiplier = 1.75f;
+                    break;
+                case 5:
+                    multiplier = 2.0f;
+                    break;
+                default:
+                    multiplier = 1.0f;
+                    break;
+            }
+
+            currentHealth = (s8)(currentHealth * multiplier);
+            actor->colChkInfo.health = currentHealth;
+        }
+
+        sLastBossHealth[actor] = currentHealth;
+    }
+}
+
+void RegisterBossHealthMultiplier() {
+    // Specific COND_ID_HOOK hooks are used instead of a global OnActorUpdate to optimize performance.
+    // This prevents the engine from performing checks on thousands of regular actors in every frame,
+    // ensuring that this code connects ONLY to these 5 specific boss IDs.
+    COND_ID_HOOK(OnActorUpdate, ACTOR_BOSS_01, CVAR > 1, HandleBossHealthMultiplier);
+    COND_ID_HOOK(OnActorUpdate, ACTOR_BOSS_HAKUGIN, CVAR > 1, HandleBossHealthMultiplier);
+    COND_ID_HOOK(OnActorUpdate, ACTOR_BOSS_03, CVAR > 1, HandleBossHealthMultiplier);
+    COND_ID_HOOK(OnActorUpdate, ACTOR_BOSS_02, CVAR > 1, HandleBossHealthMultiplier);
+    COND_ID_HOOK(OnActorUpdate, ACTOR_BOSS_07, CVAR > 1, HandleBossHealthMultiplier);
 }
 
 static RegisterShipInitFunc initFunc(RegisterBossHealthMultiplier, { CVAR_NAME });

--- a/mm/2s2h/Enhancements/DifficultyOptions/BossHealthMultiplier.cpp
+++ b/mm/2s2h/Enhancements/DifficultyOptions/BossHealthMultiplier.cpp
@@ -9,12 +9,13 @@ extern "C" {
 }
 
 #define CVAR_NAME "gEnhancements.DifficultyOptions.BossHealthMultiplier"
+#define CVAR CVarGetInteger(CVAR_NAME, 1)
 
 static std::unordered_map<Actor*, int> sLastBossHealth;
 static uint32_t sLastFrames = 0;
 
 void RegisterBossHealthMultiplier() {
-    COND_HOOK(OnActorUpdate, 1, [](Actor* actor) {
+    COND_HOOK(OnActorUpdate, CVAR > 1, [](Actor* actor) {
         if (actor->id == ACTOR_BOSS_01 || actor->id == ACTOR_BOSS_HAKUGIN || actor->id == ACTOR_BOSS_03 ||
             actor->id == ACTOR_BOSS_02 || actor->id == ACTOR_BOSS_07) {
 

--- a/mm/2s2h/Enhancements/Graphics/EnemyHealthBars.cpp
+++ b/mm/2s2h/Enhancements/Graphics/EnemyHealthBars.cpp
@@ -80,6 +80,14 @@ void Interface_DrawEnemyHealthBar(Attention* attention, PlayState* play) {
     // Convert health to signed value and clamp to 0 (some actors overflow the health when subtracting damage)
     s8 curHealth = CLAMP_MIN((s8)healthActor->colChkInfo.health, 0);
     u8 maxHealth = GetActorMaxHealth(healthActor);
+
+    // If an enhancement like BossHealthMultiplier increases boss health above the original limit the UI knew about
+    // we update the maximum health to recalculate the percentage and keep the red bar inside the box.
+    if (curHealth > maxHealth) {
+        maxHealth = curHealth;
+        SetActorMaximumHealth(healthActor, maxHealth);
+    }
+
     s16 healthBarFill = ((f32)curHealth / maxHealth) * healthBar_fillWidth;
 
     if (anchorType == ENEMYHEALTH_ANCHOR_ACTOR) {


### PR DESCRIPTION
## Description ## 

This pull request introduces a new option in the difficulty settings: a **Boss Health Multiplier** dropdown menu with precise increments (1x, 1.25x, 1.50x, 1.75x, 2x). This multiplier adjusts the health of the game's four main bosses and all phases of the final battle against Majora.

It also fixes a rendering issue where, when multiplying an enemy's health, the red fill bar of the Z-Targeting system would overflow its white box.

## Changes Made

* **`BenMenu.cpp`**: Added a checkbox to a dropdown menu (combobox) for easy selection of different difficulty options.

* **`BossHealthMultiplier.cpp`**: Created a new file that handles boss health. It utilizes ID-specific hooks (`COND_ID_HOOK`) to ensure zero performance overhead on regular actors. Memory lifecycle is safely handled via the `OnActorDestroy` hook, clearing the tracking map automatically whenever a boss unloads to prevent stale data or accumulation.

* **`EnemyHealthBars.cpp`**: The UI renderer has been updated to automatically increase the maximum health if the boss's current health exceeds it. This prevents the red bar from extending beyond its white border.

## Tests Performed

* **Odolwa**, **Goht**, **Gyorg**, and **Twinmold** were tested via the debug mode. It was verified that the health scaling is applied correctly.

* **Goht** was fought multiple times; it was confirmed that the multiplier activates correctly after the thawing cutscene and does not exhibit memory leaks or accumulate indefinitely upon the player's death/scene reload thanks to the destroy hooks.

* **Majora** was fought in all three phases; it was confirmed that Majora's Rage (Phase 3) inherits the correct health bar.

* It was verified that, with Z-Targeting enabled, the red health bar empties smoothly and remains completely within the white box.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7771721694.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7771687469.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7771597987.zip)
<!--- section:artifacts:end -->