### PR TITLE
Various house-keeping tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ _packages/
 /clang-format.exe
 
 build/
+.cache

--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -107,7 +107,7 @@ static const std::vector<const char*> debugSaveOptions = {
 };
 
 #ifdef _DEBUG
-DebugLogOption defaultLogLevel = DEBUG_LOG_TRACE;
+DebugLogOption defaultLogLevel = DEBUG_LOG_DEBUG;
 #else
 DebugLogOption defaultLogLevel = DEBUG_LOG_INFO;
 #endif

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -624,7 +624,7 @@ void OTRGlobals::Initialize() {
     std::unordered_set<uint32_t> validHashes = { MM_NTSC_US_10, MM_NTSC_US_GC };
 
 #if (_DEBUG)
-    auto defaultLogLevel = spdlog::level::trace;
+    auto defaultLogLevel = spdlog::level::debug;
 #else
     auto defaultLogLevel = spdlog::level::info;
 #endif
@@ -632,7 +632,7 @@ void OTRGlobals::Initialize() {
     context->InitConsoleVariables();
     auto logLevel = static_cast<spdlog::level::level_enum>(CVarGetInteger("gDeveloperTools.LogLevel", defaultLogLevel));
     context->InitLogging(logLevel, logLevel);
-    Ship::Context::GetInstance()->GetLogger()->set_pattern("[%H:%M:%S.%e] [%s:%#] [%l] %v");
+    Ship::Context::GetInstance()->GetLogger()->set_pattern("[%H:%M:%S.%e] [%s:%#] [%^%l%$] %v");
 
     context->InitGfxDebugger();
     context->InitFileDropMgr();

--- a/mm/2s2h/DeveloperTools/DeveloperTools.cpp
+++ b/mm/2s2h/DeveloperTools/DeveloperTools.cpp
@@ -149,11 +149,11 @@ void RegisterPreventActorInitHooks() {
 void RegisterDebugMode() {
     // Disable various debug options when toggled off
     if (!CVAR_DEBUG_MODE) {
-        CVarSetInteger(CVAR_SAVE_FILE_MODE_NAME, DEBUG_SAVE_INFO_NONE);
-        CVarSetInteger(CVAR_PREVENT_ACTOR_UPDATE_NAME, 0);
-        CVarSetInteger(CVAR_PREVENT_ACTOR_DRAW_NAME, 0);
-        CVarSetInteger(CVAR_PREVENT_ACTOR_INIT_NAME, 0);
-        CVarSetInteger("gDeveloperTools.DisableObjectDependency", 0);
+        CVarClear(CVAR_SAVE_FILE_MODE_NAME);
+        CVarClear(CVAR_PREVENT_ACTOR_UPDATE_NAME);
+        CVarClear(CVAR_PREVENT_ACTOR_DRAW_NAME);
+        CVarClear(CVAR_PREVENT_ACTOR_INIT_NAME);
+        CVarClear("gDeveloperTools.DisableObjectDependency");
 
         if (gPlayState != NULL) {
             gPlayState->frameAdvCtx.enabled = false;

--- a/mm/2s2h/Enhancements/Trackers/TimeSplits/TimeSplitsActions.cpp
+++ b/mm/2s2h/Enhancements/Trackers/TimeSplits/TimeSplitsActions.cpp
@@ -6,7 +6,6 @@
 #include <ship/window/Window.h>
 #include "2s2h/BenGui/UIWidgets.hpp"
 #include <fstream>
-#include <filesystem>
 
 #include "assets/archives/icon_item_static/icon_item_static_yar.h"
 
@@ -361,13 +360,6 @@ void SplitSaveFileAction(uint32_t action, std::string listName) {
 }
 
 void RegisterTimesplits() {
-    if (!std::filesystem::exists(Ship::Context::GetPathRelativeToAppDirectory("2S2HTimeSplitData.json"))) {
-        json initFile;
-        std::ofstream file(Ship::Context::GetPathRelativeToAppDirectory("2S2HTimeSplitData.json"));
-        file << initFile.dump(4);
-        file.close();
-    }
-
     SplitSaveFileAction(SPLIT_RETRIEVE, "");
 
     COND_HOOK(OnItemGive, CVAR, [](u8 item) {

--- a/mm/2s2h/Rando/Spoiler/RefreshOptions.cpp
+++ b/mm/2s2h/Rando/Spoiler/RefreshOptions.cpp
@@ -37,8 +37,8 @@ void Rando::Spoiler::RefreshOptions() {
 
     // If the current spoiler file is not in the randomizer folder, reset the cvar
     if (spoilerFileIndex == -1) {
-        CVarSetInteger("gRando.SpoilerFileIndex", 0);
-        CVarSetString("gRando.SpoilerFile", "");
+        CVarClear("gRando.SpoilerFileIndex");
+        CVarClear("gRando.SpoilerFile");
     } else {
         CVarSetInteger("gRando.SpoilerFileIndex", spoilerFileIndex);
     }

--- a/mm/2s2h/config/ConfigUpdaters.cpp
+++ b/mm/2s2h/config/ConfigUpdaters.cpp
@@ -36,7 +36,7 @@ static bool HasDisplayOverlayModeInConfig(Ship::Config* conf) {
 }
 
 static void MigrateDisplayOverlayTimerMode(Ship::Config* conf) {
-    if (HasDisplayOverlayModeInConfig(conf)) {
+    if (!HasDisplayOverlayModeInConfig(conf)) {
         return;
     }
 
@@ -51,10 +51,10 @@ static void MigrateDisplayOverlayTimerMode(Ship::Config* conf) {
 }
 
 static void MigrateWarpPoints(Ship::Config* conf) {
-    auto warpPoints = nlohmann::json::object();
-
     if (conf->GetNestedJson().contains("CVars")) {
         if (CVarGetInteger("gDeveloperTools.WarpPoint.Saved", 0) != 0) {
+            auto warpPoints = nlohmann::json::object();
+
             s32 entranceId = CVarGetInteger("gDeveloperTools.WarpPoint.Entrance", 0);
             s8 roomNum = CVarGetInteger("gDeveloperTools.WarpPoint.Room", 0);
             Vec3f pos = { CVarGetFloat("gDeveloperTools.WarpPoint.X", 0.0f),
@@ -67,10 +67,10 @@ static void MigrateWarpPoints(Ship::Config* conf) {
                                                { "pos", { { "x", pos.x }, { "y", pos.y }, { "z", pos.z } } },
                                                { "rotY", rotY },
                                                { "bootToPoint", bootToPoint } };
+
+            Ship::Context::GetInstance()->GetConfig()->SetBlock("WarpPoints", warpPoints);
         }
     }
-
-    Ship::Context::GetInstance()->GetConfig()->SetBlock("WarpPoints", warpPoints);
 }
 
 ConfigVersion1Updater::ConfigVersion1Updater() : ConfigVersionUpdater(1) {

--- a/mm/2s2h/z_scene_2SH.cpp
+++ b/mm/2s2h/z_scene_2SH.cpp
@@ -513,7 +513,6 @@ extern "C" s32 OTRfunc_8009728C(PlayState* play, RoomContext* roomCtx, s32 roomN
         // DmaMgr_SendRequest2(&roomCtx->dmaRequest, roomCtx->unk_34, play->roomList.romFiles[roomNum].vromStart, size,
         // 0,
         //&roomCtx->loadQueue, NULL, __FILE__, __LINE__);
-        printf("File Name %s\n", play->roomList.romFiles[roomNum].fileName);
         auto roomData = std::static_pointer_cast<SOH::Scene>(ResourceLoad(play->roomList.romFiles[roomNum].fileName));
         roomCtx->status = 1;
         roomCtx->roomRequestAddr = roomData.get();


### PR DESCRIPTION
- add .cache to gitignore
- change default log level to debug in debug mode (trace is way too noisy from LUS)
- restored colored log level lost in #1709
- Fix some cvars being set to 0 on boot (clear instead)
- Fixes display overlay migration and tweak to warpPoint migration so it's not always leaving `null` in config
- Stop printing scene file name
- Stop creating timesplit JSON file on boot

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8146493948.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8146230789.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8145979405.zip)
<!--- section:artifacts:end -->