### PR TITLE
Fix some shadow flickering

### DIFF
--- a/mm/2s2h/Enhancements/FrameInterpolation/FrameInterpolation.cpp
+++ b/mm/2s2h/Enhancements/FrameInterpolation/FrameInterpolation.cpp
@@ -121,6 +121,10 @@ union Data {
     struct {
         Mtx* dest;
         MtxF src;
+        // The matrix as it actually was for this frame, before any actor-relative adjustment. Kept around
+        // (regardless of has_adjusted) so a has_adjusted mismatch between frames has a correct, non-relative
+        // matrix to fall back to instead of blending across incompatible spaces.
+        MtxF raw;
         bool has_adjusted;
     } matrix_to_mtx;
 
@@ -385,7 +389,15 @@ struct InterpolateCtx {
 
                         case Op::MatrixToMtx: {
                             //*new_replacement(new_op.matrix_to_mtx.dest) = *Matrix_GetCurrent();
-                            if (old_op.matrix_to_mtx.has_adjusted && new_op.matrix_to_mtx.has_adjusted) {
+                            if (old_op.matrix_to_mtx.has_adjusted != new_op.matrix_to_mtx.has_adjusted) {
+                                // has_adjusted toggled between frames (e.g. ActorShadow_Draw's isotropic-shadow
+                                // check flipping as scale.x drifts in and out of equality with scale.z). old.src
+                                // and new.src aren't comparable here: whichever side has has_adjusted=true holds
+                                // an actor-relative matrix that still needs actor_mtx re-applied, not a final
+                                // matrix. Use raw (the true un-relativized matrix for that frame) and snap to the
+                                // new frame instead of interpolating.
+                                *new_replacement(new_op.matrix_to_mtx.dest) = new_op.matrix_to_mtx.raw;
+                            } else if (old_op.matrix_to_mtx.has_adjusted && new_op.matrix_to_mtx.has_adjusted) {
                                 interpolate_mtxf(&tmp_mtxf, &old_op.matrix_to_mtx.src, &new_op.matrix_to_mtx.src);
                                 SkinMatrix_MtxFMtxFMult(&actor_mtx, &tmp_mtxf,
                                                         new_replacement(new_op.matrix_to_mtx.dest));
@@ -592,11 +604,12 @@ void FrameInterpolation_RecordMatrixToMtx(Mtx* dest, char* file, s32 line) {
     if (!is_recording)
         return;
     auto& d = append(Op::MatrixToMtx).matrix_to_mtx = { dest };
+    d.raw = *Matrix_GetCurrent();
     if (has_inv_actor_mtx && !ignore_inv_actor_mtx) {
         d.has_adjusted = true;
         SkinMatrix_MtxFMtxFMult(&inv_actor_mtx, Matrix_GetCurrent(), &d.src);
     } else {
-        d.src = *Matrix_GetCurrent();
+        d.src = d.raw;
     }
 }
 


### PR DESCRIPTION
**Disclaimer**, not only do I not fully understand our interpolation mechanism, but I also don't fully understand this fix. This was what was suggested after some back and forth with claude, and it does indeed resolve the issue in-game without any known side effects.

### Claude summary:
Cause: The cow's body scale wobbles slightly (breathing animation) each frame, and its scale.x keeps crossing back and forth over equal-to-scale.z. The shadow code treats "circle with equal x/z scale" as a special fast path that skips rotation. So the shadow's draw call keeps flip-flopping between "rotated" and "not rotated" code paths.

The interpolation system stores those two paths' matrices differently — one is a finished matrix, the other is a half-finished matrix waiting on an extra step. When one frame used path A and the next used path B, the code blended these two different-shaped matrices together like they were compatible. They're not, so you get garbage for a frame — which shows up as the shadow vanishing.

Fix: Always also store the finished matrix, untouched, regardless of which path was taken. When adjacent frames took different paths, just use that finished matrix from the new frame instead of trying to blend.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8083054884.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8082979314.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8082904382.zip)
<!--- section:artifacts:end -->