### PR TITLE
XML Skeleton Support

### DIFF
--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -664,9 +664,13 @@ void OTRGlobals::Initialize() {
                                     static_cast<uint32_t>(SOH::ResourceType::SOH_CollisionHeader), 0);
     loader->RegisterResourceFactory(std::make_shared<SOH::ResourceFactoryBinarySkeletonV0>(), RESOURCE_FORMAT_BINARY,
                                     "Skeleton", static_cast<uint32_t>(SOH::ResourceType::SOH_Skeleton), 0);
+    loader->RegisterResourceFactory(std::make_shared<SOH::ResourceFactoryXMLSkeletonV0>(), RESOURCE_FORMAT_XML,
+                                    "Skeleton", static_cast<uint32_t>(SOH::ResourceType::SOH_Skeleton), 0);
     loader->RegisterResourceFactory(std::make_shared<SOH::ResourceFactoryBinarySkeletonLimbV0>(),
                                     RESOURCE_FORMAT_BINARY, "SkeletonLimb",
                                     static_cast<uint32_t>(SOH::ResourceType::SOH_SkeletonLimb), 0);
+    loader->RegisterResourceFactory(std::make_shared<SOH::ResourceFactoryXMLSkeletonLimbV0>(), RESOURCE_FORMAT_XML,
+                                    "SkeletonLimb", static_cast<uint32_t>(SOH::ResourceType::SOH_SkeletonLimb), 0);
     loader->RegisterResourceFactory(std::make_shared<SOH::ResourceFactoryBinaryPathMMV0>(), RESOURCE_FORMAT_BINARY,
                                     "Path", static_cast<uint32_t>(SOH::ResourceType::SOH_Path), 0);
     loader->RegisterResourceFactory(std::make_shared<SOH::ResourceFactoryBinaryCutsceneV0>(), RESOURCE_FORMAT_BINARY,

--- a/mm/2s2h/resource/importer/SkeletonFactory.cpp
+++ b/mm/2s2h/resource/importer/SkeletonFactory.cpp
@@ -6,6 +6,31 @@
 #include <ship/resource/ResourceManager.h>
 
 namespace SOH {
+static void InitializeSkeletonData(const std::shared_ptr<Skeleton>& skeleton) {
+    switch (skeleton->type) {
+        case SkeletonType::Normal:
+            skeleton->skeletonData.skeletonHeader.limbCount = skeleton->limbCount;
+            skeleton->standardLimbArray.reserve(skeleton->limbCount);
+            skeleton->skeletonData.skeletonHeader.segment = (void**)skeleton->skeletonHeaderSegments.data();
+            break;
+
+        case SkeletonType::Flex:
+            skeleton->skeletonData.flexSkeletonHeader.sh.limbCount = skeleton->limbCount;
+            skeleton->skeletonData.flexSkeletonHeader.dListCount = skeleton->dListCount;
+            skeleton->standardLimbArray.reserve(skeleton->limbCount);
+            skeleton->skeletonData.flexSkeletonHeader.sh.segment = (void**)skeleton->skeletonHeaderSegments.data();
+            break;
+
+        case SkeletonType::Curve:
+            skeleton->skeletonData.skelCurveLimbList.limbCount = skeleton->limbCount;
+            skeleton->curveLimbArray.reserve(skeleton->limbCount);
+            skeleton->skeletonData.skelCurveLimbList.limbs = (SkelCurveLimb**)skeleton->skeletonHeaderSegments.data();
+            break;
+    }
+
+    skeleton->skeletonData.skeletonHeader.skeletonType = static_cast<uint8_t>(skeleton->type);
+}
+
 std::shared_ptr<Ship::IResource>
 ResourceFactoryBinarySkeletonV0::ReadResource(std::shared_ptr<Ship::File> file,
                                               std::shared_ptr<Ship::ResourceInitData> initData) {
@@ -30,38 +55,13 @@ ResourceFactoryBinarySkeletonV0::ReadResource(std::shared_ptr<Ship::File> file,
         skeleton->limbTable.push_back(limbPath);
     }
 
-    if (skeleton->type == SkeletonType::Curve) {
-        skeleton->skeletonData.skelCurveLimbList.limbCount = skeleton->limbCount;
-        skeleton->curveLimbArray.reserve(skeleton->skeletonData.skelCurveLimbList.limbCount);
-    } else if (skeleton->type == SkeletonType::Flex) {
-        skeleton->skeletonData.flexSkeletonHeader.dListCount = skeleton->dListCount;
-    }
-
-    if (skeleton->type == SkeletonType::Normal) {
-        skeleton->skeletonData.skeletonHeader.limbCount = skeleton->limbCount;
-        skeleton->standardLimbArray.reserve(skeleton->skeletonData.skeletonHeader.limbCount);
-    } else if (skeleton->type == SkeletonType::Flex) {
-        skeleton->skeletonData.flexSkeletonHeader.sh.limbCount = skeleton->limbCount;
-        skeleton->standardLimbArray.reserve(skeleton->skeletonData.flexSkeletonHeader.sh.limbCount);
-    }
-
     for (size_t i = 0; i < skeleton->limbTable.size(); i++) {
         std::string limbStr = skeleton->limbTable[i];
         auto limb = Ship::Context::GetInstance()->GetResourceManager()->LoadResourceProcess(limbStr.c_str());
         skeleton->skeletonHeaderSegments.push_back(limb ? limb->GetRawPointer() : nullptr);
     }
 
-    if (skeleton->type == SkeletonType::Normal) {
-        skeleton->skeletonData.skeletonHeader.segment = (void**)skeleton->skeletonHeaderSegments.data();
-    } else if (skeleton->type == SkeletonType::Flex) {
-        skeleton->skeletonData.flexSkeletonHeader.sh.segment = (void**)skeleton->skeletonHeaderSegments.data();
-    } else if (skeleton->type == SkeletonType::Curve) {
-        skeleton->skeletonData.skelCurveLimbList.limbs = (SkelCurveLimb**)skeleton->skeletonHeaderSegments.data();
-    } else {
-        SPDLOG_ERROR("unknown skeleton type {}", (uint32_t)skeleton->type);
-    }
-
-    skeleton->skeletonData.skeletonHeader.skeletonType = (uint8_t)skeleton->type;
+    InitializeSkeletonData(skeleton);
 
     return skeleton;
 }
@@ -124,10 +124,7 @@ ResourceFactoryXMLSkeletonV0::ReadResource(std::shared_ptr<Ship::File> file,
         child = child->NextSiblingElement();
     }
 
-    skel->skeletonData.flexSkeletonHeader.sh.limbCount = skel->limbCount;
-    skel->skeletonData.flexSkeletonHeader.sh.segment = (void**)skel->skeletonHeaderSegments.data();
-    skel->skeletonData.flexSkeletonHeader.dListCount = skel->dListCount;
-    skel->skeletonData.skeletonHeader.skeletonType = (uint8_t)skel->type;
+    InitializeSkeletonData(skel);
 
     return skel;
 }

--- a/mm/2s2h/resource/importer/SkeletonLimbFactory.cpp
+++ b/mm/2s2h/resource/importer/SkeletonLimbFactory.cpp
@@ -3,22 +3,6 @@
 #include <tinyxml2.h>
 
 namespace SOH {
-static LimbType ParseLimbType(const std::string& limbType) {
-    if (limbType == "Standard") {
-        return LimbType::Standard;
-    }
-    if (limbType == "LOD") {
-        return LimbType::LOD;
-    }
-    if (limbType == "Skin") {
-        return LimbType::Skin;
-    }
-    if (limbType == "Curve") {
-        return LimbType::Curve;
-    }
-    return LimbType::Invalid;
-}
-
 static void BuildSkeletonLimbData(const std::shared_ptr<SkeletonLimb>& skeletonLimb) {
     if (skeletonLimb->limbType == LimbType::LOD) {
         skeletonLimb->limbData.lodLimb.jointPos.x = skeletonLimb->transX;
@@ -266,8 +250,7 @@ ResourceFactoryXMLSkeletonLimbV0::ReadResource(std::shared_ptr<Ship::File> file,
     auto skelLimb = std::make_shared<SkeletonLimb>(initData);
     auto reader = std::get<std::shared_ptr<tinyxml2::XMLDocument>>(file->Reader)->FirstChildElement();
 
-    const char* limbTypeAttr = reader->Attribute("Type");
-    skelLimb->limbType = limbTypeAttr != nullptr ? ParseLimbType(limbTypeAttr) : LimbType::LOD;
+    skelLimb->limbType = LimbType::LOD;
 
     // skelLimb->legTransX = reader->FloatAttribute("LegTransX");
     // skelLimb->legTransY = reader->FloatAttribute("LegTransY");

--- a/mm/2s2h/resource/importer/SkeletonLimbFactory.cpp
+++ b/mm/2s2h/resource/importer/SkeletonLimbFactory.cpp
@@ -3,6 +3,73 @@
 #include <tinyxml2.h>
 
 namespace SOH {
+static LimbType ParseLimbType(const std::string& limbType) {
+    if (limbType == "Standard") {
+        return LimbType::Standard;
+    }
+    if (limbType == "LOD") {
+        return LimbType::LOD;
+    }
+    if (limbType == "Skin") {
+        return LimbType::Skin;
+    }
+    if (limbType == "Curve") {
+        return LimbType::Curve;
+    }
+    return LimbType::Invalid;
+}
+
+static void BuildSkeletonLimbData(const std::shared_ptr<SkeletonLimb>& skeletonLimb) {
+    if (skeletonLimb->limbType == LimbType::LOD) {
+        skeletonLimb->limbData.lodLimb.jointPos.x = skeletonLimb->transX;
+        skeletonLimb->limbData.lodLimb.jointPos.y = skeletonLimb->transY;
+        skeletonLimb->limbData.lodLimb.jointPos.z = skeletonLimb->transZ;
+        skeletonLimb->limbData.lodLimb.child = skeletonLimb->childIndex;
+        skeletonLimb->limbData.lodLimb.sibling = skeletonLimb->siblingIndex;
+
+        if (!skeletonLimb->dListPtr.empty()) {
+            skeletonLimb->dListPtr = "__OTR__" + skeletonLimb->dListPtr;
+            skeletonLimb->limbData.lodLimb.dLists[0] = (Gfx*)skeletonLimb->dListPtr.c_str();
+        } else {
+            skeletonLimb->limbData.lodLimb.dLists[0] = nullptr;
+        }
+
+        if (!skeletonLimb->dList2Ptr.empty()) {
+            skeletonLimb->dList2Ptr = "__OTR__" + skeletonLimb->dList2Ptr;
+            skeletonLimb->limbData.lodLimb.dLists[1] = (Gfx*)skeletonLimb->dList2Ptr.c_str();
+        } else {
+            skeletonLimb->limbData.lodLimb.dLists[1] = nullptr;
+        }
+    } else if (skeletonLimb->limbType == LimbType::Standard) {
+        skeletonLimb->limbData.standardLimb.jointPos.x = skeletonLimb->transX;
+        skeletonLimb->limbData.standardLimb.jointPos.y = skeletonLimb->transY;
+        skeletonLimb->limbData.standardLimb.jointPos.z = skeletonLimb->transZ;
+        skeletonLimb->limbData.standardLimb.child = skeletonLimb->childIndex;
+        skeletonLimb->limbData.standardLimb.sibling = skeletonLimb->siblingIndex;
+        skeletonLimb->limbData.standardLimb.dList = nullptr;
+
+        if (!skeletonLimb->dListPtr.empty()) {
+            skeletonLimb->dListPtr = "__OTR__" + skeletonLimb->dListPtr;
+            skeletonLimb->limbData.standardLimb.dList = (Gfx*)skeletonLimb->dListPtr.c_str();
+        }
+    } else if (skeletonLimb->limbType == LimbType::Curve) {
+        skeletonLimb->limbData.skelCurveLimb.firstChildIdx = skeletonLimb->childIndex;
+        skeletonLimb->limbData.skelCurveLimb.nextLimbIdx = skeletonLimb->siblingIndex;
+        skeletonLimb->limbData.skelCurveLimb.dList[0] = nullptr;
+        skeletonLimb->limbData.skelCurveLimb.dList[1] = nullptr;
+
+        if (!skeletonLimb->dListPtr.empty()) {
+            skeletonLimb->dListPtr = "__OTR__" + skeletonLimb->dListPtr;
+            skeletonLimb->limbData.skelCurveLimb.dList[0] = (Gfx*)skeletonLimb->dListPtr.c_str();
+        }
+
+        if (!skeletonLimb->dList2Ptr.empty()) {
+            skeletonLimb->dList2Ptr = "__OTR__" + skeletonLimb->dList2Ptr;
+            skeletonLimb->limbData.skelCurveLimb.dList[1] = (Gfx*)skeletonLimb->dList2Ptr.c_str();
+        }
+    }
+}
+
 std::shared_ptr<Ship::IResource>
 ResourceFactoryBinarySkeletonLimbV0::ReadResource(std::shared_ptr<Ship::File> file,
                                                   std::shared_ptr<Ship::ResourceInitData> initData) {
@@ -199,10 +266,8 @@ ResourceFactoryXMLSkeletonLimbV0::ReadResource(std::shared_ptr<Ship::File> file,
     auto skelLimb = std::make_shared<SkeletonLimb>(initData);
     auto reader = std::get<std::shared_ptr<tinyxml2::XMLDocument>>(file->Reader)->FirstChildElement();
 
-    std::string limbType = reader->Attribute("Type");
-
-    // OTRTODO
-    skelLimb->limbType = LimbType::LOD;
+    const char* limbTypeAttr = reader->Attribute("Type");
+    skelLimb->limbType = limbTypeAttr != nullptr ? ParseLimbType(limbTypeAttr) : LimbType::LOD;
 
     // skelLimb->legTransX = reader->FloatAttribute("LegTransX");
     // skelLimb->legTransY = reader->FloatAttribute("LegTransY");
@@ -224,31 +289,21 @@ ResourceFactoryXMLSkeletonLimbV0::ReadResource(std::shared_ptr<Ship::File> file,
 
     // skelLimb->childPtr = reader->Attribute("ChildLimb");
     // skelLimb->siblingPtr = reader->Attribute("SiblingLimb");
-    skelLimb->dListPtr = reader->Attribute("DisplayList1");
+    if (const char* dList1 = reader->Attribute("DisplayList1")) {
+        skelLimb->dListPtr = dList1;
+    }
+    if (const char* dList2 = reader->Attribute("DisplayList2")) {
+        skelLimb->dList2Ptr = dList2;
+    }
 
-    if (std::string(reader->Attribute("DisplayList1")) == "gEmptyDL") {
+    if (skelLimb->dListPtr == "gEmptyDL") {
         skelLimb->dListPtr = "";
     }
-
-    auto& limbData = skelLimb->limbData;
-
-    limbData.lodLimb.jointPos.x = skelLimb->transX;
-    limbData.lodLimb.jointPos.y = skelLimb->transY;
-    limbData.lodLimb.jointPos.z = skelLimb->transZ;
-
-    if (skelLimb->dListPtr != "") {
-        skelLimb->dListPtr = "__OTR__" + skelLimb->dListPtr;
-        limbData.lodLimb.dLists[0] = (Gfx*)skelLimb->dListPtr.c_str();
-    } else {
-        limbData.lodLimb.dLists[0] = nullptr;
+    if (skelLimb->dList2Ptr == "gEmptyDL") {
+        skelLimb->dList2Ptr = "";
     }
 
-    limbData.lodLimb.dLists[1] = nullptr;
-
-    limbData.lodLimb.child = skelLimb->childIndex;
-    limbData.lodLimb.sibling = skelLimb->siblingIndex;
-
-    // skelLimb->dList2Ptr = reader->Attribute("DisplayList2");
+    BuildSkeletonLimbData(skelLimb);
 
     return skelLimb;
 }

--- a/mm/src/code/z_player_lib.c
+++ b/mm/src/code/z_player_lib.c
@@ -2107,6 +2107,10 @@ void Player_DrawImpl(PlayState* play, void** skeleton, Vec3s* jointTable, s32 dL
     POLY_OPA_DISP = &gfx[2];
 
     D_801F59E0 = playerForm * 2;
+    // 2S2H [Port] Disable LOD when a custom player model is used
+    if (Player_IsCustomLinkModel((Player*)actor)) {
+        lod = 0;
+    }
     sPlayerLod = lod;
     SkelAnime_DrawFlexLod(play, skeleton, jointTable, dListCount, overrideLimbDraw, postLimbDraw, actor, lod);
 

--- a/mm/src/code/z_player_lib.c
+++ b/mm/src/code/z_player_lib.c
@@ -44,6 +44,9 @@
 // Assets for other actors
 #include "overlays/actors/ovl_En_Arrow/z_en_arrow.h"
 
+// Play as Kafei waist DL override
+#include "objects/object_test3/object_test3.h"
+
 #include "2s2h/BenPort.h"
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
@@ -651,6 +654,20 @@ void func_80123140(PlayState* play, Player* player) {
 
     Actor_SetScale(&player->actor, scale);
 }
+
+// #region 2S2H [Port] Determine if we're using a custom model for link
+uint8_t Player_IsCustomLinkModel(Player* player) {
+    return ((player->transformation == PLAYER_FORM_HUMAN) && ResourceGetIsCustomByName(gLinkHumanSkel)) ||
+           ((player->transformation == PLAYER_FORM_DEKU) && ResourceGetIsCustomByName(gLinkDekuSkel)) ||
+           ((player->transformation == PLAYER_FORM_GORON) && ResourceGetIsCustomByName(gLinkGoronSkel)) ||
+           ((player->transformation == PLAYER_FORM_ZORA) && ResourceGetIsCustomByName(gLinkZoraSkel)) ||
+           ((player->transformation == PLAYER_FORM_FIERCE_DEITY) && ResourceGetIsCustomByName(gLinkFierceDeitySkel)) ||
+
+           // special case for kafei model swaps when using Play as Kafei enhancement
+           ((player->transformation == PLAYER_FORM_HUMAN) && CVarGetInteger("gModes.PlayAsKafei", 0) &&
+            ResourceGetIsCustomByName(gKafeiSkel));
+}
+// #endregion
 
 bool Player_InBlockingCsMode(PlayState* play, Player* player) {
     return (player->stateFlags1 & (PLAYER_STATE1_DEAD | PLAYER_STATE1_200 | PLAYER_STATE1_20000000)) ||
@@ -2698,7 +2715,9 @@ s32 Player_OverrideLimbDrawGameplayDefault(PlayState* play, s32 limbIndex, Gfx**
 
             *dList = sheathDLists[sPlayerLod];
         } else if (limbIndex == PLAYER_LIMB_WAIST) {
-            *dList = player->waistDLists[sPlayerLod];
+            if (!Player_IsCustomLinkModel(player)) {
+                *dList = player->waistDLists[sPlayerLod];
+            }
         } else if (limbIndex == PLAYER_LIMB_HAT) {
             if (player->transformation == PLAYER_FORM_ZORA) {
                 Matrix_Scale((player->unk_B10[0] * 1) + 1.0f, 1.0f, 1.0f, MTXMODE_APPLY);

--- a/mm/src/code/z_player_lib.c
+++ b/mm/src/code/z_player_lib.c
@@ -51,6 +51,7 @@
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
 #include <libultraship/bridge/consolevariablebridge.h>
+#include <libultraship/bridge/resourcebridge.h>
 
 typedef struct {
     /* 0x00 */ Vec3f unk_00;


### PR DESCRIPTION
Adds support for XML skeletons exported from Fast64.

2ship would no longer need its own skeleton exporter in Fast64, it will be able to load full XML skeletons as they are created for SoH in the exact same way.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8510574487.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8510316765.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8510028568.zip)
<!--- section:artifacts:end -->