### PR TITLE
Update curated preset & add voyage 3 preset

### DIFF
--- a/mm/2s2h/PresetManager/PresetManager.cpp
+++ b/mm/2s2h/PresetManager/PresetManager.cpp
@@ -27,7 +27,6 @@ nlohmann::json defaultsPresetJ = R"(
         "gCheats",
         "gCollisionViewer",
         "gDeveloperTools",
-        "gDisplayOverlay",
         "gEnhancements",
         "gEventLog",
         "gFixes",
@@ -37,7 +36,8 @@ nlohmann::json defaultsPresetJ = R"(
         "gNotifications",
         "gRando",
         "gWindows",
-        "ItemTracker"
+        "ItemTracker",
+        "gAudioEditor"
     ],
     "CVars": {},
     "type": "2S2H_PRESET",
@@ -64,6 +64,9 @@ nlohmann::json curatedPresetJ = R"(
             "LogLevel": 2
         },
         "gEnhancements": {
+            "Camera": {
+                "FixTargettingCameraSnap": 1
+            },
             "Cutscenes": {
                 "HideTitleCards": 1,
                 "SkipEnemyCutscenes": 1,
@@ -78,20 +81,25 @@ nlohmann::json curatedPresetJ = R"(
             },
             "Cycle": {
                 "DoNotResetBottleContent": 1,
+                "DoNotResetChateau": 1,
                 "DoNotResetConsumables": 1,
                 "DoNotResetRazorSword": 1,
                 "DoNotResetRupees": 1,
+                "DoNotResetScarecrowSong": 1,
                 "DoNotResetTimeSpeed": 1,
                 "KeepExpressMail": 1,
                 "OceansideWalletAnyDay": 1,
+                "SaveOnMoonCrash": 1,
                 "StopOceansideSpiderHouseSquatter": 1
             },
             "Dialogue": {
                 "FastBankSelection": 1,
-                "FastText": 1
+                "FastText": 1,
+                "SkipBottlePickupMessages": 1
             },
             "DifficultyOptions": {
                 "GoronRace": 1,
+                "JinxedTimer": 20,
                 "LowerBankRewardThresholds": 1
             },
             "Dpad": {
@@ -106,6 +114,7 @@ nlohmann::json curatedPresetJ = R"(
             "Fixes": {
                 "CompletedHeartContainerAudio": 1,
                 "ControlCharacters": 1,
+                "DekuButlerFixShockLoopAnimation": 1,
                 "FierceDeityZTargetMovement": 1
             },
             "Graphics": {
@@ -118,12 +127,15 @@ nlohmann::json curatedPresetJ = R"(
                 "FixSceneGeometrySeams": 1,
                 "IncreaseActorDrawDistance": 5
             },
+            "Items": {
+                "ColorPictograph": 1,
+                "RemoveExplosiveLimit": 1
+            },
             "Masks": {
+                "3DSMaskEquip": 1,
                 "FastTransformation": 1,
                 "FierceDeitysAnywhere": 1,
-                "GoronRollingFastSpikes": 1,
-                "GoronRollingIgnoresMagic": 1,
-                "BlastMaskCooldown": 0,
+                "BlastMaskCooldown": 0.0,
                 "PersistentBunnyHood": {
                     "Enabled": 1
                 }
@@ -173,6 +185,7 @@ nlohmann::json curatedPresetJ = R"(
                 "OoTFasterSwim": 1,
                 "PowerCrouchStab": 1,
                 "SideRoll": 1,
+                "SoilPatch": 1,
                 "TatlISG": 1,
                 "WoodfallMountainAppearance": 1
             },
@@ -183,16 +196,21 @@ nlohmann::json curatedPresetJ = R"(
                 "PersistentOwlSaves": 1
             },
             "Songs": {
+                "BetterOwlWarpMenu": 1,
                 "BetterSongOfDoubleTime": 1,
                 "EnableSunsSong": 1,
                 "FasterSongPlayback": 1,
                 "PauseOwlWarp": 1,
                 "SkipSoTCutscenes": 1,
-                "SkipSoaringCutscene": 1
+                "SkipSoaringCutscene": 1,
+                "ZoraEggCount": 1
             },
             "Timesavers": {
+                "AlwaysShowShrineFeathers": 1,
                 "DampeDiggingSkip": 1,
                 "FastChests": 1,
+                "FasterBottles": 1,
+                "FasterSceneTransitions": 1,
                 "GalleryTwofer": 1,
                 "MarineLabHP": 1,
                 "SkipBalladOfWindfish": 1,
@@ -269,6 +287,296 @@ nlohmann::json curatedPresetJ = R"(
 }
 )"_json;
 
+nlohmann::json voyage3PresetJ = R"(
+{
+    "ClearCVars": [
+        "gCheats",
+        "gCollisionViewer",
+        "gDeveloperTools",
+        "gEventLog",
+        "gFixes",
+        "gNetwork",
+        "gNotifications",
+        "gRando"
+    ],
+    "CVars": {
+        "gCheats": {
+            "EasyFrameAdvance": 1,
+            "SpeedModifier": {
+                "Mode": 0
+            }
+        },
+        "gEnhancements": {
+            "Cutscenes": {
+                "HideTitleCards": 1,
+                "SkipEnemyCutscenes": 1,
+                "SkipEntranceCutscenes": 1,
+                "SkipFirstCycle": 1,
+                "SkipGetItemCutscenes": 2,
+                "SkipIntroSequence": 1,
+                "SkipMiscInteractions": 1,
+                "SkipOnePointCutscenes": 1,
+                "SkipStoryCutscenes": 1,
+                "SkipToFileSelect": 1
+            },
+            "Cycle": {
+                "DoNotResetChateau": 0,
+                "DoNotResetConsumables": 0,
+                "DoNotResetRazorSword": 0,
+                "DoNotResetRupees": 0,
+                "DoNotResetTimeSpeed": 0,
+                "SaveOnMoonCrash": 0,
+                "TingleAlwaysInClockTown": 0
+            },
+            "Dialogue": {
+                "AutoBombersCode": 1,
+                "FastBankSelection": 1,
+                "FastText": 1,
+                "SkipBottlePickupMessages": 1
+            },
+            "DifficultyOptions": {
+                "DamageMultiplier": 0,
+                "DekuGuardSearchBalls": 0,
+                "DeleteFileOnDeath": 0,
+                "DisableTakkuriSteal": 1,
+                "FrogChoirCount": 5,
+                "GibdoTradeSequence": 1,
+                "GoronRace": 1,
+                "HiddenGrottosVisibility": 0,
+                "HyperEnemies": 0,
+                "JinxedTimer": 60,
+                "LowerBankRewardThresholds": 1,
+				"NoHeartDrops": 0,
+                "NoRandomDrops": 0,
+                "PermanentHeartLoss": 0
+            },
+            "Dpad": {
+                "DpadEquips": 1
+            },
+            "Equipment": {
+                "BetterPictoMessage": 1,
+                "BombArrows": 0,
+                "ChuDrops": 1,
+                "GreatFairySwordBButton": 0,
+                "ItemUnequip": 0,
+                "MagicArrowEquipSpeed": 1,
+                "TwoHandedSwordSpinAttack": 0
+            },
+            "Fixes": {
+                "CompletedHeartContainerAudio": 1,
+                "ConsoleCrashes": 1,
+                "ControlCharacters": 1,
+                "FierceDeityZTargetMovement": 1,
+                "FixTexturesOOB": 1
+            },
+            "Gameplay": {
+                "ExtendedProjectileInteractionDistance": 0
+            },
+            "Graphics": {
+                "3DItemDrops": 1,
+                "AuthenticLogo": 1,
+                "DisableBlackBars": 1,
+                "FixSceneGeometrySeams": 0,
+                "IncreaseActorDrawDistance": 3,
+                "MotionBlur": {
+                    "Mode": 1
+                }
+            },
+            "Items": {
+                "AmmoBuyback": 0,
+                "ColorPictograph": 1,
+                "ExtraPowderKegs": 0,
+                "PictoBoxOnCUp": 0,
+                "RemoveExplosiveLimit": 0
+            },
+            "Masks": {
+                "3DSMaskEquip": 1,
+                "BlastMaskCooldown": 3.0,
+                "BlastMaskKeg": 1,
+                "FastTransformation": 1,
+                "FierceDeitysAnywhere": 1,
+                "GoronRollingFastSpikes": 0,
+                "GoronRollingIgnoresMagic": 0,
+                "NoBlastMaskCooldown": 1,
+                "PersistentBunnyHood": {
+                    "Enabled": 1
+                }
+            },
+            "Minigames": {
+                "AlwaysWinDoggyRace": 1,
+                "BeaverRaceRingsCollected": 20,
+                "BoatArcheryHealth": 30,
+                "BoatArcheryInvincible": 1,
+                "BoatArcheryScore": 10,
+                "BombersHideAndSeek": 5,
+                "CremiaHugs": 0,
+                "CuccoShackCuccoCount": 1,
+                "HoneyAndDarlingDay1": 8,
+                "HoneyAndDarlingDay2": 8,
+                "HoneyAndDarlingDay3": 16,
+                "RomaniTargetPractice": 10,
+                "SkipLittleBeaver": 1,
+                "SwampArcheryScore": 2120,
+                "SwordsmanSchoolScore": 30,
+                "TownArcheryScore": 50,
+                "TreasureChestShopShowFullMaze": 0
+            },
+            "Mods": {
+                "AlternateAssets": 1
+            },
+            "Playback": {
+                "DpadOcarina": 1,
+                "NoDropOcarinaInput": 1,
+                "SkipScarecrowSong": 1
+            },
+            "Player": {
+                "ClimbSpeed": 4,
+                "FastFlowerLaunch": 1,
+                "FasterPushAndPull": 1,
+                "FierceDeityPutaway": 1,
+                "InfiniteDekuHopping": 0,
+                "InstantPutaway": 1,
+                "ManualJump": 0,
+                "PreventDiveOverWater": 0,
+                "UnderwaterOcarina": 1,
+                "UnsheatheWithoutSlashing": 0
+            },
+            "PlayerActions": {
+                "ArrowCycle": 1,
+                "InstantRecall": 1,
+                "RemoteBombchu": 0
+            },
+            "Restorations": {
+                "BonkCollision": 0,
+                "ConstantFlipsHops": 0,
+                "JPGrottos": 0,
+                "OoTFasterSwim": 0,
+                "PowerCrouchStab": 2,
+                "SideRoll": 0,
+                "TatlISG": 1,
+                "WoodfallMountainAppearance": 1
+            },
+            "Saving": {
+                "Autosave": 0,
+                "FileSlot3": 1,
+                "PauseSave": 1,
+                "PersistentOwlSaves": 0,
+                "RememberSaveLocation": 0
+            },
+            "Shops": {
+                "CuriosityShopRefills": 0
+            },
+            "Songs": {
+                "BetterSongOfDoubleTime": 1,
+                "FasterSongPlayback": 1,
+                "SkipSoTCutscenes": 1,
+                "SkipSoaringCutscene": 1,
+                "ZoraEggCount": 1
+            },
+            "Timesavers": {
+                "AlwaysShowShrineFeathers": 0,
+                "AutoBankDeposit": 0,
+                "DampeDiggingSkip": 1,
+                "FastChests": 1,
+                "FasterRupeeAccumulator": 1,
+                "FasterSceneTransitions": 1,
+                "GalleryTwofer": 1,
+                "MarineLabHP": 1,
+                "PowderKegCertification": 0,
+                "SkipBalladOfWindfish": 1,
+                "SwampBoatSpeed": 1
+            }
+        },
+        "gFixes": {
+            "FixAmmoCountEnvColor": 1,
+            "FixButtonEnvColor": 1,
+            "FixEponaStealingSword": 1,
+            "FixIkanaGreatFairyFountainColor": 1
+        },
+        "gForceCursorVisibility": 1,
+        "gMatchRefreshRate": 0,
+		"gModes": {
+			"MirroredWorld": {
+                "Mode": 0,
+                "StoneTowerTempleFix": 0
+            },
+			"TimeMovesWhenYouMove": 0
+		},
+        "gRando": {
+            "CSMC": 1,
+            "Enabled": 1,
+            "ExcludedChecks": "6,20,24,55,57,76,98,99,100,101,102,103,104,105,106,138,139,140,141,142,143,144,146,242,243,244,245,246,247,248,249,258,374,375,376,377,378,379,380,381,382,383,384,385,1195,",
+            "GenerateSpoiler": 0,
+            "JunkItems": 0,
+            "Options": {
+                "RO_ACCESS_MAJORA_MASKS_COUNT": 0,
+                "RO_ACCESS_MAJORA_REMAINS_COUNT": 4,
+                "RO_ACCESS_MOON_REMAINS_COUNT": 4,
+                "RO_HINTS_BANK_SIGN": 1,
+                "RO_HINTS_BOSS_REMAINS": 1,
+                "RO_HINTS_GOSSIP_STONES": 1,
+                "RO_HINTS_GOSSIP_STONE_STRENGTH": 100,
+                "RO_HINTS_HOOKSHOT": 1,
+                "RO_HINTS_OATH_TO_ORDER": 1,
+                "RO_HINTS_PURCHASEABLE": 0,
+                "RO_HINTS_SONG_OF_SOARING": 1,
+                "RO_HINTS_SPIDER_HOUSES": 1,
+                "RO_HINTS_TRANSFORMATIONS": 1,
+                "RO_MINIMUM_STRAY_FAIRIES": 5,
+                "RO_PLENTIFUL_ITEMS": 0,
+				"RO_PLACEMENT_BOSS_KEYS": 1,
+                "RO_PLACEMENT_SMALL_KEYS": 0,
+                "RO_PLACEMENT_STRAY_FAIRIES": 0,
+                "RO_SHUFFLE_BOSS_REMAINS": 1,
+                "RO_SHUFFLE_COWS": 1,
+                "RO_SHUFFLE_FREESTANDING_ITEMS": 0,
+                "RO_SHUFFLE_GOLD_SKULLTULAS": 0,
+                "RO_SHUFFLE_GRASS_DROPS": 0,
+                "RO_SHUFFLE_OWL_STATUES": 0,
+                "RO_SHUFFLE_SHOPS": 1,
+                "RO_SHUFFLE_SONG_SARIA": 1,
+                "RO_SHUFFLE_TINGLE_SHOPS": 1,
+                "RO_SHUFFLE_TRAPS": 1,
+                "RO_SHUFFLE_TYCOON_WALLET": 0,
+                "RO_STARTING_MAPS_AND_COMPASSES": 1,
+                "RO_STARTING_RUPEES": 1,
+                "RO_STRAY_FAIRIES_MAX": 15,
+                "RO_STRAY_FAIRIES_REQUIRED": 5,
+                "RO_TRAP_AMOUNT": 6
+            },
+            "StartingItems": [
+                "RI_PROGRESSIVE_SWORD",
+                "RI_SHIELD_HERO",
+                "RI_OCARINA",
+                "RI_SONG_TIME",
+                "RI_MASK_BUNNY",
+                "RI_SONG_EPONA"
+            ],
+            "SariaPriorityItems": [
+                "RI_BOW",
+                "RI_MASK_BLAST",
+                "RI_BOMB_BAG_20",
+                "RI_SINGLE_MAGIC",
+                "RI_ARROW_FIRE",
+                "RI_ARROW_ICE",
+                "RI_ARROW_LIGHT",
+                "RI_SONG_SONATA",
+                "RI_SONG_LULLABY",
+                "RI_SONG_NOVA",
+                "RI_SONG_ELEGY",
+                "RI_MASK_FIERCE_DEITY"
+            ],
+            "Traps": {
+                "Freeze": 1,
+                "Shock": 1
+            }
+        }
+    },
+    "type": "2S2H_PRESET",
+    "version": 1
+}
+)"_json;
+
 std::unordered_map<std::string, std::pair<nlohmann::json, std::set<std::string>>> presets = {};
 const std::filesystem::path presetsFolderPath(Ship::Context::GetPathRelativeToAppDirectory("presets", appShortName));
 
@@ -277,6 +585,7 @@ void PresetManager_RefreshPresets() {
     presets.insert(
         { "Defaults (Everything Off)", { defaultsPresetJ, { "Developer Tools", "Enhancements", "HUD", "Rando" } } });
     presets.insert({ "Curated", { curatedPresetJ, { "Developer Tools", "Enhancements", "HUD" } } });
+    presets.insert({ "Voyage 3", { voyage3PresetJ, { "Developer Tools", "Enhancements", "Rando" } } });
 
     // ensure the presets folder exists
     if (!std::filesystem::exists(presetsFolderPath)) {


### PR DESCRIPTION
Copied the voyage preset from #1762 in addition to adding the "SariaPriorityItems" section for when #1780 gets merged. 

If any further changes to the voyage preset are made on the voyage build (#1762) we can merge them into develop here as well.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8160116785.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8159949392.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8159796695.zip)
<!--- section:artifacts:end -->