### PR TITLE
Fix Goron rolling ignores magic

### DIFF
--- a/mm/2s2h/Enhancements/Masks/GoronRollingIgnoresMagic.cpp
+++ b/mm/2s2h/Enhancements/Masks/GoronRollingIgnoresMagic.cpp
@@ -17,7 +17,10 @@ void RegisterGoronRollingIgnoresMagic() {
     COND_VB_SHOULD(VB_GORON_ROLL_CONSUME_MAGIC, CVAR, { *should = false; });
 
     // Disable check for if the player has magic to increase spike level
-    COND_VB_SHOULD(VB_GORON_ROLL_INCREASE_SPIKE_LEVEL, CVAR, { *should = true; });
+    COND_VB_SHOULD(VB_GORON_ROLL_INCREASE_SPIKE_LEVEL, CVAR, {
+        Player* player = GET_PLAYER(gPlayState);
+        *should = player->av2.actionVar2 >= 0x36B0;
+    });
 
     // Mimicking the vanilla condition minus the magic check
     COND_VB_SHOULD(VB_GORON_ROLL_DISABLE_SPIKE_MODE, CVAR, {


### PR DESCRIPTION
This has been a bug since this feature was introduced, with this enabled simply holding A and not moving would charge your spikes and launch you into a random direction (when combined with instant spikes this was extremely annoying).

Re-adds the vanilla movement check so it's only charging your spikes when it should be

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8818420283.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8818365150.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8818298133.zip)
<!--- section:artifacts:end -->