### PR TITLE
Fix big-endian crash reading cutscene command entry count (#802)

### DIFF
--- a/mm/2s2h/resource/importer/CutsceneFactory.cpp
+++ b/mm/2s2h/resource/importer/CutsceneFactory.cpp
@@ -112,7 +112,14 @@ ResourceFactoryBinaryCutsceneV0::ReadResource(std::shared_ptr<Ship::File> file,
                     // We need to store the first half of the header to get the number of entries.
                     uint32_t header1 = read_CMD_HH(reader);
 
+                    // read_CMD_HH swaps the two half words to native order on big-endian,
+                    // which leaves the entry count in the high half there rather than the
+                    // low half. Without this, big-endian reads a bogus numEntries and walks
+                    // past the command list (crash after the intro cutscene on PPC).
                     uint32_t numEntries = header1 & 0xFFFF;
+                    if (reader->GetEndianness() != Ship::Endianness::Native) {
+                        numEntries = header1 >> 16 & 0xFFFF;
+                    }
 
                     cutscene->commands.push_back(header1);
                     if (numEntries == 0xFFFF) {


### PR DESCRIPTION
## Problem

On big-endian hosts (PowerMac G5 / PPC64, Wii U) the game crashes right after the libultraship intro, when the first cutscene resource loads (#802). Shipwright runs fine on the same hardware, so this is a 2ship-specific resource issue, not a libultraship one.

## Cause

In `ResourceFactoryBinaryCutsceneV0::ReadResource` (`mm/2s2h/resource/importer/CutsceneFactory.cpp`), the per-command entry count is derived as:

```cpp
uint32_t header1 = read_CMD_HH(reader);
uint32_t numEntries = header1 & 0xFFFF;
```

But `read_CMD_HH()` swaps the two half words to native order on big-endian, which leaves the entry count in the **high** half there, not the low half. So on big-endian `numEntries` reads a bogus value and the loop walks past the command list → out-of-bounds → crash after the intro cutscene.

The other reads in this same file already guard on `reader->GetEndianness() != Ship::Endianness::Native` (`read_CMD_HBB`, `read_CMD_HH`, etc.); this one spot was missed.

## Fix

Read the count from the high half on big-endian, matching the file's existing endianness convention:

```cpp
uint32_t numEntries = header1 & 0xFFFF;
if (reader->GetEndianness() != Ship::Endianness::Native) {
    numEntries = header1 >> 16 & 0xFFFF;
}
```

Little-endian behavior is unchanged. This mirrors the not-yet-upstreamed fix from the **2ship2harkinian-WiiU** fork (`a6852fd1`, "wiiu: Endianness fixes") that @GaryOderNichts pointed to in #802 — bringing it upstream so desktop big-endian builds work too.

## Testing

Verification on real big-endian hardware (PowerMac G5 + a modded Wii U) is in progress; will confirm the intro-cutscene boot here. Reasoning and the matching WiiU-fork fix are above in the meantime.

Fixes #802.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7740288722.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7740236161.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7740055350.zip)
<!--- section:artifacts:end -->