### PR TITLE
Fix remaining '2' on file select code

### DIFF
--- a/mm/src/code/z_sram_NES.c
+++ b/mm/src/code/z_sram_NES.c
@@ -1739,7 +1739,8 @@ void func_801457CC(GameState* gameState, SramContext* sramCtx) {
                         fileSelect->maskCount[sp76] = maskCount;
                         fileSelect->heartPieceCount[sp76] = GET_QUEST_HEART_PIECE_COUNT;
 
-                        GameInteractor_ExecuteOnFileSelectSaveLoad(sp76 - 2, true, &gSaveContext);
+                        GameInteractor_ExecuteOnFileSelectSaveLoad(sp76 - FILE_NUM_OWL_SAVE_OFFSET, true,
+                                                                   &gSaveContext);
                     }
 
                     if (sp6E == 1) {


### PR DESCRIPTION
This one just got missed in #900 likely because the hook was introduced separately in the rando branch prior, and when we updated the branch it was overlooked.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8874821693.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8874793880.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8874591721.zip)
<!--- section:artifacts:end -->