### PR TITLE
Tweak the TreasureChestShopShowFullMaze enhancement to progressively show different heights

### DIFF
--- a/mm/2s2h/BenGui/BenMenu.cpp
+++ b/mm/2s2h/BenGui/BenMenu.cpp
@@ -74,6 +74,12 @@ static const std::vector<const char*> cremiaRewardOptions = {
     "Rupee",   // CREMIA_REWARD_ALWAYS_RUPEE
 };
 
+static const std::vector<const char*> treasureChestShopMazeOptions = {
+    "Off",         // TREASURE_CHEST_SHOP_MAZE_OFF
+    "Full Height", // TREASURE_CHEST_SHOP_MAZE_FULL_HEIGHT
+    "Tiered",      // TREASURE_CHEST_SHOP_MAZE_TIERED
+};
+
 static const std::vector<const char*> ammoBuybackOptions = {
     "Vanilla",    // AMMO_BUYBACK_VANILLA
     "Full Price", // AMMO_BUYBACK_FULL_PRICE
@@ -1900,10 +1906,16 @@ void BenMenu::AddEnhancements() {
     AddWidget(path, "Invincible", WIDGET_CVAR_CHECKBOX)
         .CVar("gEnhancements.Minigames.BoatArcheryInvincible")
         .Options(CheckboxOptions().Tooltip("Koume's health does not decrease when hit."));
-    AddWidget(path, "Treasure Chest Shop Show Full Maze", WIDGET_CVAR_CHECKBOX)
+    AddWidget(path, "Treasure Chest Shop Maze", WIDGET_CVAR_COMBOBOX)
         .CVar("gEnhancements.Minigames.TreasureChestShopShowFullMaze")
-        .Options(CheckboxOptions().Tooltip("Shows the entire maze layout in the Treasure Chest Shop minigame "
-                                           "instead of only revealing tiles near Link."));
+        .Options(ComboboxOptions()
+                     .Tooltip("Shows the entire maze layout in the Treasure Chest Shop minigame instead of only "
+                              "revealing tiles near Link.\n"
+                              "-Off: Only tiles near Link are revealed\n"
+                              "-Full Height: The whole maze is raised to the same height\n"
+                              "-Tiered: Tiles are raised higher the further back they are, so the front rows "
+                              "don't hide the rest")
+                     .ComboVec(&treasureChestShopMazeOptions));
 
     path.column = SECTION_COLUMN_3;
     AddWidget(path, "Other", WIDGET_SEPARATOR_TEXT);

--- a/mm/2s2h/Enhancements/Enhancements.h
+++ b/mm/2s2h/Enhancements/Enhancements.h
@@ -62,6 +62,12 @@ enum GoronRaceDifficultyOptions {
     GORON_RACE_DIFFICULTY_SKIP,
 };
 
+enum TreasureChestShopMazeOptions {
+    TREASURE_CHEST_SHOP_MAZE_OFF,
+    TREASURE_CHEST_SHOP_MAZE_FULL_HEIGHT,
+    TREASURE_CHEST_SHOP_MAZE_TIERED,
+};
+
 enum MirroredWorldModeOptions {
     MIRRORED_WORLD_OFF,
     MIRRORED_WORLD_ALWAYS,

--- a/mm/2s2h/Enhancements/Minigames/TreasureChestShopFullMaze.cpp
+++ b/mm/2s2h/Enhancements/Minigames/TreasureChestShopFullMaze.cpp
@@ -1,10 +1,13 @@
 #include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
+#include "2s2h/Enhancements/Enhancements.h"
 #include "2s2h/ShipInit.hpp"
 
 // Re-definitions to avoid modifying source headers
 #define TAKARAYA_WALL_ROWS 11
 #define TAKARAYA_WALL_COLUMNS 8
+#define TAKARAYA_WALL_FRONT_HEIGHT 20.0f
+#define TAKARAYA_WALL_BACK_HEIGHT 120.0f
 
 extern "C" {
 extern f32 sTakarayaWallHeights[TAKARAYA_WALL_ROWS][TAKARAYA_WALL_COLUMNS];
@@ -15,18 +18,25 @@ extern u8 sTakarayaWallStates[TAKARAYA_WALL_ROWS][TAKARAYA_WALL_COLUMNS];
 typedef enum { TAKARAYA_WALL_INACTIVE, TAKARAYA_WALL_RISING, TAKARAYA_WALL_FALLING } TakarayaWallCellState;
 
 #define CVAR_NAME "gEnhancements.Minigames.TreasureChestShopShowFullMaze"
-#define CVAR CVarGetInteger(CVAR_NAME, 0)
+#define CVAR CVarGetInteger(CVAR_NAME, TREASURE_CHEST_SHOP_MAZE_OFF)
 
 static void RegisterTreasureChestShopFullMaze() {
-    COND_ID_HOOK(OnActorUpdate, ACTOR_OBJ_TAKARAYA_WALL, CVAR, [](Actor* actor) {
+    COND_ID_HOOK(OnActorUpdate, ACTOR_OBJ_TAKARAYA_WALL, CVAR != TREASURE_CHEST_SHOP_MAZE_OFF, [](Actor* actor) {
         if (gSaveContext.timerStates[TIMER_ID_MINIGAME_2] == TIMER_STATE_OFF) {
             return;
         }
 
         for (int i = 0; i < TAKARAYA_WALL_ROWS; i++) {
+            f32 targetHeight = 120.0f;
+            if (CVAR == TREASURE_CHEST_SHOP_MAZE_TIERED) {
+                f32 distanceFromFront = (f32)(TAKARAYA_WALL_ROWS - 1 - i) / (TAKARAYA_WALL_ROWS - 1);
+                targetHeight = TAKARAYA_WALL_FRONT_HEIGHT +
+                               ((TAKARAYA_WALL_BACK_HEIGHT - TAKARAYA_WALL_FRONT_HEIGHT) * distanceFromFront);
+            }
+
             for (int j = 0; j < TAKARAYA_WALL_COLUMNS; j++) {
                 if (sTakarayaWallHeights[i][j] >= 0.0f) {
-                    if (Math_StepToF(&sTakarayaWallHeights[i][j], 120.0f, 15.0f)) {
+                    if (Math_StepToF(&sTakarayaWallHeights[i][j], targetHeight, 15.0f)) {
                         sTakarayaWallStates[i][j] = TAKARAYA_WALL_INACTIVE;
                     } else {
                         sTakarayaWallStates[i][j] = TAKARAYA_WALL_RISING;

--- a/mm/2s2h/Enhancements/Minigames/TreasureChestShopFullMaze.cpp
+++ b/mm/2s2h/Enhancements/Minigames/TreasureChestShopFullMaze.cpp
@@ -27,7 +27,7 @@ static void RegisterTreasureChestShopFullMaze() {
         }
 
         for (int i = 0; i < TAKARAYA_WALL_ROWS; i++) {
-            f32 targetHeight = 120.0f;
+            f32 targetHeight = TAKARAYA_WALL_BACK_HEIGHT;
             if (CVAR == TREASURE_CHEST_SHOP_MAZE_TIERED) {
                 f32 distanceFromFront = (f32)(TAKARAYA_WALL_ROWS - 1 - i) / (TAKARAYA_WALL_ROWS - 1);
                 targetHeight = TAKARAYA_WALL_FRONT_HEIGHT +


### PR DESCRIPTION
Been on my todo list for a while. @mckinlee let me know if you dont like it

before:
<img width="1868" height="1198" alt="Screenshot 2026-07-31 at 8 21 19 PM" src="https://github.com/user-attachments/assets/3c6df301-47be-4697-96e2-1eac88f0136e" />

After:
<img width="1912" height="1242" alt="Screenshot 2026-07-31 at 8 18 16 PM" src="https://github.com/user-attachments/assets/89d00e75-26f0-4ef7-949c-d24cc5435b96" />




<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8812636047.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8812604743.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8812509175.zip)
<!--- section:artifacts:end -->