### PR TITLE
Make randomized checks no longer use custom texture after first obtain

### DIFF
--- a/mm/2s2h/Rando/ActorBehavior/ObjGrass.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ObjGrass.cpp
@@ -451,7 +451,8 @@ void Rando::ActorBehavior::InitObjGrassBehavior() {
 
     COND_VB_SHOULD(VB_KUSA_BUSH_DRAW_BE_OVERRIDDEN, IS_RANDO, {
         Actor* actor = va_arg(args, Actor*);
-        if (GetObjectRandoCheckId(actor) != RC_UNKNOWN) {
+        RandoCheckId randoCheckId = GetObjectRandoCheckId(actor);
+        if (randoCheckId != RC_UNKNOWN && !RANDO_SAVE_CHECKS[randoCheckId].obtained) {
             *should = false;
             actor->draw = EnKusaBush_RandoDraw;
         }
@@ -462,7 +463,7 @@ void Rando::ActorBehavior::InitObjGrassBehavior() {
         ObjGrassElement* grassElem = va_arg(args, ObjGrassElement*);
         s32 j = va_arg(args, s32);
         RandoCheckId randoCheckId = GetObjectRandoCheckId(grassElem);
-        if (randoCheckId != RC_UNKNOWN) {
+        if (randoCheckId != RC_UNKNOWN && !RANDO_SAVE_CHECKS[randoCheckId].obtained) {
             *should = false;
             ObjGrass_RandoDrawOpa(objGrass, grassElem, j, randoCheckId);
         }
@@ -472,7 +473,7 @@ void Rando::ActorBehavior::InitObjGrassBehavior() {
         ObjGrass* objGrass = va_arg(args, ObjGrass*);
         ObjGrassElement* grassElem = va_arg(args, ObjGrassElement*);
         RandoCheckId randoCheckId = GetObjectRandoCheckId(grassElem);
-        if (randoCheckId != RC_UNKNOWN) {
+        if (randoCheckId != RC_UNKNOWN && !RANDO_SAVE_CHECKS[randoCheckId].obtained) {
             *should = false;
             ObjGrass_RandoDrawXlu(objGrass, grassElem, randoCheckId);
         }

--- a/mm/2s2h/Rando/ActorBehavior/ObjKibako.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ObjKibako.cpp
@@ -10,6 +10,9 @@ extern "C" {
 #include "src/overlays/actors/ovl_Obj_Kibako2/z_obj_kibako2.h"
 }
 
+void ObjKibako_RandoDraw(Actor* actor, PlayState* play);
+void ObjKibako2_RandoDraw(Actor* actor, PlayState* play);
+
 std::map<std::tuple<s16, s16, s16>, RandoCheckId> crateMap = {
     // Clock Town //
     { { SCENE_ALLEY, 0, 7 }, RC_CLOCK_TOWN_LAUNDRY_SMALL_CRATE },
@@ -118,7 +121,7 @@ std::map<std::tuple<s16, s16, s16>, RandoCheckId> crateMap = {
 };
 
 // Identify the crate RC by scene ID, room, and actor list index
-RandoCheckId IdentifyCrate(Actor* actor) {
+void IdentifyCrate(Actor* actor) {
     RandoCheckId randoCheckId = RC_UNKNOWN;
 
     s16 actorListIndex = GetActorListIndex(actor);
@@ -127,13 +130,18 @@ RandoCheckId IdentifyCrate(Actor* actor) {
         randoCheckId = it->second;
     }
 
-    if (randoCheckId == RC_UNKNOWN || !RANDO_SAVE_CHECKS[randoCheckId].shuffled ||
-        RANDO_SAVE_CHECKS[randoCheckId].cycleObtained) {
-        return RC_UNKNOWN;
+    if (!RANDO_SAVE_CHECKS[randoCheckId].shuffled || RANDO_SAVE_CHECKS[randoCheckId].cycleObtained) {
+        return;
     }
 
     Rando::ActorBehavior::SetObjectRandoCheckId(actor, randoCheckId);
-    return randoCheckId;
+    if (!RANDO_SAVE_CHECKS[randoCheckId].obtained) {
+        if (actor->id == ACTOR_OBJ_KIBAKO) {
+            actor->draw = ObjKibako_RandoDraw;
+        } else if (actor->id == ACTOR_OBJ_KIBAKO2) {
+            actor->draw = ObjKibako2_RandoDraw;
+        }
+    }
 }
 
 void ObjKibako_RandoDraw(Actor* actor, PlayState* play) {
@@ -219,17 +227,9 @@ void ObjKibako2_RandoDraw(Actor* actor, PlayState* play) {
 }
 
 void Rando::ActorBehavior::InitObjKibakoBehavior() {
-    COND_ID_HOOK(OnActorInit, ACTOR_OBJ_KIBAKO, IS_RANDO, [](Actor* actor) {
-        if (IdentifyCrate(actor) != RC_UNKNOWN) {
-            actor->draw = ObjKibako_RandoDraw;
-        }
-    });
+    COND_ID_HOOK(OnActorInit, ACTOR_OBJ_KIBAKO, IS_RANDO, IdentifyCrate);
 
-    COND_ID_HOOK(OnActorInit, ACTOR_OBJ_KIBAKO2, IS_RANDO, [](Actor* actor) {
-        if (IdentifyCrate(actor) != RC_UNKNOWN) {
-            actor->draw = ObjKibako2_RandoDraw;
-        }
-    });
+    COND_ID_HOOK(OnActorInit, ACTOR_OBJ_KIBAKO2, IS_RANDO, IdentifyCrate);
 
     COND_VB_SHOULD(VB_CRATE_DRAW_BE_OVERRIDDEN, IS_RANDO, {
         Actor* actor = va_arg(args, Actor*);

--- a/mm/2s2h/Rando/ActorBehavior/ObjTaru.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ObjTaru.cpp
@@ -116,7 +116,9 @@ void Rando::ActorBehavior::InitObjTaruBehavior() {
         }
 
         Rando::ActorBehavior::SetObjectRandoCheckId(actor, randoCheckId);
-        actor->draw = ObjTaru_RandoDraw;
+        if (!RANDO_SAVE_CHECKS[randoCheckId].obtained) {
+            actor->draw = ObjTaru_RandoDraw;
+        }
     });
 
     COND_VB_SHOULD(VB_BARREL_OR_CRATE_DROP_COLLECTIBLE, IS_RANDO, {

--- a/mm/2s2h/Rando/ActorBehavior/ObjTsubo.cpp
+++ b/mm/2s2h/Rando/ActorBehavior/ObjTsubo.cpp
@@ -380,7 +380,8 @@ void Rando::ActorBehavior::InitObjTsuboBehavior() {
     COND_VB_SHOULD(VB_POT_DRAW_BE_OVERRIDDEN, IS_RANDO, {
         Actor* actor = va_arg(args, Actor*);
         RandoCheckId randoCheckId = Rando::ActorBehavior::GetObjectRandoCheckId(actor);
-        if (randoCheckId != RC_UNKNOWN) {
+        RandoSaveCheck& randoSaveCheck = RANDO_SAVE_CHECKS[randoCheckId];
+        if (randoCheckId != RC_UNKNOWN && !randoSaveCheck.obtained) {
             *should = false;
             actor->draw = ObjTsubo_RandoDraw;
         }


### PR DESCRIPTION
This is purely visual, and has been requested several times. This affects grass, pots, barrels and crates.

Current behavior:
Unobtained: Texture shown (Grants check item)
Obtained this cycle: Texture not shown (Grants vanilla item if any)
Obtained previous cycle: Texture shown (Grants converted check item)

New behavior:
Unobtained: Texture shown (Grants check item)
Obtained this cycle: Texture not shown (Grants vanilla item if any)
Obtained previous cycle: Texture not shown (Grants converted check item)

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8611427458.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8611273433.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8611076133.zip)
<!--- section:artifacts:end -->