### PR TITLE
Make swamp archery bonus speedup apply with misc interactions

### DIFF
--- a/mm/2s2h/Enhancements/Minigames/Archery.cpp
+++ b/mm/2s2h/Enhancements/Minigames/Archery.cpp
@@ -20,6 +20,8 @@ void EnSyatekiMan_Town_RunGame(EnSyatekiMan* enSyatekiMan, PlayState* play);
 #define BOAT_HEALTH_CVAR CVarGetInteger(BOAT_HEALTH_CVAR_NAME, 10)
 #define BOAT_NO_DAMAGE_CVAR_NAME "gEnhancements.Minigames.BoatArcheryInvincible"
 #define BOAT_NO_DAMAGE_CVAR CVarGetInteger(BOAT_NO_DAMAGE_CVAR_NAME, 0)
+#define SKIP_MISC_CVAR_NAME "gEnhancements.Cutscenes.SkipMiscInteractions"
+#define SKIP_MISC_CVAR CVarGetInteger(SKIP_MISC_CVAR_NAME, 0)
 
 static constexpr u16 TEXT_BOAT_ARCHERY_FAIL = 0x877;
 
@@ -40,7 +42,7 @@ static void RegisterSwampArchery() {
         }
     });
 
-    COND_VB_SHOULD(VB_ARCHERY_ADD_BONUS_POINTS, SWAMP_CVAR != 2180, {
+    COND_VB_SHOULD(VB_ARCHERY_ADD_BONUS_POINTS, SKIP_MISC_CVAR, {
         Actor* actor = va_arg(args, Actor*);
         s32* sBonusTimer = va_arg(args, s32*);
 


### PR DESCRIPTION
previously the speedup only applied when the score was changed from vanilla. sorry for all of the lost seconds of life from this earlier decision lol

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8248801007.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8248697189.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8248632637.zip)
<!--- section:artifacts:end -->