### PR TITLE
Add extra frames to new day title card to simulate load time

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -1704,6 +1704,10 @@ void BenMenu::AddEnhancements() {
     AddWidget(path, "JP Deku Palace Grottos", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Restorations.JPGrottos")
         .Options(CheckboxOptions().Tooltip("Restores the Deku Palace Grottos to their original Japanese layout."));
+    AddWidget(path, "Day Transition Duration", WIDGET_CVAR_CHECKBOX)
+        .CVar("gEnhancements.Restorations.DayTelopDuration")
+        .Options(CheckboxOptions().Tooltip("Restores the day transition title card duration, which was longer on "
+                                           "original hardware due to disguising load times."));
     AddWidget(path, "Bonk Collision", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Restorations.BonkCollision")
         .Options(

--- a/mm/2s2h/Enhancements/Restorations/DayTelopDuration.cpp
+++ b/mm/2s2h/Enhancements/Restorations/DayTelopDuration.cpp
@@ -16,10 +16,10 @@ void RegisterDayTelopDurationRestoration() {
             return;
         }
 
-	// Only add frames the first time the DayTelop state is detected
-	if (gGameState -> frames != 1) {
-	    return;
-	}
+        // Only add frames the first time the DayTelop state is detected
+        if (gGameState -> frames != 1) {
+            return;
+        }
 
         DayTelopState* dayTelop = reinterpret_cast<DayTelopState*>(gGameState);
         dayTelop->transitionCountdown += 120;

--- a/mm/2s2h/Enhancements/Restorations/DayTelopDuration.cpp
+++ b/mm/2s2h/Enhancements/Restorations/DayTelopDuration.cpp
@@ -17,7 +17,7 @@ void RegisterDayTelopDurationRestoration() {
         }
 
         // Only add frames the first time the DayTelop state is detected
-        if (gGameState -> frames != 1) {
+        if (gGameState->frames != 1) {
             return;
         }
 

--- a/mm/2s2h/Enhancements/Restorations/DayTelopDuration.cpp
+++ b/mm/2s2h/Enhancements/Restorations/DayTelopDuration.cpp
@@ -1,0 +1,29 @@
+#include <libultraship/bridge/consolevariablebridge.h>
+#include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/ShipInit.hpp"
+
+extern "C" {
+#include "variables.h"
+#include "overlays/gamestates/ovl_daytelop/z_daytelop.h"
+}
+
+#define CVAR_NAME "gEnhancements.Restorations.DayTelopDuration"
+#define CVAR CVarGetInteger(CVAR_NAME, 0)
+
+void RegisterDayTelopDurationRestoration() {
+    COND_HOOK(OnGameStateMainStart, CVAR, []() {
+        if (gGameState == nullptr || gGameState->destroy != DayTelop_Destroy) {
+            return;
+        }
+
+	// Only add frames the first time the DayTelop state is detected
+	if (gGameState -> frames != 1) {
+	    return;
+	}
+
+        DayTelopState* dayTelop = reinterpret_cast<DayTelopState*>(gGameState);
+        dayTelop->transitionCountdown += 120;
+    });
+}
+
+static RegisterShipInitFunc initFunc(RegisterDayTelopDurationRestoration, { CVAR_NAME });

--- a/mm/src/overlays/gamestates/ovl_daytelop/z_daytelop.c
+++ b/mm/src/overlays/gamestates/ovl_daytelop/z_daytelop.c
@@ -246,7 +246,7 @@ void DayTelop_Init(GameState* thisx) {
     View_Init(&this->view, this->state.gfxCtx);
     this->state.main = DayTelop_Main;
     this->state.destroy = DayTelop_Destroy;
-    this->transitionCountdown = 260;
+    this->transitionCountdown = 140;
     this->fadeInState = DAYTELOP_HOURSTEXT_OFF;
 
     if (gSaveContext.save.day < 9) {

--- a/mm/src/overlays/gamestates/ovl_daytelop/z_daytelop.c
+++ b/mm/src/overlays/gamestates/ovl_daytelop/z_daytelop.c
@@ -246,7 +246,7 @@ void DayTelop_Init(GameState* thisx) {
     View_Init(&this->view, this->state.gfxCtx);
     this->state.main = DayTelop_Main;
     this->state.destroy = DayTelop_Destroy;
-    this->transitionCountdown = 140;
+    this->transitionCountdown = 260;
     this->fadeInState = DAYTELOP_HOURSTEXT_OFF;
 
     if (gSaveContext.save.day < 9) {


### PR DESCRIPTION
Fixes https://github.com/HarbourMasters/2ship2harkinian/issues/1786

This is a very simple tweak to add additional frames to the "new day" title card duration, so that its perceived length is closer to what it was on real hardware.

The same approach is taken [in this PR, in the Zelda64 recomp project](https://github.com/Zelda64Recomp/Zelda64Recomp/pull/266) which also displayed the bug.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8272572998.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8272360049.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8272146882.zip)
<!--- section:artifacts:end -->