### PR TITLE
Fix mod menu child scope

### DIFF
--- a/mm/2s2h/Enhancements/ModMenu/ModMenu.cpp
+++ b/mm/2s2h/Enhancements/ModMenu/ModMenu.cpp
@@ -352,9 +352,8 @@ void ModMenuWindow::DrawElement() {
 
         if (ImGui::BeginChild("Enabled Mods", ImVec2(0, -8))) {
             DrawMods(true);
-
-            ImGui::EndChild();
         }
+        ImGui::EndChild();
 
         /*ImGui::TableNextColumn();
 


### PR DESCRIPTION
This was causing crashes on debug builds and warnings on release builds when using the menu search.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7830801538.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7830649367.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7830325899.zip)
<!--- section:artifacts:end -->