### PR TITLE
Fix deku baba stick interp issue

### DIFF
--- a/mm/src/overlays/actors/ovl_En_Karebaba/z_en_karebaba.c
+++ b/mm/src/overlays/actors/ovl_En_Karebaba/z_en_karebaba.c
@@ -8,6 +8,7 @@
 #include "overlays/actors/ovl_En_Clear_Tag/z_en_clear_tag.h"
 #include "overlays/effects/ovl_Effect_Ss_Hahen/z_eff_ss_hahen.h"
 #include "objects/gameplay_keep/gameplay_keep.h"
+#include "2s2h/Enhancements/FrameInterpolation/FrameInterpolation.h"
 
 #define FLAGS (ACTOR_FLAG_ATTENTION_ENABLED | ACTOR_FLAG_HOSTILE)
 
@@ -658,9 +659,11 @@ void EnKarebaba_Draw(Actor* thisx, PlayState* play) {
 
     if (this->actionFunc == EnKarebaba_DeadItemDrop) {
         if ((this->timer > 40) || (this->timer & 1)) {
+            FrameInterpolation_RecordOpenChild(this, 0);
             Matrix_Translate(0.0f, 0.0f, 200.0f, MTXMODE_APPLY);
             MATRIX_FINALIZE_AND_LOAD(POLY_OPA_DISP++, play->state.gfxCtx);
             gSPDisplayList(POLY_OPA_DISP++, gDekuBabaStickDropDL);
+            FrameInterpolation_RecordCloseChild();
         }
     } else if (this->actionFunc != EnKarebaba_Dead) {
         func_800AE2A0(play, &sFogColor, 1, 2);


### PR DESCRIPTION
This has been around forever, but I saw it happen like 3 times on a stream tonight and figured I'd find and fix it.

When the deku baba dies and drops its stick, as its stick starts flashing there's an interp issue where it's swapping positions with the deku baba's leafs on the ground.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8813376669.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8813357077.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8813265875.zip)
<!--- section:artifacts:end -->