### PR TITLE
Fix issue with A button and hour hand disappearing

### DIFF
--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -1867,7 +1867,8 @@ extern "C" int32_t OTRConvertHUDXToScreenX(int32_t v) {
 
     float hudScreenRatio = (hudWidth / 320.0f);
     float hudCoord = v * hudScreenRatio;
-    float gameOffset = (gameWidth - hudWidth) / 2;
+    // Prevent unsigned underflow
+    float gameOffset = gameAspectRatio < hudAspectRatio ? ((hudWidth - gameWidth) / 2) : ((gameWidth - hudWidth) / 2);
     float gameCoord = hudCoord + gameOffset;
     float gameScreenRatio = (320.0f / gameWidth);
     float screenScaledCoord = gameCoord * gameScreenRatio;

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -1868,7 +1868,7 @@ extern "C" int32_t OTRConvertHUDXToScreenX(int32_t v) {
     float hudScreenRatio = (hudWidth / 320.0f);
     float hudCoord = v * hudScreenRatio;
     // Prevent unsigned underflow
-    float gameOffset = gameAspectRatio < hudAspectRatio ? ((hudWidth - gameWidth) / 2) : ((gameWidth - hudWidth) / 2);
+    float gameOffset = (gameAspectRatio < hudAspectRatio ? (hudWidth - gameWidth) : (gameWidth - hudWidth)) / 2;
     float gameCoord = hudCoord + gameOffset;
     float gameScreenRatio = (320.0f / gameWidth);
     float screenScaledCoord = gameCoord * gameScreenRatio;

--- a/mm/2s2h/BenPort.cpp
+++ b/mm/2s2h/BenPort.cpp
@@ -1867,8 +1867,7 @@ extern "C" int32_t OTRConvertHUDXToScreenX(int32_t v) {
 
     float hudScreenRatio = (hudWidth / 320.0f);
     float hudCoord = v * hudScreenRatio;
-    // Prevent unsigned underflow
-    float gameOffset = (gameAspectRatio < hudAspectRatio ? (hudWidth - gameWidth) : (gameWidth - hudWidth)) / 2;
+    float gameOffset = (int32_t(gameWidth) - hudWidth) / 2;
     float gameCoord = hudCoord + gameOffset;
     float gameScreenRatio = (320.0f / gameWidth);
     float screenScaledCoord = gameCoord * gameScreenRatio;


### PR DESCRIPTION
tl;dr certain resolutions would result in an unsigned underflow in the `OTRConvertHUDXToScreenX` calculation, resulting in a large number and effectively not displaying things. Only the A button and hour hand seem to use this, hence why they are  the only ones affected. The A button would be drawn off-screen, while the hour hand uses the result for a scissor calculation.

Casting `gameWidth` to signed fixes the issue.

Closes #1253.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8599665504.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8597467069.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8597298043.zip)
<!--- section:artifacts:end -->