### PR TITLE
[Restoration] Re-bottle soil patch bugs

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1693,6 +1693,10 @@ void BenMenu::AddEnhancements() {
         .CVar("gEnhancements.Restorations.BonkCollision")
         .Options(
             CheckboxOptions().Tooltip("Corrects rolls to allow bonking trees near the end of the roll, as in OoT."));
+    AddWidget(path, "Soil Patch Burrowed Bugs", WIDGET_CVAR_CHECKBOX)
+        .CVar("gEnhancements.Restorations.SoilPatch")
+        .Options(CheckboxOptions().Tooltip("Removes the cutscene lock when bugs burrow into a Skulltula soil patch, "
+                                           "allowing the player to re-bottle them, as in OoT."));
     AddWidget(path, "Simulated Input Lag", WIDGET_CVAR_SLIDER_INT)
         .CVar(CVAR_SIMULATED_INPUT_LAG)
         .Options(IntSliderOptions()

--- a/mm/2s2h/Enhancements/Cutscenes/SkipOnePointCutscenes.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/SkipOnePointCutscenes.cpp
@@ -51,8 +51,7 @@ void RegisterSkipOnePointCutscenes() {
                     *should = false;
                 }
                 break;
-            case ACTOR_OBJ_BEAN:        // Bean Patch
-            case ACTOR_OBJ_MAKEKINSUTA: // Bean Patch
+            case ACTOR_OBJ_BEAN: // Bean Patch
             case ACTOR_OBJ_SPIDERTENT:
                 actor->csId = -1;
                 *should = false;

--- a/mm/2s2h/Enhancements/Restorations/SoilPatch.cpp
+++ b/mm/2s2h/Enhancements/Restorations/SoilPatch.cpp
@@ -1,0 +1,38 @@
+#include <libultraship/bridge/consolevariablebridge.h>
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/ShipInit.hpp"
+
+extern "C" {
+#include "overlays/actors/ovl_Obj_Bean/z_obj_bean.h"
+}
+
+#define CVAR_NAME "gEnhancements.Restorations.SoilPatch"
+#define CVAR CVarGetInteger(CVAR_NAME, 0)
+
+static void RegisterSoilPatchRestoration() {
+    COND_VB_SHOULD(VB_START_CUTSCENE, CVAR, {
+        s16* csId = va_arg(args, s16*);
+        Actor* actor = va_arg(args, Actor*);
+
+        if (*csId == -1 || actor == NULL) {
+            return;
+        }
+
+        if (actor->id == ACTOR_OBJ_MAKEKINSUTA) { // Soil patch Skulltula spawner
+            actor->csId = -1;
+            *should = false;
+        }
+    });
+
+    COND_VB_SHOULD(VB_COUNT_BURROWED_BUGS, CVAR, {
+        ObjBean* bean = va_arg(args, ObjBean*);
+        if (*should) {
+            if (bean->unk_1E4 == 2 && bean->unk_1E0 < 2) {
+                bean->unk_1E0 = 2;
+            }
+            *should = false;
+        }
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterSoilPatchRestoration, { CVAR_NAME });

--- a/mm/2s2h/GameInteractor/GameInteractor_VanillaBehavior.h
+++ b/mm/2s2h/GameInteractor/GameInteractor_VanillaBehavior.h
@@ -328,6 +328,14 @@ typedef enum {
 
     // #### `result`
     // ```c
+    // (bean->unk_1E4 == 2) || (bean->unk_1E4 == 1)
+    // ```
+    // #### `args`
+    // - `ObjBean*`
+    VB_COUNT_BURROWED_BUGS,
+
+    // #### `result`
+    // ```c
     // gHorsePlayedEponasSong
     // ```
     // #### `args`

--- a/mm/src/overlays/actors/ovl_En_Mushi2/z_en_mushi2.c
+++ b/mm/src/overlays/actors/ovl_En_Mushi2/z_en_mushi2.c
@@ -6,6 +6,7 @@
 
 #include "overlays/actors/ovl_Obj_Bean/z_obj_bean.h"
 #include "z_en_mushi2.h"
+#include "2s2h/GameInteractor/GameInteractor.h"
 
 #define FLAGS (ACTOR_FLAG_UPDATE_CULLING_DISABLED)
 
@@ -721,7 +722,7 @@ s32 func_80A6A094(EnMushi2* this) {
     if (this->unk_34C != NULL) {
         ObjBean* bean = this->unk_34C;
 
-        if ((bean->unk_1E4 == 2) || (bean->unk_1E4 == 1)) {
+        if (GameInteractor_Should(VB_COUNT_BURROWED_BUGS, (bean->unk_1E4 == 2) || (bean->unk_1E4 == 1), bean)) {
             bean->unk_1E4 = 4;
             return true;
         }


### PR DESCRIPTION
This moves the bug burrow cutscene skip from One Point Skips to its own setting, and it also removes the count so that not all three bugs have to burrow for the Skulltula to pop out. Based on my own feedback from the linked PR, I think packaging the two together as one restoration will make the most sense to players.

Supersedes #1538

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7860743007.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7860488155.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/7860396097.zip)
<!--- section:artifacts:end -->