### PR TITLE
remove skeleton dListCount rewrite on alt toggle

### DIFF
--- a/mm/2s2h/resource/type/Skeleton.cpp
+++ b/mm/2s2h/resource/type/Skeleton.cpp
@@ -83,7 +83,6 @@ void SkeletonPatcher::UpdateSkeletons() {
         switch (newSkel->type) {
             case SkeletonType::Flex:
                 skel.skelAnime->skeleton = newSkel->skeletonData.flexSkeletonHeader.sh.segment;
-                skel.skelAnime->dListCount = newSkel->skeletonData.flexSkeletonHeader.dListCount;
                 break;
             case SkeletonType::Normal:
                 skel.skelAnime->skeleton = newSkel->skeletonData.skeletonHeader.segment;


### PR DESCRIPTION
caused crashes in certain areas when toggling mods off (even when no mods were used)

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8421475425.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8421342790.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8421165199.zip)
<!--- section:artifacts:end -->