### PR TITLE
Always shuffle first bomb bag

### DIFF
--- a/mm/2s2h/Rando/Logic/GeneratePools.cpp
+++ b/mm/2s2h/Rando/Logic/GeneratePools.cpp
@@ -127,10 +127,10 @@ void GeneratePools(RandoSaveInfo& saveInfo, std::vector<RandoCheckId>& checkPool
             }
 
             if (randoStaticCheck.randoCheckType == RCTYPE_SHOP) {
-                // We always want shuffle RC_CURIOSITY_SHOP_SPECIAL_ITEM &
+                // We always want shuffle RC_CURIOSITY_SHOP_SPECIAL_ITEM, RC_BOMB_SHOP_ITEM_03 &
                 // RC_BOMB_SHOP_ITEM_04_OR_CURIOSITY_SHOP_ITEM
                 if (saveInfo.randoSaveOptions[RO_SHUFFLE_SHOPS] == RO_GENERIC_NO &&
-                    randoCheckId != RC_CURIOSITY_SHOP_SPECIAL_ITEM &&
+                    randoCheckId != RC_CURIOSITY_SHOP_SPECIAL_ITEM && randoCheckId != RC_BOMB_SHOP_ITEM_03 &&
                     randoCheckId != RC_BOMB_SHOP_ITEM_04_OR_CURIOSITY_SHOP_ITEM) {
                     continue;
                 } else {

--- a/mm/2s2h/Rando/Menu.cpp
+++ b/mm/2s2h/Rando/Menu.cpp
@@ -434,6 +434,7 @@ static RegisterShipInitFunc refreshMetricsInit(RefreshMetrics, {
 // Shop checks that Rando::Logic::GeneratePools always shuffles even with Shops off
 static constexpr RandoCheckId ALWAYS_SHUFFLED_SHOP_CHECKS[] = {
     RC_CURIOSITY_SHOP_SPECIAL_ITEM,
+    RC_BOMB_SHOP_ITEM_03,
     RC_BOMB_SHOP_ITEM_04_OR_CURIOSITY_SHOP_ITEM,
 };
 
@@ -705,7 +706,7 @@ static void DrawCheckPoolTab() {
                       "Activating an owl statue is a check. Song of Soaring destinations are unaffected.");
     CheckPoolCheckbox("Shops", RO_SHUFFLE_SHOPS, RCTYPE_SHOP,
                       "Items sold in shops are checks, with randomized prices.\n\nThe Curiosity Shop special item "
-                      "and the Bomb Shop's 4th item are always shuffled, even with this off.");
+                      "and the Bomb Shop's bomb bags are always shuffled, even with this off.");
     CheckPoolCheckbox("Tingle Maps", RO_SHUFFLE_TINGLE_SHOPS, RCTYPE_TINGLE_SHOP,
                       "Maps sold by Tingle are checks, with randomized prices.");
     CheckPoolCheckbox("Boss Remains", RO_SHUFFLE_BOSS_REMAINS, RCTYPE_REMAINS,


### PR DESCRIPTION
This was accidental early on and I just never fixed it. This forces the shuffling of the first bomb bag (which appears in the bomb shop) regardless of if shops are shuffled or not. 

This was intended anyway, and is already the case for the other bomb bag and all night mask, just slipped through the cracks for the first bomb bag.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8843259268.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8843224789.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8843118411.zip)
<!--- section:artifacts:end -->