### PR TITLE
Prevent faster song playback when falling (for song storage)

### DIFF
--- a/mm/2s2h/Enhancements/Songs/FasterSongPlayback.cpp
+++ b/mm/2s2h/Enhancements/Songs/FasterSongPlayback.cpp
@@ -16,10 +16,14 @@ extern u8 sPlaybackState;
     (gPlayState->msgCtx.ocarinaAction < OCARINA_ACTION_PROMPT_WIND_FISH_HUMAN || \
      gPlayState->msgCtx.ocarinaAction > OCARINA_ACTION_PROMPT_WIND_FISH_DEKU)
 
+static bool IsFallingThroughAir(Player* player) {
+    return !(player->actor.bgCheckFlags & BGCHECKFLAG_GROUND) && (player->actor.velocity.y < 0.0f);
+}
+
 void RegisterFasterSongPlayback() {
     COND_ID_HOOK(OnActorUpdate, ACTOR_PLAYER, CVAR, [](Actor* actor) {
         if (gPlayState->msgCtx.msgMode >= MSGMODE_SONG_PLAYED && gPlayState->msgCtx.msgMode <= MSGMODE_17 &&
-            !gPlayState->csCtx.state && NOT_OCARINA_ACTION_BALAD_WIND_FISH) {
+            !gPlayState->csCtx.state && NOT_OCARINA_ACTION_BALAD_WIND_FISH && !IsFallingThroughAir((Player*)actor)) {
             if (gPlayState->msgCtx.stateTimer > 1) {
                 gPlayState->msgCtx.stateTimer = 1;
             }


### PR DESCRIPTION
This enhancement prevents the window you need for the [Song Storage](https://www.zeldaspeedruns.com/mm/tech/song-storage) glitch.

This simply prevents the faster song playback when we detect you aren't on the ground and you have a negative Y velocity. (falling towards a void out)