### PR TITLE
[Rando] Add NPC to perform SoT reset on Moon

### DIFF
--- a/mm/2s2h/Rando/ActorBehavior/EnJs.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/EnJs.cpp
@@ -2,11 +2,18 @@
 #include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/Rando/Logic/Logic.h"
 #include "2s2h/CustomMessage/CustomMessage.h"
+#include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
 
 extern "C" {
 #include "variables.h"
 #include "overlays/actors/ovl_En_Js/z_en_js.h"
+#include "objects/object_stk/object_stk.h"
+s32 func_80968DD0(EnJs* enJs, PlayState* play);
+void func_8096971C(EnJs* enJs, PlayState* play);
+extern Vec3f D_8096AC30;
 }
+
+void EnJs_PromptForDialog(EnJs* enJs, PlayState* play);
 
 void OverrideSubJsText(u16* textId, bool* loadFromMessageTable) {
     Player* player = GET_PLAYER(gPlayState);
@@ -143,6 +150,50 @@ void OverrideMainJsText(u16* textId, bool* loadFromMessageTable) {
     }
 }
 
+void EnJs_PostLimbDraw_NoMask(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s* rot, Actor* thisx) {
+    if (limbIndex == MOONCHILD_LIMB_HEAD) {
+        Matrix_MultVec3f(&D_8096AC30, &thisx->focus.pos);
+        OPEN_DISPS(play->state.gfxCtx);
+        Matrix_RotateZYX(0x8000, 0x8000, -0x4000, MTXMODE_APPLY);
+        Matrix_Translate(-128.0, -256.0, 0.0, MTXMODE_APPLY);
+        MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, play->state.gfxCtx);
+        gSPDisplayList(POLY_OPA_DISP++, (Gfx*)gSkullKidLinkMask1DL);
+        CLOSE_DISPS(play->state.gfxCtx);
+    }
+}
+
+void EnJs_Draw_NoMask(Actor* thisx, PlayState* play) {
+    EnJs* enJs = (EnJs*)thisx;
+
+    Gfx_SetupDL25_Opa(play->state.gfxCtx);
+    SkelAnime_DrawFlexOpa(play, enJs->skelAnime.skeleton, enJs->skelAnime.jointTable, enJs->skelAnime.dListCount, NULL,
+                          EnJs_PostLimbDraw_NoMask, &enJs->actor);
+}
+
+void EnJs_ResetTime(EnJs* enJs, PlayState* play) {
+    func_8096971C(enJs, play);
+    if (play->msgCtx.ocarinaMode == OCARINA_MODE_APPLY_SOT) {
+        play->nextEntrance = ENTRANCE(CUTSCENE, 0);
+        gSaveContext.nextCutsceneIndex = 0xFFF7;
+        play->transitionTrigger = TRANS_TRIGGER_START;
+        enJs->actionFunc = func_8096971C;
+    } else if (Message_GetState(&play->msgCtx) == TEXT_STATE_CHOICE && Message_ShouldAdvance(play) &&
+               play->msgCtx.choiceIndex == 1) {
+        enJs->actionFunc = EnJs_PromptForDialog;
+    }
+}
+
+void EnJs_PromptForDialog(EnJs* enJs, PlayState* play) {
+    func_8096971C(enJs, play);
+    if (Actor_TalkOfferAccepted(&enJs->actor, &play->state)) {
+        enJs->actionFunc = EnJs_ResetTime;
+        Message_StartTextbox(play, 0x1B8A, &enJs->actor);
+        play->msgCtx.ocarinaMode = OCARINA_MODE_PROCESS_SOT;
+    } else if (func_80968DD0(enJs, play)) {
+        Actor_OfferTalk(&enJs->actor, play, 120.0f);
+    }
+}
+
 void Rando::ActorBehavior::InitEnJsBehavior() {
     COND_VB_SHOULD(VB_JS_CONSIDER_ELIGIBLE_FOR_DEITY, IS_RANDO, { *should = false; });
 
@@ -169,6 +220,19 @@ void Rando::ActorBehavior::InitEnJsBehavior() {
                 break;
             default:
                 break;
+        }
+    });
+
+    COND_ID_HOOK(OnSceneInit, SCENE_SOUGEN, IS_RANDO, [](s8 sceneId, s8 spawnNum) {
+        u32 params = 8;
+        Actor* actor = Actor_Spawn(&gPlayState->actorCtx, gPlayState, ACTOR_EN_JS, -150, 40, 50, 0, -15000, 0, params);
+        actor->draw = EnJs_Draw_NoMask;
+    });
+
+    COND_ID_HOOK(OnActorInit, ACTOR_EN_JS, IS_RANDO, [](Actor* actor) {
+        if (actor->draw == EnJs_Draw_NoMask) {
+            ((EnJs*)actor)->actionFunc = EnJs_PromptForDialog;
+            actor->world.pos.y = 0;
         }
     });
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/953eb832-7ec8-4971-8dff-7ca50c90fc60

- Addresses soft locks in seeds where the SoT is not playable on the moon
- Honors Time Shuffle settings
- Currently always enabled in rando, but am open to making it toggleable. imo it should at least be always enabled for glitchless seeds when SoT is not playable
- NPC wears unused mask for funsies

Closes #1720

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8415544907.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8415309249.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8415048766.zip)
<!--- section:artifacts:end -->