### PR TITLE
Bugfix, Deku Hookshot pull out crash

### DIFF
--- a/mm/2s2h/Enhancements/Cheats/UnrestrictedItems.cpp
+++ b/mm/2s2h/Enhancements/Cheats/UnrestrictedItems.cpp
@@ -7,6 +7,21 @@
 
 void RegisterUnrestrictedItems() {
     COND_VB_SHOULD(VB_ITEM_BE_RESTRICTED, CVAR, { *should = false; });
+
+    // Prevent Deku Hookshot crash from float overflow/failed raycasts
+    COND_VB_SHOULD(VB_DEKU_COMMON_HEAD_OVERRIDE_HELD_ACTOR, CVAR, {
+        Actor* heldActor = va_arg(args, Actor*);
+        if (heldActor->id == ACTOR_ARMS_HOOK) {
+            *should = false;
+        }
+    });
+
+    COND_VB_SHOULD(VB_DEKU_COMMON_UPPER_LIMB_OVERRIDE_HELD_ACTOR, CVAR, {
+        Actor* heldActor = va_arg(args, Actor*);
+        if (heldActor->id == ACTOR_ARMS_HOOK) {
+            *should = false;
+        }
+    });
 }
 
 static RegisterShipInitFunc initFunc(RegisterUnrestrictedItems, { CVAR_NAME });

--- a/mm/2s2h/Enhancements/Cheats/UnrestrictedItems.cpp
+++ b/mm/2s2h/Enhancements/Cheats/UnrestrictedItems.cpp
@@ -14,22 +14,22 @@ void RegisterUnrestrictedItems() {
     COND_VB_SHOULD(VB_ITEM_BE_RESTRICTED, CVAR, { *should = false; });
 
     // Prevent Deku Hookshot crash from float overflow/failed raycasts
-    COND_VB_SHOULD(VB_DEKU_COMMON_HEAD_OVERRIDE_HELD_ACTOR, CVAR || CONSOLE_CRASH_CVAR, {
+    COND_VB_SHOULD(VB_DEKU_COMMON_HEAD_OVERRIDE_HELD_ACTOR, true, {
         Actor* heldActor = va_arg(args, Actor*);
-        if (CVAR && heldActor != NULL && heldActor->id == ACTOR_ARMS_HOOK) {
+        if (heldActor != NULL && heldActor->id == ACTOR_ARMS_HOOK) {
             *should = false;
-            if (!CONSOLE_CRASH_CVAR) {
+            if (!CVAR && !CONSOLE_CRASH_CVAR) {
                 LUSLOG_WARN("Using Hookshot as Deku crashes on console");
                 Ship_HandleConsoleCrashAsReset();
             }
         }
     });
 
-    COND_VB_SHOULD(VB_DEKU_COMMON_UPPER_LIMB_OVERRIDE_HELD_ACTOR, CVAR || CONSOLE_CRASH_CVAR, {
+    COND_VB_SHOULD(VB_DEKU_COMMON_UPPER_LIMB_OVERRIDE_HELD_ACTOR, true, {
         Actor* heldActor = va_arg(args, Actor*);
-        if (CVAR && heldActor != NULL && heldActor->id == ACTOR_ARMS_HOOK) {
+        if (heldActor != NULL && heldActor->id == ACTOR_ARMS_HOOK) {
             *should = false;
-            if (!CONSOLE_CRASH_CVAR) {
+            if (!CVAR && !CONSOLE_CRASH_CVAR) {
                 LUSLOG_WARN("Using Hookshot as Deku crashes on console");
                 Ship_HandleConsoleCrashAsReset();
             }

--- a/mm/2s2h/Enhancements/Cheats/UnrestrictedItems.cpp
+++ b/mm/2s2h/Enhancements/Cheats/UnrestrictedItems.cpp
@@ -11,14 +11,14 @@ void RegisterUnrestrictedItems() {
     // Prevent Deku Hookshot crash from float overflow/failed raycasts
     COND_VB_SHOULD(VB_DEKU_COMMON_HEAD_OVERRIDE_HELD_ACTOR, CVAR, {
         Actor* heldActor = va_arg(args, Actor*);
-        if (heldActor->id == ACTOR_ARMS_HOOK) {
+        if (heldActor != NULL && heldActor->id == ACTOR_ARMS_HOOK) {
             *should = false;
         }
     });
 
     COND_VB_SHOULD(VB_DEKU_COMMON_UPPER_LIMB_OVERRIDE_HELD_ACTOR, CVAR, {
         Actor* heldActor = va_arg(args, Actor*);
-        if (heldActor->id == ACTOR_ARMS_HOOK) {
+        if (heldActor != NULL && heldActor->id == ACTOR_ARMS_HOOK) {
             *should = false;
         }
     });

--- a/mm/2s2h/Enhancements/Cheats/UnrestrictedItems.cpp
+++ b/mm/2s2h/Enhancements/Cheats/UnrestrictedItems.cpp
@@ -1,27 +1,40 @@
 #include <libultraship/bridge/consolevariablebridge.h>
 #include "2s2h/GameInteractor/GameInteractor.h"
 #include "2s2h/ShipInit.hpp"
+#include <libultraship/log/luslog.h>
 
+#define CONSOLE_CRASH_CVAR_NAME "gEnhancements.Fixes.ConsoleCrashes"
+#define CONSOLE_CRASH_CVAR CVarGetInteger(CONSOLE_CRASH_CVAR_NAME, true)
 #define CVAR_NAME "gCheats.UnrestrictedItems"
-#define CVAR CVarGetInteger(CVAR_NAME, 0)
+#define CVAR CVarGetInteger(CVAR_NAME, false)
+
+extern "C" bool Ship_HandleConsoleCrashAsReset();
 
 void RegisterUnrestrictedItems() {
     COND_VB_SHOULD(VB_ITEM_BE_RESTRICTED, CVAR, { *should = false; });
 
     // Prevent Deku Hookshot crash from float overflow/failed raycasts
-    COND_VB_SHOULD(VB_DEKU_COMMON_HEAD_OVERRIDE_HELD_ACTOR, CVAR, {
+    COND_VB_SHOULD(VB_DEKU_COMMON_HEAD_OVERRIDE_HELD_ACTOR, CVAR || CONSOLE_CRASH_CVAR, {
         Actor* heldActor = va_arg(args, Actor*);
-        if (heldActor != NULL && heldActor->id == ACTOR_ARMS_HOOK) {
+        if (CVAR && heldActor != NULL && heldActor->id == ACTOR_ARMS_HOOK) {
             *should = false;
+            if (!CONSOLE_CRASH_CVAR) {
+                LUSLOG_WARN("Using Hookshot as Deku crashes on console");
+                Ship_HandleConsoleCrashAsReset();
+            }
         }
     });
 
-    COND_VB_SHOULD(VB_DEKU_COMMON_UPPER_LIMB_OVERRIDE_HELD_ACTOR, CVAR, {
+    COND_VB_SHOULD(VB_DEKU_COMMON_UPPER_LIMB_OVERRIDE_HELD_ACTOR, CVAR || CONSOLE_CRASH_CVAR, {
         Actor* heldActor = va_arg(args, Actor*);
-        if (heldActor != NULL && heldActor->id == ACTOR_ARMS_HOOK) {
+        if (CVAR && heldActor != NULL && heldActor->id == ACTOR_ARMS_HOOK) {
             *should = false;
+            if (!CONSOLE_CRASH_CVAR) {
+                LUSLOG_WARN("Using Hookshot as Deku crashes on console");
+                Ship_HandleConsoleCrashAsReset();
+            }
         }
     });
 }
 
-static RegisterShipInitFunc initFunc(RegisterUnrestrictedItems, { CVAR_NAME });
+static RegisterShipInitFunc initFunc(RegisterUnrestrictedItems, { CVAR_NAME, CONSOLE_CRASH_CVAR_NAME });

--- a/mm/2s2h/GameInteractor/GameInteractor_VanillaBehavior.h
+++ b/mm/2s2h/GameInteractor/GameInteractor_VanillaBehavior.h
@@ -1237,6 +1237,22 @@ typedef enum {
 
     // #### `result`
     // ```c
+    // bubble != NULL
+    // ```
+    // #### `args`
+    // - `*Player`
+    VB_DEKU_COMMON_HEAD_OVERRIDE_HELD_ACTOR,
+
+    // #### `result`
+    // ```c
+    // player->heldActor != NULL
+    // ```
+    // #### `args`
+    // - `*Actor` (player->heldActor)
+    VB_DEKU_COMMON_UPPER_LIMB_OVERRIDE_HELD_ACTOR,
+
+    // #### `result`
+    // ```c
     // true
     // ```
     // #### `args`

--- a/mm/src/code/z_player_lib.c
+++ b/mm/src/code/z_player_lib.c
@@ -2515,7 +2515,7 @@ s32 Player_OverrideLimbDrawGameplayCommon(PlayState* play, s32 limbIndex, Gfx** 
                     func_80125340();
                     func_80125318(pos, rot);
 
-                    if (bubble != NULL) {
+                    if (GameInteractor_Should(VB_DEKU_COMMON_HEAD_OVERRIDE_HELD_ACTOR, (bubble != NULL), bubble)) {
                         s32 requiredScopeTemp[2];
 
                         player->unk_AF0[0].x = 1.0f - (bubble->bubble.unk_144 * 0.03f);
@@ -2580,7 +2580,8 @@ s32 Player_OverrideLimbDrawGameplayCommon(PlayState* play, s32 limbIndex, Gfx** 
 
             rotX = player->upperLimbRot.x;
             if ((player->transformation == PLAYER_FORM_DEKU) && (player->stateFlags3 & PLAYER_STATE3_40)) {
-                if (player->heldActor != NULL) {
+                if (GameInteractor_Should(VB_DEKU_COMMON_UPPER_LIMB_OVERRIDE_HELD_ACTOR, (player->heldActor != NULL),
+                                          player->heldActor)) {
                     rotX += TRUNCF_BINANG(((EnArrow*)(player->heldActor))->bubble.unk_144 * -470.0f);
                 }
             }


### PR DESCRIPTION
Fixes #1673
Assumption that Deku's `heldActor` is `EnArrow` leads to reading out of bounds on drawing Hookshot, giving floating point overflow crash on N64 and often crashes in dungeons on 2ship due to camera, null `floorPoly` or floor raycast failing due to head/focus Y position becoming extremely large positive values (don't know VC behavior).

Fix in `Player_OverrideLimbDrawGameplayCommon`, if unrestricted items don't run bubble things if `heldActor` is Hookshot.

This is just crash fix, Hookshot doesn't work fully for Deku (can only be fired once in a row).

https://github.com/user-attachments/assets/28c29363-22d2-44ad-b8a2-592aaed95b59



<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8951806561.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8951781309.zip)
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8951771993.zip)
<!--- section:artifacts:end -->