### PR TITLE
Improve controller speed modifier behavior

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1006,6 +1006,11 @@ void BenMenu::AddEnhancements() {
     AddWidget(path, "Speed Modifier Mode", WIDGET_CVAR_COMBOBOX)
         .CVar("gCheats.SpeedModifier.Mode")
         .Options(ComboboxOptions().ComboVec(&speedModifierModeOptions).LabelPosition(LabelPosition::None));
+    AddWidget(path, "Don't affect jump distance/velocity", WIDGET_CVAR_CHECKBOX)
+        .CVar("gCheats.SpeedModifier.DoesntChangeJump")
+        .PreFunc([](WidgetInfo& info) { info.isHidden = !CVarGetInteger("gCheats.SpeedModifier.Mode", 0); })
+        .Options(CheckboxOptions().Tooltip(
+            "Prevents the speed modifier from carrying into jump distance by restoring vanilla horizontal jump velocity."));
     AddWidget(path, "Multiplier:", WIDGET_CVAR_SLIDER_FLOAT)
         .CVar("gCheats.SpeedModifier.Value")
         .PreFunc([](WidgetInfo& info) { info.isHidden = !CVarGetInteger("gCheats.SpeedModifier.Mode", 0); })

--- a/mm/2s2h/Enhancements/Player/LinkSpeedModifier.cpp
+++ b/mm/2s2h/Enhancements/Player/LinkSpeedModifier.cpp
@@ -12,12 +12,18 @@ extern Input* sPlayerControlInput;
 #define CVAR_SPEED_MODIFIER_TOGGLE_NAME "gCheats.SpeedModifier.Toggle"
 #define CVAR_SPEED_MODIFIER_VALUE_NAME "gCheats.SpeedModifier.Value"
 #define CVAR_SPEED_MODIFIER_BTN_NAME "gCheats.SpeedModifier.Btn"
+#define CVAR_SPEED_MODIFIER_DOESNT_CHANGE_JUMP_NAME "gCheats.SpeedModifier.DoesntChangeJump"
 #define CVAR_SPEED_MODIFIER_MODE CVarGetInteger(CVAR_SPEED_MODIFIER_MODE_NAME, 0)
 #define CVAR_SPEED_MODIFIER_TOGGLE CVarGetInteger(CVAR_SPEED_MODIFIER_TOGGLE_NAME, 0)
 #define CVAR_SPEED_MODIFIER_VALUE CVarGetFloat(CVAR_SPEED_MODIFIER_VALUE_NAME, 1.0f)
 #define CVAR_SPEED_MODIFIER_BTN CVarGetInteger(CVAR_SPEED_MODIFIER_BTN_NAME, BTN_CUSTOM_MODIFIER1)
+#define CVAR_SPEED_MODIFIER_DOESNT_CHANGE_JUMP CVarGetInteger(CVAR_SPEED_MODIFIER_DOESNT_CHANGE_JUMP_NAME, 0)
 
 bool btnHeldOrToggled = false;
+
+static bool IsSpeedModifierActive() {
+    return CVAR_SPEED_MODIFIER_MODE == 1 || btnHeldOrToggled;
+}
 
 void RegisterLinkSpeedModifier() {
     // Reset in case they disabled while toggled
@@ -26,7 +32,7 @@ void RegisterLinkSpeedModifier() {
     COND_VB_SHOULD(VB_SPEED_MODIFIER_WALK, CVAR_SPEED_MODIFIER_MODE, {
         f32* speedTarget = va_arg(args, f32*);
 
-        if (CVAR_SPEED_MODIFIER_MODE == 1 || btnHeldOrToggled) {
+        if (IsSpeedModifierActive()) {
             *speedTarget *= CVAR_SPEED_MODIFIER_VALUE;
         }
     });
@@ -44,7 +50,7 @@ void RegisterLinkSpeedModifier() {
             return;
         }
 
-        if (CVAR_SPEED_MODIFIER_MODE == 1 || btnHeldOrToggled) {
+        if (IsSpeedModifierActive()) {
             swimMod *= CVAR_SPEED_MODIFIER_VALUE;
             *maxSpeed *= swimMod;
             Math_AsymStepToF(speed, *speedTarget * 0.8f * swimMod, *incrStep, (fabsf(*speed) * 0.02f) + 0.05f);
@@ -52,18 +58,26 @@ void RegisterLinkSpeedModifier() {
         }
     });
 
+    COND_VB_SHOULD(VB_SPEED_MODIFIER_JUMP, CVAR_SPEED_MODIFIER_MODE && CVAR_SPEED_MODIFIER_DOESNT_CHANGE_JUMP, {
+        f32* speedXZ = va_arg(args, f32*);
+
+        if (IsSpeedModifierActive() && CVAR_SPEED_MODIFIER_VALUE != 0.0f) {
+            *speedXZ /= CVAR_SPEED_MODIFIER_VALUE;
+        }
+    });
+
     COND_HOOK(OnPassPlayerInputs, CVAR_SPEED_MODIFIER_MODE >= 2, [](Input* input) {
+        const s32 modMask = CVAR_SPEED_MODIFIER_BTN;
+
+        if (modMask == 0) {
+            btnHeldOrToggled = false;
+            return;
+        }
+
         if (CVAR_SPEED_MODIFIER_MODE == 2) {
-            if (CHECK_BTN_ALL(input->cur.button, CVAR_SPEED_MODIFIER_BTN)) {
-                btnHeldOrToggled = true;
-            } else {
-                btnHeldOrToggled = false;
-            }
-        } else {
-            if (CHECK_BTN_ALL(input->cur.button, CVAR_SPEED_MODIFIER_BTN) &&
-                CHECK_BTN_ANY(input->press.button, CVAR_SPEED_MODIFIER_BTN)) {
-                btnHeldOrToggled = !btnHeldOrToggled;
-            }
+            btnHeldOrToggled = CHECK_BTN_ANY(input->cur.button, modMask);
+        } else if (CHECK_BTN_ANY(input->press.button, modMask)) {
+            btnHeldOrToggled = !btnHeldOrToggled;
         }
     });
 }

--- a/mm/2s2h/GameInteractor/GameInteractor_VanillaBehavior.h
+++ b/mm/2s2h/GameInteractor/GameInteractor_VanillaBehavior.h
@@ -2198,6 +2198,14 @@ typedef enum {
 
     // #### `result`
     // ```c
+    // true
+    // ```
+    // #### `args`
+    // - '*f32' (speedXZ)
+    VB_SPEED_MODIFIER_JUMP,
+
+    // #### `result`
+    // ```c
     // this->actor.xzDistToPlayer < 350.0f
     // ```
     // #### `args`

--- a/mm/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/mm/src/overlays/actors/ovl_player_actor/z_player.c
@@ -6319,6 +6319,9 @@ void func_80834D50(PlayState* play, Player* this, PlayerAnimationHeader* anim, f
     if (anim != NULL) {
         Player_Anim_PlayOnceAdjusted(play, this, anim);
     }
+
+    GameInteractor_Should(VB_SPEED_MODIFIER_JUMP, true, &this->speedXZ);
+
     func_80834CD0(this, speed, sfxId);
 }
 


### PR DESCRIPTION
Adds Shipwright-style improvements to the 2S2H controller speed modifier.

Changes:
- Adds a "Don't affect jump distance/velocity" option.
- Preserves vanilla horizontal jump velocity when the speed modifier is active.
- Keeps speed modifier behavior applied to swimming.
- Allows any selected modifier button to activate/toggle the speed modifier instead of requiring all selected modifier buttons at once.

The patch touches:

mm/2s2h/BenGui/BenMenu.cpp
mm/2s2h/Enhancements/Player/LinkSpeedModifier.cpp
mm/2s2h/GameInteractor/GameInteractor_VanillaBehavior.h
mm/src/overlays/actors/ovl_player_actor/z_player.c