### PR TITLE
Don't skip one point cs for a specific block in stone tower

### DIFF
--- a/mm/2s2h/Enhancements/Cutscenes/SkipOnePointCutscenes.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/SkipOnePointCutscenes.cpp
@@ -68,6 +68,12 @@ void RegisterSkipOnePointCutscenes() {
                     *should = false;
                 }
                 break;
+            case ACTOR_BG_F40_BLOCK:
+                // Play the cutscene for one block in Stone tower for a glitch
+                if (!(gPlayState->sceneId == SCENE_F40 && actor->params == (s16)0xCE3C)) {
+                    *should = false;
+                }
+                break;
             case ACTOR_EN_CHA:    // Bell in Laundry Pool
             case ACTOR_BG_SPDWEB: // Spider Web
             case ACTOR_DOOR_SHUTTER:
@@ -94,7 +100,6 @@ void RegisterSkipOnePointCutscenes() {
             case ACTOR_EN_SW:
             case ACTOR_OBJ_CHAN:
             case ACTOR_EN_MM:
-            case ACTOR_BG_F40_BLOCK:
             case ACTOR_EN_BAL:
             case ACTOR_BG_TOBIRA01:
             case ACTOR_OBJ_BIGICICLE:


### PR DESCRIPTION
One might argue we could have a glitch useful cutscenes but just this one so far

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8976416138.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8976384215.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/8976377317.zip)
<!--- section:artifacts:end -->