### PR TITLE
Make transformation mask hint use GetLocationNameForHint

### DIFF
--- a/mm/2s2h/Rando/ActorBehavior/EnTalk.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnTalk.cpp
@@ -1,7 +1,6 @@
 #include "ActorBehavior.h"
 #include "2s2h/CustomMessage/CustomMessage.h"
 #include "2s2h/GameInteractor/GameInteractor.h"
-#include "2s2h/ShipUtils.h"
 
 extern "C" {
 #include "variables.h"
@@ -118,7 +117,7 @@ void ApplyTransformationHints(u16* textId, bool* loadFromMessageTable) {
                     locationStr += " %w&%y\n";
                 }
 
-                locationStr += Ship_GetSceneName(Rando::StaticData::Checks[location].sceneId);
+                locationStr += Rando::StaticData::GetLocationNameForHint(location, false);
             }
             CustomMessage::Replace(&msg, "{{locations}}", locationStr);
         } else {


### PR DESCRIPTION
This fixes the issue where the mask hint says lone peak shrine & grottos when it's in a grotto, among other things.

This is already being used for all other hints.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8083151231.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8083075348.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8083002392.zip)
<!--- section:artifacts:end -->