### PR TITLE
Fix SkipBottleCatch turning chests into ocarinas

### DIFF
--- a/mm/2s2h/Enhancements/Dialogue/SkipBottleCatch.cpp
+++ b/mm/2s2h/Enhancements/Dialogue/SkipBottleCatch.cpp
@@ -8,26 +8,28 @@
 
 void RegisterSkipBottleCatchCutscene() {
     COND_VB_SHOULD(VB_PLAY_BOTTLE_CATCH_TEXT, CVAR, {
-        Player* player = va_arg(args, Player*);
-        Actor* interactRangeActor = va_arg(args, Actor*);
-        ItemId itemId = (ItemId)va_arg(args, int);
-        PlayerItemAction itemAction = (PlayerItemAction)va_arg(args, int);
+        if (*should) {
+            Player* player = va_arg(args, Player*);
+            Actor* interactRangeActor = va_arg(args, Actor*);
+            ItemId itemId = (ItemId)va_arg(args, int);
+            PlayerItemAction itemAction = (PlayerItemAction)va_arg(args, int);
 
-        interactRangeActor->parent = &player->actor;
-        Player_UpdateBottleHeld(gPlayState, player, itemId, itemAction);
-        Audio_PlayFanfare(NA_BGM_GET_ITEM);
+            interactRangeActor->parent = &player->actor;
+            Player_UpdateBottleHeld(gPlayState, player, itemId, itemAction);
+            Audio_PlayFanfare(NA_BGM_GET_ITEM);
 
-        if (itemAction == PLAYER_IA_BOTTLE_DEKU_PRINCESS) {
-            // Kill Deku Princess actor immediately upon capture
-            Actor_Kill(interactRangeActor);
+            if (itemAction == PLAYER_IA_BOTTLE_DEKU_PRINCESS) {
+                // Kill Deku Princess actor immediately upon capture
+                Actor_Kill(interactRangeActor);
+            }
+
+            Notification::Emit({
+                .itemIcon = (const char*)gItemIcons[itemId],
+                .message = "Caught!",
+            });
+
+            *should = false;
         }
-
-        Notification::Emit({
-            .itemIcon = (const char*)gItemIcons[itemId],
-            .message = "Caught!",
-        });
-
-        *should = false;
     });
 }
 


### PR DESCRIPTION
The `SkipBottlePickupMessages` enhancement short-circuited the scenario where actor params match but the resulting actor is out of range, resulting in chests becoming bottleable ocarinas. This change only runs the enhancement if the bottle swing would normally result in a pickup message.

Fixes #1815.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8626788565.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8626787314.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8626736847.zip)
<!--- section:artifacts:end -->