### PR TITLE
Fix mod load time regression

### DIFF
--- a/mm/2s2h/BenGui/DynamicCosmeticEditor.cpp
+++ b/mm/2s2h/BenGui/DynamicCosmeticEditor.cpp
@@ -416,14 +416,73 @@ void ScanDynamicCosmetics() {
     auto resourceManager = Ship::Context::GetInstance()->GetResourceManager();
     auto archiveManager = resourceManager->GetArchiveManager();
     RefreshCustomModelActiveFlags(archiveManager.get());
-    auto materialPaths = archiveManager->ListFiles("*");
+    auto archives = archiveManager->GetArchives();
+    struct ManifestEntry {
+        std::string materialPath;
+        std::string cosmeticEntry;
+        std::string cosmeticCategory;
+        bool hasCosmeticCategory = false;
+        bool isPrimColor = false;
+    };
+    std::vector<ManifestEntry> manifestEntries;
     std::unordered_map<std::string, size_t> entryIndicesByKey;
 
-    for (const auto& materialPath : *materialPaths) {
-        if (!IsCustomArchive(archiveManager->GetArchiveFromFile(materialPath))) {
+    for (const auto& archive : *archives) {
+        if (!IsCustomArchive(archive)) {
             continue;
         }
 
+        auto manifestFile = archive->LoadFile("CosmeticEntries");
+        if (manifestFile == nullptr || !manifestFile->IsLoaded || manifestFile->Buffer == nullptr) {
+            continue;
+        }
+
+        tinyxml2::XMLDocument manifestDocument;
+        manifestDocument.Parse(manifestFile->Buffer->data(), manifestFile->Buffer->size());
+        if (manifestDocument.Error()) {
+            continue;
+        }
+
+        tinyxml2::XMLElement* manifestRoot = manifestDocument.FirstChildElement();
+        if (manifestRoot == nullptr) {
+            continue;
+        }
+
+        for (auto* manifestEntry = manifestRoot->FirstChildElement(); manifestEntry != nullptr;
+             manifestEntry = manifestEntry->NextSiblingElement()) {
+            const char* cosmeticEntry = manifestEntry->Attribute("CosmeticEntry");
+            const char* materialPath = manifestEntry->Attribute("MaterialPath");
+            std::string resolvedMaterialPath;
+            if (materialPath != nullptr && materialPath[0] != '\0') {
+                resolvedMaterialPath = materialPath;
+                if (!archiveManager->HasFile(resolvedMaterialPath)) {
+                    if (!resolvedMaterialPath.starts_with("alt/") &&
+                        archiveManager->HasFile("alt/" + resolvedMaterialPath)) {
+                        resolvedMaterialPath = "alt/" + resolvedMaterialPath;
+                    } else {
+                        resolvedMaterialPath.clear();
+                    }
+                }
+            }
+
+            const char* cosmeticType = manifestEntry->Attribute("CosmeticType");
+            const bool isPrimColor = cosmeticType != nullptr && std::string(cosmeticType) == "Prim";
+            const bool isEnvColor = cosmeticType != nullptr && std::string(cosmeticType) == "Env";
+
+            if (cosmeticEntry == nullptr || cosmeticEntry[0] == '\0' || resolvedMaterialPath.empty() ||
+                (!isPrimColor && !isEnvColor)) {
+                continue;
+            }
+
+            const char* cosmeticCategory = manifestEntry->Attribute("CosmeticCategory");
+            manifestEntries.push_back({ resolvedMaterialPath, cosmeticEntry,
+                                        cosmeticCategory != nullptr ? cosmeticCategory : "",
+                                        cosmeticCategory != nullptr, isPrimColor });
+        }
+    }
+
+    for (const auto& manifestEntry : manifestEntries) {
+        const auto& materialPath = manifestEntry.materialPath;
         tinyxml2::XMLDocument document;
         std::shared_ptr<Fast::DisplayList> material;
         tinyxml2::XMLElement* root = nullptr;
@@ -436,15 +495,17 @@ void ScanDynamicCosmetics() {
         for (auto* child = root->FirstChildElement(); child != nullptr; child = child->NextSiblingElement()) {
             std::string childName = child->Name();
             bool isPrimColor = childName == "SetPrimColor";
-            if (!isPrimColor && childName != "SetEnvColor") {
+            if ((!isPrimColor && childName != "SetEnvColor") || isPrimColor != manifestEntry.isPrimColor) {
                 continue;
             }
 
             const char* cosmeticEntry = child->Attribute("CosmeticEntry");
-            const char* cosmeticCategory = child->Attribute("CosmeticCategory");
-            if (cosmeticEntry == nullptr || cosmeticEntry[0] == '\0') {
+            if (cosmeticEntry == nullptr || cosmeticEntry != manifestEntry.cosmeticEntry) {
                 continue;
             }
+            const char* cosmeticCategory =
+                manifestEntry.hasCosmeticCategory ? manifestEntry.cosmeticCategory.c_str()
+                                                  : child->Attribute("CosmeticCategory");
 
             std::string key = cosmeticEntry;
             SanitizeCustomKey(key);

--- a/mm/2s2h/BenGui/DynamicCosmeticEditor.cpp
+++ b/mm/2s2h/BenGui/DynamicCosmeticEditor.cpp
@@ -46,6 +46,15 @@ struct CustomCosmeticEntry {
     std::vector<CustomCosmeticBinding> bindings;
 };
 
+struct ManifestEntry {
+    std::string materialPath;
+    std::string cosmeticEntry;
+    std::string key;
+    std::string cosmeticCategory;
+    bool hasCosmeticCategory = false;
+    bool isPrimColor = false;
+};
+
 static std::vector<CustomCosmeticEntry> customCosmeticEntries;
 static bool customHumanModelActive = false;
 static bool customDekuModelActive = false;
@@ -417,14 +426,6 @@ void ScanDynamicCosmetics() {
     auto archiveManager = resourceManager->GetArchiveManager();
     RefreshCustomModelActiveFlags(archiveManager.get());
     auto archives = archiveManager->GetArchives();
-    struct ManifestEntry {
-        std::string materialPath;
-        std::string cosmeticEntry;
-        std::string key;
-        std::string cosmeticCategory;
-        bool hasCosmeticCategory = false;
-        bool isPrimColor = false;
-    };
     std::vector<ManifestEntry> manifestEntries;
     std::unordered_map<std::string, size_t> entryIndicesByKey;
 

--- a/mm/2s2h/BenGui/DynamicCosmeticEditor.cpp
+++ b/mm/2s2h/BenGui/DynamicCosmeticEditor.cpp
@@ -510,9 +510,8 @@ void ScanDynamicCosmetics() {
             if (cosmeticEntry == nullptr || cosmeticEntry != manifestEntry.cosmeticEntry) {
                 continue;
             }
-            const char* cosmeticCategory =
-                manifestEntry.hasCosmeticCategory ? manifestEntry.cosmeticCategory.c_str()
-                                                  : child->Attribute("CosmeticCategory");
+            const char* cosmeticCategory = manifestEntry.hasCosmeticCategory ? manifestEntry.cosmeticCategory.c_str()
+                                                                             : child->Attribute("CosmeticCategory");
 
             const auto& key = manifestEntry.key;
 

--- a/mm/2s2h/BenGui/DynamicCosmeticEditor.cpp
+++ b/mm/2s2h/BenGui/DynamicCosmeticEditor.cpp
@@ -420,6 +420,7 @@ void ScanDynamicCosmetics() {
     struct ManifestEntry {
         std::string materialPath;
         std::string cosmeticEntry;
+        std::string key;
         std::string cosmeticCategory;
         bool hasCosmeticCategory = false;
         bool isPrimColor = false;
@@ -474,8 +475,14 @@ void ScanDynamicCosmetics() {
                 continue;
             }
 
+            std::string key = cosmeticEntry;
+            SanitizeCustomKey(key);
+            if (key.empty()) {
+                continue;
+            }
+
             const char* cosmeticCategory = manifestEntry->Attribute("CosmeticCategory");
-            manifestEntries.push_back({ resolvedMaterialPath, cosmeticEntry,
+            manifestEntries.push_back({ resolvedMaterialPath, cosmeticEntry, std::move(key),
                                         cosmeticCategory != nullptr ? cosmeticCategory : "",
                                         cosmeticCategory != nullptr, isPrimColor });
         }
@@ -507,11 +514,7 @@ void ScanDynamicCosmetics() {
                 manifestEntry.hasCosmeticCategory ? manifestEntry.cosmeticCategory.c_str()
                                                   : child->Attribute("CosmeticCategory");
 
-            std::string key = cosmeticEntry;
-            SanitizeCustomKey(key);
-            if (key.empty()) {
-                continue;
-            }
+            const auto& key = manifestEntry.key;
 
             Gfx expectedInstruction;
             if (isPrimColor) {
@@ -572,8 +575,8 @@ void ScanDynamicCosmetics() {
     std::stable_sort(
         customCosmeticEntries.begin(), customCosmeticEntries.end(),
         [](const CustomCosmeticEntry& lhs, const CustomCosmeticEntry& rhs) {
-            int lhsOrder = 2;
-            int rhsOrder = 2;
+            int lhsOrder = GetDynamicMaterialFormSortOrder(DynamicCosmeticForm::Other);
+            int rhsOrder = GetDynamicMaterialFormSortOrder(DynamicCosmeticForm::Other);
 
             for (const auto& binding : lhs.bindings) {
                 lhsOrder =


### PR DESCRIPTION
Resolves https://github.com/HarbourMasters/2ship2harkinian/issues/1789

The long startup time turned out to be caused by eager loading of archived resources for custom cosmetics.

**What was causing long load times?**
Prior to this PR, when `ScanDynamicCosmetics` was called, it did a `archiveManager->ListFiles("*");` to retrieve every path of every loaded resource from any mods, and then indiscriminately called `TryLoadCustomDisplayListXml` on each path. With a large texture pack such as MM Reloaded, this means allocating memory and decompressing many gigabytes of texture files - only to determine they are not XML and do nothing with them. In practice this ends up translating to > 60 second boot times when using the 4k version of MM Reloaded on a Steam Deck.

**Fix Approach**
Really, this issue has already been handled reasonably well in [Shipwright](https://github.com/HarbourMasters/Shipwright/blob/585530f68d8c3c94fef4e08d8616aa06f1d19feb/soh/soh/Enhancements/cosmetics/DynamicCosmeticsEditor.cpp#L209). My changes here simply reflect what Shipwright was already doing, which is to read a cosmetics manifest from a known path in the archive, and use that to find the resources that actually need to be processed.

It should be noted that this *will* require that 2ship mods providing custom cosmetics will need to provide this manifest file.

**Differences from Shipwright**
In this PR I opted to aggregate all the manifest entries in one pass, and then process their contents in another. This isn't a behavioral change and the outcome should be the same. But I found this produced a nicer diff and read rather cleanly (IMO).

I also fixed a pre-existing bug I noticed when comparing Shipwright and 2ship: in the stable sort 2ship was initializing the sort order to `2` (probably because that's correct for Shipwright), but it should really be `6` due to the fact 2ship has more categories.


<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8357214522.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8357124671.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8356877033.zip)
<!--- section:artifacts:end -->