### PR TITLE
Fix OOB crash with randoinf flag editor

### DIFF
--- a/mm/2s2h/BenGui/UIWidgets.cpp
+++ b/mm/2s2h/BenGui/UIWidgets.cpp
@@ -1226,13 +1226,18 @@ template <typename T> static void DrawFlagTableArrayRowImpl(const FlagTable& fla
     constexpr int16_t width = sizeof(T) * 8;
     ImGui::PushID(flagTable.name);
     for (int16_t flagIndex = 0; flagIndex < width; flagIndex++) {
+        size_t flagEntryIndex = row * width + flagIndex;
+        if (flagEntryIndex >= flagTable.entries.size()) {
+            break;
+        }
+
         if (flagIndex != 0) {
             ImGui::SameLine();
         }
         ImGui::PushID(flagIndex);
         T bitMask = 1 << flagIndex;
         bool flag = (flags & bitMask) != 0;
-        FlagEntry flagEntry = flagTable.entries.at(row * width + flagIndex);
+        FlagEntry flagEntry = flagTable.entries.at(flagEntryIndex);
         PushStyleCheckbox(LightBlue);
         ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(4.0f, 6.0f));
         std::string id = fmt::format("####{}", flagIndex);


### PR DESCRIPTION
The RandoInf editor leverages the common flagTable editor, which assumes 16 entries per row. This is fine with vanilla game data, but RandoInfs are not guaranteed to be a multiple of 16. This would result in an OOB crash for trying to read RandInfs that do not exist.

This adds a guard to `DrawFlagTableArrayRowImpl` for size of the associated flagTable.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8600169347.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8599893357.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8599588450.zip)
<!--- section:artifacts:end -->