### PR TITLE
Fix bean patch cutscene skips

### DIFF
--- a/mm/2s2h/Enhancements/Cutscenes/SkipOnePointCutscenes.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/SkipOnePointCutscenes.cpp
@@ -4,6 +4,7 @@
 
 extern "C" {
 #include "overlays/actors/ovl_Obj_Syokudai/z_obj_syokudai.h"
+#include "overlays/actors/ovl_Obj_Bean/z_obj_bean.h"
 }
 
 #define CVAR_NAME "gEnhancements.Cutscenes.SkipOnePointCutscenes"
@@ -52,6 +53,11 @@ void RegisterSkipOnePointCutscenes() {
                 }
                 break;
             case ACTOR_OBJ_BEAN: // Bean Patch
+                if (OBJBEAN_GET_C000(actor) == ENOBJBEAN_GET_C000_0) {
+                    actor->csId = -1;
+                    *should = false;
+                }
+                break;
             case ACTOR_OBJ_SPIDERTENT:
                 actor->csId = -1;
                 *should = false;

--- a/mm/2s2h/Enhancements/Restorations/SoilPatch.cpp
+++ b/mm/2s2h/Enhancements/Restorations/SoilPatch.cpp
@@ -18,7 +18,8 @@ static void RegisterSoilPatchRestoration() {
             return;
         }
 
-        if (actor->id == ACTOR_OBJ_MAKEKINSUTA) { // Soil patch Skulltula spawner
+        if (actor->id == ACTOR_OBJ_MAKEKINSUTA ||
+            (actor->id == ACTOR_OBJ_BEAN && OBJBEAN_GET_C000(actor) != ENOBJBEAN_GET_C000_0)) {
             actor->csId = -1;
             *should = false;
         }


### PR DESCRIPTION
The bean patch actors are shared and differ by a subtype. Fixes #1764

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8050292537.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8050060538.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8049850504.zip)
<!--- section:artifacts:end -->