### PR TITLE
Activate owl statue flag right away

### DIFF
--- a/mm/2s2h/Enhancements/Cutscenes/SkipOnePointCutscenes.cpp
+++ b/mm/2s2h/Enhancements/Cutscenes/SkipOnePointCutscenes.cpp
@@ -5,6 +5,7 @@
 extern "C" {
 #include "overlays/actors/ovl_Obj_Syokudai/z_obj_syokudai.h"
 #include "overlays/actors/ovl_Obj_Bean/z_obj_bean.h"
+#include "overlays/actors/ovl_Obj_Warpstone/z_obj_warpstone.h"
 }
 
 #define CVAR_NAME "gEnhancements.Cutscenes.SkipOnePointCutscenes"
@@ -62,6 +63,13 @@ void RegisterSkipOnePointCutscenes() {
                 actor->csId = -1;
                 *should = false;
                 break;
+            case ACTOR_OBJ_WARPSTONE: // Owl Statue
+                // Instantly set the flag, if the player walks away too fast it gets culled and doesn't grant the flag
+                if (GameInteractor_Should(VB_OWL_STATUE_ACTIVATE, true, OBJ_WARPSTONE_GET_OWL_WARP_ID(actor))) {
+                    Sram_ActivateOwl(OBJ_WARPSTONE_GET_OWL_WARP_ID(actor));
+                }
+                *should = false;
+                break;
             case ACTOR_EN_BOX: // Chest
                 // Currently this breaks the treasure chest minigame, so we're not skipping there
                 if (gPlayState->sceneId != SCENE_TAKARAYA) {
@@ -112,7 +120,6 @@ void RegisterSkipOnePointCutscenes() {
             case ACTOR_BG_IKNIN_SUSCEIL:
             case ACTOR_BG_IKANA_DHARMA:
             case ACTOR_OBJ_HUGEBOMBIWA:
-            case ACTOR_OBJ_WARPSTONE:
                 *should = false;
                 break;
             default:

--- a/mm/src/overlays/actors/ovl_Obj_Warpstone/z_obj_warpstone.h
+++ b/mm/src/overlays/actors/ovl_Obj_Warpstone/z_obj_warpstone.h
@@ -5,7 +5,8 @@
 
 struct ObjWarpstone;
 
-typedef s32 (*ObjWarpstoneActionFunc)(struct ObjWarpstone* this, PlayState* play);
+// 2S2H [Port] Unnamed parameters so this header can be included from C++
+typedef s32 (*ObjWarpstoneActionFunc)(struct ObjWarpstone*, PlayState*);
 
 typedef enum {
     /* 0 */ SEK_MODEL_CLOSED,


### PR DESCRIPTION
Fixes the issue where walking away from the owl statue too fast after hitting it doesn't grant you the item (or flag)

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/9088049954.zip)
  - [2ship-windows.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/9088008860.zip)
  - [2ship-mac.zip](https://nightly.link/HarbourMasters/2ship2harkinian/actions/artifacts/9087851700.zip)
<!--- section:artifacts:end -->